### PR TITLE
fix: Fix SessionStart hooks for reliable package installation

### DIFF
--- a/.claude/hooks/install-packages.sh
+++ b/.claude/hooks/install-packages.sh
@@ -103,6 +103,10 @@ done
 # These are needed for husky and other tooling
 download_pkg "husky" "0.8.0"
 
+# AOT compiler runtime packages (not in packages.lock.json, resolved at restore time)
+download_pkg "runtime.linux-x64.Microsoft.DotNet.ILCompiler" "10.0.1"
+download_pkg "Microsoft.DotNet.ILCompiler" "10.0.1"
+
 # Clean up
 rm -f "$PACKAGES_FILE"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,15 +6,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install-dotnet.sh"
+            "command": "./scripts/install-dotnet.sh"
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install-hooks.sh"
+            "command": "./scripts/install-hooks.sh"
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/install-packages.sh"
+            "command": "./.claude/hooks/install-packages.sh"
           }
         ]
       },
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/resume-dotnet.sh"
+            "command": "./scripts/resume-dotnet.sh"
           }
         ]
       }


### PR DESCRIPTION
- Use relative paths (./scripts/...) instead of $CLAUDE_PROJECT_DIR which wasn't expanding correctly during hook execution
- Add runtime.linux-x64.Microsoft.DotNet.ILCompiler package to install script (required for AOT compilation, not in lock files)