### PR TITLE
fix: Generate actual method calls in QueryGenerator instead of comments

### DIFF
--- a/src/KeenEyes.Generators/QueryGenerator.cs
+++ b/src/KeenEyes.Generators/QueryGenerator.cs
@@ -142,7 +142,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
 
             if (methodName is not null)
             {
-                sb.AppendLine($"        // {field.Name}: {field.AccessType}");
+                sb.AppendLine($"        desc.{methodName}<{field.ComponentType}>();");
             }
         }
 

--- a/tests/KeenEyes.Generators.Tests/QueryGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/QueryGeneratorTests.cs
@@ -117,7 +117,7 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Velocity: With"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWith<TestApp.Velocity>()"));
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Frozen: Without"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWithout<TestApp.Frozen>()"));
     }
 
     [Fact]
@@ -195,9 +195,9 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
-        Assert.Contains(generatedTrees, t => t.Contains("// Velocity: Write"));
-        Assert.Contains(generatedTrees, t => t.Contains("// Health: Write"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Position>()"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Velocity>()"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Health>()"));
     }
 
     [Fact]
@@ -240,8 +240,8 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
-        Assert.DoesNotContain(generatedTrees, t => t.Contains("// Counter"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Position>()"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("Counter"));
     }
 
     [Fact]
@@ -265,8 +265,8 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
-        Assert.DoesNotContain(generatedTrees, t => t.Contains("// Version"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Position>()"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("Version"));
     }
 
     [Fact]
@@ -478,10 +478,10 @@ public class QueryGeneratorTests
         var (diagnostics, generatedTrees) = RunGenerator(source);
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(generatedTrees, t => t.Contains("// Position: Write"));
-        Assert.Contains(generatedTrees, t => t.Contains("// Player: With"));
-        Assert.Contains(generatedTrees, t => t.Contains("// Enemy: Without"));
-        // Optional doesn't add comment
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWrite<TestApp.Position>()"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWith<TestApp.Player>()"));
+        Assert.Contains(generatedTrees, t => t.Contains("desc.AddWithout<TestApp.Enemy>()"));
+        // Optional doesn't add method call
     }
 
     private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)


### PR DESCRIPTION
The QueryGenerator was determining which descriptor methods to call (AddRead, AddWrite, AddWith, AddWithout) but only generating comments in the output code instead of actual method invocations. This broke the [Query] attribute functionality as query descriptions had no actual component filters.

Changes:
- QueryGenerator.cs: Changed line 145 to generate actual method calls like desc.AddWrite<ComponentType>() instead of just comments
- QueryGeneratorTests.cs: Updated 6 tests to verify the generated method calls instead of comments

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)