### PR TITLE
sdk: Add custom MSBuild SDK packages for KeenEyes projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,12 +144,72 @@ keen-eye/
 │   │   ├── Queries/                  # QueryBuilder, QueryEnumerator
 │   │   └── Systems/                  # ISystem, SystemBase
 │   ├── KeenEyes.Generators/           # Source generators
-│   └── KeenEyes.Generators.Attributes/ # Attributes (netstandard2.0)
+│   ├── KeenEyes.Abstractions/         # Interfaces and attributes
+│   ├── KeenEyes.Sdk/                  # MSBuild SDK for games
+│   ├── KeenEyes.Sdk.Plugin/           # MSBuild SDK for plugins
+│   └── KeenEyes.Sdk.Library/          # MSBuild SDK for libraries
 ├── tests/                            # Unit and integration tests
 ├── samples/                          # Example projects
+├── templates/                        # dotnet new templates
 ├── benchmarks/                       # Performance benchmarks
 └── docs/                             # Documentation
 ```
+
+## Custom MSBuild SDK
+
+KeenEyes provides custom MSBuild SDK packages that simplify project setup for consumers and enable future editor integration.
+
+### Why Custom SDKs?
+
+1. **Minimal boilerplate** - New projects need only the SDK reference
+2. **Convention enforcement** - C# 13, nullable, AOT enabled by default
+3. **Version coupling** - SDK version implies compatible package versions
+4. **Editor foundation** - Project detection, metadata, custom item types
+5. **Asset pipeline ready** - Custom ItemGroups for build-time processing
+
+### SDK Packages
+
+| Package | Use Case | Location |
+|---------|----------|----------|
+| `KeenEyes.Sdk` | Games/apps | `src/KeenEyes.Sdk/` |
+| `KeenEyes.Sdk.Plugin` | Plugin libraries | `src/KeenEyes.Sdk.Plugin/` |
+| `KeenEyes.Sdk.Library` | Reusable ECS libraries | `src/KeenEyes.Sdk.Library/` |
+
+### Usage
+
+External consumers use the SDK like this:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <!-- Everything configured automatically -->
+</Project>
+```
+
+This replaces 15+ lines of boilerplate (TFM, LangVersion, package references, etc.).
+
+### Custom ItemGroup Types
+
+The SDK defines item types for future editor integration:
+
+- `<KeenEyesScene>` - Scene files (`.kescene`)
+- `<KeenEyesPrefab>` - Prefab definitions (`.keprefab`)
+- `<KeenEyesAsset>` - Game assets (auto-copied to output)
+- `<KeenEyesWorld>` - World configuration (`.keworld`)
+
+### Project Metadata
+
+Each build generates `keeneyes.project.json` in the output directory with version info, enabling:
+- Editor project detection
+- Version compatibility checking
+- Upgrade path recommendations
+
+### Internal vs External Usage
+
+- **External consumers**: Use `<Project Sdk="KeenEyes.Sdk/0.1.0">`
+- **Monorepo samples**: Continue using `ProjectReference` (not SDK) for local development
+- **Templates**: Updated to use SDK for accurate external consumer experience
+
+See [ADR-006](docs/adr/006-custom-msbuild-sdk.md) and [SDK Documentation](docs/sdk.md) for details.
 
 ## Coding Conventions
 

