### PR TITLE
feat: Add dotnet project templates for KeenEyes ECS

### DIFF
--- a/KeenEyes.sln
+++ b/KeenEyes.sln
@@ -100,6 +100,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeenEyes.Sample.Relationshi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeenEyes.Sample.RenderingCulling", "samples\KeenEyes.Sample.RenderingCulling\KeenEyes.Sample.RenderingCulling.csproj", "{3BC92FB3-9D4E-761B-45DC-2C09DF436441}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{808186BE-9BD0-DD1D-D574-36EEAD1E7F8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeenEyes.Templates", "templates\KeenEyes.Templates\KeenEyes.Templates.csproj", "{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -506,6 +510,18 @@ Global
 		{3BC92FB3-9D4E-761B-45DC-2C09DF436441}.Release|x64.Build.0 = Release|Any CPU
 		{3BC92FB3-9D4E-761B-45DC-2C09DF436441}.Release|x86.ActiveCfg = Release|Any CPU
 		{3BC92FB3-9D4E-761B-45DC-2C09DF436441}.Release|x86.Build.0 = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|x64.Build.0 = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -545,6 +561,7 @@ Global
 		{1CC6011D-E028-B874-0543-807D7A6E65C8} = {F6789012-CDEF-1234-5678-901234567890}
 		{3FCED8E7-F64B-A274-07C9-57AF03437450} = {F6789012-CDEF-1234-5678-901234567890}
 		{3BC92FB3-9D4E-761B-45DC-2C09DF436441} = {F6789012-CDEF-1234-5678-901234567890}
+		{3C15B4AD-EFA4-40B8-BDCB-0E9FBE6CFD4A} = {808186BE-9BD0-DD1D-D574-36EEAD1E7F8F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {074345D4-2E9C-4743-8915-67A2DA09075C}

--- a/templates/Directory.Build.props
+++ b/templates/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <!--
+    Override root Directory.Build.props for template content.
+    Template source files should not inherit the main build settings
+    since they are template content, not actual buildable projects.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    <!-- Disable Husky hooks for template projects -->
+    <HUSKY>0</HUSKY>
+  </PropertyGroup>
+</Project>

--- a/templates/Directory.Build.targets
+++ b/templates/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!--
+    Override root Directory.Build.targets for templates folder.
+    Templates don't need Husky hooks or tool restore.
+  -->
+</Project>

--- a/templates/KeenEyes.Templates/KeenEyes.Templates.csproj
+++ b/templates/KeenEyes.Templates/KeenEyes.Templates.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageId>KeenEyes.Templates</PackageId>
+    <Title>KeenEyes ECS Templates</Title>
+    <Description>Project templates for the KeenEyes Entity Component System framework. Includes templates for games and plugins.</Description>
+    <PackageTags>dotnet-new;templates;ecs;entity;component;system;game;framework;keeneyes</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="../keeneyes-game/**/*" Exclude="../keeneyes-game/**/bin/**;..keeneyes-game/**/obj/**" />
+    <Content Include="../keeneyes-plugin/**/*" Exclude="../keeneyes-plugin/**/bin/**;../keeneyes-plugin/**/obj/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/templates/KeenEyes.Templates/README.md
+++ b/templates/KeenEyes.Templates/README.md
@@ -1,0 +1,71 @@
+# KeenEyes ECS Templates
+
+Project templates for the [KeenEyes ECS](https://github.com/orion-ecs/keen-eye) framework.
+
+## Installation
+
+```bash
+dotnet new install KeenEyes.Templates
+```
+
+## Available Templates
+
+| Template | Short Name | Description |
+|----------|------------|-------------|
+| KeenEyes Game | `keeneyes-game` | Console application for building games with KeenEyes ECS |
+| KeenEyes Plugin | `keeneyes-plugin` | Class library for creating KeenEyes plugins |
+
+## Usage
+
+### Create a Game Project
+
+```bash
+dotnet new keeneyes-game -n MyGame
+cd MyGame
+dotnet run
+```
+
+### Create a Plugin Project
+
+```bash
+dotnet new keeneyes-plugin -n MyPlugin
+cd MyPlugin
+dotnet build
+```
+
+#### Plugin Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--IncludeCommon` | Include reference to KeenEyes.Common for shared components | `false` |
+
+```bash
+# Include KeenEyes.Common for shared components like Transform2D, Velocity2D
+dotnet new keeneyes-plugin -n MyPlugin --IncludeCommon
+```
+
+## Template Contents
+
+### Game Template (`keeneyes-game`)
+
+- `Program.cs` - Entry point with game loop
+- `Components.cs` - Example component definitions
+- `Systems.cs` - Example system implementations
+
+### Plugin Template (`keeneyes-plugin`)
+
+- `Plugin.cs` - Plugin class implementing `IWorldPlugin`
+- `Components.cs` - Example plugin components
+- `Systems.cs` - Example plugin systems
+- `CommonComponents.cs` - Systems using KeenEyes.Common (only with `--IncludeCommon`)
+
+## Uninstallation
+
+```bash
+dotnet new uninstall KeenEyes.Templates
+```
+
+## Learn More
+
+- [KeenEyes Documentation](https://github.com/orion-ecs/keen-eye)
+- [ECS Architecture Overview](https://github.com/orion-ecs/keen-eye/blob/main/CLAUDE.md)

--- a/templates/keeneyes-game/.template.config/template.json
+++ b/templates/keeneyes-game/.template.config/template.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "orion-ecs",
+  "classifications": [
+    "Console",
+    "ECS",
+    "Game"
+  ],
+  "identity": "KeenEyes.Templates.Game",
+  "name": "KeenEyes Game",
+  "shortName": "keeneyes-game",
+  "description": "A console application template for building games with the KeenEyes ECS framework",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "KeenEyesGame",
+  "preferNameDirectory": true,
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10.0"
+        }
+      ],
+      "replaces": "net10.0",
+      "defaultValue": "net10.0"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "KeenEyesGame.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Program.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/keeneyes-game/Components.cs
+++ b/templates/keeneyes-game/Components.cs
@@ -1,0 +1,39 @@
+namespace KeenEyesGame;
+
+/// <summary>
+/// Position in 2D space.
+/// </summary>
+[Component]
+public partial struct Position
+{
+    /// <summary>X coordinate.</summary>
+    public float X;
+
+    /// <summary>Y coordinate.</summary>
+    public float Y;
+}
+
+/// <summary>
+/// Velocity for movement.
+/// </summary>
+[Component]
+public partial struct Velocity
+{
+    /// <summary>X velocity component.</summary>
+    public float X;
+
+    /// <summary>Y velocity component.</summary>
+    public float Y;
+}
+
+/// <summary>
+/// Marks an entity as player-controlled.
+/// </summary>
+[TagComponent]
+public partial struct Player;
+
+/// <summary>
+/// Marks an entity as an enemy.
+/// </summary>
+[TagComponent]
+public partial struct Enemy;

--- a/templates/keeneyes-game/KeenEyesGame.csproj
+++ b/templates/keeneyes-game/KeenEyesGame.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KeenEyes.Core" Version="0.1.0" />
+    <PackageReference Include="KeenEyes.Generators" Version="0.1.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/templates/keeneyes-game/Program.cs
+++ b/templates/keeneyes-game/Program.cs
@@ -1,0 +1,41 @@
+using KeenEyes;
+using KeenEyesGame;
+
+// Create the world
+using var world = new World();
+
+// Register systems
+world
+    .AddSystem<MovementSystem>()
+    .AddSystem<RenderSystem>();
+
+// Create entities with the fluent builder API
+var player = world.Spawn()
+    .WithPosition(x: 0, y: 0)
+    .WithVelocity(x: 1, y: 0)
+    .WithPlayer()
+    .Build();
+
+Console.WriteLine($"Created player: {player}");
+
+// Create some enemies
+for (int i = 0; i < 3; i++)
+{
+    world.Spawn()
+        .WithPosition(x: i * 10, y: i * 5)
+        .WithVelocity(x: -0.5f, y: 0)
+        .WithEnemy()
+        .Build();
+}
+
+Console.WriteLine($"Total entities: {world.EntityCount}");
+
+// Run game loop
+const float deltaTime = 1f / 60f;
+for (int frame = 0; frame < 5; frame++)
+{
+    Console.WriteLine($"\n--- Frame {frame + 1} ---");
+    world.Update(deltaTime);
+}
+
+Console.WriteLine("\nGame finished!");

--- a/templates/keeneyes-game/Systems.cs
+++ b/templates/keeneyes-game/Systems.cs
@@ -1,0 +1,40 @@
+using KeenEyes;
+
+namespace KeenEyesGame;
+
+/// <summary>
+/// Moves entities by applying velocity to position.
+/// </summary>
+[System(Phase = SystemPhase.Update, Order = 0)]
+public partial class MovementSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Position, Velocity>())
+        {
+            ref var pos = ref World.Get<Position>(entity);
+            ref readonly var vel = ref World.Get<Velocity>(entity);
+
+            pos.X += vel.X * deltaTime;
+            pos.Y += vel.Y * deltaTime;
+        }
+    }
+}
+
+/// <summary>
+/// Renders entities (placeholder for actual rendering logic).
+/// </summary>
+[System(Phase = SystemPhase.Render, Order = 0)]
+public partial class RenderSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Position>())
+        {
+            ref readonly var pos = ref World.Get<Position>(entity);
+            Console.WriteLine($"  Render {entity} at ({pos.X:F2}, {pos.Y:F2})");
+        }
+    }
+}

