### PR TITLE
feat: Move statistics logic from World to StatisticsManager

### DIFF
--- a/src/KeenEyes.Core/StatisticsManager.cs
+++ b/src/KeenEyes.Core/StatisticsManager.cs
@@ -1,0 +1,81 @@
+namespace KeenEyes;
+
+/// <summary>
+/// Manages world statistics collection and reporting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is an internal manager class that handles all statistics operations.
+/// The public API is exposed through <see cref="World"/>.
+/// </para>
+/// <para>
+/// Statistics are computed on-demand and represent a snapshot in time.
+/// They include entity allocations, component storage, and pooling metrics.
+/// </para>
+/// </remarks>
+internal sealed class StatisticsManager
+{
+    private readonly EntityPool entityPool;
+    private readonly ArchetypeManager archetypeManager;
+    private readonly ComponentRegistry components;
+    private readonly SystemManager systemManager;
+    private readonly QueryManager queryManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StatisticsManager"/> class.
+    /// </summary>
+    /// <param name="entityPool">The entity pool to gather statistics from.</param>
+    /// <param name="archetypeManager">The archetype manager to gather statistics from.</param>
+    /// <param name="components">The component registry to gather statistics from.</param>
+    /// <param name="systemManager">The system manager to gather statistics from.</param>
+    /// <param name="queryManager">The query manager to gather statistics from.</param>
+    internal StatisticsManager(
+        EntityPool entityPool,
+        ArchetypeManager archetypeManager,
+        ComponentRegistry components,
+        SystemManager systemManager,
+        QueryManager queryManager)
+    {
+        this.entityPool = entityPool;
+        this.archetypeManager = archetypeManager;
+        this.components = components;
+        this.systemManager = systemManager;
+        this.queryManager = queryManager;
+    }
+
+    /// <summary>
+    /// Gets memory usage statistics for the world.
+    /// </summary>
+    /// <returns>A snapshot of current memory statistics.</returns>
+    internal MemoryStats GetMemoryStats()
+    {
+        // Calculate estimated component bytes
+        long estimatedBytes = 0;
+        foreach (var archetype in archetypeManager.Archetypes)
+        {
+            foreach (var componentType in archetype.ComponentTypes)
+            {
+                var info = components.Get(componentType);
+                if (info is not null)
+                {
+                    estimatedBytes += (long)info.Size * archetype.Count;
+                }
+            }
+        }
+
+        return new MemoryStats
+        {
+            EntitiesAllocated = entityPool.TotalAllocated,
+            EntitiesActive = entityPool.ActiveCount,
+            EntitiesRecycled = entityPool.AvailableCount,
+            EntityRecycleCount = entityPool.RecycleCount,
+            ArchetypeCount = archetypeManager.ArchetypeCount,
+            ComponentTypeCount = components.Count,
+            SystemCount = systemManager.Count,
+            CachedQueryCount = queryManager.CachedQueryCount,
+            QueryCacheHits = queryManager.CacheHits,
+            QueryCacheMisses = queryManager.CacheMisses,
+            EstimatedComponentBytes = estimatedBytes
+        };
+    }
+}

--- a/src/KeenEyes.Core/World.Statistics.cs
+++ b/src/KeenEyes.Core/World.Statistics.cs
@@ -23,36 +23,7 @@ public sealed partial class World
     /// </code>
     /// </example>
     public MemoryStats GetMemoryStats()
