### PR TITLE
Add api.nuget.org to no_proxy for NuGet proxy bypass

### DIFF
--- a/.claude/hooks/set-nuget-proxy.sh
+++ b/.claude/hooks/set-nuget-proxy.sh
@@ -8,7 +8,14 @@ fi
 
 # Add api.nuget.org to no_proxy if not already present
 if [[ -n "$no_proxy" && "$no_proxy" != *"api.nuget.org"* ]]; then
-    export no_proxy="$no_proxy,api.nuget.org"
-    export NO_PROXY="$NO_PROXY,api.nuget.org"
+    new_no_proxy="$no_proxy,api.nuget.org"
+    new_NO_PROXY="$NO_PROXY,api.nuget.org"
+
+    # Persist for subsequent bash commands via CLAUDE_ENV_FILE
+    if [[ -n "$CLAUDE_ENV_FILE" ]]; then
+        echo "no_proxy=$new_no_proxy" >> "$CLAUDE_ENV_FILE"
+        echo "NO_PROXY=$new_NO_PROXY" >> "$CLAUDE_ENV_FILE"
+    fi
+
     echo "Added api.nuget.org to no_proxy"
 fi


### PR DESCRIPTION
- Create set-nuget-proxy.sh SessionStart hook that adds api.nuget.org to no_proxy
- Use CLAUDE_ENV_FILE to persist env vars for subsequent bash commands
- Update dotnet-pre.sh to also set no_proxy before dotnet commands
- Replace install-packages.sh with simpler proxy bypass approach in settings.json

## Description

<!-- Describe what this PR does and why -->

## Changes

<!-- List the main changes in this PR -->

-

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

<!-- Describe how you tested your changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally
