### PR TITLE
feat: Add deterministic RNG support to World

### DIFF
--- a/samples/KeenEyes.Sample.MassSimulation/Systems.cs
+++ b/samples/KeenEyes.Sample.MassSimulation/Systems.cs
@@ -119,10 +119,12 @@ public class CleanupSystem : SystemBase
 /// <summary>
 /// Spawns new particles to maintain target entity count.
 /// </summary>
+/// <remarks>
+/// Uses World.NextFloat() for random number generation, ensuring deterministic behavior
+/// when the world is seeded. This is important for replay systems and testing.
+/// </remarks>
 public class SpawnerSystem : SystemBase
 {
-    private readonly Random random = new();
-
     /// <summary>Target number of active particles.</summary>
     public int TargetCount { get; set; } = 100_000;
 
@@ -152,17 +154,17 @@ public class SpawnerSystem : SystemBase
 
         for (var i = 0; i < toSpawn; i++)
         {
-            var hasGravity = random.NextDouble() < 0.3; // 30% chance of gravity
+            var hasGravity = World.NextBool(0.3f); // 30% chance of gravity
 
             var builder = World.Spawn()
                 .WithPosition(
-                    x: (float)(random.NextDouble() * WorldWidth),
-                    y: (float)(random.NextDouble() * WorldHeight))
+                    x: World.NextFloat() * WorldWidth,
+                    y: World.NextFloat() * WorldHeight)
                 .WithVelocity(
-                    x: (float)(random.NextDouble() * 20 - 10),
-                    y: (float)(random.NextDouble() * 20 - 10))
-                .WithLifetime(remaining: (float)(random.NextDouble() * 5 + 1))
-                .WithParticleColor(hue: (float)(random.NextDouble() * 360))
+                    x: World.NextFloat() * 20 - 10,
+                    y: World.NextFloat() * 20 - 10)
+                .WithLifetime(remaining: World.NextFloat() * 5 + 1)
+                .WithParticleColor(hue: World.NextFloat() * 360)
                 .WithActive();
 
             if (hasGravity)

--- a/samples/KeenEyes.Sample.Simulation/Systems.cs
+++ b/samples/KeenEyes.Sample.Simulation/Systems.cs
@@ -249,10 +249,13 @@ public partial class CleanupSystem : SystemBase
 /// <summary>
 /// Spawns enemies periodically.
 /// </summary>
