### PR TITLE
fix: Add missing using statement to Simulation sample

### DIFF
--- a/samples/KeenEyes.Sample.Simulation/Systems.cs
+++ b/samples/KeenEyes.Sample.Simulation/Systems.cs
@@ -1,3 +1,5 @@
+using KeenEyes;
+
 namespace KeenEyes.Sample.Simulation;
 
 // =============================================================================

--- a/tests/KeenEyes.Core.Tests/KeenEyes.Core.Tests.csproj
+++ b/tests/KeenEyes.Core.Tests/KeenEyes.Core.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\samples\KeenEyes.Sample.Simulation\KeenEyes.Sample.Simulation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/KeenEyes.Core.Tests/SampleCompilationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SampleCompilationTests.cs
@@ -1,0 +1,59 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Tests to ensure sample code compiles and runs correctly.
+/// These tests catch issues like missing using statements that would confuse new users.
+/// </summary>
+public class SampleCompilationTests
+{
+    /// <summary>
+    /// Verifies that the Simulation sample systems can be instantiated.
+    /// This ensures all required using statements are present (e.g., KeenEyes.Commands for CommandBuffer).
+    /// </summary>
+    [Fact]
+    public void SimulationSample_Systems_CanBeInstantiated()
+    {
+        // This test verifies that all systems from the Simulation sample can be instantiated
+        // If the using statement for KeenEyes.Commands is missing, this would fail to compile
+
+        using var world = new World();
+
+        // Test that we can create instances of the systems that use CommandBuffer
+        var movementSystem = new Sample.Simulation.MovementSystem();
+        var healthSystem = new Sample.Simulation.HealthSystem();
+        var lifetimeSystem = new Sample.Simulation.LifetimeSystem();
+        var shootingSystem = new Sample.Simulation.ShootingSystem();
+        var enemyShootingSystem = new Sample.Simulation.EnemyShootingSystem();
+
+        // Verify systems can be added to world
+        world.AddSystem(movementSystem);
+        world.AddSystem(healthSystem);
+        world.AddSystem(lifetimeSystem);
+        world.AddSystem(shootingSystem);
+        world.AddSystem(enemyShootingSystem);
+
+        // Verify they were added successfully
+        Assert.NotNull(movementSystem);
+        Assert.NotNull(healthSystem);
+        Assert.NotNull(lifetimeSystem);
+        Assert.NotNull(shootingSystem);
+        Assert.NotNull(enemyShootingSystem);
+    }
+
+    /// <summary>
+    /// Verifies that systems from the Simulation sample can execute without errors.
+    /// </summary>
+    [Fact]
+    public void SimulationSample_Systems_CanExecuteUpdate()
+    {
+        using var world = new World();
+
+        var movementSystem = new Sample.Simulation.MovementSystem();
+        world.AddSystem(movementSystem);
+
+        // Should not throw when updating
+        world.Update(0.016f);
+
+        Assert.NotNull(movementSystem);
+    }
+}


### PR DESCRIPTION
## Summary

Added `using KeenEyes;` to `samples/KeenEyes.Sample.Simulation/Systems.cs` to clarify where CommandBuffer comes from. This resolves user confusion when first encountering the sample code.

Also added compilation tests to ensure sample code builds correctly and to catch similar issues in the future.

Fixes #221

---

Generated with [Claude Code](https://claude.com/claude-code)) | [Branch](https://github.com/orion-ecs/keen-eye/tree/claude/issue-221-20251211-1903) | [View job run](https://github.com/orion-ecs/keen-eye/actions/runs/20144249725