### PR TITLE
Add comprehensive tests for QueryBuilder, Systems, ComponentRegistry,…

### DIFF
--- a/tests/KeenEyes.Core.Tests/ComponentRegistryTests.cs
+++ b/tests/KeenEyes.Core.Tests/ComponentRegistryTests.cs
@@ -1,0 +1,456 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Simple test struct for registry tests.
+/// </summary>
+public struct RegistryTestComponent : IComponent
+{
+    public int Value;
+}
+
+/// <summary>
+/// Another test struct for registry tests.
+/// </summary>
+public struct AnotherRegistryComponent : IComponent
+{
+    public string Name;
+}
+
+/// <summary>
+/// Test tag component for registry tests.
+/// </summary>
+public struct RegistryTestTag : ITagComponent;
+
+/// <summary>
+/// Tests for ComponentRegistry class.
+/// </summary>
+public class ComponentRegistryTests
+{
+    #region Constructor and Initial State
+
+    [Fact]
+    public void ComponentRegistry_NewInstance_HasEmptyAll()
+    {
+        var registry = new ComponentRegistry();
+
+        Assert.Empty(registry.All);
+    }
+
+    [Fact]
+    public void ComponentRegistry_NewInstance_HasZeroCount()
+    {
+        var registry = new ComponentRegistry();
+
+        Assert.Equal(0, registry.Count);
+    }
+
+    #endregion
+
+    #region Register Tests
+
+    [Fact]
+    public void Register_FirstComponent_ReturnsInfoWithIdZero()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.Equal(0, info.Id.Value);
+    }
+
+    [Fact]
+    public void Register_SecondComponent_ReturnsInfoWithIdOne()
+    {
+        var registry = new ComponentRegistry();
+
+        registry.Register<RegistryTestComponent>();
+        var info = registry.Register<AnotherRegistryComponent>();
+
+        Assert.Equal(1, info.Id.Value);
+    }
+
+    [Fact]
+    public void Register_SameTypeTwice_ReturnsSameInfo()
+    {
+        var registry = new ComponentRegistry();
+
+        var info1 = registry.Register<RegistryTestComponent>();
+        var info2 = registry.Register<RegistryTestComponent>();
+
+        Assert.Same(info1, info2);
+        Assert.Equal(0, info1.Id.Value);
+    }
+
+    [Fact]
+    public void Register_ReturnsCorrectType()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.Equal(typeof(RegistryTestComponent), info.Type);
+    }
+
+    [Fact]
+    public void Register_RegularComponent_HasNonZeroSize()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.True(info.Size > 0);
+    }
+
+    [Fact]
+    public void Register_RegularComponent_IsNotTag()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.False(info.IsTag);
+    }
+
+    [Fact]
+    public void Register_TagComponent_HasZeroSize()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestTag>(isTag: true);
+
+        Assert.Equal(0, info.Size);
+    }
+
+    [Fact]
+    public void Register_TagComponent_IsTag()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestTag>(isTag: true);
+
+        Assert.True(info.IsTag);
+    }
+
+    [Fact]
+    public void Register_IncrementsCount()
+    {
+        var registry = new ComponentRegistry();
+
+        registry.Register<RegistryTestComponent>();
+        Assert.Equal(1, registry.Count);
+
+        registry.Register<AnotherRegistryComponent>();
+        Assert.Equal(2, registry.Count);
+    }
+
+    [Fact]
+    public void Register_AddsToAll()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.Contains(info, registry.All);
+    }
+
+    #endregion
+
+    #region Get Tests
+
+    [Fact]
+    public void GetGeneric_RegisteredComponent_ReturnsInfo()
+    {
+        var registry = new ComponentRegistry();
+        var registered = registry.Register<RegistryTestComponent>();
+
+        var retrieved = registry.Get<RegistryTestComponent>();
+
+        Assert.Same(registered, retrieved);
+    }
+
+    [Fact]
+    public void GetGeneric_UnregisteredComponent_ReturnsNull()
+    {
+        var registry = new ComponentRegistry();
+
+        var retrieved = registry.Get<RegistryTestComponent>();
+
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public void GetByType_RegisteredComponent_ReturnsInfo()
+    {
+        var registry = new ComponentRegistry();
+        var registered = registry.Register<RegistryTestComponent>();
+
+        var retrieved = registry.Get(typeof(RegistryTestComponent));
+
+        Assert.Same(registered, retrieved);
+    }
+
+    [Fact]
+    public void GetByType_UnregisteredComponent_ReturnsNull()
+    {
+        var registry = new ComponentRegistry();
+
+        var retrieved = registry.Get(typeof(RegistryTestComponent));
+
+        Assert.Null(retrieved);
+    }
+
+    #endregion
+
+    #region GetOrRegister Tests
+
+    [Fact]
+    public void GetOrRegister_UnregisteredComponent_RegistersAndReturns()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.GetOrRegister<RegistryTestComponent>();
+
+        Assert.NotNull(info);
+        Assert.Equal(typeof(RegistryTestComponent), info.Type);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void GetOrRegister_RegisteredComponent_ReturnsExisting()
+    {
+        var registry = new ComponentRegistry();
+        var original = registry.Register<RegistryTestComponent>();
+
+        var retrieved = registry.GetOrRegister<RegistryTestComponent>();
+
+        Assert.Same(original, retrieved);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void GetOrRegister_TagComponent_RegistersAsTag()
+    {
+        var registry = new ComponentRegistry();
+
+        var info = registry.GetOrRegister<RegistryTestTag>(isTag: true);
+
+        Assert.True(info.IsTag);
+        Assert.Equal(0, info.Size);
+    }
+
+    #endregion
+
+    #region IsRegistered Tests
+
+    [Fact]
+    public void IsRegistered_RegisteredComponent_ReturnsTrue()
+    {
+        var registry = new ComponentRegistry();
+        registry.Register<RegistryTestComponent>();
+
+        Assert.True(registry.IsRegistered<RegistryTestComponent>());
+    }
+
+    [Fact]
+    public void IsRegistered_UnregisteredComponent_ReturnsFalse()
+    {
+        var registry = new ComponentRegistry();
+
+        Assert.False(registry.IsRegistered<RegistryTestComponent>());
+    }
+
+    [Fact]
+    public void IsRegistered_AfterGetOrRegister_ReturnsTrue()
+    {
+        var registry = new ComponentRegistry();
+        registry.GetOrRegister<RegistryTestComponent>();
+
+        Assert.True(registry.IsRegistered<RegistryTestComponent>());
+    }
+
+    #endregion
+
+    #region Isolation Tests
+
+    [Fact]
+    public void ComponentRegistry_DifferentInstances_HaveIndependentIds()
+    {
+        var registry1 = new ComponentRegistry();
+        var registry2 = new ComponentRegistry();
+
+        var info1 = registry1.Register<RegistryTestComponent>();
+        var info2 = registry2.Register<AnotherRegistryComponent>();
+
+        // Both should have ID 0 since they're in different registries
+        Assert.Equal(0, info1.Id.Value);
+        Assert.Equal(0, info2.Id.Value);
+    }
+
+    [Fact]
+    public void ComponentRegistry_DifferentInstances_HaveIndependentRegistrations()
+    {
+        var registry1 = new ComponentRegistry();
+        var registry2 = new ComponentRegistry();
+
+        registry1.Register<RegistryTestComponent>();
+
+        Assert.True(registry1.IsRegistered<RegistryTestComponent>());
+        Assert.False(registry2.IsRegistered<RegistryTestComponent>());
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Tests for ComponentInfo class.
+/// </summary>
+public class ComponentInfoTests
+{
+    [Fact]
+    public void ComponentInfo_Name_ReturnsTypeName()
+    {
+        var registry = new ComponentRegistry();
+        var info = registry.Register<RegistryTestComponent>();
+
+        Assert.Equal("RegistryTestComponent", info.Name);
+    }
+
+    [Fact]
+    public void ComponentInfo_ToString_ContainsRelevantInfo()
+    {
+        var registry = new ComponentRegistry();
+        var info = registry.Register<RegistryTestComponent>();
+
+        var str = info.ToString();
+
+        Assert.Contains("RegistryTestComponent", str);
+        Assert.Contains("Id=", str);
+        Assert.Contains("Size=", str);
+        Assert.Contains("IsTag=", str);
+    }
+}
+
+/// <summary>
+/// Tests for ComponentMeta static class.
+/// </summary>
+public class ComponentMetaTests
+{
+    [Fact]
+    public void ComponentMeta_Size_ReturnsCorrectSize()
+    {
+        // RegistryTestComponent has a single int field (4 bytes)
+        Assert.True(ComponentMeta<RegistryTestComponent>.Size > 0);
+    }
+
+    [Fact]
+    public void ComponentMeta_Type_ReturnsCorrectType()
+    {
+        Assert.Equal(typeof(RegistryTestComponent), ComponentMeta<RegistryTestComponent>.Type);
+    }
+}
+
+/// <summary>
+/// Tests for ComponentId struct.
+/// </summary>
+public class ComponentIdTests
+{
+    [Fact]
+    public void ComponentId_Value_ReturnsConstructedValue()
+    {
+        var id = new ComponentId(42);
+
+        Assert.Equal(42, id.Value);
+    }
+
+    [Fact]
+    public void ComponentId_Equality_SameValue_AreEqual()
+    {
+        var id1 = new ComponentId(5);
+        var id2 = new ComponentId(5);
+
+        Assert.Equal(id1, id2);
+        Assert.True(id1 == id2);
+        Assert.False(id1 != id2);
+    }
+
+    [Fact]
+    public void ComponentId_Equality_DifferentValue_AreNotEqual()
+    {
+        var id1 = new ComponentId(5);
+        var id2 = new ComponentId(10);
+
+        Assert.NotEqual(id1, id2);
+        Assert.False(id1 == id2);
+        Assert.True(id1 != id2);
+    }
+
+    [Fact]
+    public void ComponentId_GetHashCode_SameValue_SameHash()
+    {
+        var id1 = new ComponentId(42);
+        var id2 = new ComponentId(42);
+
+        Assert.Equal(id1.GetHashCode(), id2.GetHashCode());
+    }
+
+    [Fact]
+    public void ComponentId_None_HasNegativeValue()
+    {
+        Assert.Equal(-1, ComponentId.None.Value);
+    }
+
+    [Fact]
+    public void ComponentId_None_IsNotValid()
+    {
+        Assert.False(ComponentId.None.IsValid);
+    }
+
+    [Fact]
+    public void ComponentId_PositiveValue_IsValid()
+    {
+        var id = new ComponentId(0);
+
+        Assert.True(id.IsValid);
+    }
+
+    [Fact]
+    public void ComponentId_NegativeValue_IsNotValid()
+    {
+        var id = new ComponentId(-5);
+
+        Assert.False(id.IsValid);
+    }
+
+    [Fact]
+    public void ComponentId_CompareTo_ReturnsCorrectOrder()
+    {
+        var id1 = new ComponentId(5);
+        var id2 = new ComponentId(10);
+        var id3 = new ComponentId(5);
+
+        Assert.True(id1.CompareTo(id2) < 0);
+        Assert.True(id2.CompareTo(id1) > 0);
+        Assert.Equal(0, id1.CompareTo(id3));
+    }
+
+    [Fact]
+    public void ComponentId_ToString_ContainsValue()
+    {
+        var id = new ComponentId(42);
+
+        var str = id.ToString();
+
+        Assert.Contains("42", str);
+        Assert.Contains("ComponentId", str);
+    }
+
+    [Fact]
+    public void ComponentId_ImplicitConversionToInt_ReturnsValue()
+    {
+        var id = new ComponentId(42);
+
+        int value = id;
+
+        Assert.Equal(42, value);
+    }
+}

--- a/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
@@ -1,0 +1,551 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Test component for builder tests.
+/// </summary>
+public struct BuilderTestPosition : IComponent
+{
+    public float X;
+    public float Y;
+}
+
+/// <summary>
+/// Test component for builder tests.
+/// </summary>
+public struct BuilderTestVelocity : IComponent
+{
+    public float X;
+    public float Y;
+}
+
+/// <summary>
+/// Test tag component for builder tests.
+/// </summary>
+public struct BuilderTestTag : ITagComponent;
+
+/// <summary>
+/// Another test tag component for builder tests.
+/// </summary>
+public struct AnotherBuilderTag : ITagComponent;
+
+/// <summary>
+/// Tests for EntityBuilder class.
+/// </summary>
+public class EntityBuilderTests
+{
+    #region Basic Construction
+
+    [Fact]
+    public void EntityBuilder_World_ReturnsCorrectWorld()
+    {
+        using var world = new World();
+
+        var builder = world.Spawn();
+
+        Assert.Same(world, builder.World);
+    }
+
+    [Fact]
+    public void EntityBuilder_Build_CreatesValidEntity()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.True(entity.IsValid);
+        Assert.True(world.IsAlive(entity));
+    }
+
+    [Fact]
+    public void EntityBuilder_Build_EntityHasComponents()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 10f, Y = 20f })
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+        ref var position = ref world.Get<BuilderTestPosition>(entity);
+        Assert.Equal(10f, position.X);
+        Assert.Equal(20f, position.Y);
+    }
+
+    #endregion
+
+    #region With Method
+
+    [Fact]
+    public void EntityBuilder_With_ReturnsSelf()
+    {
+        using var world = new World();
+
+        var builder = world.Spawn();
+        var result = builder.With(new BuilderTestPosition { X = 0f, Y = 0f });
+
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void EntityBuilder_With_AddsComponent()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 5f, Y = 10f })
+            .Build();
+
+        ref var position = ref world.Get<BuilderTestPosition>(entity);
+        Assert.Equal(5f, position.X);
+        Assert.Equal(10f, position.Y);
+    }
+
+    [Fact]
+    public void EntityBuilder_With_MultipleTimes_AddsAllComponents()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 2f })
+            .With(new BuilderTestVelocity { X = 3f, Y = 4f })
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+        Assert.True(world.Has<BuilderTestVelocity>(entity));
+
+        ref var position = ref world.Get<BuilderTestPosition>(entity);
+        ref var velocity = ref world.Get<BuilderTestVelocity>(entity);
+
+        Assert.Equal(1f, position.X);
+        Assert.Equal(2f, position.Y);
+        Assert.Equal(3f, velocity.X);
+        Assert.Equal(4f, velocity.Y);
+    }
+
+    [Fact]
+    public void EntityBuilder_With_RegistersComponentType()
+    {
+        using var world = new World();
+
+        world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.True(world.Components.IsRegistered<BuilderTestPosition>());
+    }
+
+    #endregion
+
+    #region WithTag Method
+
+    [Fact]
+    public void EntityBuilder_WithTag_ReturnsSelf()
+    {
+        using var world = new World();
+
+        var builder = world.Spawn();
+        var result = builder.WithTag<BuilderTestTag>();
+
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void EntityBuilder_WithTag_AddsTagComponent()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .WithTag<BuilderTestTag>()
+            .Build();
+
+        Assert.True(world.Has<BuilderTestTag>(entity));
+    }
+
+    [Fact]
+    public void EntityBuilder_WithTag_MultipleTags()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .WithTag<BuilderTestTag>()
+            .WithTag<AnotherBuilderTag>()
+            .Build();
+
+        Assert.True(world.Has<BuilderTestTag>(entity));
+        Assert.True(world.Has<AnotherBuilderTag>(entity));
+    }
+
+    [Fact]
+    public void EntityBuilder_WithTag_RegistersAsTag()
+    {
+        using var world = new World();
+
+        world.Spawn()
+            .WithTag<BuilderTestTag>()
+            .Build();
+
+        var info = world.Components.Get<BuilderTestTag>();
+        Assert.NotNull(info);
+        Assert.True(info.IsTag);
+    }
+
+    #endregion
+
+    #region Chaining and Fluent API
+
+    [Fact]
+    public void EntityBuilder_FluentChaining_WorksCorrectly()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 2f })
+            .With(new BuilderTestVelocity { X = 3f, Y = 4f })
+            .WithTag<BuilderTestTag>()
+            .WithTag<AnotherBuilderTag>()
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+        Assert.True(world.Has<BuilderTestVelocity>(entity));
+        Assert.True(world.Has<BuilderTestTag>(entity));
+        Assert.True(world.Has<AnotherBuilderTag>(entity));
+    }
+
+    #endregion
+
+    #region Multiple Entities
+
+    [Fact]
+    public void EntityBuilder_MultipleEntities_EachHasOwnComponents()
+    {
+        using var world = new World();
+
+        var entity1 = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 1f })
+            .Build();
+        var entity2 = world.Spawn()
+            .With(new BuilderTestPosition { X = 2f, Y = 2f })
+            .Build();
+
+        ref var pos1 = ref world.Get<BuilderTestPosition>(entity1);
+        ref var pos2 = ref world.Get<BuilderTestPosition>(entity2);
+
+        Assert.Equal(1f, pos1.X);
+        Assert.Equal(2f, pos2.X);
+    }
+
+    [Fact]
+    public void EntityBuilder_MultipleEntities_HaveUniqueIds()
+    {
+        using var world = new World();
+
+        var entity1 = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+        var entity2 = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.NotEqual(entity1.Id, entity2.Id);
+    }
+
+    [Fact]
+    public void EntityBuilder_ReuseSpawn_ClearsState()
+    {
+        using var world = new World();
+
+        // First entity with Position
+        var entity1 = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 1f })
+            .Build();
+
+        // Second entity with only Velocity (no Position)
+        var entity2 = world.Spawn()
+            .With(new BuilderTestVelocity { X = 2f, Y = 2f })
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity1));
+        Assert.False(world.Has<BuilderTestVelocity>(entity1));
+
+        Assert.False(world.Has<BuilderTestPosition>(entity2));
+        Assert.True(world.Has<BuilderTestVelocity>(entity2));
+    }
+
+    #endregion
+
+    #region Interface Implementation
+
+    [Fact]
+    public void EntityBuilder_IEntityBuilder_With_Works()
+    {
+        using var world = new World();
+
+        IEntityBuilder builder = world.Spawn();
+        builder = builder.With(new BuilderTestPosition { X = 5f, Y = 10f });
+
+        // Build through the concrete type
+        var entity = ((EntityBuilder)builder).Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+    }
+
+    [Fact]
+    public void EntityBuilder_IEntityBuilder_WithTag_Works()
+    {
+        using var world = new World();
+
+        IEntityBuilder builder = world.Spawn();
+        builder = builder
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .WithTag<BuilderTestTag>();
+
+        var entity = ((EntityBuilder)builder).Build();
+
+        Assert.True(world.Has<BuilderTestTag>(entity));
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void EntityBuilder_EmptyEntity_IsValid()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn().Build();
+
+        Assert.True(entity.IsValid);
+        Assert.True(world.IsAlive(entity));
+    }
+
+    [Fact]
+    public void EntityBuilder_WithDefaultComponent_Works()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .With(default(BuilderTestPosition))
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+        ref var position = ref world.Get<BuilderTestPosition>(entity);
+        Assert.Equal(0f, position.X);
+        Assert.Equal(0f, position.Y);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Tests for World.Has&lt;T&gt; method.
+/// </summary>
+public class WorldHasTests
+{
+    [Fact]
+    public void Has_EntityWithComponent_ReturnsTrue()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.True(world.Has<BuilderTestPosition>(entity));
+    }
+
+    [Fact]
+    public void Has_EntityWithoutComponent_ReturnsFalse()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.False(world.Has<BuilderTestVelocity>(entity));
+    }
+
+    [Fact]
+    public void Has_DeadEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        world.Despawn(entity);
+
+        Assert.False(world.Has<BuilderTestPosition>(entity));
+    }
+
+    [Fact]
+    public void Has_InvalidEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var invalidEntity = new Entity(999, 1);
+
+        Assert.False(world.Has<BuilderTestPosition>(invalidEntity));
+    }
+
+    [Fact]
+    public void Has_UnregisteredComponentType_ReturnsFalse()
+    {
+        using var world = new World();
+        var entity = world.Spawn().Build();
+
+        // BuilderTestPosition is not registered yet
+        Assert.False(world.Has<BuilderTestPosition>(entity));
+    }
+}
+
+/// <summary>
+/// Tests for World.Despawn method.
+/// </summary>
+public class WorldDespawnTests
+{
+    [Fact]
+    public void Despawn_AliveEntity_ReturnsTrue()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        var result = world.Despawn(entity);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Despawn_AliveEntity_EntityNoLongerAlive()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        world.Despawn(entity);
+
+        Assert.False(world.IsAlive(entity));
+    }
+
+    [Fact]
+    public void Despawn_DeadEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        world.Despawn(entity);
+        var result = world.Despawn(entity);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Despawn_InvalidEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var invalidEntity = new Entity(999, 1);
+
+        var result = world.Despawn(invalidEntity);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Despawn_IncrementsVersion()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        world.Despawn(entity);
+
+        // After despawning, if we create a new entity with same ID,
+        // the original entity handle should be stale
+        var newEntity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        // Original entity should not be alive (version mismatch)
+        Assert.False(world.IsAlive(entity));
+    }
+}
+
+/// <summary>
+/// Tests for World.GetAllEntities method.
+/// </summary>
+public class WorldGetAllEntitiesTests
+{
+    [Fact]
+    public void GetAllEntities_NoEntities_ReturnsEmpty()
+    {
+        using var world = new World();
+
+        var entities = world.GetAllEntities().ToList();
+
+        Assert.Empty(entities);
+    }
+
+    [Fact]
+    public void GetAllEntities_SingleEntity_ReturnsThatEntity()
+    {
+        using var world = new World();
+        var entity = world.Spawn()
+            .With(new BuilderTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        var entities = world.GetAllEntities().ToList();
+
+        Assert.Single(entities);
+        Assert.Contains(entity, entities);
+    }
+
+    [Fact]
+    public void GetAllEntities_MultipleEntities_ReturnsAll()
+    {
+        using var world = new World();
+        var entity1 = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 1f })
+            .Build();
+        var entity2 = world.Spawn()
+            .With(new BuilderTestPosition { X = 2f, Y = 2f })
+            .Build();
+        var entity3 = world.Spawn()
+            .With(new BuilderTestPosition { X = 3f, Y = 3f })
+            .Build();
+
+        var entities = world.GetAllEntities().ToList();
+
+        Assert.Equal(3, entities.Count);
+        Assert.Contains(entity1, entities);
+        Assert.Contains(entity2, entities);
+        Assert.Contains(entity3, entities);
+    }
+
+    [Fact]
+    public void GetAllEntities_AfterDespawn_ExcludesDespawned()
+    {
+        using var world = new World();
+        var entity1 = world.Spawn()
+            .With(new BuilderTestPosition { X = 1f, Y = 1f })
+            .Build();
+        var entity2 = world.Spawn()
+            .With(new BuilderTestPosition { X = 2f, Y = 2f })
+            .Build();
+
+        world.Despawn(entity1);
+
+        var entities = world.GetAllEntities().ToList();
+
+        Assert.Single(entities);
+        Assert.Contains(entity2, entities);
+        Assert.DoesNotContain(entity1, entities);
+    }
+}

