### PR TITLE
Fix CS0649 compiler warnings in test component structs

### DIFF
--- a/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
+++ b/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
@@ -21,8 +21,8 @@ public class ArchetypeTests
 
     private struct Health : IComponent
     {
-        public int Current;
-        public int Max;
+        public int Current = 0;
+        public int Max = 0;
 
         public Health() { }
     }

--- a/tests/KeenEyes.Core.Tests/EdgeCaseTests.cs
+++ b/tests/KeenEyes.Core.Tests/EdgeCaseTests.cs
@@ -16,19 +16,25 @@ public class EdgeCaseTests
 
     private struct Velocity : IComponent
     {
-        public float X;
-        public float Y;
+        public float X = 0;
+        public float Y = 0;
+
+        public Velocity() { }
     }
 
     private struct Health : IComponent
     {
-        public int Current;
-        public int Max;
+        public int Current = 0;
+        public int Max = 0;
+
+        public Health() { }
     }
 
     private struct Rotation : IComponent
     {
-        public float Angle;
+        public float Angle = 0;
+
+        public Rotation() { }
     }
 
     private struct EnemyTag : ITagComponent;

--- a/tests/KeenEyes.Core.Tests/InternalApiTests.cs
+++ b/tests/KeenEyes.Core.Tests/InternalApiTests.cs
@@ -18,19 +18,25 @@ public class InternalApiTests
 
     private struct Velocity : IComponent
     {
-        public float X;
-        public float Y;
+        public float X = 0;
+        public float Y = 0;
+
+        public Velocity() { }
     }
 
     private struct Health : IComponent
     {
-        public int Current;
-        public int Max;
+        public int Current = 0;
+        public int Max = 0;
+
+        public Health() { }
     }
 
     private struct Rotation : IComponent
     {
-        public float Angle;
+        public float Angle = 0;
+
+        public Rotation() { }
     }
 
     #endregion

--- a/tests/KeenEyes.Core.Tests/QueryCachingTests.cs
+++ b/tests/KeenEyes.Core.Tests/QueryCachingTests.cs
@@ -9,24 +9,24 @@ public class QueryCachingTests
 
     private struct Position : IComponent
     {
-        public float X;
-        public float Y;
+        public float X = 0;
+        public float Y = 0;
 
         public Position() { }
     }
 
     private struct Velocity : IComponent
     {
-        public float X;
-        public float Y;
+        public float X = 0;
+        public float Y = 0;
 
         public Velocity() { }
     }
 
     private struct Health : IComponent
     {
-        public int Current;
-        public int Max;
+        public int Current = 0;
+        public int Max = 0;
 
         public Health() { }
     }


### PR DESCRIPTION
Add explicit field initializers (= 0) and parameterless constructors to test component structs to eliminate "field is never assigned" warnings. These warnings occurred because struct fields were only used with default values in tests.