### PR TITLE
feat: Add analyzer rule for IWorld to World cast

### DIFF
--- a/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
+++ b/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
@@ -1,5 +1,8 @@
 using KeenEyes.Serialization;
 
+// TODO: Remove this suppression after refactoring to use IWorld interface
+#pragma warning disable KEEN050 // IWorld to World cast - legacy code pending refactoring
+
 namespace KeenEyes.Systems;
 
 /// <summary>

--- a/src/KeenEyes.Generators/IWorldCastAnalyzer.cs
+++ b/src/KeenEyes.Generators/IWorldCastAnalyzer.cs
@@ -1,0 +1,196 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace KeenEyes.Generators;
+
+/// <summary>
+/// Roslyn analyzer that detects attempts to cast IWorld to World and reports an error.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>IWorld</c> interface is the public contract for interacting with an ECS world.
+/// Casting to the concrete <c>World</c> class bypasses this abstraction and creates tight coupling
+/// to implementation details that may change.
+/// </para>
+/// <para>
+/// This analyzer detects:
+/// <list type="bullet">
+/// <item><description>Direct casts: <c>(World)iWorld</c></description></item>
+/// <item><description>Safe casts: <c>iWorld as World</c></description></item>
+/// <item><description>Type checks: <c>iWorld is World</c></description></item>
+/// <item><description>Pattern matching: <c>iWorld is World w</c></description></item>
+/// </list>
+/// </para>
+/// <para>
+/// Instead of casting, use the <c>IWorld</c> interface methods directly, or use
+/// <c>IWorld.GetExtension&lt;T&gt;()</c> if you need additional functionality.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class IWorldCastAnalyzer : DiagnosticAnalyzer
+{
+    private const string IWorldTypeName = "KeenEyes.IWorld";
+    private const string WorldTypeName = "KeenEyes.World";
+
+    /// <summary>
+    /// KEEN050: IWorld to World cast detected.
+    /// </summary>
+    public static readonly DiagnosticDescriptor IWorldCastDetected = new(
+        id: "KEEN050",
+        title: "Avoid casting IWorld to World",
+        messageFormat: "Avoid casting IWorld to World; use the IWorld interface methods or GetExtension<T>() instead",
+        category: "KeenEyes.Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Casting IWorld to World bypasses the interface abstraction and creates tight coupling " +
+                     "to implementation details. Use the IWorld interface methods directly, or use " +
+                     "IWorld.GetExtension<T>() if you need additional functionality provided by plugins.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(IWorldCastDetected);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Detect explicit casts: (World)iWorld and iWorld as World
+        context.RegisterOperationAction(AnalyzeConversion, OperationKind.Conversion);
+
+        // Detect type checks: iWorld is World
+        context.RegisterOperationAction(AnalyzeIsType, OperationKind.IsType);
+
+        // Detect pattern matching: iWorld is World w
+        context.RegisterOperationAction(AnalyzeIsPattern, OperationKind.IsPattern);
+
+        // Detect switch expression arms: world switch { World w => ... }
+        context.RegisterOperationAction(AnalyzeSwitchExpressionArm, OperationKind.SwitchExpressionArm);
+    }
+
+    private static void AnalyzeConversion(OperationAnalysisContext context)
+    {
+        var conversion = (IConversionOperation)context.Operation;
+
+        // Only check explicit conversions (casts)
+        if (conversion.IsImplicit)
+        {
+            return;
+        }
+
+        // Check if converting from IWorld to World
+        if (IsIWorldToWorldCast(conversion.Operand.Type, conversion.Type))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                IWorldCastDetected,
+                conversion.Syntax.GetLocation()));
+        }
+    }
+
+    private static void AnalyzeIsType(OperationAnalysisContext context)
+    {
+        var isType = (IIsTypeOperation)context.Operation;
+
+        // Check if checking IWorld is World
+        if (IsIWorldToWorldCast(isType.ValueOperand.Type, isType.TypeOperand))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                IWorldCastDetected,
+                isType.Syntax.GetLocation()));
+        }
+    }
+
+    private static void AnalyzeIsPattern(OperationAnalysisContext context)
+    {
+        var isPattern = (IIsPatternOperation)context.Operation;
+
+        // Check if the pattern involves casting IWorld to World
+        if (IsIWorldType(isPattern.Value.Type) && IsWorldPatternTarget(isPattern.Pattern))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                IWorldCastDetected,
+                isPattern.Syntax.GetLocation()));
+        }
+    }
+
+    private static void AnalyzeSwitchExpressionArm(OperationAnalysisContext context)
+    {
+        var arm = (ISwitchExpressionArmOperation)context.Operation;
+
+        // Get the switch expression to check the input type
+        if (arm.Parent is ISwitchExpressionOperation switchExpr &&
+            IsIWorldType(switchExpr.Value.Type) &&
+            IsWorldPatternTarget(arm.Pattern))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                IWorldCastDetected,
+                arm.Pattern.Syntax.GetLocation()));
+        }
+    }
+
+    private static bool IsIWorldToWorldCast(ITypeSymbol? sourceType, ITypeSymbol? targetType)
+    {
+        return IsIWorldType(sourceType) && IsWorldType(targetType);
+    }
+
+    private static bool IsIWorldType(ITypeSymbol? type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        // Check the type itself
+        if (type.ToDisplayString() == IWorldTypeName)
+        {
+            return true;
+        }
+
+        // Check if any interface is IWorld
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (iface.ToDisplayString() == IWorldTypeName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsWorldType(ITypeSymbol? type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        return type.ToDisplayString() == WorldTypeName;
+    }
+
+    private static bool IsWorldPatternTarget(IPatternOperation pattern)
+    {
+        // Handle declaration pattern: is World w
+        if (pattern is IDeclarationPatternOperation declarationPattern)
+        {
+            return IsWorldType(declarationPattern.MatchedType);
+        }
+
+        // Handle type pattern: is World (C# 9+)
+        if (pattern is ITypePatternOperation typePattern)
+        {
+            return IsWorldType(typePattern.MatchedType);
+        }
+
+        // Handle negated pattern: is not World
+        if (pattern is INegatedPatternOperation negatedPattern)
+        {
+            return IsWorldPatternTarget(negatedPattern.Pattern);
+        }
+
+        return false;
+    }
+}

--- a/src/KeenEyes.Persistence/PersistencePlugin.cs
+++ b/src/KeenEyes.Persistence/PersistencePlugin.cs
@@ -1,5 +1,8 @@
 using KeenEyes.Capabilities;
 
+// TODO: Remove this suppression after refactoring to use IWorld interface
+#pragma warning disable KEEN050 // IWorld to World cast - legacy code pending refactoring
+
 namespace KeenEyes.Persistence;
 
 /// <summary>

--- a/tests/KeenEyes.Core.Tests/PluginTests.cs
+++ b/tests/KeenEyes.Core.Tests/PluginTests.cs
@@ -1,3 +1,6 @@
+// TODO: Remove this suppression after refactoring to use IWorld interface
+#pragma warning disable KEEN050 // IWorld to World cast - test code pending refactoring
+
 namespace KeenEyes.Tests;
 
 /// <summary>

--- a/tests/KeenEyes.Core.Tests/SystemHookPluginIntegrationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SystemHookPluginIntegrationTests.cs
@@ -1,3 +1,6 @@
+// TODO: Remove this suppression after refactoring to use IWorld interface
+#pragma warning disable KEEN050 // IWorld to World cast - test code pending refactoring
+
 namespace KeenEyes.Tests;
 
 /// <summary>

--- a/tests/KeenEyes.Generators.Tests/IWorldCastAnalyzerTests.cs
+++ b/tests/KeenEyes.Generators.Tests/IWorldCastAnalyzerTests.cs
@@ -1,0 +1,472 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Tests for the IWorldCastAnalyzer diagnostic analyzer.
+/// </summary>
+public class IWorldCastAnalyzerTests
+{
+    private const string IWorldInterface = """
+        namespace KeenEyes;
+
+        public interface IWorld
+        {
+            int EntityCount { get; }
+        }
+        """;
+
+    private const string WorldClass = """
+        namespace KeenEyes;
+
+        public sealed class World : IWorld
+        {
+            public int EntityCount => 0;
+        }
+        """;
+
+    #region KEEN050: Direct Cast (Type)expression
+
+    [Fact]
+    public void DirectCastIWorldToWorld_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    var w = (World)world;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void DirectCastInMethodCall_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    AcceptWorld((World)world);
+                }
+
+                private void AcceptWorld(World world) { }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    #endregion
+
+    #region KEEN050: As Cast
+
+    [Fact]
+    public void AsCastIWorldToWorld_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    var w = world as World;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void AsCastWithNullCheck_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    if (world as World != null)
+                    {
+                        // Do something
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    #endregion
+
+    #region KEEN050: Is Type Check
+
+    [Fact]
+    public void IsTypeCheck_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public bool IsWorldType(IWorld world)
+                {
+                    return world is World;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void IsTypeCheckInIfCondition_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    if (world is World)
+                    {
+                        // Do something
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    #endregion
+
+    #region KEEN050: Pattern Matching
+
+    [Fact]
+    public void PatternMatchingWithVariable_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    if (world is World w)
+                    {
+                        var count = w.EntityCount;
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void PatternMatchingInSwitch_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public string GetTypeName(IWorld world)
+                {
+                    return world switch
+                    {
+                        World w => "World",
+                        _ => "Unknown"
+                    };
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    [Fact]
+    public void NegatedPatternMatching_ReportsError()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    if (world is not World)
+                    {
+                        // Do something
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN050");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    #endregion
+
+    #region No False Positives
+
+    [Fact]
+    public void CastUnrelatedTypes_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            public class TestClass
+            {
+                public void Process(object obj)
+                {
+                    var str = (string)obj;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    [Fact]
+    public void CastIWorldToOtherInterface_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+            using System;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    var disposable = (IDisposable)world;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    [Fact]
+    public void ImplicitConversion_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process()
+                {
+                    IWorld world = new World();
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    [Fact]
+    public void WorldToIWorldCast_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(World world)
+                {
+                    var iworld = (IWorld)world;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    [Fact]
+    public void UsingIWorldInterface_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    var count = world.EntityCount;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    [Fact]
+    public void IsCheckWithOtherType_NoDiagnostics()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public bool IsString(object obj)
+                {
+                    return obj is string;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN050");
+    }
+
+    #endregion
+
+    #region Multiple Violations
+
+    [Fact]
+    public void MultipleCasts_ReportsAll()
+    {
+        var source = """
+            namespace TestApp;
+
+            using KeenEyes;
+
+            public class TestClass
+            {
+                public void Process(IWorld world)
+                {
+                    var w1 = (World)world;
+                    var w2 = world as World;
+                    var isWorld = world is World;
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.Equal(3, diagnostics.Count(d => d.Id == "KEEN050"));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static IReadOnlyList<Diagnostic> RunAnalyzer(string source)
+    {
+        var syntaxTrees = new[]
+        {
+            CSharpSyntaxTree.ParseText(IWorldInterface),
+            CSharpSyntaxTree.ParseText(WorldClass),
+            CSharpSyntaxTree.ParseText(source)
+        };
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new IWorldCastAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var diagnostics = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+
+        return diagnostics.ToList();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Add new Roslyn analyzer (KEEN050) that reports errors when code attempts to cast IWorld to the concrete World type. This enforces the interface abstraction and prevents tight coupling to implementation details.

The analyzer detects:
- Direct casts: (World)iWorld
- Safe casts: iWorld as World
- Type checks: iWorld is World
- Pattern matching: iWorld is World w
- Switch expressions: world switch { World w => ... }

Existing code that casts IWorld to World has #pragma warning disable KEEN050 suppressions added with TODO comments to be addressed in future refactoring.