### PR TITLE
Extract EntityNamingManager and EventManager from World class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ World (facade)
 ├── PluginManager         - Plugin lifecycle
 ├── SingletonManager      - Global resource storage
 ├── ExtensionManager      - Plugin-provided APIs
+├── EntityNamingManager   - Entity name registration and lookup
+├── EventManager          - Component and entity lifecycle events
 ├── ArchetypeManager      - Component storage
 ├── QueryManager          - Query caching
 └── ComponentRegistry     - Component type registry

--- a/src/KeenEyes.Core/EntityNamingManager.cs
+++ b/src/KeenEyes.Core/EntityNamingManager.cs
@@ -1,0 +1,111 @@
+namespace KeenEyes;
+
+/// <summary>
+/// Manages entity naming and lookup.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is an internal manager class that handles all entity naming operations.
+/// The public API is exposed through <see cref="World"/>.
+/// </para>
+/// <para>
+/// Entity names are unique within a world. Named entities can be retrieved
+/// by name for debugging, editor integration, and scenarios where entities
+/// need human-readable identifiers.
+/// </para>
+/// </remarks>
+internal sealed class EntityNamingManager
+{
+    // Entity ID -> Name
+    private readonly Dictionary<int, string> entityNames = [];
+
+    // Name -> Entity ID (for O(1) lookups by name)
+    private readonly Dictionary<string, int> namesToEntityIds = [];
+
+    /// <summary>
+    /// Validates that a name is available for use.
+    /// </summary>
+    /// <param name="name">The name to validate.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the name is already assigned to another entity.
+    /// </exception>
+    internal void ValidateName(string? name)
+    {
+        if (name is not null && namesToEntityIds.ContainsKey(name))
+        {
+            throw new ArgumentException(
+                $"An entity with the name '{name}' already exists in this world.", nameof(name));
+        }
+    }
+
+    /// <summary>
+    /// Registers a name for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to register the name for.</param>
+    /// <param name="name">The name to register. If null, no registration occurs.</param>
+    /// <remarks>
+    /// <para>
+    /// Call <see cref="ValidateName"/> before this method to ensure the name is available.
+    /// </para>
+    /// </remarks>
+    internal void RegisterName(int entityId, string? name)
+    {
+        if (name is null)
+        {
+            return;
+        }
+
+        entityNames[entityId] = name;
+        namesToEntityIds[name] = entityId;
+    }
+
+    /// <summary>
+    /// Unregisters the name for an entity if it has one.
+    /// </summary>
+    /// <param name="entityId">The entity ID to unregister the name for.</param>
+    internal void UnregisterName(int entityId)
+    {
+        if (entityNames.TryGetValue(entityId, out var name))
+        {
+            entityNames.Remove(entityId);
+            namesToEntityIds.Remove(name);
+        }
+    }
+
+    /// <summary>
+    /// Gets the name assigned to an entity, if any.
+    /// </summary>
+    /// <param name="entityId">The entity ID to get the name for.</param>
+    /// <returns>
+    /// The name assigned to the entity, or <c>null</c> if the entity has no name.
+    /// </returns>
+    internal string? GetName(int entityId)
+    {
+        return entityNames.TryGetValue(entityId, out var name) ? name : null;
+    }
+
+    /// <summary>
+    /// Finds an entity ID by its assigned name.
+    /// </summary>
+    /// <param name="name">The name to search for.</param>
+    /// <param name="entityId">
+    /// When this method returns <c>true</c>, contains the entity ID with the specified name.
+    /// When this method returns <c>false</c>, contains -1.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if an entity with the specified name exists; <c>false</c> otherwise.
+    /// </returns>
+    internal bool TryGetEntityIdByName(string name, out int entityId)
+    {
+        return namesToEntityIds.TryGetValue(name, out entityId);
+    }
+
+    /// <summary>
+    /// Clears all name mappings.
+    /// </summary>
+    internal void Clear()
+    {
+        entityNames.Clear();
+        namesToEntityIds.Clear();
+    }
+}

