### PR TITLE
fix: Remove ToList() allocation in Archetype chunk cleanup

### DIFF
--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -409,12 +409,14 @@ public sealed class Archetype : IDisposable
     private void UpdateLocationsAfterChunkRemoval(int removedChunkIndex)
     {
         // Update all entity locations that were in chunks after the removed one
-        foreach (var entityId in entityLocations.Keys.ToList())
+        // We iterate through the dictionary's entries and only update when necessary
+        // to avoid allocating a list copy
+        foreach (var kvp in entityLocations)
         {
-            var (chunkIdx, indexInChunk) = entityLocations[entityId];
+            var (chunkIdx, indexInChunk) = kvp.Value;
             if (chunkIdx > removedChunkIndex)
             {
-                entityLocations[entityId] = (chunkIdx - 1, indexInChunk);
+                entityLocations[kvp.Key] = (chunkIdx - 1, indexInChunk);
             }
         }
     }

--- a/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
+++ b/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
@@ -1174,6 +1174,70 @@ public class ArchetypeTests
         Assert.Equal(10, archetype.Count);
     }
 
+    [Fact]
+    public void Archetype_ChunkRemoval_UpdatesEntityLocationsCorrectly()
+    {
+        var registry = new ComponentRegistry();
+        registry.Register<Position>();
+        var pool = new ChunkPool();
+        var manager = new ArchetypeManager(registry, pool);
+        var archetype = manager.GetOrCreateArchetype([typeof(Position)]);
+
+        // Create entities across multiple chunks
+        var entitiesInFirstChunk = new List<Entity>();
+        var entitiesInSecondChunk = new List<Entity>();
+
+        // Fill first chunk
+        for (int i = 0; i < ArchetypeChunk.DefaultCapacity; i++)
+        {
+            var entity = new Entity(i, 1);
+            entitiesInFirstChunk.Add(entity);
+            archetype.AddEntity(entity);
+            archetype.AddComponent(new Position { X = i });
+        }
+
+        // Add entities to second chunk
+        for (int i = 0; i < 5; i++)
+        {
+            var entity = new Entity(ArchetypeChunk.DefaultCapacity + i, 1);
+            entitiesInSecondChunk.Add(entity);
+            archetype.AddEntity(entity);
+            archetype.AddComponent(new Position { X = ArchetypeChunk.DefaultCapacity + i });
+        }
+
+        Assert.Equal(2, archetype.ChunkCount);
+
+        // Verify entities in second chunk are at chunk index 1
+        foreach (var entity in entitiesInSecondChunk)
+        {
+            var (chunkIdx, _) = archetype.GetEntityLocation(entity);
+            Assert.Equal(1, chunkIdx);
+        }
+
+        // Remove all entities from first chunk to trigger chunk removal
+        foreach (var entity in entitiesInFirstChunk)
+        {
+            archetype.RemoveEntity(entity);
+        }
+
+        // Now only one chunk should remain
+        Assert.Equal(1, archetype.ChunkCount);
+
+        // Verify entities that were in second chunk are now in first chunk (index 0)
+        foreach (var entity in entitiesInSecondChunk)
+        {
+            var (chunkIdx, _) = archetype.GetEntityLocation(entity);
+            Assert.Equal(0, chunkIdx);
+        }
+
+        // Verify we can still access components for these entities
+        foreach (var entity in entitiesInSecondChunk)
+        {
+            ref var pos = ref archetype.GetByEntity<Position>(entity);
+            Assert.True(pos.X >= ArchetypeChunk.DefaultCapacity);
+        }
+    }
+
     #endregion
 
     #region ArchetypeManager Advanced Coverage Tests


### PR DESCRIPTION
Replaced ToList() allocation in UpdateLocationsAfterChunkRemoval by iterating over dictionary entries instead of keys. This is safe because we're only updating values, not modifying the key collection.

Added comprehensive test to verify entity locations are correctly updated after chunk removal, ensuring the optimization maintains correctness.

Fixes #227

🤖 Generated with [Claude Code](https://claude.ai/code)