### PR TITLE
Fix benchmark comparison to find compressed JSON reports

### DIFF
--- a/tools/BenchmarkCompare/Program.cs
+++ b/tools/BenchmarkCompare/Program.cs
@@ -110,7 +110,9 @@ static Dictionary<string, BenchmarkResult> LoadBenchmarkResults(DirectoryInfo di
     }
 
     // Find all JSON report files in the directory tree
-    var jsonFiles = dir.GetFiles("*-report-full.json", SearchOption.AllDirectories)
+    // BenchmarkDotNet exports to *-report-full-compressed.json by default
+    var jsonFiles = dir.GetFiles("*-report-full-compressed.json", SearchOption.AllDirectories)
+        .Concat(dir.GetFiles("*-report-full.json", SearchOption.AllDirectories))
         .Concat(dir.GetFiles("*-report.json", SearchOption.AllDirectories))
         .ToList();
 


### PR DESCRIPTION
BenchmarkDotNet exports results to *-report-full-compressed.json by default, but BenchmarkCompare was only looking for *-report-full.json and *-report.json patterns. This caused the workflow to report no benchmark results found.