### PR TITLE
Add path filters to skip CI for docs-only changes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,10 +5,22 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'docfx.json'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches:
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'docfx.json'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:
       benchmark_filter:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,22 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'docfx.json'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches:
       - main
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'docfx.json'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Skip build/test and benchmark workflows when only documentation files are changed (docs/**, *.md, docfx.json, LICENSE).

This reduces CI costs and provides faster feedback on PRs that only update documentation content.