### PR TITLE
ci: Enable CS1591 XML documentation warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -197,3 +197,7 @@ dotnet_diagnostic.IDE0161.severity = warning
 
 # CA diagnostics
 dotnet_diagnostic.CA1852.severity = warning
+
+# CS diagnostics
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = warning


### PR DESCRIPTION
Per issue #168, enable CS1591 warning to enforce XML documentation coverage on all public APIs. Analysis shows 100% coverage already exists across all source projects, so no documentation additions needed.

This ensures future public APIs without documentation will be caught during build, maintaining high documentation standards.