### PR TITLE
Add gh-sub-issue extension support to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install gh sub-issue extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh extension install yahsan2/gh-sub-issue
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -41,4 +46,4 @@ jobs:
             actions: read
             pull-requests: write
             issues: write
-          claude_args: '--allowed-tools "Bash(gh issue *),Bash(gh pr *)"'
+          claude_args: '--allowed-tools "Bash(gh issue *),Bash(gh pr *),Bash(gh sub-issue *)"'


### PR DESCRIPTION
Enable Claude to create and manage hierarchical issue relationships using the yahsan2/gh-sub-issue GitHub CLI extension. This allows organizing complex features into parent/child issue structures.

Changes:
- Install gh-sub-issue extension before running Claude
- Add 'gh sub-issue *' to allowed tools