### PR TITLE
refactor: Use pattern matching instead of direct cast in PluginExtens…

### DIFF
--- a/src/KeenEyes.Generators/PluginExtensionGenerator.cs
+++ b/src/KeenEyes.Generators/PluginExtensionGenerator.cs
@@ -71,7 +71,10 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
     private static ExtensionResult GetExtensionResult(GeneratorAttributeSyntaxContext context)
     {
         // Predicate guarantees ClassDeclarationSyntax, which always has INamedTypeSymbol
-        var typeSymbol = (INamedTypeSymbol)context.TargetSymbol;
+        if (context.TargetSymbol is not INamedTypeSymbol typeSymbol)
+        {
+            return new ExtensionResult(null, null);
+        }
 
         // ForAttributeWithMetadataName guarantees the attribute exists
         var attributeData = context.Attributes.First(


### PR DESCRIPTION
…ionGenerator

Replace direct cast with pattern matching for safer and more idiomatic code. While the predicate guarantees the cast would succeed, pattern matching provides defensive coding and aligns with C# best practices.

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)