### PR TITLE
fix: Fix LINQ allocation in TagManager.RemoveAllTags

### DIFF
--- a/src/KeenEyes.Core/TagManager.cs
+++ b/src/KeenEyes.Core/TagManager.cs
@@ -179,15 +179,17 @@ internal sealed class TagManager
         }
 
         // Remove entity from all tag reverse indexes (only process tags that exist in reverse index)
-        foreach (var tag in tags.Where(t => tagToEntities.ContainsKey(t)))
+        foreach (var tag in tags)
         {
-            var entities = tagToEntities[tag];
-            entities.Remove(entityId);
-
-            // Clean up empty entity set
-            if (entities.Count == 0)
+            if (tagToEntities.TryGetValue(tag, out var entities))
             {
-                tagToEntities.Remove(tag);
+                entities.Remove(entityId);
+
+                // Clean up empty entity set
+                if (entities.Count == 0)
+                {
+                    tagToEntities.Remove(tag);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #228 by eliminating a LINQ allocation in `TagManager.RemoveAllTags`.

## Changes

- **TagManager.cs:182** - Replaced LINQ `.Where()` with manual loop using `TryGetValue`
- **StringTagTests.cs** - Added test to verify proper cleanup of reverse indexes with shared tags

## Impact

Eliminates unnecessary LINQ enumerator allocation when removing all tags from an entity during despawn.

## Testing

✅ All existing tests pass
✅ New test added for coverage
✅ Build successful with zero warnings

Fixes #228

---

Generated with [Claude Code](https://claude.ai/code)