### PR TITLE
docs: Update editor research doc and add research section to docs TOC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,24 @@ foreach (var e in world.Query<Position, Velocity>())
 
 - [ADR-001: World Manager Architecture](adr/001-world-manager-architecture.md) - Refactoring World into specialized managers
 
+## Research
+
+Technical research reports for future features and integrations:
+
+### Graphics & Rendering
+- [OpenGL C# Bindings](research/opengl-csharp-bindings.md) - Evaluate OpenGL binding libraries for .NET
+- [Shader Management](research/shader-management.md) - Shader compilation, caching, and hot reload
+- [Windowing & Input](research/windowing-input.md) - Cross-platform window and input handling
+
+### Engine Features
+- [Framework Editor](research/framework-editor.md) - Feasibility study for building an ECS editor
+- [Asset Loading](research/asset-loading.md) - Asset pipeline and resource management
+- [Audio Systems](research/audio-systems.md) - Audio playback and spatial sound
+- [Game Math Libraries](research/game-math-libraries.md) - Vector, matrix, and math library options
+
+### Deployment
+- [Cross-Platform Deployment](research/cross-platform-deployment.md) - Publishing to Windows, Linux, macOS
+
 ## API Reference
 
 See the [API Documentation](../api/index.md) for detailed reference.

--- a/docs/research/framework-editor.md
+++ b/docs/research/framework-editor.md
@@ -1,12 +1,12 @@
 # Framework Editor Feasibility - Research Report
 
-**Date:** December 2024
+**Date:** December 2024 (Updated: December 2024)
 **Author:** Claude (Anthropic)
 **Purpose:** Evaluate the feasibility of building a rudimentary editor for the KeenEyes ECS framework, including live entity editing, debugging/diagnostics, and hot reload capabilities
 
 ## Executive Summary
 
-Building a rudimentary editor for KeenEyes is **highly feasible**. The framework already provides many foundational pieces: a robust plugin system, entity inspection APIs, change tracking, event subscriptions, and inter-system messaging. The main development effort involves layering higher-level features (serialization, undo/redo, hot reload) on top of these solid foundations.
+Building a rudimentary editor for KeenEyes is **highly feasible**. The framework provides comprehensive foundational pieces: a robust plugin system, entity inspection APIs, change tracking, event subscriptions, inter-system messaging, **world serialization**, **prefab system**, **pluggable logging**, **string-based tagging**, and **component validation**. The main remaining work involves the UI layer and undo/redo system.
 
 **Recommended approach:** Build the editor as a set of modular plugins that can be installed into any World instance. This leverages the existing plugin architecture and maintains the framework's core principle of per-world isolation.
 
@@ -18,11 +18,18 @@ Building a rudimentary editor for KeenEyes is **highly feasible**. The framework
 | Event System | ✅ Complete | Ready to use |
 | Inter-System Messaging | ✅ Complete | Ready to use |
 | Memory Statistics | ✅ Complete | Ready to use |
-| Serialization | ❌ Missing | Medium |
+| Serialization & Snapshots | ✅ Complete | Ready to use |
+| Prefabs/Templates | ✅ Complete | Ready to use |
+| String-Based Tags | ✅ Complete | Ready to use |
+| Pluggable Logging | ✅ Complete | Ready to use |
+| Component Validation | ✅ Complete | Ready to use |
+| Testing Utilities | ✅ Complete | Ready to use |
+| Graphics Plugin | ✅ Complete | Reference implementation |
 | Undo/Redo | ❌ Missing | Medium-High |
-| Prefabs/Templates | ❌ Missing | Medium |
 | Hot Reload | ❌ Missing | High |
 | Per-Field Inspection | ❌ Missing | Low |
+
+> **Note:** Since the initial research, the framework has added serialization, prefabs, logging, string tags, component validation, a testing library, and a graphics plugin. The framework now provides **~90% of the infrastructure** needed for a full editor.
 
 ---
 
@@ -890,8 +897,11 @@ public class ScriptCompiler
 | Event Subscriptions | Phase 4 | ✅ Complete |
 | Plugin System | Phase 6 | ✅ Complete |
 | Messaging | Phase 7 | ✅ Complete |
-| Prefabs | Phase 8 | ❌ Pending |
-| Serialization | Phase 11 | ❌ Pending |
+| Prefabs | Phase 8 | ✅ Complete |
+| String Tags | Phase 9 | ✅ Complete |
+| Component Validation | Phase 10 | ✅ Complete |
+| Serialization | Phase 11 | ✅ Complete |
+| Logging | Phase 12 | ✅ Complete |
 | Debug Mode | Phase 13 | ❌ Pending |
 | System Profiling | Phase 13 | ❌ Pending |
 
@@ -1004,30 +1014,40 @@ When choosing a UI framework for the editor:
 |-----|-------------|----------|
 | **Per-field introspection** | Need field metadata | Reflection wrapper (~100 lines) |
 | **Property attributes** | `[Range]`, `[Tooltip]`, etc. | Define attributes, inspector reads |
-| **RemoveSystem API** | No way to remove system | Add to SystemManager |
-| **Serialization** | No save/load | Phase 11 or custom JSON |
-| **Prefabs** | No entity templates | Phase 8 |
-| **System BeforeUpdate hook** | Need to hook timing | Add virtual methods or events |
+| **Undo/Redo** | No transaction history | Build on ChangeTracker + snapshots |
+| **Hot Reload** | No runtime code swapping | AssemblyLoadContext approach |
+
+> **Resolved Since Initial Research:**
+> - ~~Serialization~~ → `SnapshotManager` with JSON and AOT support
+> - ~~Prefabs~~ → `PrefabManager` with inheritance support
+> - ~~RemoveSystem API~~ → Now available via SystemManager
+> - ~~System BeforeUpdate hook~~ → `ISystemLifecycle` interface added
 
 ---
 
 ## Conclusion
 
-Building a rudimentary editor for KeenEyes is **feasible with moderate effort**. The architecture was designed with editor-friendly patterns:
+Building a rudimentary editor for KeenEyes is **feasible with minimal effort**. The architecture was designed with editor-friendly patterns and now includes comprehensive tooling:
 
 - **Per-world isolation** enables editor/game separation
 - **Event system** enables reactive UI updates
 - **Plugin system** enables modular editor features
 - **Entity inspection APIs** already exist and are comprehensive
 - **Change tracking** provides foundation for undo/redo
+- **Serialization & Snapshots** provide complete save/load support
+- **Prefab system** enables entity templates with inheritance
+- **Pluggable logging** enables debug output and diagnostics
+- **String tags** enable designer-friendly entity categorization
+- **Component validation** enables dependency visualization
+- **Testing utilities** enable deterministic editor testing
+- **Graphics plugin** provides reference for rendering integration
 
 The main work involves:
 1. **Building the UI layer** (choose framework based on needs)
-2. **Implementing serialization** (Phase 11 or custom)
-3. **Adding undo/redo** (layer on ChangeTracker)
-4. **Hot reload** (AssemblyLoadContext approach recommended)
+2. **Adding undo/redo** (layer on ChangeTracker + Snapshots)
+3. **Hot reload** (AssemblyLoadContext approach recommended)
 
-The framework provides approximately **70% of the infrastructure** needed for a basic editor. The remaining 30% is primarily UI/UX and the persistence layer.
+The framework provides approximately **90% of the infrastructure** needed for a full-featured editor. The remaining 10% is primarily UI/UX, undo/redo transactions, and hot reload.
 
 ---
 


### PR DESCRIPTION
Updates to framework-editor.md:
- Mark serialization, prefabs, logging, string tags, and component validation as complete (were listed as missing gaps)
- Update conclusion: framework now provides ~90% of editor infrastructure
- Update gaps summary to show resolved items
- Update dependencies table with new completed phases

Updates to docs/index.md:
- Add Research section with links to all 8 research documents
- Organize by category: Graphics & Rendering, Engine Features, Deployment