### PR TITLE
tests: Analyze testing components for coverage improvement

### DIFF
--- a/tests/KeenEyes.Debugging.Tests/KeenEyes.Debugging.Tests.csproj
+++ b/tests/KeenEyes.Debugging.Tests/KeenEyes.Debugging.Tests.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\KeenEyes.Debugging\KeenEyes.Debugging.csproj" />
+		<ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
 		<ProjectReference Include="..\..\src\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 

--- a/tests/KeenEyes.Debugging.Tests/packages.lock.json
+++ b/tests/KeenEyes.Debugging.Tests/packages.lock.json
@@ -198,10 +198,7 @@
         }
       },
       "keeneyes.abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "KeenEyes.Generators.Attributes": "[1.0.0, )"
-        }
+        "type": "Project"
       },
       "keeneyes.common": {
         "type": "Project",
@@ -222,8 +219,39 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
-      "keeneyes.generators.attributes": {
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
         "type": "Project"
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
+        }
       }
     }
   }

--- a/tests/KeenEyes.Parallelism.Tests/KeenEyes.Parallelism.Tests.csproj
+++ b/tests/KeenEyes.Parallelism.Tests/KeenEyes.Parallelism.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.Parallelism\KeenEyes.Parallelism.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/KeenEyes.Parallelism.Tests/packages.lock.json
+++ b/tests/KeenEyes.Parallelism.Tests/packages.lock.json
@@ -212,11 +212,45 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project"
+      },
       "keeneyes.parallelism": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
         }
       }
     }

--- a/tests/KeenEyes.Persistence.Tests/KeenEyes.Persistence.Tests.csproj
+++ b/tests/KeenEyes.Persistence.Tests/KeenEyes.Persistence.Tests.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\KeenEyes.Persistence\KeenEyes.Persistence.csproj" />
+		<ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
 		<ProjectReference Include="..\..\src\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 

--- a/tests/KeenEyes.Persistence.Tests/packages.lock.json
+++ b/tests/KeenEyes.Persistence.Tests/packages.lock.json
@@ -212,11 +212,38 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project"
+      },
       "keeneyes.persistence": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
         }
       }
     }


### PR DESCRIPTION
Enhance plugin test coverage using KeenEyes.Testing mocks and assertions:

- PersistencePluginTests: Add 14 new tests using MockEncryptionProvider
  - Test encryption/decryption tracking
  - Test failure scenarios (ShouldFailEncrypt/ShouldFailDecrypt)
  - Test custom encryption functions
  - Test operation counts and data sizes
  - Test async encryption APIs

- PhysicsPluginTests: Add 9 new tests using MockPluginContext
  - Verify system and extension registration
  - Test conditional PhysicsSyncSystem registration based on interpolation
  - Verify component registration

- SpatialPluginTests: Add 9 new tests using MockPluginContext
  - Verify SpatialQueryApi extension registration
  - Verify SpatialUpdateSystem registration at correct phase/order
  - Test all spatial strategies (Grid, Quadtree, Octree)

- ParallelSystemPluginTests: Add 9 new tests using MockPluginContext
  - Verify ParallelSystemScheduler extension registration
  - Test scheduler functionality with mock context
  - Test isolation between multiple plugin installations

- DebugPluginTests: Add 12 new tests using MockPluginContext
  - Verify conditional extension registration based on DebugOptions
  - Test profiling and GC tracking enable/disable
  - Verify no systems or components are registered