### PR TITLE
Fix API documentation for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ coverage/
 
 # BenchmarkDotNet
 BenchmarkDotNet.Artifacts/
+
+# DocFX
+_site/
+api/*.yml
+api/.manifest

--- a/api/index.md
+++ b/api/index.md
@@ -1,0 +1,48 @@
+# API Reference
+
+Welcome to the KeenEyes ECS API documentation.
+
+This reference is automatically generated from XML documentation comments in the source code.
+
+## Namespaces
+
+- **KeenEyes.Core** - Core ECS types including `World`, `Entity`, components, and queries
+- **KeenEyes.Generators.Attributes** - Attributes for source generator code generation
+
+## Getting Started
+
+The main entry point is the @KeenEyes.Core.World class:
+
+```csharp
+using KeenEyes.Core;
+
+// Create an isolated ECS world
+var world = new World();
+
+// Create entities with components
+var entity = world.CreateEntity();
+
+// Query entities
+foreach (var e in world.Query<Position, Velocity>())
+{
+    ref var pos = ref world.Get<Position>(e);
+    ref readonly var vel = ref world.Get<Velocity>(e);
+
+    pos.X += vel.X;
+    pos.Y += vel.Y;
+}
+
+// Clean up
+world.Dispose();
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **World** | Isolated container for entities, components, and systems |
+| **Entity** | Lightweight ID with version for staleness detection |
+| **Component** | Plain data struct attached to entities |
+| **Query** | Fluent API for filtering and iterating entities |
+
+Browse the namespace documentation below for detailed API information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,4 +37,4 @@ foreach (var (pos, vel) in world.Query<Position, Velocity>())
 
 ## API Reference
 
-See the [API Documentation](api/index.md) for detailed reference.
+See the [API Documentation](../api/index.md) for detailed reference.


### PR DESCRIPTION
- Add api/index.md as the API reference landing page for DocFX
- Fix link in docs/index.md to use correct relative path (../api/index.md)
- Update .gitignore to exclude DocFX generated files (_site/, api/*.yml)

The API documentation was unavailable on GitHub Pages because the api/index.md source file was missing. DocFX requires this file to generate the API section landing page.