+/// <remarks>
+/// Uses World.NextInt() and World.NextFloat() for random number generation,
+/// ensuring deterministic behavior when the world is seeded.
+/// </remarks>
 [System(Phase = SystemPhase.EarlyUpdate, Order = 0)]
 public partial class SpawnerSystem : SystemBase
 {
-    private readonly Random random = new();
     private float spawnTimer;
 
     /// <summary>Seconds between spawns.</summary>
@@ -293,33 +296,33 @@ public partial class SpawnerSystem : SystemBase
     {
         // Random edge spawn
         float x, y, vx, vy;
-        int edge = random.Next(4);
+        int edge = World.NextInt(4);
 
         switch (edge)
         {
             case 0: // Top
-                x = random.NextSingle() * WorldWidth;
+                x = World.NextFloat() * WorldWidth;
                 y = 0;
-                vx = (random.NextSingle() - 0.5f) * 10;
-                vy = random.NextSingle() * 5 + 2;
+                vx = (World.NextFloat() - 0.5f) * 10;
+                vy = World.NextFloat() * 5 + 2;
                 break;
             case 1: // Bottom
-                x = random.NextSingle() * WorldWidth;
+                x = World.NextFloat() * WorldWidth;
                 y = WorldHeight - 1;
-                vx = (random.NextSingle() - 0.5f) * 10;
-                vy = -(random.NextSingle() * 5 + 2);
+                vx = (World.NextFloat() - 0.5f) * 10;
+                vy = -(World.NextFloat() * 5 + 2);
                 break;
             case 2: // Left
                 x = 0;
-                y = random.NextSingle() * WorldHeight;
-                vx = random.NextSingle() * 5 + 2;
-                vy = (random.NextSingle() - 0.5f) * 10;
+                y = World.NextFloat() * WorldHeight;
+                vx = World.NextFloat() * 5 + 2;
+                vy = (World.NextFloat() - 0.5f) * 10;
                 break;
             default: // Right
                 x = WorldWidth - 1;
-                y = random.NextSingle() * WorldHeight;
-                vx = -(random.NextSingle() * 5 + 2);
-                vy = (random.NextSingle() - 0.5f) * 10;
+                y = World.NextFloat() * WorldHeight;
+                vx = -(World.NextFloat() * 5 + 2);
+                vy = (World.NextFloat() - 0.5f) * 10;
                 break;
         }
 
@@ -328,7 +331,7 @@ public partial class SpawnerSystem : SystemBase
         ConsoleColor color;
         int health;
 
-        int type = random.Next(3);
+        int type = World.NextInt(3);
         switch (type)
         {
             case 0: // Fast, weak
@@ -444,10 +447,13 @@ public partial class ShootingSystem : SystemBase
 /// <summary>
 /// Enemy shooting behavior.
 /// </summary>
+/// <remarks>
+/// Uses World.NextFloat() for random cooldowns, ensuring deterministic behavior
+/// when the world is seeded.
+/// </remarks>
 [System(Phase = SystemPhase.Update, Order = -4)]
 public partial class EnemyShootingSystem : SystemBase
 {
-    private readonly Random random = new();
     private readonly CommandBuffer buffer = new();
 
     /// <inheritdoc />
@@ -490,7 +496,7 @@ public partial class EnemyShootingSystem : SystemBase
 
             if (cooldown.Remaining <= 0)
             {
-                cooldown.Remaining = 1.5f + random.NextSingle();
+                cooldown.Remaining = 1.5f + World.NextFloat();
 
                 // Shoot toward player
                 float dx = playerPos.X - pos.X;

--- a/src/KeenEyes.Abstractions/IWorld.cs
+++ b/src/KeenEyes.Abstractions/IWorld.cs
@@ -345,4 +345,63 @@ public interface IWorld : IDisposable
     IEnumerable<Entity> GetAllEntities();
 
     #endregion
+
+    #region Random Number Generation
+
+    /// <summary>
+    /// Gets a random integer between 0 (inclusive) and maxValue (exclusive).
+    /// </summary>
+    /// <param name="maxValue">The exclusive upper bound of the random number to be generated.</param>
+    /// <returns>A 32-bit signed integer greater than or equal to 0, and less than maxValue.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">maxValue is less than 0.</exception>
+    /// <remarks>
+    /// <para>
+    /// Uses the world's deterministic random number generator. If the world was created with a seed,
+    /// this method will produce the same sequence of values across runs.
+    /// </para>
+    /// </remarks>
+    int NextInt(int maxValue);
+
+    /// <summary>
+    /// Gets a random integer between minValue (inclusive) and maxValue (exclusive).
+    /// </summary>
+    /// <param name="minValue">The inclusive lower bound of the random number returned.</param>
+    /// <param name="maxValue">The exclusive upper bound of the random number returned.</param>
+    /// <returns>
+    /// A 32-bit signed integer greater than or equal to minValue and less than maxValue.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// minValue is greater than maxValue.
+    /// </exception>
+    int NextInt(int minValue, int maxValue);
+
+    /// <summary>
+    /// Gets a random floating-point number between 0.0 (inclusive) and 1.0 (exclusive).
+    /// </summary>
+    /// <returns>A single-precision floating point number greater than or equal to 0.0, and less than 1.0.</returns>
+    float NextFloat();
+
+    /// <summary>
+    /// Gets a random double-precision floating-point number between 0.0 (inclusive) and 1.0 (exclusive).
+    /// </summary>
+    /// <returns>A double-precision floating point number greater than or equal to 0.0, and less than 1.0.</returns>
+    double NextDouble();
+
+    /// <summary>
+    /// Gets a random boolean value.
+    /// </summary>
+    /// <returns>True or false with equal probability.</returns>
+    bool NextBool();
+
+    /// <summary>
+    /// Returns a random boolean with the specified probability of being true.
+    /// </summary>
+    /// <param name="probability">The probability (0.0 to 1.0) that the result will be true.</param>
+    /// <returns>True with the specified probability, false otherwise.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// probability is less than 0.0 or greater than 1.0.
+    /// </exception>
+    bool NextBool(float probability);
+
+    #endregion
 }

--- a/src/KeenEyes.Core/World.Random.cs
+++ b/src/KeenEyes.Core/World.Random.cs
@@ -1,0 +1,115 @@
+namespace KeenEyes;
+
+/// <summary>
+/// Random number generation support for the World.
+/// </summary>
+public sealed partial class World
+{
+    private readonly Random random;
+
+    /// <summary>
+    /// Gets a random integer between 0 (inclusive) and maxValue (exclusive).
+    /// </summary>
+    /// <param name="maxValue">The exclusive upper bound of the random number to be generated.</param>
+    /// <returns>A 32-bit signed integer greater than or equal to 0, and less than maxValue.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">maxValue is less than 0.</exception>
+    /// <remarks>
+    /// <para>
+    /// Uses the world's deterministic random number generator. If the world was created with a seed,
+    /// this method will produce the same sequence of values across runs.
+    /// </para>
+    /// <para>
+    /// Each world has its own isolated RNG state, ensuring deterministic behavior for replays and testing.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Spawn enemy at random edge (0-3)
+    /// int edge = world.NextInt(4);
+    /// </code>
+    /// </example>
+    public int NextInt(int maxValue) => random.Next(maxValue);
+
+    /// <summary>
+    /// Gets a random integer between minValue (inclusive) and maxValue (exclusive).
+    /// </summary>
+    /// <param name="minValue">The inclusive lower bound of the random number returned.</param>
+    /// <param name="maxValue">The exclusive upper bound of the random number returned.</param>
+    /// <returns>
+    /// A 32-bit signed integer greater than or equal to minValue and less than maxValue.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// minValue is greater than maxValue.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// // Random velocity between -10 and 10
+    /// int velocity = world.NextInt(-10, 11);
+    /// </code>
+    /// </example>
+    public int NextInt(int minValue, int maxValue) => random.Next(minValue, maxValue);
+
+    /// <summary>
+    /// Gets a random floating-point number between 0.0 (inclusive) and 1.0 (exclusive).
+    /// </summary>
+    /// <returns>A single-precision floating point number greater than or equal to 0.0, and less than 1.0.</returns>
+    /// <example>
+    /// <code>
+    /// // 30% chance of gravity
+    /// bool hasGravity = world.NextFloat() &lt; 0.3f;
+    ///
+    /// // Random position in world
+    /// float x = world.NextFloat() * worldWidth;
+    /// float y = world.NextFloat() * worldHeight;
+    /// </code>
+    /// </example>
+    public float NextFloat() => random.NextSingle();
+
+    /// <summary>
+    /// Gets a random double-precision floating-point number between 0.0 (inclusive) and 1.0 (exclusive).
+    /// </summary>
+    /// <returns>A double-precision floating point number greater than or equal to 0.0, and less than 1.0.</returns>
+    public double NextDouble() => random.NextDouble();
+
+    /// <summary>
+    /// Gets a random boolean value.
+    /// </summary>
+    /// <returns>True or false with equal probability.</returns>
+    /// <example>
+    /// <code>
+    /// // Randomly choose between two options
+    /// if (world.NextBool())
+    /// {
+    ///     entity.WithGravity(9.8f);
+    /// }
+    /// </code>
+    /// </example>
+    public bool NextBool() => random.Next(2) == 0;
+
+    /// <summary>
+    /// Returns a random boolean with the specified probability of being true.
+    /// </summary>
+    /// <param name="probability">The probability (0.0 to 1.0) that the result will be true.</param>
+    /// <returns>True with the specified probability, false otherwise.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// probability is less than 0.0 or greater than 1.0.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// // 30% chance of gravity
+    /// if (world.NextBool(0.3f))
+    /// {
+    ///     entity.WithGravity(9.8f);
+    /// }
+    /// </code>
+    /// </example>
+    public bool NextBool(float probability)
+    {
+        if (probability < 0.0f || probability > 1.0f)
+        {
+            throw new ArgumentOutOfRangeException(nameof(probability), "Probability must be between 0.0 and 1.0");
+        }
+
+        return NextFloat() < probability;
+    }
+}

--- a/src/KeenEyes.Core/World.cs
+++ b/src/KeenEyes.Core/World.cs
@@ -99,8 +99,31 @@ public sealed partial class World : IWorld
     /// <summary>
     /// Creates a new ECS world.
     /// </summary>
-    public World()
+    /// <param name="seed">
+    /// Optional seed for the world's random number generator.
+    /// If null, uses a time-based seed. If specified, enables deterministic behavior
+    /// for replays and testing.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Each world has its own isolated random number generator state. Providing a seed
+    /// ensures that all random operations (via <see cref="NextInt(int)"/>, <see cref="NextFloat"/>, etc.)
+    /// will produce the same sequence of values across runs, enabling deterministic simulations.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Non-deterministic world (different results each run)
+    /// var world1 = new World();
+    ///
+    /// // Deterministic world (same results with same seed)
+    /// var world2 = new World(seed: 12345);
+    /// var world3 = new World(seed: 12345); // Same sequence as world2
+    /// </code>
+    /// </example>
+    public World(int? seed = null)
     {
+        random = seed.HasValue ? new Random(seed.Value) : new Random();
         entityPool = new EntityPool();
         archetypeManager = new ArchetypeManager(Components);
         queryManager = new QueryManager(archetypeManager);


### PR DESCRIPTION
## Summary

Addresses #226 by providing a World-level random number generator that supports deterministic seeding for replays and testing.

### Changes

- Add `World.Random.cs` with `NextInt()`, `NextFloat()`, `NextDouble()`, `NextBool()` methods
- Update `IWorld` interface to include RNG methods for systems
- Update World constructor to accept optional seed parameter
- Replace Random fields in sample systems with `World.Next*()` calls
- Add comprehensive XML documentation

### Benefits

- ✅ Per-world RNG isolation (no static state)
- ✅ Deterministic behavior when seeded
- ✅ Clean API accessible from all systems
- ✅ Samples now demonstrate best practices

Fixes #226

🤖 Generated with [Claude Code](https://claude.ai/code)