--- a/docs/adr/006-custom-msbuild-sdk.md
+++ b/docs/adr/006-custom-msbuild-sdk.md
@@ -1,0 +1,236 @@
+# ADR-006: Custom MSBuild SDK for KeenEyes Projects
+
+**Status:** Accepted
+**Date:** 2025-12-18
+
+## Context
+
+External consumers of KeenEyes must currently configure their projects with significant boilerplate:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KeenEyes.Core" Version="0.1.0" />
+    <PackageReference Include="KeenEyes.Generators" Version="0.1.0"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>
+```
+
+This creates several problems:
+
+1. **Error-prone setup** - Forgetting `OutputItemType="Analyzer"` on generators causes silent failures
+2. **Version coupling** - Core and Generators versions must match but are specified separately
+3. **Convention drift** - Users may not enable nullable, AOT compatibility, or C# 13 features
+4. **No tooling hooks** - No standard way to detect KeenEyes projects or their configuration
+5. **Editor integration blocked** - A future visual editor needs to identify and introspect KeenEyes projects
+
+## Decision
+
+Create custom MSBuild SDK packages that encapsulate KeenEyes conventions and dependencies:
+
+### SDK Flavors
+
+| Package | Target Use Case | Default Dependencies |
+|---------|-----------------|---------------------|
+| `KeenEyes.Sdk` | Games and applications | Core + Generators |
+| `KeenEyes.Sdk.Plugin` | Plugin libraries | Abstractions + Generators |
+| `KeenEyes.Sdk.Library` | Reusable ECS libraries | Core + Generators (private) |
+
+### Minimal Project File
+
+With the SDK, a game project becomes:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+</Project>
+```
+
+The SDK automatically:
+- Imports `Microsoft.NET.Sdk` as the base
+- Sets `TargetFramework=net10.0`, `LangVersion=preview`, `Nullable=enable`
+- Sets `OutputType=Exe` (for main SDK) or `Library` (for Plugin/Library SDKs)
+- Enables `IsAotCompatible=true`
+- References appropriate KeenEyes packages with correct attributes
+- Defines custom ItemGroup types for editor integration
+
+### Custom ItemGroups
+
+The SDK defines item types for future editor and build pipeline integration:
+
+```xml
+<!-- Scene definitions -->
+<ItemGroup>
+  <KeenEyesScene Include="Scenes/**/*.kescene" />
+</ItemGroup>
+
+<!-- Prefab templates -->
+<ItemGroup>
+  <KeenEyesPrefab Include="Prefabs/**/*.keprefab" />
+</ItemGroup>
+
+<!-- Game assets (auto-copied to output) -->
+<ItemGroup>
+  <KeenEyesAsset Include="Assets/**/*" />
+</ItemGroup>
+
+<!-- World configuration -->
+<ItemGroup>
+  <KeenEyesWorld Include="Worlds/**/*.keworld" />
+</ItemGroup>
+```
+
+### Project Metadata
+
+The SDK generates `keeneyes.project.json` in the output directory:
+
+```json
+{
+  "projectName": "MyGame",
+  "projectType": "Game",
+  "sdkVersion": "0.1.0",
+  "coreVersion": "0.1.0",
+  "targetFramework": "net10.0",
+  "isAotCompatible": true,
+  "features": ["ECS", "SourceGenerators", "AOT"]
+}
+```
+
+This enables:
+- Editor project detection without loading the full MSBuild graph
+- Version compatibility checking
+- Upgrade path recommendations
+- Feature flag queries
+
+### Version Properties
+
+The SDK exposes version metadata for tooling:
+
+| Property | Description |
+|----------|-------------|
+| `$(KeenEyesSdkVersion)` | SDK package version |
+| `$(KeenEyesCoreVersion)` | KeenEyes.Core version included |
+| `$(KeenEyesMinimumCoreVersion)` | Minimum compatible Core version |
+| `$(KeenEyesProjectType)` | Project type (Game, Plugin, Library) |
+| `$(IsKeenEyesProject)` | Always `true` for SDK projects |
+
+## Alternatives Considered
+
+### Option 1: NuGet Meta-Package Only
+
+Create a single `KeenEyes` package that references Core and Generators:
+
+```xml
+<PackageReference Include="KeenEyes" Version="0.1.0" />
+```
+
+**Rejected because:**
+- Cannot set project properties (TargetFramework, LangVersion, etc.)
+- Cannot define custom ItemGroup types
+- No project metadata generation
+- Generators still need special attributes that meta-packages can't enforce
+
+### Option 2: dotnet new Templates Only
+
+Rely solely on `dotnet new keeneyes-game` templates:
+
+**Rejected because:**
+- Templates are point-in-time snapshots; don't receive updates
+- No version tracking or upgrade tooling
+- Custom ItemGroups would need manual documentation
+- Editor integration still needs project detection
+
+### Option 3: MSBuild Props/Targets Package
+
+Create a package with `.props` and `.targets` files instead of an SDK:
+
+```xml
+<PackageReference Include="KeenEyes.Build" Version="0.1.0" />
+```
+
+**Rejected because:**
+- Users still need to reference Core, Generators separately
+- Props/targets are added to existing SDK, not replacements
+- Cannot override TFM or LangVersion defaults cleanly
+- Less elegant than `Sdk="..."` attribute
+
+## Consequences
+
+### Positive
+
+- **Minimal boilerplate** - New projects need only the SDK reference
+- **Convention enforcement** - C# 13, nullable, AOT enabled by default
+- **Version coupling** - SDK version implies compatible package versions
+- **Editor foundation** - Project detection, metadata, custom item types ready
+- **Upgrade tooling** - Version properties enable compatibility checking
+- **Asset pipeline ready** - Custom ItemGroups for future build-time processing
+
+### Negative
+
+- **SDK resolution complexity** - Requires NuGet SDK resolution (not just packages)
+- **Version lock-in** - SDK version determines all package versions
+- **Additional packages** - Three more packages to publish and maintain
+- **Learning curve** - Users must understand SDK vs regular packages
+
+### Neutral
+
+- **Opt-in architecture** - Users can still use regular `Microsoft.NET.Sdk` with explicit references
+- **Internal usage optional** - Monorepo samples continue using ProjectReferences
+
+## Implementation Notes
+
+### Package Structure
+
+```
+KeenEyes.Sdk/
+├── Sdk/
+│   ├── Sdk.props    # Imported first (sets defaults)
+│   └── Sdk.targets  # Imported last (adds references, targets)
+├── README.md
+└── KeenEyes.Sdk.csproj
+```
+
+### SDK Props/Targets Flow
+
+1. **Sdk.props** runs before user's PropertyGroups
+   - Sets conditional defaults (only if not already set)
+   - Imports `Microsoft.NET.Sdk.props`
+   - Defines custom ItemDefinitionGroups
+
+2. **User's .csproj content** runs
+   - Can override any SDK defaults
+   - Can add custom ItemGroups
+
+3. **Sdk.targets** runs after user's content
+   - Imports `Microsoft.NET.Sdk.targets`
+   - Adds PackageReferences based on Include properties
+   - Defines build targets for asset processing
+   - Generates project metadata JSON
+
+### Opting Out
+
+Users can disable automatic references:
+
+```xml
+<PropertyGroup>
+  <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+  <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
+</PropertyGroup>
+```
+
+## Future Considerations
+
+1. **Editor integration** - Read `keeneyes.project.json` for project discovery
+2. **Asset processing** - Build targets for scene/prefab compilation
+3. **Analyzers** - Include KeenEyes-specific Roslyn analyzers
+4. **Upgrade CLI** - `dotnet keeneyes upgrade` command using version metadata

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,285 @@
+# KeenEyes SDK
+
+The KeenEyes SDK packages simplify project setup by providing sensible defaults, automatic package references, and custom item types for editor integration.
+
+## Quick Start
+
+Replace the standard SDK with `KeenEyes.Sdk`:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+</Project>
+```
+
+That's it! Your project is now configured with:
+- .NET 10 targeting
+- C# 13 features enabled
+- Nullable reference types
+- AOT compatibility
+- KeenEyes.Core and Generators referenced
+
+## SDK Packages
+
+| Package | Use Case | Output Type | Dependencies |
+|---------|----------|-------------|--------------|
+| `KeenEyes.Sdk` | Games and applications | Exe | Core + Generators |
+| `KeenEyes.Sdk.Plugin` | Plugin libraries | Library | Abstractions + Generators |
+| `KeenEyes.Sdk.Library` | Reusable ECS libraries | Library | Core + Generators |
+
+### Game SDK
+
+For standalone games and applications:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <!-- Everything configured automatically -->
+</Project>
+```
+
+### Plugin SDK
+
+For plugins that extend KeenEyes without depending on Core:
+
+```xml
+<Project Sdk="KeenEyes.Sdk.Plugin/0.1.0">
+  <!-- References Abstractions, not Core -->
+</Project>
+```
+
+To include common components:
+
+```xml
+<Project Sdk="KeenEyes.Sdk.Plugin/0.1.0">
+  <PropertyGroup>
+    <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
+  </PropertyGroup>
+</Project>
+```
+
+### Library SDK
+
+For creating reusable NuGet packages:
+
+```xml
+<Project Sdk="KeenEyes.Sdk.Library/0.1.0">
+  <PropertyGroup>
+    <PackageId>MyCompany.KeenEyes.Physics</PackageId>
+    <Description>Custom physics components</Description>
+  </PropertyGroup>
+</Project>
+```
+
+The Library SDK enables `IsPackable=true` and `GenerateDocumentationFile=true` by default.
+
+## Default Properties
+
+The SDK sets these defaults (all can be overridden):
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `TargetFramework` | `net10.0` | .NET version |
+| `LangVersion` | `preview` | C# 13 features |
+| `Nullable` | `enable` | Nullable reference types |
+| `ImplicitUsings` | `enable` | Implicit global usings |
+| `IsAotCompatible` | `true` | Native AOT ready |
+| `TreatWarningsAsErrors` | `true` | Strict compilation |
+| `EnableNETAnalyzers` | `true` | Code analysis |
+
+### Overriding Defaults
+
+Set properties explicitly to override:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>
+```
+
+## Automatic Package References
+
+### Opting Out
+
+Disable automatic package references:
+
+```xml
+<PropertyGroup>
+  <!-- Don't include KeenEyes.Core -->
+  <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+
+  <!-- Don't include KeenEyes.Generators -->
+  <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
+
+  <!-- Plugin SDK only: Include KeenEyes.Common -->
+  <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
+</PropertyGroup>
+```
+
+### Adding Feature Packages
+
+Add additional KeenEyes packages as needed:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <ItemGroup>
+    <PackageReference Include="KeenEyes.Physics" Version="0.1.0" />
+    <PackageReference Include="KeenEyes.Graphics.Silk" Version="0.1.0" />
+  </ItemGroup>
+</Project>
+```
+
+## Custom Item Types
+
+The SDK defines item types for game assets and editor integration.
+
+### Scenes
+
+Scene files define world configuration and entity setup:
+
+```xml
+<ItemGroup>
+  <KeenEyesScene Include="Scenes/**/*.kescene" />
+</ItemGroup>
+```
+
+### Prefabs
+
+Prefab files define reusable entity templates:
+
+```xml
+<ItemGroup>
+  <KeenEyesPrefab Include="Prefabs/**/*.keprefab" />
+</ItemGroup>
+```
+
+### Assets
+
+Game assets (textures, audio, data) are automatically copied to output:
+
+```xml
+<ItemGroup>
+  <KeenEyesAsset Include="Assets/**/*" />
+</ItemGroup>
+```
+
+### World Configuration
+
+World files define initial world setup:
+
+```xml
+<ItemGroup>
+  <KeenEyesWorld Include="Worlds/**/*.keworld" />
+</ItemGroup>
+```
+
+## Version Information
+
+The SDK exposes version metadata through MSBuild properties:
+
+| Property | Description |
+|----------|-------------|
+| `$(KeenEyesSdkVersion)` | SDK package version |
+| `$(KeenEyesCoreVersion)` | KeenEyes.Core version |
+| `$(KeenEyesMinimumCoreVersion)` | Minimum compatible version |
+| `$(KeenEyesProjectType)` | `Game`, `Plugin`, or `Library` |
+| `$(IsKeenEyesProject)` | Always `true` for SDK projects |
+
+### Generated Metadata
+
+The SDK generates `keeneyes.project.json` in the output directory:
+
+```json
+{
+  "projectName": "MyGame",
+  "projectType": "Game",
+  "sdkVersion": "0.1.0",
+  "coreVersion": "0.1.0",
+  "targetFramework": "net10.0",
+  "isAotCompatible": true
+}
+```
+
+This file enables tooling to detect and introspect KeenEyes projects.
+
+## Comparison: SDK vs Manual Setup
+
+### With SDK
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+</Project>
+```
+
+### Without SDK (Manual)
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAotCompatible>true</IsAotCompatible>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KeenEyes.Core" Version="0.1.0" />
+    <PackageReference Include="KeenEyes.Generators" Version="0.1.0"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>
+```
+
+## Troubleshooting
+
+### SDK Not Found
+
+If you see "SDK not found" errors:
+
+1. Ensure NuGet can resolve the SDK package
+2. Check your `nuget.config` includes the KeenEyes package source
+3. Try `dotnet restore --force`
+
+### Version Mismatch
+
+The SDK version determines the Core/Generators versions. If you need specific versions:
+
+```xml
+<PropertyGroup>
+  <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="KeenEyes.Core" Version="0.2.0" />
+</ItemGroup>
+```
+
+### Disabling SDK Features
+
+To use the SDK for conventions but manage dependencies manually:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <PropertyGroup>
+    <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+    <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
+  </PropertyGroup>
+
+  <!-- Manual references -->
+  <ItemGroup>
+    <ProjectReference Include="../KeenEyes.Core/KeenEyes.Core.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+## See Also
+
+- [ADR-006: Custom MSBuild SDK](adr/006-custom-msbuild-sdk.md) - Design decision record
+- [Getting Started](getting-started.md) - New to KeenEyes?
+- [AOT Deployment](aot-deployment.md) - Native AOT compilation guide

