### PR TITLE
Add code coverage publishing to action summary and PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,28 +67,23 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
           echo "Found coverage files: $files"
 
-      - name: Generate coverage summary
-        uses: irongut/CodeCoverageSummary@v1.3.0
+      - name: Generate coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5
         with:
-          filename: '**/TestResults/**/*.cobertura.xml'
-          badge: true
-          fail_below_min: false
-          format: markdown
-          hide_branch_rate: false
-          hide_complexity: false
-          indicators: true
-          output: both
-          thresholds: '60 80'
+          reports: '**/TestResults/**/*.cobertura.xml'
+          targetdir: coverage-report
+          reporttypes: 'MarkdownSummaryGithub;Cobertura'
+          verbosity: 'Info'
 
       - name: Add coverage to summary
-        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+        run: cat coverage-report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
       - name: Add coverage PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
           recreate: true
-          path: code-coverage-results.md
+          path: coverage-report/SummaryGithub.md
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
- Add CodeCoverageSummary action to generate markdown coverage reports
- Publish coverage summary to GitHub Actions job summary
- Add sticky PR comment with coverage results on pull requests
- Add pull-requests write permission for PR comments