### PR TITLE
feat: Create analyzer rule for Random class usage

### DIFF
--- a/src/KeenEyes.Generators/RandomClassAnalyzer.cs
+++ b/src/KeenEyes.Generators/RandomClassAnalyzer.cs
@@ -1,0 +1,175 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace KeenEyes.Generators;
+
+/// <summary>
+/// Roslyn analyzer that detects usage of System.Random and suggests using World.Next* methods instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In an ECS architecture, random number generation should be centralized through the World instance
+/// to ensure deterministic behavior for replays, testing, and debugging. Each World maintains its
+/// own random state that can be seeded for reproducibility.
+/// </para>
+/// <para>
+/// This analyzer detects:
+/// <list type="bullet">
+/// <item><description>Object creation expressions: <c>new Random()</c></description></item>
+/// <item><description>Field declarations of type <c>System.Random</c></description></item>
+/// <item><description>Parameter declarations of type <c>System.Random</c></description></item>
+/// </list>
+/// </para>
+/// <para>
+/// Instead of using <c>System.Random</c> directly, use the World's random methods:
+/// <list type="bullet">
+/// <item><description><c>world.NextInt(maxValue)</c> - Random integer [0, maxValue)</description></item>
+/// <item><description><c>world.NextInt(min, max)</c> - Random integer [min, max)</description></item>
+/// <item><description><c>world.NextFloat()</c> - Random float [0.0, 1.0)</description></item>
+/// <item><description><c>world.NextDouble()</c> - Random double [0.0, 1.0)</description></item>
+/// <item><description><c>world.NextBool()</c> - Random boolean</description></item>
+/// <item><description><c>world.NextBool(probability)</c> - Boolean with specified probability</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RandomClassAnalyzer : DiagnosticAnalyzer
+{
+    private const string SystemRandomType = "System.Random";
+
+    /// <summary>
+    /// KEEN030: System.Random usage detected.
+    /// </summary>
+    public static readonly DiagnosticDescriptor RandomUsageDetected = new(
+        id: "KEEN030",
+        title: "Avoid using System.Random directly",
+        messageFormat: "Avoid using System.Random directly; use World.NextInt(), World.NextFloat(), World.NextDouble(), or World.NextBool() instead for deterministic random number generation",
+        category: "KeenEyes.Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "In an ECS architecture, random number generation should be centralized through the World instance. " +
+                     "This ensures deterministic behavior for replays, testing, and debugging. Each World maintains its " +
+                     "own random state that can be seeded for reproducibility. Use world.NextInt(), world.NextFloat(), " +
+                     "world.NextDouble(), or world.NextBool() instead of creating Random instances directly.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(RandomUsageDetected);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Detect new Random() object creation
+        context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
+
+        // Detect field declarations of type Random
+        context.RegisterSymbolAction(AnalyzeFieldDeclaration, SymbolKind.Field);
+
+        // Detect parameters of type Random
+        context.RegisterSymbolAction(AnalyzeParameterDeclaration, SymbolKind.Parameter);
+    }
+
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context)
+    {
+        var objectCreation = (IObjectCreationOperation)context.Operation;
+
+        if (objectCreation.Type is INamedTypeSymbol typeSymbol &&
+            typeSymbol.ToDisplayString() == SystemRandomType)
+        {
+            // Skip object creation in the World class itself (it legitimately uses Random)
+            var containingType = GetContainingType(context.Operation);
+            if (IsWorldClass(containingType))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                RandomUsageDetected,
+                objectCreation.Syntax.GetLocation()));
+        }
+    }
+
+    private static INamedTypeSymbol? GetContainingType(IOperation operation)
+    {
+        // Walk up the containing symbols to find the type
+        var symbol = operation.SemanticModel?.GetEnclosingSymbol(operation.Syntax.SpanStart);
+        while (symbol != null)
+        {
+            if (symbol is INamedTypeSymbol namedType)
+            {
+                return namedType;
+            }
+
+            symbol = symbol.ContainingSymbol;
+        }
+
+        return null;
+    }
+
+    private static void AnalyzeFieldDeclaration(SymbolAnalysisContext context)
+    {
+        var fieldSymbol = (IFieldSymbol)context.Symbol;
+
+        // Skip compiler-generated fields
+        if (fieldSymbol.IsImplicitlyDeclared)
+        {
+            return;
+        }
+
+        // Skip fields in the World class itself (it legitimately uses Random)
+        if (IsWorldClass(fieldSymbol.ContainingType))
+        {
+            return;
+        }
+
+        if (fieldSymbol.Type.ToDisplayString() == SystemRandomType)
+        {
+            var location = fieldSymbol.Locations.FirstOrDefault();
+            if (location != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    RandomUsageDetected,
+                    location));
+            }
+        }
+    }
+
+    private static void AnalyzeParameterDeclaration(SymbolAnalysisContext context)
+    {
+        var parameterSymbol = (IParameterSymbol)context.Symbol;
+
+        // Skip parameters in the World class itself
+        if (IsWorldClass(parameterSymbol.ContainingType))
+        {
+            return;
+        }
+
+        if (parameterSymbol.Type.ToDisplayString() == SystemRandomType)
+        {
+            var location = parameterSymbol.Locations.FirstOrDefault();
+            if (location != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    RandomUsageDetected,
+                    location));
+            }
+        }
+    }
+
+    private static bool IsWorldClass(INamedTypeSymbol? typeSymbol)
+    {
+        if (typeSymbol == null)
+        {
+            return false;
+        }
+
+        // Check if this is the KeenEyes.World class
+        return typeSymbol.ToDisplayString() == "KeenEyes.World";
+    }
+}

