### PR TITLE
Add NuGet proxy workaround for restricted environments

### DIFF
--- a/.claude/hooks/dotnet-post.sh
+++ b/.claude/hooks/dotnet-post.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# PostToolUse hook: Re-enable nuget.org after dotnet commands (web only)
+
+# Skip if not in web environment
+[[ "$CLAUDE_CODE_REMOTE" != "true" ]] && exit 0
+
+# Read tool input from stdin
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only process dotnet commands
+[[ "$command" != *"dotnet"* ]] && exit 0
+
+# Restore source states (keeps nuget.config clean for commits)
+if command -v dotnet &> /dev/null; then
+    dotnet nuget disable source local-feed 2>/dev/null || true
+    dotnet nuget enable source nuget.org 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/hooks/dotnet-pre.sh
+++ b/.claude/hooks/dotnet-pre.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# PreToolUse hook: Disable nuget.org before dotnet commands (web only)
+
+# Skip if not in web environment
+[[ "$CLAUDE_CODE_REMOTE" != "true" ]] && exit 0
+
+# Read tool input from stdin
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only process dotnet commands
+[[ "$command" != *"dotnet"* ]] && exit 0
+
+# Enable local-feed and disable nuget.org to force offline resolution
+if command -v dotnet &> /dev/null; then
+    dotnet nuget enable source local-feed 2>/dev/null || true
+    dotnet nuget disable source nuget.org 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,28 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dotnet-pre.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dotnet-post.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -1,19 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
-    <!-- Local cache populated by install-packages.sh for proxy environments -->
-    <add key="local-cache" value="/tmp/nuget-feed" />
+    <!-- Local feed for offline resolution (populated by install-packages.sh, enabled by hooks on web) -->
+    <add key="local-feed" value="/tmp/nuget-feed" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <!-- Uncomment for .NET 10 preview packages if needed -->
     <!-- <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" /> -->
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="local-cache">
+    <packageSource key="local-feed">
       <package pattern="*" />
     </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
+  <!-- local-feed disabled by default; enabled by PreToolUse hook on web -->
+  <disabledPackageSources>
+    <add key="local-feed" value="true" />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Claude Code web has proxy restrictions where NuGet fails with 401 but wget works. This adds a comprehensive workaround:

SessionStart hook (install-packages.sh):
- Downloads ~75 packages via wget to both global cache and local feed
- Only runs when CLAUDE_CODE_REMOTE=true

PreToolUse/PostToolUse hooks (dotnet-pre.sh, dotnet-post.sh):
- Dynamically enable local-feed and disable nuget.org around dotnet commands
- Restore sources after commands to keep nuget.config clean for commits

nuget.config:
- local-feed disabled by default (for clean local development)
- Source mapping allows both sources to provide any package
