### PR TITLE
fix: Fix graphics window lifecycle and GPU resource disposal

### DIFF
--- a/samples/KeenEyes.Sample.Graphics/Program.cs
+++ b/samples/KeenEyes.Sample.Graphics/Program.cs
@@ -84,41 +84,27 @@ graphics.OnClosing += () =>
     Console.WriteLine("Window closing...");
 };
 
-// Initialize and run the graphics
-graphics.Initialize();
+// Handle render events - this is called each frame by Silk.NET
+graphics.OnRender += (deltaTime) =>
+{
+    if (sceneReady)
+    {
+        // Update the world (runs all systems including render)
+        world.Update((float)deltaTime);
+    }
+};
 
-// Main loop - run until window is closed
-Console.WriteLine("Starting main loop...");
-var lastTime = DateTime.UtcNow;
+// Initialize and run the graphics (blocks until window closes)
+Console.WriteLine("Starting graphics...");
 
 try
 {
-    while (!graphics.ShouldClose)
-    {
-        // Calculate delta time
-        var currentTime = DateTime.UtcNow;
-        var deltaTime = (float)(currentTime - lastTime).TotalSeconds;
-        lastTime = currentTime;
-
-        // Cap delta time to prevent physics issues
-        deltaTime = Math.Min(deltaTime, 0.1f);
-
-        // Process window events
-        graphics.ProcessEvents();
-
-        if (sceneReady)
-        {
-            // Update the world (runs all systems including render)
-            world.Update(deltaTime);
-
-            // Swap buffers to display the frame
-            graphics.SwapBuffers();
-        }
-    }
+    graphics.Initialize();
+    graphics.Run(); // This blocks until the window is closed
 }
 catch (Exception ex)
 {
-    Console.WriteLine($"Error during main loop: {ex.Message}");
+    Console.WriteLine($"Error running graphics: {ex.Message}");
     Console.WriteLine("This sample requires a display. Make sure you're running in a graphical environment.");
 }
 


### PR DESCRIPTION
## Summary

Fixes critical graphics window lifecycle issues and GPU resource disposal bugs that caused runtime exceptions and improper cleanup.

## Problem

1. **"NoContext" Exception**: When closing the graphics window, the application would throw `NoContext: Cannot query entry point without a current OpenGL or OpenGL ES context` because GPU resources were being disposed after the OpenGL context was destroyed.

2. **Improper Window Pattern**: The graphics sample used a manual loop checking `Window.IsClosing`, which doesn't follow Silk.NET best practices and can cause lifecycle issues.

## Solution

### 1. GPU Resource Disposal Fix

- Added `DisposeGpuResources()` method that cleans up GPU resources (meshes, textures, shaders)
- Hook into `OnClosing` event to dispose resources **before** OpenGL context is destroyed
- Add guard flag to prevent double-disposal
- Resources are now properly cleaned up while context is still valid

### 2. Silk.NET Event-Driven Pattern

- Added `OnUpdate` and `OnRender` events to `GraphicsContext`
- Updated graphics sample to use proper event-driven pattern with `graphics.Run()`
- Replaced manual `Window.IsClosing` loop with `OnRender` event handler
- Follows official Silk.NET best practices

### 3. Documentation Updates

- Updated `docs/graphics.md` to show proper event-driven pattern as recommended approach
- Added warning about manual control pattern
- Documented all window lifecycle events (`OnLoad`, `OnUpdate`, `OnRender`, `OnResize`, `OnClosing`)
- Updated complete example to demonstrate proper usage

### 4. Test Coverage Improvements

Added 4 new tests:
- `OnUpdate_RaisesWhenSimulated` - Verifies OnUpdate event
- `OnRender_RaisesWhenSimulated` - Verifies OnRender event  
- `Closing_DisposesGpuResources` - Verifies GPU cleanup on window close
- `Dispose_AfterClosing_DoesNotDoubleDisposeGpuResources` - Verifies disposal guard

Improved existing test:
- `Initialize_CalledTwice_OnlyInitializesOnce` - Now properly tests defensive code path

**Coverage Results:**
- GraphicsContext: 94.58% line coverage (+0.98%)
- GraphicsContext: 64.58% branch coverage (+2.08%)
- All critical paths tested ✅

## Testing

- ✅ All 2,042 tests pass (4 new tests added)
- ✅ Graphics sample runs without errors
- ✅ Window closes cleanly without exceptions
- ✅ GPU resources properly disposed
- ✅ Coverage increased

## Files Changed

- `src/KeenEyes.Graphics/Extensions/GraphicsContext.cs` - Add events and disposal logic
- `samples/KeenEyes.Sample.Graphics/Program.cs` - Use proper Silk.NET pattern
- `tests/KeenEyes.Graphics.Tests/GraphicsContextTests.cs` - Add and improve tests
- `docs/graphics.md` - Update documentation with best practices

## Breaking Changes

None - this is purely a bug fix and improvement. The API surface expands (new events), but existing code continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)