### PR TITLE
refactor: Remove redundant field assignment in ComponentValidationMan…

### DIFF
--- a/src/KeenEyes.Core/Components/ComponentValidationManager.cs
+++ b/src/KeenEyes.Core/Components/ComponentValidationManager.cs
@@ -33,7 +33,6 @@ public delegate bool ComponentValidator<T>(World world, Entity entity, T compone
 /// <param name="world">The world this manager belongs to.</param>
 internal sealed class ComponentValidationManager(World world)
 {
-    private readonly World world = world;
     private readonly Dictionary<Type, ComponentValidationInfo> validationCache = [];
     private readonly Dictionary<Type, Delegate> customValidators = [];
 


### PR DESCRIPTION
…ager

Primary constructor parameters in C# 12+ are automatically captured, making the explicit field assignment `private readonly World world = world;` redundant. This change removes the unnecessary assignment while maintaining the same functionality.

Fixes #336