-    {
-        // Calculate estimated component bytes
-        long estimatedBytes = 0;
-        foreach (var archetype in archetypeManager.Archetypes)
-        {
-            foreach (var componentType in archetype.ComponentTypes)
-            {
-                var info = Components.Get(componentType);
-                if (info is not null)
-                {
-                    estimatedBytes += (long)info.Size * archetype.Count;
-                }
-            }
-        }
-
-        return new MemoryStats
-        {
-            EntitiesAllocated = entityPool.TotalAllocated,
-            EntitiesActive = entityPool.ActiveCount,
-            EntitiesRecycled = entityPool.AvailableCount,
-            EntityRecycleCount = entityPool.RecycleCount,
-            ArchetypeCount = archetypeManager.ArchetypeCount,
-            ComponentTypeCount = Components.Count,
-            SystemCount = systemManager.Count,
-            CachedQueryCount = queryManager.CachedQueryCount,
-            QueryCacheHits = queryManager.CacheHits,
-            QueryCacheMisses = queryManager.CacheMisses,
-            EstimatedComponentBytes = estimatedBytes
-        };
-    }
+        => statisticsManager.GetMemoryStats();
 
     #endregion
 }

--- a/src/KeenEyes.Core/World.cs
+++ b/src/KeenEyes.Core/World.cs
@@ -36,6 +36,7 @@ public sealed partial class World : IWorld
     private readonly TagManager tagManager = new();
     private readonly ComponentValidationManager validationManager;
     private readonly ComponentArrayPoolManager arrayPoolManager = new();
+    private readonly StatisticsManager statisticsManager;
     private readonly EntityBuilder builder;
 
     /// <summary>
@@ -110,6 +111,7 @@ public sealed partial class World : IWorld
         changeTracker = new ChangeTracker(entityPool);
         prefabManager = new PrefabManager(this);
         validationManager = new ComponentValidationManager(this);
+        statisticsManager = new StatisticsManager(entityPool, archetypeManager, Components, systemManager, queryManager);
         builder = new EntityBuilder(this);
     }
 