--- a/src/KeenEyes.Sdk.Library/KeenEyes.Sdk.Library.csproj
+++ b/src/KeenEyes.Sdk.Library/KeenEyes.Sdk.Library.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    KeenEyes.Sdk.Library - Custom MSBuild SDK for Library Development
+
+    For creating reusable ECS component and system libraries.
+    Usage: <Project Sdk="KeenEyes.Sdk.Library/0.1.0">
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- Package Identity -->
+    <PackageId>KeenEyes.Sdk.Library</PackageId>
+    <Version>0.1.0</Version>
+    <Description>MSBuild SDK for KeenEyes library development. Provides defaults for creating reusable ECS component and system libraries with proper packaging metadata.</Description>
+    <PackageTags>ecs;gamedev;sdk;msbuild;keeneyes;library</PackageTags>
+
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+
+    <!-- Disable default items - we only have MSBuild files, no source code -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Suppress CS1591 - no XML docs needed for SDK package (no public API) -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <PackageType>MSBuildSdk</PackageType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk\" />
+    <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk.Library/README.md
+++ b/src/KeenEyes.Sdk.Library/README.md
@@ -1,0 +1,64 @@
+# KeenEyes.Sdk.Library
+
+MSBuild SDK for KeenEyes library development.
+
+## Quick Start
+
+```xml
+<Project Sdk="KeenEyes.Sdk.Library/0.1.0">
+
+  <PropertyGroup>
+    <PackageId>MyCompany.KeenEyes.Physics</PackageId>
+    <Description>Custom physics components for KeenEyes</Description>
+  </PropertyGroup>
+
+</Project>
+```
+
+## What's Included
+
+The Library SDK is designed for creating reusable NuGet packages:
+- References `KeenEyes.Core` by default
+- Sets `IsPackable=true`
+- Enables XML documentation generation
+- Configures generators as `PrivateAssets="all"`
+
+| Feature | Default | Override |
+|---------|---------|----------|
+| Target Framework | `net10.0` | Set `<TargetFramework>` |
+| Output Type | `Library` | Set `<OutputType>` |
+| IsPackable | `true` | Set `<IsPackable>` |
+| GenerateDocumentationFile | `true` | Set `<GenerateDocumentationFile>` |
+| KeenEyes.Core | Included | Set `<IncludeKeenEyesCore>false</IncludeKeenEyesCore>` |
+| KeenEyes.Generators | Included (private) | Set `<IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>` |
+
+## Generator Configuration
+
+The generators are included with `PrivateAssets="all"`, meaning:
+- Your library uses the generators during build
+- Consumers of your library don't transitively get the generators
+- Each project controls its own generator version
+
+## Abstraction-Only Libraries
+
+For libraries that only define interfaces/abstractions without implementations:
+
+```xml
+<PropertyGroup>
+  <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="KeenEyes.Abstractions" Version="0.1.0" />
+</ItemGroup>
+```
+
+## SDK Comparison
+
+| Aspect | KeenEyes.Sdk | KeenEyes.Sdk.Library |
+|--------|--------------|----------------------|
+| Default OutputType | Exe | Library |
+| IsPackable | false | true |
+| GenerateDocumentationFile | false | true |
+| Generators PrivateAssets | none | all |
+| Use Case | Games | Reusable libraries |

