### PR TITLE
Fix typo in SnapshotManager.GetDefaultJsonOptions method name

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -137,7 +137,7 @@ The source generator creates a `ComponentSerializationRegistry` class that handl
 Customize JSON serialization:
 
 ```csharp
-var options = SnapshotManager.GetdefaultJsonOptions();
+var options = SnapshotManager.GetDefaultJsonOptions();
 options.WriteIndented = false;  // Compact JSON
 options.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
 

--- a/src/KeenEyes.Core/Serialization/SnapshotManager.cs
+++ b/src/KeenEyes.Core/Serialization/SnapshotManager.cs
@@ -287,7 +287,7 @@ public static class SnapshotManager
     /// Gets the default JSON serializer options used by the snapshot manager.
     /// </summary>
     /// <returns>A copy of the default options that can be customized.</returns>
-    public static JsonSerializerOptions GetdefaultJsonOptions()
+    public static JsonSerializerOptions GetDefaultJsonOptions()
     {
         return new JsonSerializerOptions(defaultJsonOptions);
     }

--- a/tests/KeenEyes.Core.Tests/SerializationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SerializationTests.cs
@@ -722,7 +722,7 @@ public class SerializationTests
     [Fact]
     public void GetDefaultJsonOptions_ReturnsValidOptions()
     {
-        var options = SnapshotManager.GetdefaultJsonOptions();
+        var options = SnapshotManager.GetDefaultJsonOptions();
 
         Assert.NotNull(options);
         Assert.True(options.WriteIndented);


### PR DESCRIPTION
Changed method name from GetdefaultJsonOptions() to GetDefaultJsonOptions() to follow proper PascalCase naming convention for C# public methods.

Updated all references:
- Method definition in SnapshotManager.cs
- Test usage in SerializationTests.cs
- Documentation example in docs/serialization.md

Fixes #188

🤖 Generated with [Claude Code](https://claude.ai/code)