--- a/tests/KeenEyes.Core.Tests/StatisticsManagerTests.cs
+++ b/tests/KeenEyes.Core.Tests/StatisticsManagerTests.cs
@@ -1,0 +1,211 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Tests for the StatisticsManager.
+/// </summary>
+public class StatisticsManagerTests
+{
+#pragma warning disable CS0649 // Field is never assigned to
+    [Component]
+    private partial struct Position : IComponent
+    {
+        public float X;
+        public float Y;
+    }
+
+    [Component]
+    private partial struct Velocity : IComponent
+    {
+        public float X;
+        public float Y;
+    }
+
+    [Component]
+    private partial struct Health : IComponent
+    {
+        public int Current;
+        public int Max;
+    }
+#pragma warning restore CS0649
+
+    #region GetMemoryStats Tests
+
+    [Fact]
+    public void GetMemoryStats_WithNoEntities_ReturnsZeroStats()
+    {
+        using var world = new World();
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(0, stats.EntitiesAllocated);
+        Assert.Equal(0, stats.EntitiesActive);
+        Assert.Equal(0, stats.EntitiesRecycled);
+        Assert.Equal(0, stats.EntityRecycleCount);
+        Assert.Equal(0, stats.ArchetypeCount);
+        Assert.Equal(0, stats.ComponentTypeCount);
+        Assert.Equal(0, stats.EstimatedComponentBytes);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithEntities_ReturnsCorrectEntityCount()
+    {
+        using var world = new World();
+
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Velocity()).Build();
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(3, stats.EntitiesAllocated);
+        Assert.Equal(3, stats.EntitiesActive);
+        Assert.Equal(0, stats.EntitiesRecycled);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithRecycledEntities_ReturnsCorrectRecycleCount()
+    {
+        using var world = new World();
+
+        var entity1 = world.Spawn().With(new Position()).Build();
+        var entity2 = world.Spawn().With(new Position()).Build();
+
+        world.Despawn(entity1);
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(2, stats.EntitiesAllocated);
+        Assert.Equal(1, stats.EntitiesActive);
+        Assert.Equal(1, stats.EntitiesRecycled);
+
+        // Recycle the entity
+        world.Spawn().With(new Position()).Build();
+
+        stats = world.GetMemoryStats();
+        Assert.Equal(1, stats.EntityRecycleCount);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithMultipleArchetypes_ReturnsCorrectArchetypeCount()
+    {
+        using var world = new World();
+
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Position()).With(new Velocity()).Build();
+        world.Spawn().With(new Position()).With(new Velocity()).With(new Health()).Build();
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(3, stats.ArchetypeCount);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithComponents_ReturnsCorrectComponentTypeCount()
+    {
+        using var world = new World();
+
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Position()).With(new Velocity()).Build();
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(2, stats.ComponentTypeCount);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithSystems_ReturnsCorrectSystemCount()
+    {
+        using var world = new World();
+
+        world.AddSystem(new TestSystem());
+        world.AddSystem(new TestSystem());
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(2, stats.SystemCount);
+    }
+
+    [Fact]
+    public void GetMemoryStats_WithQueries_ReturnsCorrectQueryCacheStats()
+    {
+        using var world = new World();
+
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Position()).With(new Velocity()).Build();
+
+        // Execute queries to populate cache
+        foreach (var _ in world.Query<Position>()) { }
+        foreach (var _ in world.Query<Position, Velocity>()) { }
+
+        var stats = world.GetMemoryStats();
+
+        Assert.Equal(2, stats.CachedQueryCount);
+        Assert.True(stats.QueryCacheHits >= 0);
+        Assert.True(stats.QueryCacheMisses >= 0);
+    }
+
+    [Fact]
+    public void GetMemoryStats_EstimatesComponentBytes_Correctly()
+    {
+        using var world = new World();
+
+        // Create entities with known component sizes
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Position()).Build();
+
+        var stats = world.GetMemoryStats();
+
+        // Position struct has 2 floats (8 bytes total)
+        // 2 entities * 8 bytes = 16 bytes
+        Assert.True(stats.EstimatedComponentBytes > 0);
+    }
+
+    [Fact]
+    public void GetMemoryStats_MultipleCalls_ReturnsConsistentResults()
+    {
+        using var world = new World();
+
+        world.Spawn().With(new Position()).Build();
+        world.Spawn().With(new Velocity()).Build();
+
+        var stats1 = world.GetMemoryStats();
+        var stats2 = world.GetMemoryStats();
+
+        Assert.Equal(stats1.EntitiesActive, stats2.EntitiesActive);
+        Assert.Equal(stats1.ArchetypeCount, stats2.ArchetypeCount);
+        Assert.Equal(stats1.ComponentTypeCount, stats2.ComponentTypeCount);
+        Assert.Equal(stats1.EstimatedComponentBytes, stats2.EstimatedComponentBytes);
+    }
+
+    [Fact]
+    public void GetMemoryStats_AfterDespawn_UpdatesStats()
+    {
+        using var world = new World();
+
+        var entity1 = world.Spawn().With(new Position()).Build();
+        var entity2 = world.Spawn().With(new Position()).Build();
+
+        var statsBefore = world.GetMemoryStats();
+        Assert.Equal(2, statsBefore.EntitiesActive);
+
+        world.Despawn(entity1);
+
+        var statsAfter = world.GetMemoryStats();
+        Assert.Equal(1, statsAfter.EntitiesActive);
+        Assert.Equal(1, statsAfter.EntitiesRecycled);
+    }
+
+    #endregion
+
+    #region Helper System
+
+    private sealed class TestSystem : SystemBase
+    {
+        public override void Update(float deltaTime)
+        {
+            // Empty test system
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Refactors World.GetMemoryStats() to follow the manager facade pattern by creating a new StatisticsManager that handles all statistics calculation logic.

## Changes
- Created StatisticsManager.cs with GetMemoryStats() implementation
- Updated World.cs to instantiate StatisticsManager
- Refactored World.Statistics.cs to delegate to the manager
- Added comprehensive tests for StatisticsManager

This aligns with the architectural pattern where World is a thin facade that delegates to specialized managers rather than implementing logic directly.

Fixes #222

🤖 Generated with [Claude Code](https://claude.ai/code)