### PR TITLE
docs: Add research section to GitHub Pages documentation

### DIFF
--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,0 +1,33 @@
+# Research Reports
+
+This section contains technical research reports for planned features and architectural decisions in KeenEyes ECS.
+
+## Purpose
+
+Research reports document:
+- Evaluation of third-party libraries and approaches
+- Architecture recommendations with trade-off analysis
+- Implementation strategies and phases
+- Integration patterns with existing KeenEyes infrastructure
+
+## Reports
+
+| Topic | Status | Purpose |
+|-------|--------|---------|
+| [Networking](networking.md) | Phase 16.4 | Multiplayer synchronization patterns |
+| [Audio Systems](audio-systems.md) | Research Complete | Cross-platform audio library evaluation |
+| [Asset Loading](asset-loading.md) | Research Complete | Asset pipeline and loading strategies |
+| [Cross-Platform Deployment](cross-platform-deployment.md) | Research Complete | Platform targeting and distribution |
+| [Framework Editor](framework-editor.md) | Research Complete | Editor tooling approaches |
+| [Game Math Libraries](game-math-libraries.md) | Research Complete | Math library evaluation |
+| [OpenGL C# Bindings](opengl-csharp-bindings.md) | Research Complete | Graphics API bindings |
+| [Shader Management](shader-management.md) | Research Complete | Shader compilation and management |
+| [Windowing & Input](windowing-input.md) | Research Complete | Window management and input handling |
+
+## Contributing
+
+When adding new research:
+1. Create a markdown file in `docs/research/`
+2. Follow the existing format (Executive Summary, Comparison, Recommendations)
+3. Add the report to `docs/research/toc.yml`
+4. Update this index page

--- a/docs/research/toc.yml
+++ b/docs/research/toc.yml
@@ -1,0 +1,20 @@
+- name: Overview
+  href: index.md
+- name: Networking
+  href: networking.md
+- name: Audio Systems
+  href: audio-systems.md
+- name: Asset Loading
+  href: asset-loading.md
+- name: Cross-Platform Deployment
+  href: cross-platform-deployment.md
+- name: Framework Editor
+  href: framework-editor.md
+- name: Game Math Libraries
+  href: game-math-libraries.md
+- name: OpenGL C# Bindings
+  href: opengl-csharp-bindings.md
+- name: Shader Management
+  href: shader-management.md
+- name: Windowing & Input
+  href: windowing-input.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -53,3 +53,24 @@
           href: spatial-partitioning/strategy-selection.md
         - name: Performance Tuning
           href: spatial-partitioning/performance-tuning.md
+- name: Research
+  href: research/index.md
+  items:
+    - name: Networking
+      href: research/networking.md
+    - name: Audio Systems
+      href: research/audio-systems.md
+    - name: Asset Loading
+      href: research/asset-loading.md
+    - name: Cross-Platform Deployment
+      href: research/cross-platform-deployment.md
+    - name: Framework Editor
+      href: research/framework-editor.md
+    - name: Game Math Libraries
+      href: research/game-math-libraries.md
+    - name: OpenGL C# Bindings
+      href: research/opengl-csharp-bindings.md
+    - name: Shader Management
+      href: research/shader-management.md
+    - name: Windowing & Input
+      href: research/windowing-input.md


### PR DESCRIPTION
- Add Research section to main navigation (docs/toc.yml)
- Create research/toc.yml for sub-navigation
- Add research/index.md with overview of all research reports
- Networking research is now accessible via GitHub Pages