--- a/templates/keeneyes-plugin/.template.config/template.json
+++ b/templates/keeneyes-plugin/.template.config/template.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "orion-ecs",
+  "classifications": [
+    "Library",
+    "ECS",
+    "Plugin"
+  ],
+  "identity": "KeenEyes.Templates.Plugin",
+  "name": "KeenEyes Plugin",
+  "shortName": "keeneyes-plugin",
+  "description": "A class library template for creating plugins for the KeenEyes ECS framework",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "KeenEyesPlugin",
+  "preferNameDirectory": true,
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10.0"
+        }
+      ],
+      "replaces": "net10.0",
+      "defaultValue": "net10.0"
+    },
+    "IncludeCommon": {
+      "type": "parameter",
+      "description": "Include reference to KeenEyes.Common for shared components (Transform, Velocity, etc.)",
+      "datatype": "bool",
+      "defaultValue": "false"
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!IncludeCommon)",
+          "exclude": [
+            "CommonComponents.cs"
+          ]
+        }
+      ]
+    }
+  ],
+  "primaryOutputs": [
+    {
+      "path": "KeenEyesPlugin.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Plugin.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/keeneyes-plugin/CommonComponents.cs
+++ b/templates/keeneyes-plugin/CommonComponents.cs
@@ -1,0 +1,28 @@
+using KeenEyes.Common;
+
+namespace KeenEyesPlugin;
+
+/// <summary>
+/// Example system that uses common components from KeenEyes.Common.
+/// </summary>
+/// <remarks>
+/// This file is only included when the --IncludeCommon option is specified.
+/// KeenEyes.Common provides ready-to-use components like Transform2D, Velocity2D, etc.
+/// </remarks>
+[System(Phase = SystemPhase.Update, Order = 10)]
+public partial class CommonComponentSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Process entities with Transform2D and Velocity2D from KeenEyes.Common
+        foreach (var entity in World.Query<Transform2D, Velocity2D>())
+        {
+            ref var transform = ref World.Get<Transform2D>(entity);
+            ref readonly var velocity = ref World.Get<Velocity2D>(entity);
+
+            transform.Position.X += velocity.X * deltaTime;
+            transform.Position.Y += velocity.Y * deltaTime;
+        }
+    }
+}