--- a/tests/KeenEyes.Core.Tests/SystemTests.cs
+++ b/tests/KeenEyes.Core.Tests/SystemTests.cs
@@ -1,0 +1,478 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Test system that tracks initialization and updates.
+/// </summary>
+public class TestCountingSystem : SystemBase
+{
+    public int InitializeCount { get; private set; }
+    public int UpdateCount { get; private set; }
+    public float TotalDeltaTime { get; private set; }
+    public bool WasDisposed { get; private set; }
+
+    protected override void OnInitialize()
+    {
+        InitializeCount++;
+    }
+
+    public override void Update(float deltaTime)
+    {
+        UpdateCount++;
+        TotalDeltaTime += deltaTime;
+    }
+
+    public override void Dispose()
+    {
+        WasDisposed = true;
+        base.Dispose();
+    }
+}
+
+/// <summary>
+/// Test system that accesses the World during update.
+/// </summary>
+public class TestWorldAccessSystem : SystemBase
+{
+    public int EntityCount { get; private set; }
+
+    public override void Update(float deltaTime)
+    {
+        EntityCount = World.GetAllEntities().Count();
+    }
+}
+
+/// <summary>
+/// Test system that modifies entity components.
+/// </summary>
+public class TestMovementSystem : SystemBase
+{
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<TestPosition, TestVelocity>())
+        {
+            ref var position = ref World.Get<TestPosition>(entity);
+            ref readonly var velocity = ref World.Get<TestVelocity>(entity);
+
+            position.X += velocity.X * deltaTime;
+            position.Y += velocity.Y * deltaTime;
+        }
+    }
+}
+
+/// <summary>
+/// Test system without parameterless constructor for error testing.
+/// </summary>
+public class TestNonDefaultConstructorSystem : ISystem
+{
+    private readonly string name;
+
+    public TestNonDefaultConstructorSystem(string name)
+    {
+        this.name = name;
+    }
+
+    public string Name => name;
+
+    public void Initialize(World world) { }
+    public void Update(float deltaTime) { }
+    public void Dispose() { }
+}
+
+/// <summary>
+/// Tests for SystemBase abstract class.
+/// </summary>
+public class SystemBaseTests
+{
+    [Fact]
+    public void SystemBase_Initialize_SetsWorld()
+    {
+        using var world = new World();
+        var system = new TestWorldAccessSystem();
+
+        system.Initialize(world);
+        world.Spawn().With(new TestPosition { X = 0f, Y = 0f }).Build();
+        system.Update(0f);
+
+        Assert.Equal(1, system.EntityCount);
+    }
+
+    [Fact]
+    public void SystemBase_Initialize_CallsOnInitialize()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+
+        system.Initialize(world);
+
+        Assert.Equal(1, system.InitializeCount);
+    }
+
+    [Fact]
+    public void SystemBase_World_ThrowsBeforeInitialize()
+    {
+        var system = new TestWorldAccessSystem();
+
+        Assert.Throws<InvalidOperationException>(() => system.Update(0f));
+    }
+
+    [Fact]
+    public void SystemBase_Update_ReceivesDeltaTime()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+        system.Initialize(world);
+
+        system.Update(0.016f);
+        system.Update(0.016f);
+        system.Update(0.016f);
+
+        Assert.Equal(3, system.UpdateCount);
+        Assert.Equal(0.048f, system.TotalDeltaTime, 5);
+    }
+
+    [Fact]
+    public void SystemBase_Dispose_CanBeOverridden()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+        system.Initialize(world);
+
+        system.Dispose();
+
+        Assert.True(system.WasDisposed);
+    }
+
+    [Fact]
+    public void SystemBase_Update_CanQueryAndModifyEntities()
+    {
+        using var world = new World();
+        var system = new TestMovementSystem();
+        system.Initialize(world);
+
+        var entity = world.Spawn()
+            .With(new TestPosition { X = 0f, Y = 0f })
+            .With(new TestVelocity { X = 10f, Y = 5f })
+            .Build();
+
+        system.Update(1.0f);
+
+        ref var position = ref world.Get<TestPosition>(entity);
+        Assert.Equal(10f, position.X);
+        Assert.Equal(5f, position.Y);
+    }
+}
+
+/// <summary>
+/// Tests for SystemGroup class.
+/// </summary>
+public class SystemGroupTests
+{
+    [Fact]
+    public void SystemGroup_Constructor_SetsName()
+    {
+        var group = new SystemGroup("UpdateGroup");
+
+        Assert.Equal("UpdateGroup", group.Name);
+    }
+
+    [Fact]
+    public void SystemGroup_AddGeneric_AddsSystem()
+    {
+        using var world = new World();
+        var group = new SystemGroup("TestGroup");
+
+        group.Add<TestCountingSystem>();
+        group.Initialize(world);
+        group.Update(0.016f);
+
+        // If we got here without exception, the system was added and updated
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_AddInstance_AddsSystem()
+    {
+        using var world = new World();
+        var group = new SystemGroup("TestGroup");
+        var system = new TestCountingSystem();
+
+        group.Add(system);
+        group.Initialize(world);
+        group.Update(0.016f);
+
+        Assert.Equal(1, system.UpdateCount);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_Add_ReturnsSelf_ForChaining()
+    {
+        var group = new SystemGroup("TestGroup");
+
+        var result = group.Add<TestCountingSystem>();
+
+        Assert.Same(group, result);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_AddInstance_ReturnsSelf_ForChaining()
+    {
+        var group = new SystemGroup("TestGroup");
+        var system = new TestCountingSystem();
+
+        var result = group.Add(system);
+
+        Assert.Same(group, result);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_Initialize_InitializesAllSystems()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup")
+            .Add(system1)
+            .Add(system2);
+
+        group.Initialize(world);
+
+        Assert.Equal(1, system1.InitializeCount);
+        Assert.Equal(1, system2.InitializeCount);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_Update_UpdatesAllSystems()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup")
+            .Add(system1)
+            .Add(system2);
+
+        group.Initialize(world);
+        group.Update(0.016f);
+
+        Assert.Equal(1, system1.UpdateCount);
+        Assert.Equal(1, system2.UpdateCount);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_Update_PassesDeltaTimeToAllSystems()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup")
+            .Add(system1)
+            .Add(system2);
+
+        group.Initialize(world);
+        group.Update(0.5f);
+
+        Assert.Equal(0.5f, system1.TotalDeltaTime);
+        Assert.Equal(0.5f, system2.TotalDeltaTime);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_Dispose_DisposesAllSystems()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup")
+            .Add(system1)
+            .Add(system2);
+
+        group.Initialize(world);
+        group.Dispose();
+
+        Assert.True(system1.WasDisposed);
+        Assert.True(system2.WasDisposed);
+    }
+
+    [Fact]
+    public void SystemGroup_Dispose_ClearsSystems()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup").Add(system);
+        group.Initialize(world);
+        group.Dispose();
+
+        // After dispose, update should not affect the system anymore
+        // because the systems list is cleared
+        group.Update(0.016f);
+
+        Assert.Equal(0, system.UpdateCount);
+    }
+
+    [Fact]
+    public void SystemGroup_AddAfterInitialize_InitializesNewSystem()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup").Add(system1);
+        group.Initialize(world);
+
+        // Add second system after initialization
+        group.Add(system2);
+
+        Assert.Equal(1, system1.InitializeCount);
+        Assert.Equal(1, system2.InitializeCount); // Should be auto-initialized
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_AddGenericAfterInitialize_InitializesNewSystem()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+
+        var group = new SystemGroup("TestGroup").Add(system1);
+        group.Initialize(world);
+
+        // Add system using generic method after initialization
+        group.Add<TestWorldAccessSystem>();
+
+        // Verify the group can update without errors (system is initialized)
+        group.Update(0.016f);
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_CanBeNested()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+
+        var innerGroup = new SystemGroup("InnerGroup").Add(system);
+        var outerGroup = new SystemGroup("OuterGroup").Add(innerGroup);
+
+        outerGroup.Initialize(world);
+        outerGroup.Update(0.016f);
+
+        Assert.Equal(1, system.InitializeCount);
+        Assert.Equal(1, system.UpdateCount);
+        outerGroup.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_EmptyGroup_UpdateDoesNotThrow()
+    {
+        using var world = new World();
+        var group = new SystemGroup("EmptyGroup");
+
+        group.Initialize(world);
+        group.Update(0.016f); // Should not throw
+
+        group.Dispose();
+    }
+
+    [Fact]
+    public void SystemGroup_CanAddNonDefaultConstructorSystem()
+    {
+        using var world = new World();
+        var system = new TestNonDefaultConstructorSystem("MySystem");
+
+        var group = new SystemGroup("TestGroup").Add(system);
+        group.Initialize(world);
+        group.Update(0.016f);
+
+        Assert.Equal("MySystem", system.Name);
+        group.Dispose();
+    }
+}
+
+/// <summary>
+/// Tests for World.AddSystem functionality.
+/// </summary>
+public class WorldSystemTests
+{
+    [Fact]
+    public void World_AddSystemGeneric_AddsAndInitializesSystem()
+    {
+        using var world = new World();
+
+        world.AddSystem<TestCountingSystem>();
+        world.Update(0.016f);
+
+        // If we got here without exception, the system was added and updated
+    }
+
+    [Fact]
+    public void World_AddSystemInstance_AddsAndInitializesSystem()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+
+        world.AddSystem(system);
+        world.Update(0.016f);
+
+        Assert.Equal(1, system.InitializeCount);
+        Assert.Equal(1, system.UpdateCount);
+    }
+
+    [Fact]
+    public void World_AddSystem_ReturnsSelf_ForChaining()
+    {
+        using var world = new World();
+
+        var result = world.AddSystem<TestCountingSystem>();
+
+        Assert.Same(world, result);
+    }
+
+    [Fact]
+    public void World_Update_UpdatesAllSystems()
+    {
+        using var world = new World();
+        var system1 = new TestCountingSystem();
+        var system2 = new TestCountingSystem();
+
+        world.AddSystem(system1).AddSystem(system2);
+        world.Update(0.016f);
+        world.Update(0.016f);
+
+        Assert.Equal(2, system1.UpdateCount);
+        Assert.Equal(2, system2.UpdateCount);
+    }
+
+    [Fact]
+    public void World_Dispose_DisposesAllSystems()
+    {
+        var system = new TestCountingSystem();
+        var world = new World();
+
+        world.AddSystem(system);
+        world.Dispose();
+
+        Assert.True(system.WasDisposed);
+    }
+
+    [Fact]
+    public void World_AddSystemGroup_WorksCorrectly()
+    {
+        using var world = new World();
+        var system = new TestCountingSystem();
+        var group = new SystemGroup("TestGroup").Add(system);
+
+        world.AddSystem(group);
+        world.Update(0.016f);
+
+        Assert.Equal(1, system.UpdateCount);
+    }
+}


### PR DESCRIPTION
… and EntityBuilder

Adds 95+ new tests covering previously untested areas:
- QueryTests: QueryDescription, QueryBuilder (1-4 components), QueryEnumerator
- SystemTests: SystemBase, SystemGroup, World.AddSystem
- ComponentRegistryTests: ComponentRegistry, ComponentInfo, ComponentMeta, ComponentId
- EntityBuilderTests: EntityBuilder, World.Has, World.Despawn, World.GetAllEntities

This significantly increases code coverage by testing core ECS functionality that was only covered indirectly through other tests.