--- a/src/KeenEyes.Core/EventManager.cs
+++ b/src/KeenEyes.Core/EventManager.cs
@@ -1,0 +1,152 @@
+using KeenEyes.Events;
+
+namespace KeenEyes;
+
+/// <summary>
+/// Manages all event handling for a world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is an internal manager class that consolidates all event-related operations.
+/// The public API is exposed through <see cref="World"/>.
+/// </para>
+/// <para>
+/// The event manager handles three types of events:
+/// </para>
+/// <list type="bullet">
+/// <item><description>User-defined events via the <see cref="EventBus"/></description></item>
+/// <item><description>Component lifecycle events (added, removed, changed)</description></item>
+/// <item><description>Entity lifecycle events (created, destroyed)</description></item>
+/// </list>
+/// </remarks>
+internal sealed class EventManager
+{
+    private readonly EventBus eventBus = new();
+    private readonly ComponentEventHandlers componentEvents = new();
+    private readonly EntityEventHandlers entityEvents = new();
+
+    /// <summary>
+    /// Gets the event bus for publishing and subscribing to custom user-defined events.
+    /// </summary>
+    internal EventBus Bus => eventBus;
+
+    #region Component Events
+
+    /// <summary>
+    /// Registers a handler to be called when a component of type <typeparamref name="T"/>
+    /// is added to an entity.
+    /// </summary>
+    /// <typeparam name="T">The component type to watch for additions.</typeparam>
+    /// <param name="handler">The handler to invoke when the component is added.</param>
+    /// <returns>A subscription that can be disposed to unsubscribe.</returns>
+    internal EventSubscription OnComponentAdded<T>(Action<Entity, T> handler) where T : struct, IComponent
+    {
+        return componentEvents.OnAdded(handler);
+    }
+
+    /// <summary>
+    /// Registers a handler to be called when a component of type <typeparamref name="T"/>
+    /// is removed from an entity.
+    /// </summary>
+    /// <typeparam name="T">The component type to watch for removals.</typeparam>
+    /// <param name="handler">The handler to invoke when the component is removed.</param>
+    /// <returns>A subscription that can be disposed to unsubscribe.</returns>
+    internal EventSubscription OnComponentRemoved<T>(Action<Entity> handler) where T : struct, IComponent
+    {
+        return componentEvents.OnRemoved<T>(handler);
+    }
+
+    /// <summary>
+    /// Registers a handler to be called when a component of type <typeparamref name="T"/>
+    /// is changed on an entity.
+    /// </summary>
+    /// <typeparam name="T">The component type to watch for changes.</typeparam>
+    /// <param name="handler">
+    /// The handler to invoke when the component is changed. Receives the entity,
+    /// the old value, and the new value.
+    /// </param>
+    /// <returns>A subscription that can be disposed to unsubscribe.</returns>
+    internal EventSubscription OnComponentChanged<T>(Action<Entity, T, T> handler) where T : struct, IComponent
+    {
+        return componentEvents.OnChanged(handler);
+    }
+
+    /// <summary>
+    /// Fires the component added event.
+    /// </summary>
+    internal void FireComponentAdded<T>(Entity entity, in T component) where T : struct, IComponent
+    {
+        componentEvents.FireAdded(entity, in component);
+    }
+
+    /// <summary>
+    /// Fires the component removed event.
+    /// </summary>
+    internal void FireComponentRemoved<T>(Entity entity) where T : struct, IComponent
+    {
+        componentEvents.FireRemoved<T>(entity);
+    }
+
+    /// <summary>
+    /// Fires the component changed event.
+    /// </summary>
+    internal void FireComponentChanged<T>(Entity entity, in T oldValue, in T newValue) where T : struct, IComponent
+    {
+        componentEvents.FireChanged(entity, in oldValue, in newValue);
+    }
+
+    #endregion
+
+    #region Entity Events
+
+    /// <summary>
+    /// Registers a handler to be called when an entity is created.
+    /// </summary>
+    /// <param name="handler">
+    /// The handler to invoke when an entity is created. Receives the entity
+    /// and its optional name (null if unnamed).
+    /// </param>
+    /// <returns>A subscription that can be disposed to unsubscribe.</returns>
+    internal EventSubscription OnEntityCreated(Action<Entity, string?> handler)
+    {
+        return entityEvents.OnCreated(handler);
+    }
+
+    /// <summary>
+    /// Registers a handler to be called when an entity is destroyed.
+    /// </summary>
+    /// <param name="handler">The handler to invoke when an entity is destroyed.</param>
+    /// <returns>A subscription that can be disposed to unsubscribe.</returns>
+    internal EventSubscription OnEntityDestroyed(Action<Entity> handler)
+    {
+        return entityEvents.OnDestroyed(handler);
+    }
+
+    /// <summary>
+    /// Fires the entity created event.
+    /// </summary>
+    internal void FireEntityCreated(Entity entity, string? name)
+    {
+        entityEvents.FireCreated(entity, name);
+    }
+
+    /// <summary>
+    /// Fires the entity destroyed event.
+    /// </summary>
+    internal void FireEntityDestroyed(Entity entity)
+    {
+        entityEvents.FireDestroyed(entity);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Clears all event handlers.
+    /// </summary>
+    internal void Clear()
+    {
+        eventBus.Clear();
+        componentEvents.Clear();
+        entityEvents.Clear();
+    }
+}


### PR DESCRIPTION
Continue the World manager architecture refactoring by extracting two more specialized managers:

- EntityNamingManager: Handles entity name registration, validation, and lookup (GetName, GetEntityByName, name uniqueness)
- EventManager: Consolidates EventBus, ComponentEventHandlers, and EntityEventHandlers into a single manager

World.cs reduced from 2338 to 2302 lines. All 1022 tests pass.