### PR TITLE
Add comprehensive tests for source generators

### DIFF
--- a/tests/KeenEyes.Generators.Tests/ComponentGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/ComponentGeneratorTests.cs
@@ -85,6 +85,483 @@ public class ComponentGeneratorTests
         Assert.Contains(generatedTrees, t => t.Contains("WithVelocity"));
     }
 
+    [Fact]
+    public void ComponentGenerator_WithDefaultValueAttribute_UsesCustomDefault()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Health
+            {
+                [DefaultValue(100)]
+                public int Current;
+                [DefaultValue(100)]
+                public int Max;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("int current = 100"));
+        Assert.Contains(generatedTrees, t => t.Contains("int max = 100"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithBuilderIgnoreAttribute_ExcludesField()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct CachedData
+            {
+                public float Value;
+                [BuilderIgnore]
+                public float CachedResult;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("float value"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("cachedResult"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithFieldInitializer_UsesInitializerAsDefault()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Defaults
+            {
+                public int Count = 5;
+                public float Speed = 1.5f;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("int count = 5"));
+        Assert.Contains(generatedTrees, t => t.Contains("float speed = 1.5f"));
+    }
+
+    [Theory]
+    [InlineData("int", "0")]
+    [InlineData("float", "0f")]
+    [InlineData("double", "0d")]
+    [InlineData("bool", "false")]
+    [InlineData("string", "\"\"")]
+    [InlineData("long", "0L")]
+    [InlineData("byte", "0")]
+    [InlineData("short", "0")]
+    [InlineData("uint", "0u")]
+    [InlineData("ulong", "0ul")]
+    [InlineData("decimal", "0m")]
+    [InlineData("char", "'\\0'")]
+    public void ComponentGenerator_PrimitiveTypes_HaveCorrectDefaults(string type, string expectedDefault)
+    {
+        var source = $$"""
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct PrimitiveComponent
+            {
+                public {{type}} Field;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains($"{type} field = {expectedDefault}"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithNoFields_GeneratesBuilder()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Empty { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        // Verify builder method is generated (signature may vary with no parameters)
+        Assert.Contains(generatedTrees, t => t.Contains("WithEmpty(this EntityBuilder builder"));
+        Assert.Contains(generatedTrees, t => t.Contains("new TestApp.Empty"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_IgnoresStaticFields()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct WithStatic
+            {
+                public static int StaticField;
+                public int InstanceField;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("int instanceField"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("staticField"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_IgnoresConstFields()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct WithConst
+            {
+                public const int Version = 1;
+                public int Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("int value"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("version"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_InGlobalNamespace_GeneratesWithoutNamespace()
+    {
+        var source = """
+            using KeenEyes;
+
+            [Component]
+            public partial struct GlobalComponent
+            {
+                public int Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct GlobalComponent"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_InNestedNamespace_GeneratesCorrectNamespace()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace Game.Components.Movement;
+
+            [Component]
+            public partial struct NestedPosition
+            {
+                public float X;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("namespace Game.Components.Movement;"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_MultipleComponents_GeneratesAllExtensions()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct First { public int A; }
+
+            [Component]
+            public partial struct Second { public int B; }
+
+            [TagComponent]
+            public partial struct ThirdTag { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("WithFirst"));
+        Assert.Contains(generatedTrees, t => t.Contains("WithSecond"));
+        Assert.Contains(generatedTrees, t => t.Contains("WithThirdTag"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_GeneratesAutoGeneratedHeader()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct HeaderComponent
+            {
+                public int Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.All(generatedTrees, t => Assert.Contains("// <auto-generated />", t));
+        Assert.All(generatedTrees, t => Assert.Contains("#nullable enable", t));
+    }
+
+    [Fact]
+    public void ComponentGenerator_GeneratesXmlDocumentation()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct DocComponent
+            {
+                public int Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("/// <summary>"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_ToCamelCase_HandlesVariousNames()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct CamelCaseTest
+            {
+                public int X;
+                public int Y;
+                public int LongFieldName;
+                public int ID;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("int x"));
+        Assert.Contains(generatedTrees, t => t.Contains("int y"));
+        Assert.Contains(generatedTrees, t => t.Contains("int longFieldName"));
+        Assert.Contains(generatedTrees, t => t.Contains("int iD"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_TagComponent_GeneratesWithTagMethod()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [TagComponent]
+            public partial struct Player { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("WithTag<TestApp.Player>()"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithDefaultValueString_FormatsCorrectly()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Named
+            {
+                [DefaultValue("Unknown")]
+                public string Name;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("string name = \"Unknown\""));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithDefaultValueBool_FormatsCorrectly()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Flags
+            {
+                [DefaultValue(true)]
+                public bool IsActive;
+                [DefaultValue(false)]
+                public bool IsVisible;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("bool isActive = true"));
+        Assert.Contains(generatedTrees, t => t.Contains("bool isVisible = false"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithDefaultValueFloat_FormatsCorrectly()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Speed
+            {
+                [DefaultValue(1.5f)]
+                public float Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("float value = 1.5f"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_WithNullDefaultValue_FormatsNull()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Nullable
+            {
+                [DefaultValue(null)]
+                public string? OptionalName;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("string? optionalName = null"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_UnknownType_UsesDefault()
+    {
+        var source = """
+            using KeenEyes;
+            using System;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Custom
+            {
+                public Guid Id;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("System.Guid id = default"));
+    }
+
+    [Fact]
+    public void ComponentGenerator_OnClass_GeneratesNoOutput()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial class NotAStruct { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Should not generate for classes
+        Assert.Empty(generatedTrees);
+    }
+
+    [Fact]
+    public void ComponentGenerator_BuilderExtensionUsesFullyQualifiedName()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace Game.Components;
+
+            [Component]
+            public partial struct QualifiedComponent
+            {
+                public int Value;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("new Game.Components.QualifiedComponent"));
+    }
+
     private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)
     {
         var attributesAssembly = typeof(ComponentAttribute).Assembly;
@@ -101,6 +578,7 @@ public class ComponentGeneratorTests
         // Add runtime assembly references
         var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
         references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
 
         var compilation = CSharpCompilation.Create(
             "TestAssembly",

--- a/tests/KeenEyes.Generators.Tests/QueryGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/QueryGeneratorTests.cs
@@ -1,0 +1,523 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace KeenEyes.Generators.Tests;
+
+public class QueryGeneratorTests
+{
+    [Fact]
+    public void QueryGenerator_WithNoQueries_GeneratesNoOutput()
+    {
+        var source = """
+            namespace TestApp;
+
+            public struct NotAQuery
+            {
+                public int X;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Empty(generatedTrees);
+    }
+
+    [Fact]
+    public void QueryGenerator_WithQuery_GeneratesPartialStruct()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; public float Y; }
+
+            [Query]
+            public partial struct MovingEntities
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct MovingEntities"));
+    }
+
+    [Fact]
+    public void QueryGenerator_GeneratesCreateDescriptionMethod()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; public float Y; }
+
+            [Query]
+            public partial struct TestQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("CreateDescription()"));
+        Assert.Contains(generatedTrees, t => t.Contains("QueryDescription"));
+    }
+
+    [Fact]
+    public void QueryGenerator_GeneratesWorldExtensionMethod()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct ExtensionQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("public static partial class QueryExtensions"));
+        Assert.Contains(generatedTrees, t => t.Contains("this global::KeenEyes.World world"));
+        Assert.Contains(generatedTrees, t => t.Contains("IEnumerable<global::KeenEyes.Entity>"));
+    }
+
+    [Fact]
+    public void QueryGenerator_WithWithAttribute_TracksFieldAsWithAccess()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+            public struct Velocity { public float X; }
+
+            [Query]
+            public partial struct WithQuery
+            {
+                public Position Position;
+                [With] public Velocity Velocity;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Velocity: With"));
+    }
+
+    [Fact]
+    public void QueryGenerator_WithWithoutAttribute_TracksFieldAsWithoutAccess()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+            public struct Frozen { }
+
+            [Query]
+            public partial struct WithoutQuery
+            {
+                public Position Position;
+                [Without] public Frozen Frozen;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Frozen: Without"));
+    }
+
+    [Fact]
+    public void QueryGenerator_WithOptionalAttribute_TracksFieldAsOptional()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+            public struct Sprite { public int Id; }
+
+            [Query]
+            public partial struct OptionalQuery
+            {
+                public Position Position;
+                [Optional] public Sprite Sprite;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        // Optional fields don't add comments to description (returns early)
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct OptionalQuery"));
+    }
+
+    [Fact]
+    public void QueryGenerator_WithMultipleFields_TracksAllFields()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; public float Y; }
+            public struct Velocity { public float X; public float Y; }
+            public struct Health { public int Current; }
+
+            [Query]
+            public partial struct MultiFieldQuery
+            {
+                public Position Position;
+                public Velocity Velocity;
+                public Health Health;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
+        Assert.Contains(generatedTrees, t => t.Contains("// Velocity: Write"));
+        Assert.Contains(generatedTrees, t => t.Contains("// Health: Write"));
+    }
+
+    [Fact]
+    public void QueryGenerator_WithNoFields_GeneratesEmptyDescription()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Query]
+            public partial struct EmptyQuery { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct EmptyQuery"));
+        Assert.Contains(generatedTrees, t => t.Contains("CreateDescription()"));
+    }
+
+    [Fact]
+    public void QueryGenerator_IgnoresStaticFields()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct StaticFieldQuery
+            {
+                public static int Counter;
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("// Counter"));
+    }
+
+    [Fact]
+    public void QueryGenerator_IgnoresConstFields()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct ConstFieldQuery
+            {
+                public const int Version = 1;
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("// Version"));
+    }
+
+    [Fact]
+    public void QueryGenerator_InGlobalNamespace_GeneratesWithoutNamespace()
+    {
+        var source = """
+            using KeenEyes;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct GlobalQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct GlobalQuery"));
+        // Should not have namespace declaration before the struct
+        Assert.Contains(generatedTrees, t =>
+        {
+            var lines = t.Split('\n');
+            var structLine = Array.FindIndex(lines, l => l.Contains("partial struct GlobalQuery"));
+            // Check that no namespace line appears before struct
+            for (int i = 0; i < structLine; i++)
+            {
+                if (lines[i].TrimStart().StartsWith("namespace") && !lines[i].Contains("KeenEyes"))
+                {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    [Fact]
+    public void QueryGenerator_InNestedNamespace_GeneratesCorrectNamespace()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace Game.Queries.Movement;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct NestedQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("namespace Game.Queries.Movement;"));
+    }
+
+    [Fact]
+    public void QueryGenerator_GeneratesAutoGeneratedHeader()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct HeaderQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// <auto-generated />"));
+        Assert.Contains(generatedTrees, t => t.Contains("#nullable enable"));
+    }
+
+    [Fact]
+    public void QueryGenerator_GeneratesXmlDocumentation()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct DocQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("/// <summary>Gets the query description for matching entities.</summary>"));
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("/// <summary>Query extensions for DocQuery.</summary>"));
+    }
+
+    [Fact]
+    public void QueryGenerator_OnClass_GeneratesNoOutput()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Query]
+            public partial class NotAStructQuery { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // The attribute should not apply to classes, so no output
+        Assert.Empty(generatedTrees);
+    }
+
+    [Fact]
+    public void QueryGenerator_MultipleQueries_GeneratesSeparateFiles()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+            public struct Velocity { public float X; }
+
+            [Query]
+            public partial struct FirstQuery
+            {
+                public Position Position;
+            }
+
+            [Query]
+            public partial struct SecondQuery
+            {
+                public Velocity Velocity;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct FirstQuery"));
+        Assert.Contains(generatedTrees, t => t.Contains("partial struct SecondQuery"));
+    }
+
+    [Fact]
+    public void QueryGenerator_ExtensionMethodUsesFullyQualifiedName()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace Game.Queries;
+
+            public struct Position { public float X; }
+
+            [Query]
+            public partial struct QualifiedQuery
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("Game.Queries.QualifiedQuery _)"));
+        Assert.Contains(generatedTrees, t => t.Contains("Game.Queries.QualifiedQuery.CreateDescription()"));
+    }
+
+    [Fact]
+    public void QueryGenerator_MixedAccessTypes_TracksEachCorrectly()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            public struct Position { public float X; }
+            public struct Velocity { public float X; }
+            public struct Player { }
+            public struct Enemy { }
+            public struct Sprite { public int Id; }
+
+            [Query]
+            public partial struct MixedQuery
+            {
+                public Position Position;
+                [With] public Player Player;
+                [Without] public Enemy Enemy;
+                [Optional] public Sprite Sprite;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
+        Assert.Contains(generatedTrees, t => t.Contains("// Player: With"));
+        Assert.Contains(generatedTrees, t => t.Contains("// Enemy: Without"));
+        // Optional doesn't add comment
+    }
+
+    private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)
+    {
+        var attributesAssembly = typeof(QueryAttribute).Assembly;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(attributesAssembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new QueryGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        var runResult = driver.GetRunResult();
+        var generatedSources = runResult.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToList();
+
+        return (diagnostics, generatedSources);
+    }
+}

--- a/tests/KeenEyes.Generators.Tests/SystemGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/SystemGeneratorTests.cs
@@ -1,0 +1,307 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace KeenEyes.Generators.Tests;
+
+public class SystemGeneratorTests
+{
+    [Fact]
+    public void SystemGenerator_WithNoSystems_GeneratesNoOutput()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class NotASystem
+            {
+                public void Update() { }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Empty(generatedTrees);
+    }
+
+    [Fact]
+    public void SystemGenerator_WithSystem_GeneratesPartialClass()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System]
+            public partial class MovementSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial class MovementSystem"));
+    }
+
+    [Fact]
+    public void SystemGenerator_WithDefaultValues_GeneratesUpdatePhase()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System]
+            public partial class DefaultSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("Phase => global::KeenEyes.SystemPhase.Update"));
+        Assert.Contains(generatedTrees, t => t.Contains("Order => 0"));
+        Assert.Contains(generatedTrees, t => t.Contains("Group => null"));
+    }
+
+    [Theory]
+    [InlineData("EarlyUpdate")]
+    [InlineData("FixedUpdate")]
+    [InlineData("Update")]
+    [InlineData("LateUpdate")]
+    [InlineData("Render")]
+    [InlineData("PostRender")]
+    public void SystemGenerator_WithPhase_GeneratesCorrectPhase(string phase)
+    {
+        var source = $$"""
+            namespace TestApp;
+
+            [KeenEyes.System(Phase = KeenEyes.SystemPhase.{{phase}})]
+            public partial class PhaseTestSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t =>
+            t.Contains($"Phase => global::KeenEyes.SystemPhase.{phase}"));
+    }
+
+    [Theory]
+    [InlineData(-100)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(int.MaxValue)]
+    public void SystemGenerator_WithOrder_GeneratesCorrectOrder(int order)
+    {
+        var source = $$"""
+            namespace TestApp;
+
+            [KeenEyes.System(Order = {{order}})]
+            public partial class OrderTestSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains($"Order => {order}"));
+    }
+
+    [Fact]
+    public void SystemGenerator_WithGroup_GeneratesCorrectGroup()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System(Group = "Physics")]
+            public partial class GroupTestSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("Group => \"Physics\""));
+    }
+
+    [Fact]
+    public void SystemGenerator_WithAllProperties_GeneratesAllMetadata()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System(Phase = KeenEyes.SystemPhase.FixedUpdate, Order = 10, Group = "AI")]
+            public partial class FullMetadataSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("Phase => global::KeenEyes.SystemPhase.FixedUpdate"));
+        Assert.Contains(generatedTrees, t => t.Contains("Order => 10"));
+        Assert.Contains(generatedTrees, t => t.Contains("Group => \"AI\""));
+    }
+
+    [Fact]
+    public void SystemGenerator_InGlobalNamespace_GeneratesWithoutNamespace()
+    {
+        var source = """
+            [KeenEyes.System]
+            public partial class GlobalSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial class GlobalSystem"));
+        // Should not have namespace declaration (only auto-generated header)
+        Assert.Contains(generatedTrees, t =>
+        {
+            var lines = t.Split('\n');
+            return !lines.Any(l => l.TrimStart().StartsWith("namespace") && !l.Contains("<global namespace>"));
+        });
+    }
+
+    [Fact]
+    public void SystemGenerator_InNestedNamespace_GeneratesCorrectNamespace()
+    {
+        var source = """
+            namespace Game.Systems.Movement;
+
+            [KeenEyes.System]
+            public partial class WalkSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("namespace Game.Systems.Movement;"));
+    }
+
+    [Fact]
+    public void SystemGenerator_GeneratesXmlDocumentation()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System]
+            public partial class DocumentedSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("/// <summary>The execution phase for this system.</summary>"));
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("/// <summary>The execution order within the phase.</summary>"));
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("/// <summary>The system group name, if any.</summary>"));
+    }
+
+    [Fact]
+    public void SystemGenerator_MultipleSystems_GeneratesSeparateFiles()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System(Order = 1)]
+            public partial class FirstSystem { }
+
+            [KeenEyes.System(Order = 2)]
+            public partial class SecondSystem { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("partial class FirstSystem"));
+        Assert.Contains(generatedTrees, t => t.Contains("partial class SecondSystem"));
+    }
+
+    [Fact]
+    public void SystemGenerator_GeneratesAutoGeneratedHeader()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System]
+            public partial class HeaderSystem
+            {
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains("// <auto-generated />"));
+        Assert.Contains(generatedTrees, t => t.Contains("#nullable enable"));
+    }
+
+    [Fact]
+    public void SystemGenerator_OnStruct_GeneratesNoOutput()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System]
+            public partial struct NotAClassSystem { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // The attribute should not apply to structs, so no output
+        Assert.Empty(generatedTrees);
+    }
+
+    private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)
+    {
+        var attributesAssembly = typeof(SystemAttribute).Assembly;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(attributesAssembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new SystemGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        var runResult = driver.GetRunResult();
+        var generatedSources = runResult.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToList();
+
+        return (diagnostics, generatedSources);
+    }
+}


### PR DESCRIPTION
- Add SystemGeneratorTests with 14 tests covering:
  - All SystemPhase enum values
  - Order and Group properties
  - Namespace handling (global, nested)
  - XML documentation generation
  - Auto-generated header

- Add QueryGeneratorTests with 19 tests covering:
  - Query description generation
  - With/Without/Optional attribute handling
  - Extension method generation
  - Field access type detection
  - Static/const field filtering

- Expand ComponentGeneratorTests with 27 new tests covering:
  - DefaultValue attribute handling
  - BuilderIgnore attribute handling
  - Field initializer defaults
  - All primitive type defaults
  - Namespace handling
  - CamelCase conversion
  - Multiple components
  - Fully qualified names

Coverage improved from 4 tests to 78 tests for generators.