--- a/src/KeenEyes.Sdk.Library/Sdk/Sdk.props
+++ b/src/KeenEyes.Sdk.Library/Sdk/Sdk.props
@@ -1,0 +1,61 @@
+<Project>
+  <!--
+    KeenEyes Library SDK - Core Properties
+
+    For developing ECS component and system libraries that extend KeenEyes.
+    Libraries are packable and include appropriate package metadata.
+  -->
+
+  <!-- Import the base .NET SDK props first -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- KeenEyes SDK Versioning -->
+  <PropertyGroup>
+    <KeenEyesSdkVersion>0.1.0</KeenEyesSdkVersion>
+    <KeenEyesCoreVersion>0.1.0</KeenEyesCoreVersion>
+    <KeenEyesMinimumCoreVersion>0.1.0</KeenEyesMinimumCoreVersion>
+  </PropertyGroup>
+
+  <!-- Default Framework and Language Settings -->
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net10.0</TargetFramework>
+    <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
+    <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    <ImplicitUsings Condition="'$(ImplicitUsings)' == ''">enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- Libraries output DLLs -->
+  <PropertyGroup>
+    <OutputType Condition="'$(OutputType)' == ''">Library</OutputType>
+  </PropertyGroup>
+
+  <!-- AOT Compatibility (libraries should be AOT-ready) -->
+  <PropertyGroup>
+    <IsAotCompatible Condition="'$(IsAotCompatible)' == ''">true</IsAotCompatible>
+  </PropertyGroup>
+
+  <!-- Code Quality Defaults -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">true</EnableNETAnalyzers>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">latest</AnalysisLevel>
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Libraries are packable by default -->
+  <PropertyGroup>
+    <IsPackable Condition="'$(IsPackable)' == ''">true</IsPackable>
+  </PropertyGroup>
+
+  <!-- KeenEyes Project Type Detection -->
+  <PropertyGroup>
+    <IsKeenEyesProject>true</IsKeenEyesProject>
+    <KeenEyesProjectType>Library</KeenEyesProjectType>
+  </PropertyGroup>
+
+  <!-- Feature Flags -->
+  <PropertyGroup>
+    <KeenEyesFeatures>ECS;SourceGenerators;AOT;Library</KeenEyesFeatures>
+  </PropertyGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk.Library/Sdk/Sdk.targets
+++ b/src/KeenEyes.Sdk.Library/Sdk/Sdk.targets
@@ -1,0 +1,73 @@
+<Project>
+  <!--
+    KeenEyes Library SDK - Targets
+
+    Libraries get Core (or Abstractions) and Generators.
+    Includes packaging metadata for NuGet distribution.
+  -->
+
+  <!-- Import the base .NET SDK targets -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!--
+    Automatic Package References for Libraries
+
+    Libraries typically need Core for component/system development.
+    Set IncludeKeenEyesCore=false for abstraction-only libraries.
+  -->
+  <PropertyGroup>
+    <IncludeKeenEyesCore Condition="'$(IncludeKeenEyesCore)' == ''">true</IncludeKeenEyesCore>
+    <IncludeKeenEyesGenerators Condition="'$(IncludeKeenEyesGenerators)' == ''">true</IncludeKeenEyesGenerators>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesCore)' == 'true'">
+    <PackageReference Include="KeenEyes.Core" Version="$(KeenEyesCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesGenerators)' == 'true'">
+    <PackageReference Include="KeenEyes.Generators"
+                      Version="$(KeenEyesCoreVersion)"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Package Metadata Defaults -->
+  <PropertyGroup>
+    <PackageTags Condition="'$(PackageTags)' == ''">ecs;keeneyes;gamedev</PackageTags>
+  </PropertyGroup>
+
+  <!-- Version Compatibility Check Target -->
+  <Target Name="KeenEyesVersionCheck" BeforeTargets="BeforeBuild">
+    <PropertyGroup>
+      <_KeenEyesVersionInfoFile>$(IntermediateOutputPath)keeneyes.version.json</_KeenEyesVersionInfoFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(_KeenEyesVersionInfoFile)"
+      Lines='{&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "minimumCoreVersion": "$(KeenEyesMinimumCoreVersion)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "features": "$(KeenEyesFeatures)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)"&#xD;&#xA;}'
+      Overwrite="true"
+      Condition="'$(IsKeenEyesProject)' == 'true'" />
+  </Target>
+
+  <!-- Library Project Info Target -->
+  <Target Name="GenerateKeenEyesProjectInfo"
+          AfterTargets="Build"
+          Condition="'$(IsKeenEyesProject)' == 'true'">
+    <PropertyGroup>
+      <_KeenEyesProjectInfoFile>$(OutputPath)keeneyes.project.json</_KeenEyesProjectInfoFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(_KeenEyesProjectInfoFile)"
+      Lines='{&#xD;&#xA;  "projectName": "$(MSBuildProjectName)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)",&#xD;&#xA;  "outputType": "$(OutputType)",&#xD;&#xA;  "isAotCompatible": $(IsAotCompatible),&#xD;&#xA;  "isPackable": $(IsPackable)&#xD;&#xA;}'
+      Overwrite="true" />
+  </Target>
+
+  <!-- Clean Target Extension -->
+  <Target Name="CleanKeenEyesFiles" AfterTargets="Clean">
+    <Delete Files="$(IntermediateOutputPath)keeneyes.version.json" ContinueOnError="true" />
+    <Delete Files="$(OutputPath)keeneyes.project.json" ContinueOnError="true" />
+  </Target>
+
+</Project>

