### PR TITLE
docs: Fix sample code to demonstrate component access pattern

### DIFF
--- a/samples/KeenEyes.Sample/Systems.cs
+++ b/samples/KeenEyes.Sample/Systems.cs
@@ -52,11 +52,11 @@ public partial class MovementSystem : SystemBase
         // Using the fluent query API
         foreach (var entity in World.Query<Position, Velocity>())
         {
-            // In a full implementation, we'd access components via ref:
-            // ref var pos = ref World.Get<Position>(entity);
-            // ref readonly var vel = ref World.Get<Velocity>(entity);
-            // pos.X += vel.X * deltaTime;
-            // pos.Y += vel.Y * deltaTime;
+            // Access components via ref for zero-copy modification
+            ref var pos = ref World.Get<Position>(entity);
+            ref readonly var vel = ref World.Get<Velocity>(entity);
+            pos.X += vel.X * deltaTime;
+            pos.Y += vel.Y * deltaTime;
 
             Console.WriteLine($"  MovementSystem [frame {frameCount}]: Processing {entity}");
         }


### PR DESCRIPTION
Replace commented-out code with actual implementation showing proper ref usage for zero-copy component access. This is the first sample users see and should demonstrate best practices.

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)