### PR TITLE
chore: Remove unused variable in QueryManager.OnArchetypeCreated

### DIFF
--- a/src/KeenEyes.Core/Queries/QueryManager.cs
+++ b/src/KeenEyes.Core/Queries/QueryManager.cs
@@ -144,8 +144,6 @@ public sealed class QueryManager
     private void OnArchetypeCreated(Archetype archetype)
     {
         // Incremental invalidation: only invalidate queries that could match the new archetype
-        var toInvalidate = new List<QueryDescriptor>();
-
         foreach (var (descriptor, cachedArchetypes) in cache)
         {
             // If the new archetype matches this query, we need to invalidate


### PR DESCRIPTION
Removed the unused `toInvalidate` variable declaration from the OnArchetypeCreated method. This variable was declared but never used, likely a leftover from refactoring when the code switched from batch invalidation to incremental updates.

Fixes #187



🤖 Generated with [Claude Code](https://claude.com/claude-code)