--- a/src/KeenEyes.Sdk.Library/packages.lock.json
+++ b/src/KeenEyes.Sdk.Library/packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Sdk.Plugin/KeenEyes.Sdk.Plugin.csproj
+++ b/src/KeenEyes.Sdk.Plugin/KeenEyes.Sdk.Plugin.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    KeenEyes.Sdk.Plugin - Custom MSBuild SDK for Plugin Development
+
+    For creating plugins that extend KeenEyes without depending on Core.
+    Usage: <Project Sdk="KeenEyes.Sdk.Plugin/0.1.0">
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- Package Identity -->
+    <PackageId>KeenEyes.Sdk.Plugin</PackageId>
+    <Version>0.1.0</Version>
+    <Description>MSBuild SDK for KeenEyes plugin development. Provides defaults for creating plugins that extend KeenEyes with custom components, systems, and features.</Description>
+    <PackageTags>ecs;gamedev;sdk;msbuild;keeneyes;plugin</PackageTags>
+
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+
+    <!-- Disable default items - we only have MSBuild files, no source code -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Suppress CS1591 - no XML docs needed for SDK package (no public API) -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <PackageType>MSBuildSdk</PackageType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk\" />
+    <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk.Plugin/README.md
+++ b/src/KeenEyes.Sdk.Plugin/README.md
@@ -1,0 +1,49 @@
+# KeenEyes.Sdk.Plugin
+
+MSBuild SDK for KeenEyes plugin development.
+
+## Quick Start
+
+```xml
+<Project Sdk="KeenEyes.Sdk.Plugin/0.1.0">
+
+  <PropertyGroup>
+    <Description>My awesome KeenEyes plugin</Description>
+  </PropertyGroup>
+
+</Project>
+```
+
+## What's Included
+
+Unlike the main `KeenEyes.Sdk`, the Plugin SDK:
+- References `KeenEyes.Abstractions` (not Core)
+- Defaults to `OutputType=Library`
+- Is designed for distributable plugin packages
+
+| Feature | Default | Override |
+|---------|---------|----------|
+| Target Framework | `net10.0` | Set `<TargetFramework>` |
+| Output Type | `Library` | Set `<OutputType>` |
+| KeenEyes.Abstractions | Included | Set `<IncludeKeenEyesAbstractions>false</IncludeKeenEyesAbstractions>` |
+| KeenEyes.Common | Not included | Set `<IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>` |
+| KeenEyes.Generators | Included | Set `<IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>` |
+
+## Including Common Components
+
+To use standard components from KeenEyes.Common:
+
+```xml
+<PropertyGroup>
+  <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
+</PropertyGroup>
+```
+
+## Plugin vs Game SDK
+
+| Aspect | KeenEyes.Sdk | KeenEyes.Sdk.Plugin |
+|--------|--------------|---------------------|
+| Default OutputType | Exe | Library |
+| Core Reference | Yes | No |
+| Abstractions Reference | Via Core | Direct |
+| Use Case | Games | Plugins |

--- a/src/KeenEyes.Sdk.Plugin/Sdk/Sdk.props
+++ b/src/KeenEyes.Sdk.Plugin/Sdk/Sdk.props
@@ -1,0 +1,62 @@
+<Project>
+  <!--
+    KeenEyes Plugin SDK - Core Properties
+
+    For developing plugins that extend KeenEyes without depending on Core.
+    Plugins reference Abstractions and optionally Common.
+  -->
+
+  <!-- Import the base .NET SDK props first -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- KeenEyes SDK Versioning -->
+  <PropertyGroup>
+    <KeenEyesSdkVersion>0.1.0</KeenEyesSdkVersion>
+    <KeenEyesCoreVersion>0.1.0</KeenEyesCoreVersion>
+    <KeenEyesMinimumCoreVersion>0.1.0</KeenEyesMinimumCoreVersion>
+  </PropertyGroup>
+
+  <!-- Default Framework and Language Settings -->
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net10.0</TargetFramework>
+    <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
+    <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    <ImplicitUsings Condition="'$(ImplicitUsings)' == ''">enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- Plugins are libraries by default -->
+  <PropertyGroup>
+    <OutputType Condition="'$(OutputType)' == ''">Library</OutputType>
+  </PropertyGroup>
+
+  <!-- AOT Compatibility (plugins should be AOT-ready) -->
+  <PropertyGroup>
+    <IsAotCompatible Condition="'$(IsAotCompatible)' == ''">true</IsAotCompatible>
+  </PropertyGroup>
+
+  <!-- Code Quality Defaults -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">true</EnableNETAnalyzers>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">latest</AnalysisLevel>
+  </PropertyGroup>
+
+  <!-- KeenEyes Project Type Detection -->
+  <PropertyGroup>
+    <IsKeenEyesProject>true</IsKeenEyesProject>
+    <KeenEyesProjectType>Plugin</KeenEyesProjectType>
+  </PropertyGroup>
+
+  <!-- Feature Flags -->
+  <PropertyGroup>
+    <KeenEyesFeatures>ECS;SourceGenerators;AOT;Plugin</KeenEyesFeatures>
+  </PropertyGroup>
+
+  <!-- Plugin-specific ItemGroup Definitions -->
+  <ItemDefinitionGroup>
+    <KeenEyesPluginManifest>
+      <Visible>true</Visible>
+    </KeenEyesPluginManifest>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk.Plugin/Sdk/Sdk.targets
+++ b/src/KeenEyes.Sdk.Plugin/Sdk/Sdk.targets
@@ -1,0 +1,72 @@
+<Project>
+  <!--
+    KeenEyes Plugin SDK - Targets
+
+    Plugins get Abstractions (not Core) and Generators.
+    Optionally includes Common for standard components.
+  -->
+
+  <!-- Import the base .NET SDK targets -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!--
+    Automatic Package References for Plugins
+
+    Plugins get Abstractions by default, not Core.
+    Set IncludeKeenEyesCommon=true to include common components.
+  -->
+  <PropertyGroup>
+    <IncludeKeenEyesAbstractions Condition="'$(IncludeKeenEyesAbstractions)' == ''">true</IncludeKeenEyesAbstractions>
+    <IncludeKeenEyesCommon Condition="'$(IncludeKeenEyesCommon)' == ''">false</IncludeKeenEyesCommon>
+    <IncludeKeenEyesGenerators Condition="'$(IncludeKeenEyesGenerators)' == ''">true</IncludeKeenEyesGenerators>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesAbstractions)' == 'true'">
+    <PackageReference Include="KeenEyes.Abstractions" Version="$(KeenEyesCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesCommon)' == 'true'">
+    <PackageReference Include="KeenEyes.Common" Version="$(KeenEyesCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesGenerators)' == 'true'">
+    <PackageReference Include="KeenEyes.Generators"
+                      Version="$(KeenEyesCoreVersion)"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- Version Compatibility Check Target -->
+  <Target Name="KeenEyesVersionCheck" BeforeTargets="BeforeBuild">
+    <PropertyGroup>
+      <_KeenEyesVersionInfoFile>$(IntermediateOutputPath)keeneyes.version.json</_KeenEyesVersionInfoFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(_KeenEyesVersionInfoFile)"
+      Lines='{&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "minimumCoreVersion": "$(KeenEyesMinimumCoreVersion)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "features": "$(KeenEyesFeatures)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)"&#xD;&#xA;}'
+      Overwrite="true"
+      Condition="'$(IsKeenEyesProject)' == 'true'" />
+  </Target>
+
+  <!-- Plugin Project Info Target -->
+  <Target Name="GenerateKeenEyesProjectInfo"
+          AfterTargets="Build"
+          Condition="'$(IsKeenEyesProject)' == 'true'">
+    <PropertyGroup>
+      <_KeenEyesProjectInfoFile>$(OutputPath)keeneyes.project.json</_KeenEyesProjectInfoFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(_KeenEyesProjectInfoFile)"
+      Lines='{&#xD;&#xA;  "projectName": "$(MSBuildProjectName)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)",&#xD;&#xA;  "outputType": "$(OutputType)",&#xD;&#xA;  "isAotCompatible": $(IsAotCompatible)&#xD;&#xA;}'
+      Overwrite="true" />
+  </Target>
+
+  <!-- Clean Target Extension -->
+  <Target Name="CleanKeenEyesFiles" AfterTargets="Clean">
+    <Delete Files="$(IntermediateOutputPath)keeneyes.version.json" ContinueOnError="true" />
+    <Delete Files="$(OutputPath)keeneyes.project.json" ContinueOnError="true" />
+  </Target>
+
+</Project>