--- a/templates/keeneyes-plugin/Components.cs
+++ b/templates/keeneyes-plugin/Components.cs
@@ -1,0 +1,25 @@
+namespace KeenEyesPlugin;
+
+/// <summary>
+/// Example component for the plugin.
+/// </summary>
+/// <remarks>
+/// Components should be pure data with no logic.
+/// Use the [Component] attribute to generate fluent builder methods.
+/// </remarks>
+[Component]
+public partial struct ExampleComponent
+{
+    /// <summary>Example value.</summary>
+    public int Value;
+}
+
+/// <summary>
+/// Example tag component for filtering entities.
+/// </summary>
+/// <remarks>
+/// Tag components are zero-size markers used for filtering queries.
+/// They generate parameterless builder methods.
+/// </remarks>
+[TagComponent]
+public partial struct ExampleTag;

--- a/templates/keeneyes-plugin/KeenEyesPlugin.csproj
+++ b/templates/keeneyes-plugin/KeenEyesPlugin.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KeenEyes.Abstractions" Version="0.1.0" />
+    <!--#if (IncludeCommon)-->
+    <PackageReference Include="KeenEyes.Common" Version="0.1.0" />
+    <!--#endif-->
+    <PackageReference Include="KeenEyes.Generators" Version="0.1.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/templates/keeneyes-plugin/Plugin.cs
+++ b/templates/keeneyes-plugin/Plugin.cs
@@ -1,0 +1,49 @@
+using KeenEyes;
+
+namespace KeenEyesPlugin;
+
+/// <summary>
+/// Example plugin that provides custom functionality.
+/// </summary>
+/// <remarks>
+/// Plugins encapsulate related systems, components, and extensions.
+/// They are installed per-world, maintaining isolation between worlds.
+/// </remarks>
+public class KeenEyesPluginPlugin : IWorldPlugin
+{
+    /// <inheritdoc />
+    public string Name => "KeenEyesPlugin";
+
+    /// <inheritdoc />
+    public void Install(IPluginContext context)
+    {
+        // Register systems through the context (tracked for auto-cleanup)
+        context.AddSystem<ExampleSystem>(SystemPhase.Update, order: 0);
+
+        // Expose an extension API for application code
+        context.SetExtension(new PluginExtension());
+    }
+
+    /// <inheritdoc />
+    public void Uninstall(IPluginContext context)
+    {
+        // Remove our extension (systems are auto-removed)
+        context.RemoveExtension<PluginExtension>();
+    }
+}
+
+/// <summary>
+/// Extension class that the plugin exposes to application code.
+/// </summary>
+/// <remarks>
+/// Extensions allow plugins to provide custom APIs accessible via World.GetExtension&lt;T&gt;().
+/// The [PluginExtension] attribute generates a typed property on World for convenient access.
+/// </remarks>
+[PluginExtension("KeenEyesPluginExtension")]
+public sealed class PluginExtension
+{
+    /// <summary>
+    /// Example property that application code can access.
+    /// </summary>
+    public int ExampleValue { get; set; }
+}

