### PR TITLE
feat: Add float extension methods for tolerance-based equality compar…

### DIFF
--- a/src/KeenEyes.Common/FloatExtensions.cs
+++ b/src/KeenEyes.Common/FloatExtensions.cs
@@ -1,0 +1,108 @@
+using System;
+
+namespace KeenEyes.Common;
+
+/// <summary>
+/// Extension methods for <see cref="float"/> providing tolerance-based comparisons.
+/// </summary>
+/// <remarks>
+/// Direct equality comparisons (==) with floating-point numbers can be unreliable due to
+/// precision issues. These methods provide well-established idioms for comparing floats
+/// using a small tolerance (epsilon).
+/// </remarks>
+public static class FloatExtensions
+{
+    /// <summary>
+    /// Default epsilon value for float comparisons.
+    /// </summary>
+    /// <remarks>
+    /// This value (1e-6f) is suitable for most game development scenarios.
+    /// For specific use cases requiring different precision, use the overload
+    /// that accepts a custom epsilon.
+    /// </remarks>
+    public const float DefaultEpsilon = 1e-6f;
+
+    /// <summary>
+    /// Determines whether the float value is approximately zero within the default tolerance.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns><c>true</c> if the absolute value is less than <see cref="DefaultEpsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// float threshold = 0.0000001f;
+    /// if (threshold.IsApproximatelyZero())
+    /// {
+    ///     // Treat as zero
+    /// }
+    /// </code>
+    /// </example>
+    public static bool IsApproximatelyZero(this float value)
+    {
+        return Math.Abs(value) < DefaultEpsilon;
+    }
+
+    /// <summary>
+    /// Determines whether the float value is approximately zero within the specified tolerance.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="epsilon">The tolerance for the comparison. Must be positive.</param>
+    /// <returns><c>true</c> if the absolute value is less than <paramref name="epsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// float threshold = 0.0001f;
+    /// const float customEpsilon = 1e-3f;
+    /// if (threshold.IsApproximatelyZero(customEpsilon))
+    /// {
+    ///     // Treat as zero with custom precision
+    /// }
+    /// </code>
+    /// </example>
+    public static bool IsApproximatelyZero(this float value, float epsilon)
+    {
+        return Math.Abs(value) < epsilon;
+    }
+
+    /// <summary>
+    /// Determines whether two float values are approximately equal within the default tolerance.
+    /// </summary>
+    /// <param name="value">The first value to compare.</param>
+    /// <param name="other">The second value to compare.</param>
+    /// <returns><c>true</c> if the absolute difference is less than <see cref="DefaultEpsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// float a = 1.0f;
+    /// float b = 1.0000001f;
+    /// if (a.ApproximatelyEquals(b))
+    /// {
+    ///     // Values are considered equal
+    /// }
+    /// </code>
+    /// </example>
+    public static bool ApproximatelyEquals(this float value, float other)
+    {
+        return Math.Abs(value - other) < DefaultEpsilon;
+    }
+
+    /// <summary>
+    /// Determines whether two float values are approximately equal within the specified tolerance.
+    /// </summary>
+    /// <param name="value">The first value to compare.</param>
+    /// <param name="other">The second value to compare.</param>
+    /// <param name="epsilon">The tolerance for the comparison. Must be positive.</param>
+    /// <returns><c>true</c> if the absolute difference is less than <paramref name="epsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// float a = 1.0f;
+    /// float b = 1.001f;
+    /// const float customEpsilon = 0.01f;
+    /// if (a.ApproximatelyEquals(b, customEpsilon))
+    /// {
+    ///     // Values are considered equal with custom precision
+    /// }
+    /// </code>
+    /// </example>
+    public static bool ApproximatelyEquals(this float value, float other, float epsilon)
+    {
+        return Math.Abs(value - other) < epsilon;
+    }
+}