--- a/src/KeenEyes.Sdk.Plugin/packages.lock.json
+++ b/src/KeenEyes.Sdk.Plugin/packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Sdk/KeenEyes.Sdk.csproj
+++ b/src/KeenEyes.Sdk/KeenEyes.Sdk.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    KeenEyes.Sdk - Custom MSBuild SDK Package
+
+    This project produces a NuGet package that can be used as an SDK:
+      <Project Sdk="KeenEyes.Sdk/0.1.0">
+
+    The SDK simplifies KeenEyes game development by providing sensible
+    defaults and automatic package references.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- Package Identity -->
+    <PackageId>KeenEyes.Sdk</PackageId>
+    <Version>0.1.0</Version>
+    <Description>MSBuild SDK for KeenEyes ECS game development. Provides sensible defaults, automatic package references, and custom item types for editor integration.</Description>
+    <PackageTags>ecs;gamedev;sdk;msbuild;keeneyes</PackageTags>
+
+    <!-- SDK packages must be packable -->
+    <IsPackable>true</IsPackable>
+
+    <!-- Don't produce any assembly output (SDK packages contain only MSBuild files) -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+
+    <!-- Disable default items - we only have MSBuild files, no source code -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Suppress CS1591 - no XML docs needed for SDK package (no public API) -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- SDK package type -->
+    <PackageType>MSBuildSdk</PackageType>
+
+    <!-- Include readme in package -->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <!-- SDK files must be in the Sdk/ folder at the package root -->
+  <ItemGroup>
+    <None Include="Sdk\Sdk.props" Pack="true" PackagePath="Sdk\" />
+    <None Include="Sdk\Sdk.targets" Pack="true" PackagePath="Sdk\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk/README.md
+++ b/src/KeenEyes.Sdk/README.md
@@ -1,0 +1,117 @@
+# KeenEyes.Sdk
+
+MSBuild SDK for KeenEyes ECS game development.
+
+## Quick Start
+
+Replace your standard SDK reference with KeenEyes.Sdk:
+
+```xml
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>
+```
+
+That's it! The SDK automatically:
+- Sets `TargetFramework` to `net10.0`
+- Enables `LangVersion=preview` for C# 13 features
+- Enables nullable reference types
+- References `KeenEyes.Core` and `KeenEyes.Generators`
+- Configures AOT compatibility
+
+## What's Included
+
+| Feature | Default | Override |
+|---------|---------|----------|
+| Target Framework | `net10.0` | Set `<TargetFramework>` |
+| Language Version | `preview` | Set `<LangVersion>` |
+| Nullable | `enable` | Set `<Nullable>` |
+| Output Type | `Exe` | Set `<OutputType>` |
+| AOT Compatible | `true` | Set `<IsAotCompatible>` |
+| KeenEyes.Core | Included | Set `<IncludeKeenEyesCore>false</IncludeKeenEyesCore>` |
+| KeenEyes.Generators | Included | Set `<IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>` |
+
+## Custom Item Types
+
+The SDK defines custom item types for KeenEyes editor integration:
+
+### Scenes (`.kescene`)
+
+```xml
+<ItemGroup>
+  <KeenEyesScene Include="Scenes\**\*.kescene" />
+</ItemGroup>
+```
+
+### Prefabs (`.keprefab`)
+
+```xml
+<ItemGroup>
+  <KeenEyesPrefab Include="Prefabs\**\*.keprefab" />
+</ItemGroup>
+```
+
+### Assets
+
+```xml
+<ItemGroup>
+  <KeenEyesAsset Include="Assets\**\*" />
+</ItemGroup>
+```
+
+Assets are automatically copied to the output directory.
+
+### World Configuration (`.keworld`)
+
+```xml
+<ItemGroup>
+  <KeenEyesWorld Include="Worlds\**\*.keworld" />
+</ItemGroup>
+```
+
+## Version Properties
+
+The SDK exposes version information for tooling:
+
+| Property | Description |
+|----------|-------------|
+| `$(KeenEyesSdkVersion)` | SDK package version |
+| `$(KeenEyesCoreVersion)` | KeenEyes.Core version |
+| `$(KeenEyesMinimumCoreVersion)` | Minimum compatible Core version |
+| `$(KeenEyesProjectType)` | Project type (`Game`, `Plugin`, `Library`) |
+| `$(KeenEyesFeatures)` | Enabled features (`;` separated) |
+
+## Generated Files
+
+During build, the SDK generates:
+
+- `obj/keeneyes.version.json` - Version compatibility info
+- `bin/keeneyes.project.json` - Project metadata for editor
+
+## SDK Flavors
+
+| SDK | Use Case |
+|-----|----------|
+| `KeenEyes.Sdk` | Games and applications |
+| `KeenEyes.Sdk.Plugin` | Plugin libraries |
+| `KeenEyes.Sdk.Library` | ECS component libraries |
+
+## Opting Out of Automatic References
+
+To exclude automatic package references:
+
+```xml
+<PropertyGroup>
+  <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
+  <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
+</PropertyGroup>
+```
+
+## Requirements
+
+- .NET 10.0 SDK or later
+- NuGet 6.0 or later (for SDK resolution)

