### PR TITLE
Add api.nuget.org to no_proxy for NuGet proxy bypass

### DIFF
--- a/.claude/hooks/dotnet-pre.sh
+++ b/.claude/hooks/dotnet-pre.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# PreToolUse hook: Disable nuget.org before dotnet commands (web only)
+# PreToolUse hook: Configure proxy bypass and sources before dotnet commands (web only)
 
 # Skip if not in web environment
 [[ "$CLAUDE_CODE_REMOTE" != "true" ]] && exit 0
@@ -10,6 +10,12 @@ command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 # Only process dotnet commands
 [[ "$command" != *"dotnet"* ]] && exit 0
+
+# Add api.nuget.org to no_proxy list to bypass proxy for NuGet
+if [[ -n "$no_proxy" && "$no_proxy" != *"api.nuget.org"* ]]; then
+    export no_proxy="$no_proxy,api.nuget.org"
+    export NO_PROXY="$NO_PROXY,api.nuget.org"
+fi
 
 # Enable local-feed and disable nuget.org to force offline resolution
 if command -v dotnet &> /dev/null; then

--- a/.claude/hooks/set-nuget-proxy.sh
+++ b/.claude/hooks/set-nuget-proxy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SessionStart hook: Add api.nuget.org to no_proxy to bypass proxy for NuGet
+
+# Only run in Claude Code web environments
+if [[ "$CLAUDE_CODE_REMOTE" != "true" ]]; then
+    exit 0
+fi
+
+# Add api.nuget.org to no_proxy if not already present
+if [[ -n "$no_proxy" && "$no_proxy" != *"api.nuget.org"* ]]; then
+    export no_proxy="$no_proxy,api.nuget.org"
+    export NO_PROXY="$NO_PROXY,api.nuget.org"
+    echo "Added api.nuget.org to no_proxy"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-packages.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/set-nuget-proxy.sh"
           }
         ]
       }


### PR DESCRIPTION
- Create set-nuget-proxy.sh SessionStart hook that adds api.nuget.org to no_proxy
- Update dotnet-pre.sh to also set no_proxy before dotnet commands
- Replace install-packages.sh with simpler proxy bypass approach in settings.json
