### PR TITLE
feat: Update assertions to use IWorld interface

### DIFF
--- a/src/KeenEyes.Testing/EntityAssertions.cs
+++ b/src/KeenEyes.Testing/EntityAssertions.cs
@@ -9,6 +9,10 @@ namespace KeenEyes.Testing;
 /// in unit tests. They follow FluentAssertions-style patterns and throw
 /// descriptive exceptions on failure.
 /// </para>
+/// <para>
+/// The assertions accept <see cref="IWorld"/> for maximum flexibility, allowing
+/// them to work with any world implementation.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>
@@ -29,7 +33,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity is not alive.</exception>
-    public static Entity ShouldBeAlive(this Entity entity, World world, string? because = null)
+    public static Entity ShouldBeAlive(this Entity entity, IWorld world, string? because = null)
     {
         ArgumentNullException.ThrowIfNull(world);
 
@@ -65,7 +69,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity is still alive.</exception>
-    public static Entity ShouldBeDead(this Entity entity, World world, string? because = null)
+    public static Entity ShouldBeDead(this Entity entity, IWorld world, string? because = null)
     {
         ArgumentNullException.ThrowIfNull(world);
 
@@ -102,7 +106,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity does not have the component.</exception>
-    public static Entity ShouldHaveComponent<T>(this Entity entity, World world, string? because = null)
+    public static Entity ShouldHaveComponent<T>(this Entity entity, IWorld world, string? because = null)
         where T : struct, IComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -142,7 +146,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity has the component.</exception>
-    public static Entity ShouldNotHaveComponent<T>(this Entity entity, World world, string? because = null)
+    public static Entity ShouldNotHaveComponent<T>(this Entity entity, IWorld world, string? because = null)
         where T : struct, IComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -182,7 +186,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity does not have the tag.</exception>
-    public static Entity ShouldHaveTag<T>(this Entity entity, World world, string? because = null)
+    public static Entity ShouldHaveTag<T>(this Entity entity, IWorld world, string? because = null)
         where T : struct, ITagComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -223,7 +227,7 @@ public static class EntityAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The entity for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the entity has the tag.</exception>
-    public static Entity ShouldNotHaveTag<T>(this Entity entity, World world, string? because = null)
+    public static Entity ShouldNotHaveTag<T>(this Entity entity, IWorld world, string? because = null)
         where T : struct, ITagComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -267,7 +271,7 @@ public static class EntityAssertions
     /// <exception cref="AssertionException">Thrown when the component doesn't match the predicate.</exception>
     public static Entity ShouldHaveComponentMatching<T>(
         this Entity entity,
-        World world,
+        IWorld world,
         Func<T, bool> predicate,
         string? because = null)
         where T : struct, IComponent

--- a/src/KeenEyes.Testing/WorldAssertions.cs
+++ b/src/KeenEyes.Testing/WorldAssertions.cs
@@ -1,13 +1,18 @@
 namespace KeenEyes.Testing;
 
 /// <summary>
-/// Fluent assertion extensions for <see cref="World"/> validation in tests.
+/// Fluent assertion extensions for <see cref="World"/> and <see cref="IWorld"/> validation in tests.
 /// </summary>
 /// <remarks>
 /// <para>
 /// These extensions provide a fluent, readable syntax for asserting world state
 /// in unit tests. They follow FluentAssertions-style patterns and throw
 /// descriptive exceptions on failure.
+/// </para>
+/// <para>
+/// Query-based assertions accept <see cref="IWorld"/> for maximum flexibility.
+/// Methods that require World-specific features (like plugin checks) accept
+/// the concrete <see cref="World"/> type.
 /// </para>
 /// </remarks>
 /// <example>
@@ -205,7 +210,7 @@ public static class WorldAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The world for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when no matching entities exist.</exception>
-    public static World ShouldContainEntitiesWith<T1>(this World world, string? because = null)
+    public static IWorld ShouldContainEntitiesWith<T1>(this IWorld world, string? because = null)
         where T1 : struct, IComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -229,7 +234,7 @@ public static class WorldAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The world for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when no matching entities exist.</exception>
-    public static World ShouldContainEntitiesWith<T1, T2>(this World world, string? because = null)
+    public static IWorld ShouldContainEntitiesWith<T1, T2>(this IWorld world, string? because = null)
         where T1 : struct, IComponent
         where T2 : struct, IComponent
     {
@@ -253,7 +258,7 @@ public static class WorldAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The world for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when matching entities exist.</exception>
-    public static World ShouldNotContainEntitiesWith<T1>(this World world, string? because = null)
+    public static IWorld ShouldNotContainEntitiesWith<T1>(this IWorld world, string? because = null)
         where T1 : struct, IComponent
     {
         ArgumentNullException.ThrowIfNull(world);
@@ -278,7 +283,7 @@ public static class WorldAssertions
     /// <param name="because">Optional reason for the assertion.</param>
     /// <returns>The world for method chaining.</returns>
     /// <exception cref="AssertionException">Thrown when the count doesn't match.</exception>
-    public static World ShouldContainExactlyWith<T1>(this World world, int expectedCount, string? because = null)
+    public static IWorld ShouldContainExactlyWith<T1>(this IWorld world, int expectedCount, string? because = null)
         where T1 : struct, IComponent
     {
         ArgumentNullException.ThrowIfNull(world);


### PR DESCRIPTION
- EntityAssertions: All methods now accept IWorld instead of World
- WorldAssertions: Query-based methods (ShouldContainEntitiesWith, ShouldNotContainEntitiesWith, ShouldContainExactlyWith) now accept IWorld
- World-specific methods (ShouldHaveEntityCount, ShouldHavePlugin, etc.) still require concrete World type for access to GetAllEntities/HasPlugin

This allows assertions to work with any IWorld implementation while maintaining access to World-specific features where needed.