### PR TITLE
ci: Set up Husky for .NET project

### DIFF
--- a/.claude/hooks/install-packages.sh
+++ b/.claude/hooks/install-packages.sh
@@ -99,6 +99,10 @@ sort -u "$PACKAGES_FILE" | while read -r pkg version; do
     fi
 done
 
+# Download dotnet tools (from .config/dotnet-tools.json)
+# These are needed for husky and other tooling
+download_pkg "husky" "0.8.0"
+
 # Clean up
 rm -f "$PACKAGES_FILE"
 

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.8.0",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run --group pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run --group pre-push

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,23 @@
+{
+   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+   "tasks": [
+      {
+         "name": "dotnet-format",
+         "group": "pre-commit",
+         "command": "dotnet",
+         "args": ["format", "--verify-no-changes", "--no-restore", "--verbosity", "quiet"]
+      },
+      {
+         "name": "dotnet-build",
+         "group": "pre-push",
+         "command": "dotnet",
+         "args": ["build", "--no-restore", "-c", "Release"]
+      },
+      {
+         "name": "dotnet-test",
+         "group": "pre-push",
+         "command": "dotnet",
+         "args": ["test", "--no-build", "-c", "Release"]
+      }
+   ]
+}

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,10 @@
+<Project>
+  <!-- Auto-install Husky git hooks after restore -->
+  <Target Name="HuskyRestoreTools" BeforeTargets="Restore">
+    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
+  </Target>
+
+  <Target Name="HuskyInstall" AfterTargets="Restore" Condition="'$(HUSKY)' != '0' AND '$(CI)' != 'true'">
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+</Project>


### PR DESCRIPTION
Set up Husky.Net to enforce code quality on commits:
- pre-commit: Validates code formatting (dotnet format --verify-no-changes)
- pre-push: Runs build and tests (Release configuration)

Hooks install automatically on restore via Directory.Build.targets. Skip with HUSKY=0 or in CI environments.