--- a/tests/KeenEyes.Common.Tests/FloatExtensionsTests.cs
+++ b/tests/KeenEyes.Common.Tests/FloatExtensionsTests.cs
@@ -1,0 +1,227 @@
+namespace KeenEyes.Common.Tests;
+
+/// <summary>
+/// Tests for the <see cref="FloatExtensions"/> class.
+/// </summary>
+public class FloatExtensionsTests
+{
+    #region IsApproximatelyZero Tests
+
+    [Fact]
+    public void IsApproximatelyZero_WithExactZero_ReturnsTrue()
+    {
+        float value = 0f;
+
+        Assert.True(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithVerySmallPositive_ReturnsTrue()
+    {
+        float value = 1e-7f;
+
+        Assert.True(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithVerySmallNegative_ReturnsTrue()
+    {
+        float value = -1e-7f;
+
+        Assert.True(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithValueAtEpsilon_ReturnsFalse()
+    {
+        float value = FloatExtensions.DefaultEpsilon;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithLargeValue_ReturnsFalse()
+    {
+        float value = 1.0f;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithLargeNegativeValue_ReturnsFalse()
+    {
+        float value = -1.0f;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithCustomEpsilon_UsesCustomTolerance()
+    {
+        float value = 0.005f;
+        float customEpsilon = 0.01f;
+
+        Assert.True(value.IsApproximatelyZero(customEpsilon));
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithCustomEpsilon_RejectsLargerValues()
+    {
+        float value = 0.02f;
+        float customEpsilon = 0.01f;
+
+        Assert.False(value.IsApproximatelyZero(customEpsilon));
+    }
+
+    #endregion
+
+    #region ApproximatelyEquals Tests
+
+    [Fact]
+    public void ApproximatelyEquals_WithIdenticalValues_ReturnsTrue()
+    {
+        float a = 1.0f;
+        float b = 1.0f;
+
+        Assert.True(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithVeryCloseValues_ReturnsTrue()
+    {
+        float a = 1.0f;
+        float b = 1.0000001f;
+
+        Assert.True(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithDifferentValues_ReturnsFalse()
+    {
+        float a = 1.0f;
+        float b = 2.0f;
+
+        Assert.False(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithNegativeValues_ReturnsTrue()
+    {
+        float a = -1.0f;
+        float b = -1.0000001f;
+
+        Assert.True(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithOppositeSignsNearZero_ReturnsFalse()
+    {
+        float a = FloatExtensions.DefaultEpsilon;
+        float b = -FloatExtensions.DefaultEpsilon;
+
+        Assert.False(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_IsSymmetric()
+    {
+        float a = 1.0f;
+        float b = 1.0000001f;
+
+        Assert.Equal(a.ApproximatelyEquals(b), b.ApproximatelyEquals(a));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithCustomEpsilon_UsesCustomTolerance()
+    {
+        float a = 1.0f;
+        float b = 1.005f;
+        float customEpsilon = 0.01f;
+
+        Assert.True(a.ApproximatelyEquals(b, customEpsilon));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithCustomEpsilon_RejectsLargerDifferences()
+    {
+        float a = 1.0f;
+        float b = 1.02f;
+        float customEpsilon = 0.01f;
+
+        Assert.False(a.ApproximatelyEquals(b, customEpsilon));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithZeroValues_ReturnsTrue()
+    {
+        float a = 0f;
+        float b = 0f;
+
+        Assert.True(a.ApproximatelyEquals(b));
+    }
+
+    #endregion
+
+    #region DefaultEpsilon Tests
+
+    [Fact]
+    public void DefaultEpsilon_HasExpectedValue()
+    {
+        Assert.Equal(1e-6f, FloatExtensions.DefaultEpsilon);
+    }
+
+    [Fact]
+    public void DefaultEpsilon_IsPositive()
+    {
+        Assert.True(FloatExtensions.DefaultEpsilon > 0);
+    }
+
+    #endregion
+
+    #region Edge Case Tests
+
+    [Fact]
+    public void IsApproximatelyZero_WithPositiveInfinity_ReturnsFalse()
+    {
+        float value = float.PositiveInfinity;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithNegativeInfinity_ReturnsFalse()
+    {
+        float value = float.NegativeInfinity;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void IsApproximatelyZero_WithNaN_ReturnsFalse()
+    {
+        float value = float.NaN;
+
+        Assert.False(value.IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithInfinities_ReturnsFalse()
+    {
+        float a = float.PositiveInfinity;
+        float b = float.PositiveInfinity;
+
+        // Infinity - Infinity = NaN, which is not less than epsilon
+        Assert.False(a.ApproximatelyEquals(b));
+    }
+
+    [Fact]
+    public void ApproximatelyEquals_WithNaN_ReturnsFalse()
+    {
+        float a = float.NaN;
+        float b = 0f;
+
+        Assert.False(a.ApproximatelyEquals(b));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
…isons

Add FloatExtensions class with methods for comparing floating-point numbers using epsilon tolerance, addressing the well-known issue of direct equality checks (==) being unreliable due to floating-point precision limitations.

Methods added:
- IsApproximatelyZero(): Check if value is close to zero
- IsApproximatelyZero(epsilon): Check with custom tolerance
- ApproximatelyEquals(other): Compare two floats for near-equality
- ApproximatelyEquals(other, epsilon): Compare with custom tolerance

Default epsilon is 1e-6f, suitable for most game development scenarios.