### PR TITLE
perf: Replace linear search with binary search in Archetype.Has()

### DIFF
--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -290,7 +290,7 @@ public sealed class Archetype : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has<T>() where T : struct, IComponent
     {
-        return componentTypesList.Contains(typeof(T));
+        return Has(typeof(T));
     }
 
     /// <summary>
@@ -299,7 +299,32 @@ public sealed class Archetype : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has(Type type)
     {
-        return componentTypesList.Contains(type);
+        // Binary search since componentTypesList is sorted by FullName
+        var left = 0;
+        var right = componentTypesList.Count - 1;
+        var targetName = type.FullName;
+
+        while (left <= right)
+        {
+            var mid = left + (right - left) / 2;
+            var comparison = string.CompareOrdinal(componentTypesList[mid].FullName, targetName);
+
+            if (comparison == 0)
+            {
+                return true;
+            }
+
+            if (comparison < 0)
+            {
+                left = mid + 1;
+            }
+            else
+            {
+                right = mid - 1;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
+++ b/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
@@ -221,6 +221,45 @@ public class ArchetypeTests
     }
 
     [Fact]
+    public void Archetype_Has_WithMultipleComponents_UsesEfficientLookup()
+    {
+        using var world = new World();
+        world.Components.Register<Position>();
+        world.Components.Register<Velocity>();
+        world.Components.Register<Health>();
+
+        var id = new ArchetypeId([typeof(Position), typeof(Velocity), typeof(Health)]);
+        // ArchetypeId sorts types by FullName, so we need to match that order
+        var sortedInfos = id.ComponentTypes
+            .Select(t => world.Components.Get(t)!)
+            .ToArray();
+        using var archetype = new Archetype(id, sortedInfos);
+
+        // Test all components are found
+        Assert.True(archetype.Has<Position>());
+        Assert.True(archetype.Has<Velocity>());
+        Assert.True(archetype.Has<Health>());
+
+        // Test non-existent component returns false
+        Assert.False(archetype.Has<EnemyTag>());
+    }
+
+    [Fact]
+    public void Archetype_Has_WithSingleComponent_ReturnsCorrectly()
+    {
+        using var world = new World();
+        world.Components.Register<Position>();
+
+        var id = new ArchetypeId([typeof(Position)]);
+        var infos = new[] { world.Components.Get<Position>()! };
+        using var archetype = new Archetype(id, infos);
+
+        Assert.True(archetype.Has<Position>());
+        Assert.False(archetype.Has<Velocity>());
+        Assert.False(archetype.Has<Health>());
+    }
+
+    [Fact]
     public void Archetype_GetEntityIndex_ReturnsCorrectIndex()
     {
         using var world = new World();


### PR DESCRIPTION
Optimizes Archetype.Has<T>() and Has(Type) by implementing binary search instead of linear search, improving lookup from O(n) to O(log n).

The componentTypesList is already sorted by FullName (from ArchetypeId), making binary search a natural fit. This method is called frequently during query matching, so the performance improvement will be noticeable with complex queries and larger component sets.

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)