--- a/tests/KeenEyes.Generators.Tests/RandomClassAnalyzerTests.cs
+++ b/tests/KeenEyes.Generators.Tests/RandomClassAnalyzerTests.cs
@@ -1,0 +1,386 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Tests for the RandomClassAnalyzer diagnostic analyzer.
+/// </summary>
+public class RandomClassAnalyzerTests
+{
+    #region KEEN030: Object Creation
+
+    [Fact]
+    public void NewRandomDefault_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething()
+                {
+                    var rng = new System.Random();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("World.NextInt()", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void NewRandomWithSeed_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething()
+                {
+                    var rng = new System.Random(42);
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void NewRandomUsingDirective_ReportsWarning()
+    {
+        var source = """
+            using System;
+
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething()
+                {
+                    var rng = new Random();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void NewRandomInFieldInitializer_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private readonly System.Random _random = new System.Random();
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        // Should report both field declaration AND object creation
+        Assert.Contains(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    #endregion
+
+    #region KEEN030: Field Declarations
+
+    [Fact]
+    public void FieldOfTypeRandom_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private System.Random _random;
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void StaticFieldOfTypeRandom_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private static System.Random SharedRandom;
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void ReadonlyFieldOfTypeRandom_ReportsWarning()
+    {
+        var source = """
+            using System;
+
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private readonly Random _random;
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    #endregion
+
+    #region KEEN030: Parameter Declarations
+
+    [Fact]
+    public void ParameterOfTypeRandom_ReportsWarning()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething(System.Random random)
+                {
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN030");
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void MultipleParametersWithRandom_ReportsWarning()
+    {
+        var source = """
+            using System;
+
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething(Random random1, int x, Random random2)
+                {
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.Equal(2, diagnostics.Count(d => d.Id == "KEEN030"));
+    }
+
+    #endregion
+
+    #region World Class Exclusion
+
+    [Fact]
+    public void RandomFieldInWorldClass_NoWarning()
+    {
+        var source = """
+            namespace KeenEyes;
+
+            public sealed partial class World
+            {
+                private readonly System.Random random;
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    [Fact]
+    public void RandomParameterInWorldClass_NoWarning()
+    {
+        var source = """
+            namespace KeenEyes;
+
+            public sealed partial class World
+            {
+                public void Initialize(System.Random random)
+                {
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    #endregion
+
+    #region No False Positives
+
+    [Fact]
+    public void NoRandomUsage_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private int _value;
+
+                public void DoSomething()
+                {
+                    var x = 42;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    [Fact]
+    public void OtherRandomClass_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class Random
+            {
+                public int Next() => 42;
+            }
+
+            public class TestClass
+            {
+                private Random _random;
+
+                public void DoSomething()
+                {
+                    var rng = new Random();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        // Custom Random class in different namespace should not trigger warning
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    [Fact]
+    public void UsingWorldNextMethods_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void DoSomething(KeenEyes.World world)
+                {
+                    var value = world.NextInt(100);
+                    var flag = world.NextBool();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN030");
+    }
+
+    #endregion
+
+    #region Multiple Violations
+
+    [Fact]
+    public void MultipleRandomUsages_ReportsAll()
+    {
+        var source = """
+            using System;
+
+            namespace TestApp;
+
+            public class TestClass
+            {
+                private Random _field1;
+                private Random _field2;
+
+                public void DoSomething(Random param)
+                {
+                    var local = new Random();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        // Should detect: 2 fields + 1 parameter + 1 object creation = 4
+        Assert.Equal(4, diagnostics.Count(d => d.Id == "KEEN030"));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static IReadOnlyList<Diagnostic> RunAnalyzer(string source)
+    {
+        var coreAssembly = typeof(KeenEyes.World).Assembly;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(coreAssembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new RandomClassAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var diagnostics = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+
+        return diagnostics.ToList();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Adds a new Roslyn analyzer that warns when System.Random is used directly, suggesting World.NextInt(), World.NextFloat(), World.NextDouble(), or World.NextBool() instead. This ensures deterministic random number generation through the World instance for replays, testing, and debugging.

The analyzer detects:
- Object creation: new Random()
- Field declarations of type System.Random
- Parameter declarations of type System.Random

The KeenEyes.World class is excluded since it legitimately uses Random internally.