### PR TITLE
Add SessionStart resume hook for .NET SDK PATH restoration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-packages.sh"
           }
         ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/resume-dotnet.sh"
+          }
+        ]
       }
     ]
   }

--- a/scripts/resume-dotnet.sh
+++ b/scripts/resume-dotnet.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Restore .NET SDK PATH for resumed Claude Code web sessions
+# This script is run by the SessionResume hook
+
+DOTNET_INSTALL_DIR="$HOME/.dotnet"
+
+# Only run in remote (web) environments
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+    exit 0
+fi
+
+# Check if .NET SDK is installed
+if [ ! -d "$DOTNET_INSTALL_DIR" ] || [ ! -x "$DOTNET_INSTALL_DIR/dotnet" ]; then
+    echo "Warning: .NET SDK not found at $DOTNET_INSTALL_DIR"
+    echo "Run the SessionStart hooks to install it."
+    exit 0
+fi
+
+# Persist environment variables to CLAUDE_ENV_FILE so subsequent bash commands have dotnet in PATH
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+    echo "DOTNET_ROOT=$DOTNET_INSTALL_DIR" >> "$CLAUDE_ENV_FILE"
+    echo "PATH=$DOTNET_INSTALL_DIR:\$PATH" >> "$CLAUDE_ENV_FILE"
+    echo "Restored .NET SDK environment variables for resumed session"
+fi
+
+# Export for current shell
+export DOTNET_ROOT="$DOTNET_INSTALL_DIR"
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+# Verify dotnet is accessible
+"$DOTNET_INSTALL_DIR/dotnet" --version


### PR DESCRIPTION
When a Claude Code web session is resumed, the environment variables are reset. This adds a resume-specific hook that restores DOTNET_ROOT and PATH to CLAUDE_ENV_FILE so the dotnet CLI remains accessible.

SessionStart hooks use matchers:
- "startup" runs on initial session start (full installation)
- "resume" runs on session resume (just restore PATH)