### PR TITLE
Fix IsExternalInit polyfill namespace syntax for broader SDK compatib…

### DIFF
--- a/src/KeenEye.Generators/IsExternalInit.cs
+++ b/src/KeenEye.Generators/IsExternalInit.cs
@@ -5,15 +5,16 @@
 // init-only setters (C# 9+) when targeting netstandard2.0.
 // Source generators must target netstandard2.0 for compiler compatibility.
 
-using System.ComponentModel;
-
-namespace System.Runtime.CompilerServices;
-
-/// <summary>
-/// Reserved to be used by the compiler for tracking metadata.
-/// This class should not be used by developers in source code.
-/// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-internal static class IsExternalInit
+namespace System.Runtime.CompilerServices
 {
+    using System.ComponentModel;
+
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
 }


### PR DESCRIPTION
…ility

Convert file-scoped namespace to block-scoped namespace syntax in the IsExternalInit polyfill. File-scoped namespaces (namespace X;) require C# 10+, but the effective C# version depends on the SDK being used. Block-scoped namespaces work across all C# versions.