### PR TITLE
fix: Add bounds checking and correct C# version comment

### DIFF
--- a/samples/KeenEyes.Sample/HealthExtensions.cs
+++ b/samples/KeenEyes.Sample/HealthExtensions.cs
@@ -3,7 +3,7 @@ namespace KeenEyes.Sample;
 // =============================================================================
 // HEALTH COMPONENT EXTENSION PROPERTIES
 // =============================================================================
-// This file demonstrates the C# 14 extension property feature to add computed
+// This file demonstrates the C# 13 extension property feature to add computed
 // properties to components without violating ECS principles.
 //
 // By using extension properties, we keep the Health component as pure data

--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -114,6 +114,11 @@ public sealed class Archetype : IDisposable
     /// <param name="component">The component value.</param>
     internal void AddComponent<T>(in T component) where T : struct, IComponent
     {
+        if (chunks.Count == 0)
+        {
+            throw new InvalidOperationException("Cannot add component: archetype has no chunks");
+        }
+
         // Add to the last chunk (where the entity was just added)
         var lastChunk = chunks[^1];
         lastChunk.AddComponent(in component);
@@ -124,6 +129,11 @@ public sealed class Archetype : IDisposable
     /// </summary>
     internal void AddComponentBoxed(Type type, object value)
     {
+        if (chunks.Count == 0)
+        {
+            throw new InvalidOperationException("Cannot add component: archetype has no chunks");
+        }
+
         var lastChunk = chunks[^1];
         lastChunk.AddComponentBoxed(type, value);
     }


### PR DESCRIPTION
## Summary

This PR fixes the 2 remaining minor issues from the nightly code review (#246):

1. **Archetype empty chunks check** - Added bounds checking to `AddComponent<T>()` and `AddComponentBoxed()` to prevent `IndexOutOfRangeException` when archetype has no chunks
2. **C# version comment** - Updated HealthExtensions.cs comment from C# 14 to C# 13 (correct version for extension properties feature)

## Changes

- `src/KeenEyes.Core/Archetypes/Archetype.cs`: Add bounds checking in `AddComponent<T>()` and `AddComponentBoxed()`
- `samples/KeenEyes.Sample/HealthExtensions.cs`: Correct C# version from 14 to 13

## Test Results

✅ All 2549 tests passed
✅ Build succeeded with 0 warnings
✅ Pre-commit and pre-push hooks validated

Fixes #246

---

Generated with [Claude Code](https://claude.ai/code)