--- a/src/KeenEyes.Sdk/Sdk/Sdk.props
+++ b/src/KeenEyes.Sdk/Sdk/Sdk.props
@@ -1,0 +1,104 @@
+<Project>
+  <!--
+    KeenEyes SDK - Core Properties
+
+    This file is imported at the very START of project evaluation,
+    before Microsoft.NET.Sdk.props. It sets KeenEyes defaults that
+    can be overridden by the consuming project.
+  -->
+
+  <!-- Import the base .NET SDK props first -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- KeenEyes SDK Versioning -->
+  <PropertyGroup>
+    <KeenEyesSdkVersion>0.1.0</KeenEyesSdkVersion>
+    <KeenEyesCoreVersion>0.1.0</KeenEyesCoreVersion>
+    <KeenEyesMinimumCoreVersion>0.1.0</KeenEyesMinimumCoreVersion>
+  </PropertyGroup>
+
+  <!-- Default Framework and Language Settings -->
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net10.0</TargetFramework>
+    <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
+    <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    <ImplicitUsings Condition="'$(ImplicitUsings)' == ''">enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- Default to Exe for game projects -->
+  <PropertyGroup>
+    <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
+  </PropertyGroup>
+
+  <!-- AOT Compatibility (games should be AOT-ready) -->
+  <PropertyGroup>
+    <IsAotCompatible Condition="'$(IsAotCompatible)' == ''">true</IsAotCompatible>
+  </PropertyGroup>
+
+  <!-- Code Quality Defaults -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">true</EnableNETAnalyzers>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">latest</AnalysisLevel>
+  </PropertyGroup>
+
+  <!-- KeenEyes Project Type Detection -->
+  <PropertyGroup>
+    <!-- Mark this as a KeenEyes project for editor detection -->
+    <IsKeenEyesProject>true</IsKeenEyesProject>
+    <KeenEyesProjectType Condition="'$(KeenEyesProjectType)' == ''">Game</KeenEyesProjectType>
+  </PropertyGroup>
+
+  <!-- Feature Flags (for future editor compatibility checks) -->
+  <PropertyGroup>
+    <KeenEyesFeatures>ECS;SourceGenerators;AOT</KeenEyesFeatures>
+  </PropertyGroup>
+
+  <!--
+    Custom ItemGroup Definitions for Editor Integration
+
+    These item types allow the KeenEyes editor to discover and process
+    game assets, scenes, and configuration files.
+  -->
+
+  <!-- Scene files (.kescene) - define world configuration and entity setup -->
+  <ItemDefinitionGroup>
+    <KeenEyesScene>
+      <Visible>true</Visible>
+      <Generator>KeenEyesSceneGenerator</Generator>
+    </KeenEyesScene>
+  </ItemDefinitionGroup>
+
+  <!-- Prefab files (.keprefab) - reusable entity templates -->
+  <ItemDefinitionGroup>
+    <KeenEyesPrefab>
+      <Visible>true</Visible>
+      <Generator>KeenEyesPrefabGenerator</Generator>
+    </KeenEyesPrefab>
+  </ItemDefinitionGroup>
+
+  <!-- Asset files - textures, audio, data files -->
+  <ItemDefinitionGroup>
+    <KeenEyesAsset>
+      <Visible>true</Visible>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </KeenEyesAsset>
+  </ItemDefinitionGroup>
+
+  <!-- System hints - help editor discover and categorize systems -->
+  <ItemDefinitionGroup>
+    <KeenEyesSystem>
+      <Visible>false</Visible>
+      <AutoRegister>false</AutoRegister>
+    </KeenEyesSystem>
+  </ItemDefinitionGroup>
+
+  <!-- World configuration files (.keworld) -->
+  <ItemDefinitionGroup>
+    <KeenEyesWorld>
+      <Visible>true</Visible>
+      <Generator>KeenEyesWorldGenerator</Generator>
+    </KeenEyesWorld>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/src/KeenEyes.Sdk/Sdk/Sdk.targets
+++ b/src/KeenEyes.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,125 @@
+<Project>
+  <!--
+    KeenEyes SDK - Targets
+
+    This file is imported at the very END of project evaluation,
+    after Microsoft.NET.Sdk.targets. It adds package references
+    and custom build targets.
+  -->
+
+  <!-- Import the base .NET SDK targets -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!--
+    Automatic Package References
+
+    These packages are automatically included for all KeenEyes Game projects.
+    Set IncludeKeenEyesCore=false or IncludeKeenEyesGenerators=false to opt out.
+  -->
+  <PropertyGroup>
+    <IncludeKeenEyesCore Condition="'$(IncludeKeenEyesCore)' == ''">true</IncludeKeenEyesCore>
+    <IncludeKeenEyesGenerators Condition="'$(IncludeKeenEyesGenerators)' == ''">true</IncludeKeenEyesGenerators>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesCore)' == 'true'">
+    <PackageReference Include="KeenEyes.Core" Version="$(KeenEyesCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeKeenEyesGenerators)' == 'true'">
+    <PackageReference Include="KeenEyes.Generators"
+                      Version="$(KeenEyesCoreVersion)"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!--
+    Version Compatibility Check Target
+
+    Runs during build to ensure SDK and Core versions are compatible.
+    This helps the editor provide upgrade guidance.
+  -->
+  <Target Name="KeenEyesVersionCheck" BeforeTargets="BeforeBuild">
+    <PropertyGroup>
+      <_KeenEyesVersionInfoFile>$(IntermediateOutputPath)keeneyes.version.json</_KeenEyesVersionInfoFile>
+    </PropertyGroup>
+
+    <!-- Generate version info file for editor consumption -->
+    <WriteLinesToFile
+      File="$(_KeenEyesVersionInfoFile)"
+      Lines='{&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "minimumCoreVersion": "$(KeenEyesMinimumCoreVersion)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "features": "$(KeenEyesFeatures)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)"&#xD;&#xA;}'
+      Overwrite="true"
+      Condition="'$(IsKeenEyesProject)' == 'true'" />
+  </Target>
+
+  <!--
+    Asset Processing Targets
+
+    These targets process KeenEyes-specific item types during build.
+    The actual processing logic will be implemented by the editor or
+    additional tooling packages.
+  -->
+
+  <!-- Collect all KeenEyes scenes for processing -->
+  <Target Name="CollectKeenEyesScenes" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <_KeenEyesSceneFiles Include="@(KeenEyesScene)" />
+    </ItemGroup>
+
+    <Message Condition="'@(_KeenEyesSceneFiles)' != ''"
+             Text="KeenEyes: Found %(RecursiveDir)%(Filename)%(Extension) scene(s)"
+             Importance="low" />
+  </Target>
+
+  <!-- Collect all KeenEyes prefabs for processing -->
+  <Target Name="CollectKeenEyesPrefabs" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <_KeenEyesPrefabFiles Include="@(KeenEyesPrefab)" />
+    </ItemGroup>
+
+    <Message Condition="'@(_KeenEyesPrefabFiles)' != ''"
+             Text="KeenEyes: Found %(RecursiveDir)%(Filename)%(Extension) prefab(s)"
+             Importance="low" />
+  </Target>
+
+  <!-- Copy KeenEyes assets to output directory -->
+  <Target Name="CopyKeenEyesAssets"
+          AfterTargets="Build"
+          Condition="'@(KeenEyesAsset)' != ''">
+    <Copy SourceFiles="@(KeenEyesAsset)"
+          DestinationFolder="$(OutputPath)Assets/%(RecursiveDir)"
+          SkipUnchangedFiles="true" />
+
+    <Message Text="KeenEyes: Copied @(KeenEyesAsset->Count()) asset(s) to output"
+             Importance="normal" />
+  </Target>
+
+  <!--
+    Project Info Target
+
+    Generates project metadata that the editor can read to understand
+    project configuration without fully loading the project.
+  -->
+  <Target Name="GenerateKeenEyesProjectInfo"
+          AfterTargets="Build"
+          Condition="'$(IsKeenEyesProject)' == 'true'">
+    <PropertyGroup>
+      <_KeenEyesProjectInfoFile>$(OutputPath)keeneyes.project.json</_KeenEyesProjectInfoFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(_KeenEyesProjectInfoFile)"
+      Lines='{&#xD;&#xA;  "projectName": "$(MSBuildProjectName)",&#xD;&#xA;  "projectType": "$(KeenEyesProjectType)",&#xD;&#xA;  "sdkVersion": "$(KeenEyesSdkVersion)",&#xD;&#xA;  "coreVersion": "$(KeenEyesCoreVersion)",&#xD;&#xA;  "targetFramework": "$(TargetFramework)",&#xD;&#xA;  "outputType": "$(OutputType)",&#xD;&#xA;  "isAotCompatible": $(IsAotCompatible),&#xD;&#xA;  "features": [$(KeenEyesFeatures.Replace(';', '", "').Insert(0, '"').Insert($([MSBuild]::Add($(KeenEyesFeatures.Length), 1)), '"'))]&#xD;&#xA;}'
+      Overwrite="true" />
+  </Target>
+
+  <!--
+    Clean Target Extension
+
+    Clean up KeenEyes-generated files during clean.
+  -->
+  <Target Name="CleanKeenEyesFiles" AfterTargets="Clean">
+    <Delete Files="$(IntermediateOutputPath)keeneyes.version.json" ContinueOnError="true" />
+    <Delete Files="$(OutputPath)keeneyes.project.json" ContinueOnError="true" />
+  </Target>
+
+</Project>

