### PR TITLE
Add IsExternalInit polyfill for netstandard2.0

### DIFF
--- a/src/KeenEye.Generators/IsExternalInit.cs
+++ b/src/KeenEye.Generators/IsExternalInit.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file provides a polyfill for IsExternalInit which is required for
+// init-only setters (C# 9+) when targeting netstandard2.0.
+// Source generators must target netstandard2.0 for compiler compatibility.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved to be used by the compiler for tracking metadata.
+/// This class should not be used by developers in source code.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}


### PR DESCRIPTION
Source generators must target netstandard2.0 for compiler compatibility, but the IsExternalInit type required for C# 9+ init-only setters doesn't exist in that framework. Add a minimal polyfill to enable record types with init properties in the generator code.