### PR TITLE
fix: Remove redundant field assignments in primary constructors

### DIFF
--- a/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
@@ -19,7 +19,6 @@ namespace KeenEyes;
 /// <param name="chunkPool">Optional chunk pool for chunk reuse. If null, a new pool is created.</param>
 public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkPool? chunkPool = null) : IDisposable
 {
-    private readonly ComponentRegistry componentRegistry = componentRegistry;
     private readonly Dictionary<ArchetypeId, Archetype> archetypes = [];
     private readonly Dictionary<int, (Archetype Archetype, int Index)> entityLocations = [];
     private readonly List<Archetype> archetypeList = [];

--- a/src/KeenEyes.Core/Pooling/ChunkPool.cs
+++ b/src/KeenEyes.Core/Pooling/ChunkPool.cs
@@ -20,7 +20,6 @@ namespace KeenEyes;
 public sealed class ChunkPool(int maxChunksPerArchetype = 64)
 {
     private readonly ConcurrentDictionary<ArchetypeId, ConcurrentStack<ArchetypeChunk>> pools = new();
-    private readonly int maxChunksPerArchetype = maxChunksPerArchetype;
 
     private long totalRented;
     private long totalReturned;


### PR DESCRIPTION
## Description

Removes redundant field assignments in `ArchetypeManager` and `ChunkPool` that duplicate primary constructor parameters. In C# 12+, primary constructor parameters are automatically captured, making explicit field assignments unnecessary.

## Changes

- `ArchetypeManager`: Removed redundant `componentRegistry` field
- `ChunkPool`: Removed redundant `maxChunksPerArchetype` field

Both classes now use primary constructor parameters directly, following modern C# conventions.

## Testing

✅ Build: Passed (0 warnings, 0 errors)
✅ Tests: All 3,183 tests passed
✅ Formatting: Validated

Fixes #329

---

🤖 Generated with [Claude Code](https://claude.ai/code)