### PR TITLE
refactor: Extract ToCamelCase helper to shared utility class

### DIFF
--- a/src/KeenEyes.Generators/BundleGenerator.cs
+++ b/src/KeenEyes.Generators/BundleGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -462,19 +463,19 @@ public sealed class BundleGenerator : IIncrementalGenerator
 
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"    /// <param name=\"{paramName}\">The {field.Name} component.</param>");
         }
 
         var constructorParams = string.Join(", ", info.Fields.Select(f =>
-            $"{f.Type} {ToCamelCase(f.Name)}"));
+            $"{f.Type} {StringHelpers.ToCamelCase(f.Name)}"));
 
         sb.AppendLine($"    public {info.Name}({constructorParams})");
         sb.AppendLine("    {");
 
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"        {field.Name} = {paramName};");
         }
 
@@ -571,12 +572,12 @@ public sealed class BundleGenerator : IIncrementalGenerator
 
             foreach (var field in info.Fields)
             {
-                var paramName = ToCamelCase(field.Name);
+                var paramName = StringHelpers.ToCamelCase(field.Name);
                 parameters.Add($"{field.Type} {paramName}");
             }
 
             var paramList = string.Join(", ", parameters);
-            var argList = string.Join(", ", info.Fields.Select(f => ToCamelCase(f.Name)));
+            var argList = string.Join(", ", info.Fields.Select(f => StringHelpers.ToCamelCase(f.Name)));
 
             sb.AppendLine($"    /// <summary>Adds a <see cref=\"{info.FullName}\"/> bundle to the entity.</summary>");
 
@@ -672,19 +673,19 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine("    /// </summary>");
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"    /// <param name=\"{paramName}\">Reference to the {field.Name} component.</param>");
         }
 
         var constructorParams = string.Join(", ", info.Fields.Select(f =>
-            $"ref {f.Type} {ToCamelCase(f.Name)}"));
+            $"ref {f.Type} {StringHelpers.ToCamelCase(f.Name)}"));
 
         sb.AppendLine($"    public {info.Name}Ref({constructorParams})");
         sb.AppendLine("    {");
 
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"        {field.Name} = ref {paramName};");
         }
 
@@ -923,12 +924,12 @@ public sealed class BundleGenerator : IIncrementalGenerator
         var parameters = new List<string>();
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             parameters.Add($"{field.Type} {paramName}");
         }
 
         var paramList = string.Join(", ", parameters);
-        var argList = string.Join(", ", info.Fields.Select(f => ToCamelCase(f.Name)));
+        var argList = string.Join(", ", info.Fields.Select(f => StringHelpers.ToCamelCase(f.Name)));
 
         // XML documentation
         sb.AppendLine("    /// <summary>");
@@ -939,7 +940,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
 
         foreach (var field in info.Fields)
         {
-            var paramName = ToCamelCase(field.Name);
+            var paramName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"    /// <param name=\"{paramName}\">The {field.Name} component.</param>");
         }
 
@@ -1078,21 +1079,6 @@ public sealed class BundleGenerator : IIncrementalGenerator
         }
 
         sb.AppendLine("    }");
-    }
-
-    private static string ToCamelCase(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return name;
-        }
-
-        if (name.Length == 1)
-        {
-            return name.ToLowerInvariant();
-        }
-
-        return char.ToLowerInvariant(name[0]) + name.Substring(1);
     }
 
     private sealed record BundleInfo(

--- a/src/KeenEyes.Generators/ComponentGenerator.cs
+++ b/src/KeenEyes.Generators/ComponentGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -292,7 +293,7 @@ public sealed class ComponentGenerator : IIncrementalGenerator
 
                 foreach (var field in info.Fields)
                 {
-                    var paramName = ToCamelCase(field.Name);
+                    var paramName = StringHelpers.ToCamelCase(field.Name);
                     var defaultExpr = GetDefaultExpression(field);
 
                     if (field.IsRequired || defaultExpr is null)
@@ -383,23 +384,6 @@ public sealed class ComponentGenerator : IIncrementalGenerator
             "char" or "System.Char" => "'\\0'",
             _ => "default"
         };
-    }
-
-    private static string ToCamelCase(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return name;
-        }
-
-        // Handle names like "X", "Y", "Z" - keep them lowercase
-        if (name.Length == 1)
-        {
-            return name.ToLowerInvariant();
-        }
-
-        // Handle PascalCase -> camelCase
-        return char.ToLowerInvariant(name[0]) + name.Substring(1);
     }
 
     private sealed record ComponentInfo(

--- a/src/KeenEyes.Generators/SerializationGenerator.cs
+++ b/src/KeenEyes.Generators/SerializationGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -351,7 +352,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
 
         foreach (var field in component.Fields)
         {
-            var camelFieldName = ToCamelCase(field.Name);
+            var camelFieldName = StringHelpers.ToCamelCase(field.Name);
             sb.AppendLine($"        if (json.TryGetProperty(\"{camelFieldName}\", out var {camelFieldName}Elem))");
             sb.AppendLine("        {");
 
@@ -400,7 +401,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
 
         foreach (var field in component.Fields)
         {
-            var camelFieldName = ToCamelCase(field.Name);
+            var camelFieldName = StringHelpers.ToCamelCase(field.Name);
 
             if (field.JsonTypeName == "Object")
             {
@@ -490,21 +491,6 @@ public sealed class SerializationGenerator : IIncrementalGenerator
                 => $"writer.Write({valueExpr});",
             _ => $"writer.Write(JsonSerializer.Serialize({valueExpr}));" // Complex types as JSON
         };
-    }
-
-    private static string ToCamelCase(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return name;
-        }
-
-        if (name.Length == 1)
-        {
-            return name.ToLowerInvariant();
-        }
-
-        return char.ToLowerInvariant(name[0]) + name.Substring(1);
     }
 
     private sealed record SerializableComponentInfo(

--- a/src/KeenEyes.Generators/Utilities/StringHelpers.cs
+++ b/src/KeenEyes.Generators/Utilities/StringHelpers.cs
@@ -1,0 +1,31 @@
+// Copyright (c) KeenEyes Contributors. Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace KeenEyes.Generators.Utilities;
+
+/// <summary>
+/// Provides string manipulation utilities for source generators.
+/// </summary>
+internal static class StringHelpers
+{
+    /// <summary>
+    /// Converts a PascalCase string to camelCase.
+    /// </summary>
+    /// <param name="value">The string to convert.</param>
+    /// <returns>The camelCase version of the input string.</returns>
+    public static string ToCamelCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        // Handle names like "X", "Y", "Z" - keep them lowercase
+        if (value.Length == 1)
+        {
+            return value.ToLowerInvariant();
+        }
+
+        // Handle PascalCase -> camelCase
+        return char.ToLowerInvariant(value[0]) + value.Substring(1);
+    }
+}


### PR DESCRIPTION
- Created StringHelpers utility class in KeenEyes.Generators/Utilities/
- Removed duplicate ToCamelCase implementations from:
  - ComponentGenerator.cs
  - BundleGenerator.cs
  - SerializationGenerator.cs
- Updated all usages to call StringHelpers.ToCamelCase()

This eliminates code duplication and ensures consistent behavior across all generators.

Fixes #374

🤖 Generated with [Claude Code](https://claude.ai/code)