--- a/templates/keeneyes-plugin/Systems.cs
+++ b/templates/keeneyes-plugin/Systems.cs
@@ -1,0 +1,24 @@
+using KeenEyes;
+
+namespace KeenEyesPlugin;
+
+/// <summary>
+/// Example system that processes entities with ExampleComponent.
+/// </summary>
+/// <remarks>
+/// Systems contain logic and process entities that match their queries.
+/// Use the [System] attribute to specify phase and ordering.
+/// </remarks>
+[System(Phase = SystemPhase.Update, Order = 0)]
+public partial class ExampleSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<ExampleComponent>().With<ExampleTag>())
+        {
+            ref var component = ref World.Get<ExampleComponent>(entity);
+            component.Value++;
+        }
+    }
+}


### PR DESCRIPTION
Add two dotnet templates for easier project setup:

- `keeneyes-game`: Console application template with KeenEyes.Core and Generators. Includes sample components, systems, and a basic game loop.

- `keeneyes-plugin`: Class library template for creating KeenEyes plugins with Abstractions and Generators. Includes `--IncludeCommon` option to add KeenEyes.Common package reference.

Templates are packaged via KeenEyes.Templates NuGet package.

Installation:
  dotnet new install KeenEyes.Templates

Usage:
  dotnet new keeneyes-game -n MyGame
  dotnet new keeneyes-plugin -n MyPlugin
  dotnet new keeneyes-plugin -n MyPlugin --IncludeCommon

Closes #179