### PR TITLE
fix: Use proper archetype migration in SetComponent to preserve entit…

### DIFF
--- a/src/KeenEyes.Core/Serialization/DeltaRestorer.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaRestorer.cs
@@ -278,14 +278,8 @@ public static class DeltaRestorer
                 }
             }
 
-            // SetComponent may return a new entity if archetype migration occurs
-            var newEntity = world.SetComponent(entity, info, value);
-            if (newEntity.Id != entity.Id)
-            {
-                // Update entity map with the new entity
-                entityMap[delta.EntityId] = newEntity;
-                entity = newEntity;
-            }
+            // SetComponent handles archetype migration while preserving entity ID
+            world.SetComponent(entity, info, value);
         }
 
         // Update modified components
@@ -306,14 +300,8 @@ public static class DeltaRestorer
             var value = serializer.Deserialize(modified.TypeName, modified.Data.Value);
             if (value is not null)
             {
-                // SetComponent may return a new entity if archetype migration occurs
-                var newEntity = world.SetComponent(entity, info, value);
-                if (newEntity.Id != entity.Id)
-                {
-                    // Update entity map with the new entity
-                    entityMap[delta.EntityId] = newEntity;
-                    entity = newEntity;
-                }
+                // SetComponent handles archetype migration while preserving entity ID
+                world.SetComponent(entity, info, value);
             }
         }
     }

--- a/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
+++ b/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
@@ -803,14 +803,11 @@ public class AutoSaveSystemTests : IDisposable
         };
 
         // Apply delta
-        var updatedEntityMap = DeltaRestorer.ApplyDelta(world, delta, serializer, entityMap);
+        DeltaRestorer.ApplyDelta(world, delta, serializer, entityMap);
 
-        // Get the updated entity (archetype migration may have created a new entity)
-        var updatedEntity = updatedEntityMap[entity.Id];
-
-        // Verify component was added
-        Assert.True(world.Has<SerializableVelocity>(updatedEntity));
-        ref var velocity = ref world.Get<SerializableVelocity>(updatedEntity);
+        // Verify component was added (entity ID is preserved across archetype migration)
+        Assert.True(world.Has<SerializableVelocity>(entity));
+        ref var velocity = ref world.Get<SerializableVelocity>(entity);
         Assert.Equal(5f, velocity.X);
         Assert.Equal(10f, velocity.Y);
     }


### PR DESCRIPTION
…y IDs

The previous implementation despawned the old entity and spawned a new one when adding components via SetComponent, which changed the entity ID. This broke the ECS contract that entity IDs should be stable across archetype migrations.

Changes:
- Add AddComponentBoxed method to ArchetypeManager for proper migration
- Simplify SetComponent to use AddComponentBoxed instead of despawn/spawn
- Remove unnecessary entity map workaround from DeltaRestorer
- Update test to verify entity ID stability

The entity ID is now preserved during archetype migration, matching the behavior of the generic Add<T> method.