--- a/src/KeenEyes.Sdk/packages.lock.json
+++ b/src/KeenEyes.Sdk/packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    }
+  }
+}

--- a/templates/keeneyes-game/KeenEyesGame.csproj
+++ b/templates/keeneyes-game/KeenEyesGame.csproj
@@ -1,16 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="KeenEyes.Sdk/0.1.0">
+  <!--
+    KeenEyes Game Project
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+    The KeenEyes.Sdk automatically:
+    - Sets TargetFramework to net10.0
+    - Enables LangVersion preview for C# 13 features
+    - Enables nullable reference types
+    - References KeenEyes.Core and KeenEyes.Generators
+    - Configures AOT compatibility
 
-  <ItemGroup>
-    <PackageReference Include="KeenEyes.Core" Version="0.1.0" />
-    <PackageReference Include="KeenEyes.Generators" Version="0.1.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-  </ItemGroup>
+    Override any defaults by setting properties explicitly.
+  -->
 
 </Project>

--- a/templates/keeneyes-plugin/KeenEyesPlugin.csproj
+++ b/templates/keeneyes-plugin/KeenEyesPlugin.csproj
@@ -1,19 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="KeenEyes.Sdk.Plugin/0.1.0">
+  <!--
+    KeenEyes Plugin Project
 
+    The KeenEyes.Sdk.Plugin automatically:
+    - Sets TargetFramework to net10.0
+    - Sets OutputType to Library
+    - Enables nullable reference types
+    - References KeenEyes.Abstractions and KeenEyes.Generators
+    - Configures AOT compatibility
+
+    To include common components, add:
+    <PropertyGroup>
+      <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
+    </PropertyGroup>
+  -->
+
+  <!--#if (IncludeCommon)-->
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="KeenEyes.Abstractions" Version="0.1.0" />
-    <!--#if (IncludeCommon)-->
-    <PackageReference Include="KeenEyes.Common" Version="0.1.0" />
-    <!--#endif-->
-    <PackageReference Include="KeenEyes.Generators" Version="0.1.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-  </ItemGroup>
+  <!--#endif-->
 
 </Project>


### PR DESCRIPTION
Introduce three SDK flavors that simplify project setup for consumers:

- KeenEyes.Sdk: For games/applications
  - Auto-references KeenEyes.Core and Generators
  - Sets net10.0, LangVersion=preview, nullable, AOT defaults
  - Defines custom ItemGroups for future editor integration (KeenEyesScene, KeenEyesPrefab, KeenEyesAsset, KeenEyesWorld)
  - Generates keeneyes.project.json for tooling/editor detection

- KeenEyes.Sdk.Plugin: For plugin libraries
  - References Abstractions (not Core) by default
  - Optional IncludeKeenEyesCommon property
  - OutputType=Library default

- KeenEyes.Sdk.Library: For reusable component libraries
  - IsPackable=true, GenerateDocumentationFile=true
  - Generators included with PrivateAssets=all

Usage:
  <Project Sdk="KeenEyes.Sdk/0.1.0">
  </Project>

This enables:
- Minimal boilerplate for new KeenEyes projects
- Editor detection via SDK version and project metadata
- Future asset pipeline through custom ItemGroups
- Version compatibility tracking for upgrade tooling

Documentation:
- ADR-006: Decision record with alternatives and rationale
- docs/sdk.md: User-facing guide with examples
- CLAUDE.md: Updated for future agent reference