### PR TITLE
feat: Add KeenEyes.Audio core infrastructure (Issue #419)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,4 +24,7 @@
     <PackageVersion Include="BepuPhysics" Version="2.4.0" />
     <PackageVersion Include="BepuUtilities" Version="2.4.0" />
   </ItemGroup>
+  <ItemGroup Label="Audio">
+    <PackageVersion Include="Silk.NET.OpenAL" Version="2.22.0" />
+  </ItemGroup>
 </Project>

--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -27,7 +27,11 @@
     <Project Path="samples/KeenEyes.Sample.UI/KeenEyes.Sample.UI.csproj" />
     <Project Path="samples/KeenEyes.Sample/KeenEyes.Sample.csproj" />
   </Folder>
-  <Folder Name="/src/" />
+  <Folder Name="/src/">
+    <Project Path="src/KeenEyes.Audio.Abstractions/KeenEyes.Audio.Abstractions.csproj" />
+    <Project Path="src/KeenEyes.Audio.Silk/KeenEyes.Audio.Silk.csproj" />
+    <Project Path="src/KeenEyes.Audio/KeenEyes.Audio.csproj" />
+  </Folder>
   <Folder Name="/src/core/">
     <Project Path="src/KeenEyes.Abstractions/KeenEyes.Abstractions.csproj" />
     <Project Path="src/KeenEyes.Common/KeenEyes.Common.csproj" />

--- a/src/KeenEyes.Audio.Abstractions/AudioClipInfo.cs
+++ b/src/KeenEyes.Audio.Abstractions/AudioClipInfo.cs
@@ -1,0 +1,18 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Metadata about a loaded audio clip.
+/// </summary>
+/// <param name="Handle">The handle to the audio clip.</param>
+/// <param name="Format">The audio sample format.</param>
+/// <param name="SampleRate">The sample rate in Hz (e.g., 44100).</param>
+/// <param name="Channels">The number of channels (1 for mono, 2 for stereo).</param>
+/// <param name="BitsPerSample">The bits per sample (8 or 16).</param>
+/// <param name="Duration">The duration of the clip in seconds.</param>
+public readonly record struct AudioClipInfo(
+    AudioClipHandle Handle,
+    AudioFormat Format,
+    int SampleRate,
+    int Channels,
+    int BitsPerSample,
+    float Duration);

--- a/src/KeenEyes.Audio.Abstractions/Enums/AudioEnums.cs
+++ b/src/KeenEyes.Audio.Abstractions/Enums/AudioEnums.cs
@@ -1,0 +1,48 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Audio sample format for audio data.
+/// </summary>
+public enum AudioFormat
+{
+    /// <summary>
+    /// 8-bit mono audio (1 channel, 8 bits per sample).
+    /// </summary>
+    Mono8,
+
+    /// <summary>
+    /// 16-bit mono audio (1 channel, 16 bits per sample).
+    /// </summary>
+    Mono16,
+
+    /// <summary>
+    /// 8-bit stereo audio (2 channels, 8 bits per sample).
+    /// </summary>
+    Stereo8,
+
+    /// <summary>
+    /// 16-bit stereo audio (2 channels, 16 bits per sample).
+    /// </summary>
+    Stereo16
+}
+
+/// <summary>
+/// Playback state of an audio source.
+/// </summary>
+public enum AudioPlayState
+{
+    /// <summary>
+    /// The source is stopped and at the beginning.
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The source is currently playing.
+    /// </summary>
+    Playing,
+
+    /// <summary>
+    /// The source is paused at its current position.
+    /// </summary>
+    Paused
+}

--- a/src/KeenEyes.Audio.Abstractions/Exceptions.cs
+++ b/src/KeenEyes.Audio.Abstractions/Exceptions.cs
@@ -1,0 +1,53 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Base exception for audio-related errors.
+/// </summary>
+public class AudioException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public AudioException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public AudioException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when audio device initialization fails.
+/// </summary>
+/// <param name="message">The error message.</param>
+public class AudioInitializationException(string message) : AudioException(message);
+
+/// <summary>
+/// Thrown when loading an audio file fails.
+/// </summary>
+public class AudioLoadException : AudioException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioLoadException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public AudioLoadException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioLoadException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public AudioLoadException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/KeenEyes.Audio.Abstractions/Handles/AudioClipHandle.cs
+++ b/src/KeenEyes.Audio.Abstractions/Handles/AudioClipHandle.cs
@@ -1,0 +1,35 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// An opaque handle to an audio clip resource.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Audio clip handles are returned by <see cref="IAudioContext"/> when loading audio files
+/// and must be used to reference the clip in playback operations.
+/// </para>
+/// <para>
+/// Handles are opaque identifiers that avoid exposing backend-specific resource types,
+/// enabling portability across different audio APIs (OpenAL, XAudio2, etc.).
+/// </para>
+/// </remarks>
+/// <param name="Id">The internal identifier for this audio clip resource.</param>
+public readonly record struct AudioClipHandle(int Id)
+{
+    /// <summary>
+    /// An invalid audio clip handle representing no clip.
+    /// </summary>
+    public static readonly AudioClipHandle Invalid = new(-1);
+
+    /// <summary>
+    /// Gets whether this handle refers to a valid audio clip resource.
+    /// </summary>
+    /// <remarks>
+    /// A valid handle has a non-negative ID. Note that a valid handle does not guarantee
+    /// the resource still exists - it may have been disposed.
+    /// </remarks>
+    public bool IsValid => Id >= 0;
+
+    /// <inheritdoc />
+    public override string ToString() => IsValid ? $"AudioClip({Id})" : "AudioClip(Invalid)";
+}

--- a/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
+++ b/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
@@ -1,0 +1,119 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// High-level audio API for sound playback operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface provides the primary application-level API for audio operations
+/// in KeenEyes. It abstracts resource management (audio clips) and provides
+/// playback control without exposing low-level audio backend details.
+/// </para>
+/// <para>
+/// Unlike <see cref="IAudioDevice"/>, which exposes raw audio operations,
+/// <see cref="IAudioContext"/> uses opaque handles (<see cref="AudioClipHandle"/>)
+/// to reference resources.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Load an audio clip
+/// var clip = audio.LoadClip("assets/sounds/explosion.wav");
+///
+/// // Play the clip (fire and forget)
+/// audio.Play(clip);
+///
+/// // Adjust master volume
+/// audio.MasterVolume = 0.5f;
+/// </code>
+/// </example>
+public interface IAudioContext : IDisposable
+{
+    #region State
+
+    /// <summary>
+    /// Gets the low-level audio device.
+    /// </summary>
+    IAudioDevice? Device { get; }
+
+    /// <summary>
+    /// Gets whether the audio context is initialized and ready for use.
+    /// </summary>
+    bool IsInitialized { get; }
+
+    /// <summary>
+    /// Gets or sets the master volume (0.0 to 1.0).
+    /// </summary>
+    /// <remarks>
+    /// This affects all audio playback. Values above 1.0 may cause clipping.
+    /// </remarks>
+    float MasterVolume { get; set; }
+
+    #endregion
+
+    #region Clip Operations
+
+    /// <summary>
+    /// Loads an audio clip from a file.
+    /// </summary>
+    /// <param name="path">The path to the audio file (WAV format in Phase 1).</param>
+    /// <returns>The audio clip handle.</returns>
+    /// <exception cref="AudioLoadException">Thrown when the file cannot be loaded.</exception>
+    AudioClipHandle LoadClip(string path);
+
+    /// <summary>
+    /// Loads an audio clip from raw audio data.
+    /// </summary>
+    /// <param name="data">The raw audio sample data.</param>
+    /// <param name="format">The audio format.</param>
+    /// <param name="sampleRate">The sample rate in Hz.</param>
+    /// <returns>The audio clip handle.</returns>
+    AudioClipHandle CreateClip(ReadOnlySpan<byte> data, AudioFormat format, int sampleRate);
+
+    /// <summary>
+    /// Gets information about a loaded audio clip.
+    /// </summary>
+    /// <param name="handle">The clip handle.</param>
+    /// <returns>The clip metadata, or null if handle is invalid.</returns>
+    AudioClipInfo? GetClipInfo(AudioClipHandle handle);
+
+    /// <summary>
+    /// Unloads an audio clip and frees its resources.
+    /// </summary>
+    /// <param name="handle">The clip handle.</param>
+    void UnloadClip(AudioClipHandle handle);
+
+    #endregion
+
+    #region Playback
+
+    /// <summary>
+    /// Plays an audio clip once (fire and forget).
+    /// </summary>
+    /// <param name="handle">The clip to play.</param>
+    /// <param name="volume">The playback volume (0.0 to 1.0). Defaults to 1.0.</param>
+    /// <remarks>
+    /// Uses an internal source pool for efficient one-shot playback.
+    /// The source is automatically recycled when playback completes.
+    /// </remarks>
+    void Play(AudioClipHandle handle, float volume = 1f);
+
+    /// <summary>
+    /// Stops all currently playing sounds.
+    /// </summary>
+    void StopAll();
+
+    #endregion
+
+    #region Lifecycle
+
+    /// <summary>
+    /// Updates the audio context (recycles finished sources, etc.).
+    /// </summary>
+    /// <remarks>
+    /// Call this once per frame to maintain the source pool.
+    /// </remarks>
+    void Update();
+
+    #endregion
+}

--- a/src/KeenEyes.Audio.Abstractions/IAudioDevice.cs
+++ b/src/KeenEyes.Audio.Abstractions/IAudioDevice.cs
@@ -1,0 +1,96 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Low-level audio device interface for backend-specific operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface provides direct access to audio backend operations.
+/// Most applications should use <see cref="IAudioContext"/> instead for
+/// high-level audio operations.
+/// </para>
+/// </remarks>
+public interface IAudioDevice : IDisposable
+{
+    /// <summary>
+    /// Gets whether the audio device is initialized and ready.
+    /// </summary>
+    bool IsInitialized { get; }
+
+    /// <summary>
+    /// Gets the name of the audio device.
+    /// </summary>
+    string DeviceName { get; }
+
+    /// <summary>
+    /// Creates an audio buffer for storing audio data.
+    /// </summary>
+    /// <returns>The buffer identifier.</returns>
+    uint CreateBuffer();
+
+    /// <summary>
+    /// Deletes an audio buffer.
+    /// </summary>
+    /// <param name="bufferId">The buffer to delete.</param>
+    void DeleteBuffer(uint bufferId);
+
+    /// <summary>
+    /// Uploads audio data to a buffer.
+    /// </summary>
+    /// <param name="bufferId">The target buffer.</param>
+    /// <param name="format">The audio format.</param>
+    /// <param name="data">The audio sample data.</param>
+    /// <param name="sampleRate">The sample rate in Hz.</param>
+    void BufferData(uint bufferId, AudioFormat format, ReadOnlySpan<byte> data, int sampleRate);
+
+    /// <summary>
+    /// Creates an audio source for playback.
+    /// </summary>
+    /// <returns>The source identifier.</returns>
+    uint CreateSource();
+
+    /// <summary>
+    /// Deletes an audio source.
+    /// </summary>
+    /// <param name="sourceId">The source to delete.</param>
+    void DeleteSource(uint sourceId);
+
+    /// <summary>
+    /// Attaches a buffer to a source.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="bufferId">The buffer to attach.</param>
+    void SetSourceBuffer(uint sourceId, uint bufferId);
+
+    /// <summary>
+    /// Sets the gain (volume) of a source.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="gain">The gain value (0.0 to 1.0+).</param>
+    void SetSourceGain(uint sourceId, float gain);
+
+    /// <summary>
+    /// Plays a source.
+    /// </summary>
+    /// <param name="sourceId">The source to play.</param>
+    void PlaySource(uint sourceId);
+
+    /// <summary>
+    /// Stops a source.
+    /// </summary>
+    /// <param name="sourceId">The source to stop.</param>
+    void StopSource(uint sourceId);
+
+    /// <summary>
+    /// Gets the current playback state of a source.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <returns>The playback state.</returns>
+    AudioPlayState GetSourceState(uint sourceId);
+
+    /// <summary>
+    /// Sets the listener (master) gain.
+    /// </summary>
+    /// <param name="gain">The gain value (0.0 to 1.0+).</param>
+    void SetListenerGain(float gain);
+}

--- a/src/KeenEyes.Audio.Abstractions/KeenEyes.Audio.Abstractions.csproj
+++ b/src/KeenEyes.Audio.Abstractions/KeenEyes.Audio.Abstractions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>KeenEyes.Audio.Abstractions</PackageId>
+    <Description>Backend-agnostic audio abstractions for KeenEyes ECS</Description>
+    <PackageTags>ecs;audio;sound;abstractions</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/KeenEyes.Audio.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Audio.Abstractions/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Audio.Silk/Backend/AudioBuffer.cs
+++ b/src/KeenEyes.Audio.Silk/Backend/AudioBuffer.cs
@@ -1,0 +1,39 @@
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio.Silk.Backend;
+
+/// <summary>
+/// Represents audio data stored in an OpenAL buffer.
+/// </summary>
+internal sealed class AudioBuffer
+{
+    /// <summary>
+    /// Gets the OpenAL buffer identifier.
+    /// </summary>
+    public required uint BufferId { get; init; }
+
+    /// <summary>
+    /// Gets the audio sample format.
+    /// </summary>
+    public required AudioFormat Format { get; init; }
+
+    /// <summary>
+    /// Gets the sample rate in Hz.
+    /// </summary>
+    public required int SampleRate { get; init; }
+
+    /// <summary>
+    /// Gets the number of channels.
+    /// </summary>
+    public required int Channels { get; init; }
+
+    /// <summary>
+    /// Gets the bits per sample.
+    /// </summary>
+    public required int BitsPerSample { get; init; }
+
+    /// <summary>
+    /// Gets the duration in seconds.
+    /// </summary>
+    public required float Duration { get; init; }
+}

--- a/src/KeenEyes.Audio.Silk/Backend/OpenALDevice.cs
+++ b/src/KeenEyes.Audio.Silk/Backend/OpenALDevice.cs
@@ -1,0 +1,163 @@
+using KeenEyes.Audio.Abstractions;
+using Silk.NET.OpenAL;
+using AudioExceptionType = KeenEyes.Audio.Abstractions.AudioException;
+
+namespace KeenEyes.Audio.Silk.Backend;
+
+/// <summary>
+/// OpenAL implementation of <see cref="IAudioDevice"/>.
+/// </summary>
+internal sealed unsafe class OpenALDevice : IAudioDevice
+{
+    private readonly AL al;
+    private readonly ALContext alc;
+    private readonly Device* device;
+    private readonly Context* context;
+    private bool disposed;
+
+    /// <inheritdoc />
+    public bool IsInitialized => device != null && context != null;
+
+    /// <inheritdoc />
+    public string DeviceName { get; }
+
+    internal OpenALDevice(string? deviceName = null)
+    {
+        alc = ALContext.GetApi(soft: true);
+        al = AL.GetApi(soft: true);
+
+        device = alc.OpenDevice(deviceName);
+        if (device == null)
+        {
+            throw new AudioInitializationException("Failed to open OpenAL device");
+        }
+
+        context = alc.CreateContext(device, null);
+        if (context == null)
+        {
+            alc.CloseDevice(device);
+            throw new AudioInitializationException("Failed to create OpenAL context");
+        }
+
+        alc.MakeContextCurrent(context);
+
+        DeviceName = deviceName ?? alc.GetContextProperty(device, GetContextString.DeviceSpecifier) ?? "Unknown";
+    }
+
+    /// <inheritdoc />
+    public uint CreateBuffer()
+    {
+        uint buffer = al.GenBuffer();
+        CheckError("GenBuffer");
+        return buffer;
+    }
+
+    /// <inheritdoc />
+    public void DeleteBuffer(uint bufferId)
+    {
+        al.DeleteBuffer(bufferId);
+    }
+
+    /// <inheritdoc />
+    public void BufferData(uint bufferId, AudioFormat format, ReadOnlySpan<byte> data, int sampleRate)
+    {
+        var alFormat = ToOpenALFormat(format);
+        fixed (byte* ptr = data)
+        {
+            al.BufferData(bufferId, alFormat, ptr, data.Length, sampleRate);
+        }
+        CheckError("BufferData");
+    }
+
+    /// <inheritdoc />
+    public uint CreateSource()
+    {
+        uint source = al.GenSource();
+        CheckError("GenSource");
+        return source;
+    }
+
+    /// <inheritdoc />
+    public void DeleteSource(uint sourceId)
+    {
+        al.DeleteSource(sourceId);
+    }
+
+    /// <inheritdoc />
+    public void SetSourceBuffer(uint sourceId, uint bufferId)
+    {
+        al.SetSourceProperty(sourceId, SourceInteger.Buffer, (int)bufferId);
+    }
+
+    /// <inheritdoc />
+    public void SetSourceGain(uint sourceId, float gain)
+    {
+        al.SetSourceProperty(sourceId, SourceFloat.Gain, gain);
+    }
+
+    /// <inheritdoc />
+    public void PlaySource(uint sourceId)
+    {
+        al.SourcePlay(sourceId);
+    }
+
+    /// <inheritdoc />
+    public void StopSource(uint sourceId)
+    {
+        al.SourceStop(sourceId);
+    }
+
+    /// <inheritdoc />
+    public AudioPlayState GetSourceState(uint sourceId)
+    {
+        al.GetSourceProperty(sourceId, GetSourceInteger.SourceState, out int state);
+        return state switch
+        {
+            (int)SourceState.Playing => AudioPlayState.Playing,
+            (int)SourceState.Paused => AudioPlayState.Paused,
+            _ => AudioPlayState.Stopped
+        };
+    }
+
+    /// <inheritdoc />
+    public void SetListenerGain(float gain)
+    {
+        al.SetListenerProperty(ListenerFloat.Gain, gain);
+    }
+
+    private static BufferFormat ToOpenALFormat(AudioFormat format) => format switch
+    {
+        AudioFormat.Mono8 => BufferFormat.Mono8,
+        AudioFormat.Mono16 => BufferFormat.Mono16,
+        AudioFormat.Stereo8 => BufferFormat.Stereo8,
+        AudioFormat.Stereo16 => BufferFormat.Stereo16,
+        _ => throw new ArgumentOutOfRangeException(nameof(format))
+    };
+
+    private void CheckError(string operation)
+    {
+        var error = al.GetError();
+        if (error != AudioError.NoError)
+        {
+            throw new AudioExceptionType($"OpenAL error during {operation}: {error}");
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        alc.MakeContextCurrent(null);
+        alc.DestroyContext(context);
+        alc.CloseDevice(device);
+
+        al.Dispose();
+        alc.Dispose();
+    }
+}

--- a/src/KeenEyes.Audio.Silk/Backend/SourcePool.cs
+++ b/src/KeenEyes.Audio.Silk/Backend/SourcePool.cs
@@ -1,0 +1,104 @@
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio.Silk.Backend;
+
+/// <summary>
+/// Pool of OpenAL sources for efficient one-shot playback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Creating and destroying OpenAL sources is expensive. This pool pre-allocates
+/// sources and recycles them as sounds finish playing, improving performance
+/// for games with many simultaneous sound effects.
+/// </para>
+/// </remarks>
+internal sealed class SourcePool : IDisposable
+{
+    private readonly OpenALDevice device;
+    private readonly List<uint> availableSources = [];
+    private readonly List<uint> playingSources = [];
+    private bool disposed;
+
+    internal SourcePool(OpenALDevice device, int maxSources)
+    {
+        this.device = device;
+
+        // Pre-allocate sources
+        for (int i = 0; i < maxSources; i++)
+        {
+            availableSources.Add(device.CreateSource());
+        }
+    }
+
+    /// <summary>
+    /// Gets a source for one-shot playback, or null if pool is exhausted.
+    /// </summary>
+    /// <returns>A source ID, or null if no sources are available.</returns>
+    public uint? AcquireSource()
+    {
+        if (availableSources.Count == 0)
+        {
+            return null;
+        }
+
+        int lastIndex = availableSources.Count - 1;
+        uint source = availableSources[lastIndex];
+        availableSources.RemoveAt(lastIndex);
+        playingSources.Add(source);
+        return source;
+    }
+
+    /// <summary>
+    /// Updates the pool, recycling sources that have finished playing.
+    /// </summary>
+    public void Update()
+    {
+        for (int i = playingSources.Count - 1; i >= 0; i--)
+        {
+            uint source = playingSources[i];
+            if (device.GetSourceState(source) != AudioPlayState.Playing)
+            {
+                // Reset source state
+                device.StopSource(source);
+                device.SetSourceBuffer(source, 0);
+
+                playingSources.RemoveAt(i);
+                availableSources.Add(source);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stops all playing sources and returns them to the pool.
+    /// </summary>
+    public void StopAll()
+    {
+        foreach (var source in playingSources)
+        {
+            device.StopSource(source);
+            device.SetSourceBuffer(source, 0);
+            availableSources.Add(source);
+        }
+        playingSources.Clear();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        foreach (var source in availableSources)
+        {
+            device.DeleteSource(source);
+        }
+        foreach (var source in playingSources)
+        {
+            device.DeleteSource(source);
+        }
+    }
+}

--- a/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
+++ b/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
@@ -1,0 +1,144 @@
+using System.Buffers.Binary;
+using System.Text;
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio.Silk.Decoders;
+
+/// <summary>
+/// Decodes WAV audio files.
+/// </summary>
+internal static class WavDecoder
+{
+    /// <summary>
+    /// Decodes a WAV file from a byte array.
+    /// </summary>
+    /// <param name="data">The WAV file data.</param>
+    /// <returns>The decoded audio data.</returns>
+    /// <exception cref="AudioLoadException">Thrown when the WAV file is invalid or unsupported.</exception>
+    public static WavData Decode(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 44)
+        {
+            throw new AudioLoadException("WAV file too small for header");
+        }
+
+        // RIFF header
+        var riff = Encoding.ASCII.GetString(data[..4]);
+        if (riff != "RIFF")
+        {
+            throw new AudioLoadException("Invalid WAV file: missing RIFF header");
+        }
+
+        // Skip file size (bytes 4-7)
+
+        var wave = Encoding.ASCII.GetString(data.Slice(8, 4));
+        if (wave != "WAVE")
+        {
+            throw new AudioLoadException("Invalid WAV file: missing WAVE format");
+        }
+
+        // Find fmt and data chunks
+        int offset = 12;
+        int channels = 0;
+        int sampleRate = 0;
+        int bitsPerSample = 0;
+
+        while (offset < data.Length - 8)
+        {
+            var chunkId = Encoding.ASCII.GetString(data.Slice(offset, 4));
+            var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(offset + 4, 4));
+
+            if (chunkId == "fmt ")
+            {
+                var formatTag = BinaryPrimitives.ReadInt16LittleEndian(data.Slice(offset + 8, 2));
+                if (formatTag != 1) // PCM
+                {
+                    throw new AudioLoadException($"Unsupported WAV format: {formatTag} (only PCM supported)");
+                }
+
+                channels = BinaryPrimitives.ReadInt16LittleEndian(data.Slice(offset + 10, 2));
+                sampleRate = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(offset + 12, 4));
+                // Skip byte rate (offset + 16) and block align (offset + 20)
+                bitsPerSample = BinaryPrimitives.ReadInt16LittleEndian(data.Slice(offset + 22, 2));
+            }
+            else if (chunkId == "data")
+            {
+                if (channels == 0 || sampleRate == 0 || bitsPerSample == 0)
+                {
+                    throw new AudioLoadException("Invalid WAV file: data chunk before fmt chunk");
+                }
+
+                var audioData = data.Slice(offset + 8, chunkSize).ToArray();
+                var format = GetAudioFormat(channels, bitsPerSample);
+                var duration = (float)audioData.Length / (sampleRate * channels * (bitsPerSample / 8));
+
+                return new WavData
+                {
+                    Data = audioData,
+                    Format = format,
+                    SampleRate = sampleRate,
+                    Channels = channels,
+                    BitsPerSample = bitsPerSample,
+                    Duration = duration
+                };
+            }
+
+            offset += 8 + chunkSize;
+            // Align to word boundary
+            if (chunkSize % 2 == 1)
+            {
+                offset++;
+            }
+        }
+
+        throw new AudioLoadException("Invalid WAV file: missing data chunk");
+    }
+
+    private static AudioFormat GetAudioFormat(int channels, int bitsPerSample)
+    {
+        return (channels, bitsPerSample) switch
+        {
+            (1, 8) => AudioFormat.Mono8,
+            (1, 16) => AudioFormat.Mono16,
+            (2, 8) => AudioFormat.Stereo8,
+            (2, 16) => AudioFormat.Stereo16,
+            _ => throw new AudioLoadException($"Unsupported audio format: {channels} channels, {bitsPerSample} bits")
+        };
+    }
+}
+
+/// <summary>
+/// Decoded WAV audio data.
+/// </summary>
+internal sealed class WavData
+{
+    /// <summary>
+    /// Gets the raw audio sample data.
+    /// </summary>
+    public required byte[] Data { get; init; }
+
+    /// <summary>
+    /// Gets the audio format.
+    /// </summary>
+    public required AudioFormat Format { get; init; }
+
+    /// <summary>
+    /// Gets the sample rate in Hz.
+    /// </summary>
+    public required int SampleRate { get; init; }
+
+    /// <summary>
+    /// Gets the number of channels.
+    /// </summary>
+    public required int Channels { get; init; }
+
+    /// <summary>
+    /// Gets the bits per sample.
+    /// </summary>
+    public required int BitsPerSample { get; init; }
+
+    /// <summary>
+    /// Gets the duration in seconds.
+    /// </summary>
+    public required float Duration { get; init; }
+}

--- a/src/KeenEyes.Audio.Silk/KeenEyes.Audio.Silk.csproj
+++ b/src/KeenEyes.Audio.Silk/KeenEyes.Audio.Silk.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>KeenEyes.Audio.Silk</PackageId>
+    <Description>Silk.NET OpenAL audio implementation for KeenEyes ECS</Description>
+    <PackageTags>ecs;audio;sound;openal;silk.net</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Audio.Silk.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Audio\KeenEyes.Audio.csproj" />
+    <ProjectReference Include="..\KeenEyes.Audio.Abstractions\KeenEyes.Audio.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Platform.Silk.Abstractions\KeenEyes.Platform.Silk.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Silk.NET.OpenAL" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Audio.Silk/SilkAudioConfig.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioConfig.cs
@@ -1,0 +1,26 @@
+namespace KeenEyes.Audio.Silk;
+
+/// <summary>
+/// Configuration options for the Silk.NET audio plugin.
+/// </summary>
+public sealed class SilkAudioConfig
+{
+    /// <summary>
+    /// Gets or sets the maximum number of simultaneous one-shot sounds.
+    /// </summary>
+    /// <remarks>
+    /// This determines the source pool size. Increase for games with many
+    /// simultaneous sound effects. Default is 32.
+    /// </remarks>
+    public int MaxOneShotSources { get; set; } = 32;
+
+    /// <summary>
+    /// Gets or sets the initial master volume (0.0 to 1.0).
+    /// </summary>
+    public float InitialMasterVolume { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Gets or sets the audio device name to use, or null for default device.
+    /// </summary>
+    public string? DeviceName { get; set; }
+}

--- a/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
@@ -1,0 +1,224 @@
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Audio.Silk.Backend;
+using KeenEyes.Audio.Silk.Decoders;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Audio.Silk;
+
+/// <summary>
+/// Silk.NET OpenAL implementation of <see cref="IAudioContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This context wraps OpenAL via Silk.NET and provides audio clip loading
+/// and one-shot playback functionality.
+/// </para>
+/// <para>
+/// The audio context uses a shared <see cref="ISilkWindowProvider"/> to coordinate
+/// lifecycle with the window, initializing OpenAL when the window loads and
+/// cleaning up when it closes.
+/// </para>
+/// </remarks>
+[PluginExtension("SilkAudio")]
+public sealed class SilkAudioContext : IAudioContext
+{
+    private readonly SilkAudioConfig config;
+    private readonly ISilkWindowProvider windowProvider;
+    private readonly Dictionary<int, AudioBuffer> buffers = [];
+    private int nextBufferId = 1;
+
+    private OpenALDevice? device;
+    private SourcePool? sourcePool;
+    private float masterVolume = 1f;
+    private bool initialized;
+    private bool disposed;
+
+    /// <inheritdoc />
+    public IAudioDevice? Device => device;
+
+    /// <inheritdoc />
+    public bool IsInitialized => initialized;
+
+    /// <inheritdoc />
+    public float MasterVolume
+    {
+        get => masterVolume;
+        set
+        {
+            masterVolume = Math.Clamp(value, 0f, 2f);
+            device?.SetListenerGain(masterVolume);
+        }
+    }
+
+    internal SilkAudioContext(ISilkWindowProvider windowProvider, SilkAudioConfig? config = null)
+    {
+        this.windowProvider = windowProvider;
+        this.config = config ?? new SilkAudioConfig();
+
+        // Hook into window lifecycle
+        windowProvider.Window.Load += HandleWindowLoad;
+        windowProvider.Window.Closing += HandleWindowClosing;
+    }
+
+    private void HandleWindowLoad()
+    {
+        device = new OpenALDevice(config.DeviceName);
+        sourcePool = new SourcePool(device, config.MaxOneShotSources);
+        device.SetListenerGain(config.InitialMasterVolume);
+        masterVolume = config.InitialMasterVolume;
+        initialized = true;
+    }
+
+    private void HandleWindowClosing()
+    {
+        DisposeAudioResources();
+    }
+
+    /// <inheritdoc />
+    public AudioClipHandle LoadClip(string path)
+    {
+        ThrowIfNotInitialized();
+
+        try
+        {
+            var fileData = File.ReadAllBytes(path);
+            var wavData = WavDecoder.Decode(fileData);
+
+            return CreateClipInternal(wavData.Data, wavData.Format, wavData.SampleRate,
+                wavData.Channels, wavData.BitsPerSample, wavData.Duration);
+        }
+        catch (IOException ex)
+        {
+            throw new AudioLoadException($"Failed to load audio file: {path}", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public AudioClipHandle CreateClip(ReadOnlySpan<byte> data, AudioFormat format, int sampleRate)
+    {
+        ThrowIfNotInitialized();
+
+        int channels = format is AudioFormat.Stereo8 or AudioFormat.Stereo16 ? 2 : 1;
+        int bitsPerSample = format is AudioFormat.Mono16 or AudioFormat.Stereo16 ? 16 : 8;
+        float duration = (float)data.Length / (sampleRate * channels * (bitsPerSample / 8));
+
+        return CreateClipInternal(data.ToArray(), format, sampleRate, channels, bitsPerSample, duration);
+    }
+
+    private AudioClipHandle CreateClipInternal(byte[] data, AudioFormat format, int sampleRate,
+        int channels, int bitsPerSample, float duration)
+    {
+        uint bufferId = device!.CreateBuffer();
+        device.BufferData(bufferId, format, data, sampleRate);
+
+        var buffer = new AudioBuffer
+        {
+            BufferId = bufferId,
+            Format = format,
+            SampleRate = sampleRate,
+            Channels = channels,
+            BitsPerSample = bitsPerSample,
+            Duration = duration
+        };
+
+        int id = nextBufferId++;
+        buffers[id] = buffer;
+        return new AudioClipHandle(id);
+    }
+
+    /// <inheritdoc />
+    public AudioClipInfo? GetClipInfo(AudioClipHandle handle)
+    {
+        if (!buffers.TryGetValue(handle.Id, out var buffer))
+        {
+            return null;
+        }
+
+        return new AudioClipInfo(
+            handle,
+            buffer.Format,
+            buffer.SampleRate,
+            buffer.Channels,
+            buffer.BitsPerSample,
+            buffer.Duration);
+    }
+
+    /// <inheritdoc />
+    public void UnloadClip(AudioClipHandle handle)
+    {
+        if (buffers.Remove(handle.Id, out var buffer))
+        {
+            device?.DeleteBuffer(buffer.BufferId);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Play(AudioClipHandle handle, float volume = 1f)
+    {
+        ThrowIfNotInitialized();
+
+        if (!buffers.TryGetValue(handle.Id, out var buffer))
+        {
+            return; // Invalid handle, silently ignore
+        }
+
+        var source = sourcePool!.AcquireSource();
+        if (source == null)
+        {
+            return; // Pool exhausted, silently ignore
+        }
+
+        device!.SetSourceBuffer(source.Value, buffer.BufferId);
+        device.SetSourceGain(source.Value, volume);
+        device.PlaySource(source.Value);
+    }
+
+    /// <inheritdoc />
+    public void StopAll()
+    {
+        sourcePool?.StopAll();
+    }
+
+    /// <inheritdoc />
+    public void Update()
+    {
+        sourcePool?.Update();
+    }
+
+    private void ThrowIfNotInitialized()
+    {
+        if (!initialized)
+        {
+            throw new InvalidOperationException(
+                "Audio not initialized. Wait for window to load.");
+        }
+    }
+
+    private void DisposeAudioResources()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        sourcePool?.Dispose();
+
+        foreach (var buffer in buffers.Values)
+        {
+            device?.DeleteBuffer(buffer.BufferId);
+        }
+        buffers.Clear();
+
+        device?.Dispose();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        windowProvider.Window.Load -= HandleWindowLoad;
+        windowProvider.Window.Closing -= HandleWindowClosing;
+        DisposeAudioResources();
+    }
+}

--- a/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
@@ -1,0 +1,88 @@
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Audio.Silk;
+
+/// <summary>
+/// Plugin that provides Silk.NET OpenAL audio capabilities to a KeenEyes world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin requires <c>SilkWindowPlugin</c> from KeenEyes.Platform.Silk to be installed first.
+/// It will throw an <see cref="InvalidOperationException"/> if the window plugin is not available.
+/// </para>
+/// <para>
+/// The plugin creates a <see cref="SilkAudioContext"/> extension that provides
+/// audio clip loading and one-shot playback functionality.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Install window plugin first (required)
+/// world.InstallPlugin(new SilkWindowPlugin(new WindowConfig
+/// {
+///     Title = "My Game",
+///     Width = 1920,
+///     Height = 1080
+/// }));
+///
+/// // Then install audio plugin
+/// world.InstallPlugin(new SilkAudioPlugin(new SilkAudioConfig
+/// {
+///     MaxOneShotSources = 64,
+///     InitialMasterVolume = 0.8f
+/// }));
+///
+/// // Access audio context
+/// var audio = world.GetExtension&lt;IAudioContext&gt;();
+/// var clip = audio.LoadClip("assets/sounds/explosion.wav");
+/// audio.Play(clip);
+/// </code>
+/// </example>
+/// <param name="config">The audio configuration.</param>
+public sealed class SilkAudioPlugin(SilkAudioConfig config) : IWorldPlugin
+{
+    private SilkAudioContext? audioContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SilkAudioPlugin"/> class with default configuration.
+    /// </summary>
+    public SilkAudioPlugin()
+        : this(new SilkAudioConfig())
+    {
+    }
+
+    /// <inheritdoc />
+    public string Name => "SilkAudio";
+
+    /// <inheritdoc />
+    public void Install(IPluginContext context)
+    {
+        // Explicit dependency - fail loudly if window plugin not installed
+        if (!context.TryGetExtension<ISilkWindowProvider>(out var windowProvider) || windowProvider is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SilkAudioPlugin)} requires SilkWindowPlugin to be installed first. " +
+                $"Install SilkWindowPlugin before installing {nameof(SilkAudioPlugin)}.");
+        }
+
+        // Create audio context using the shared window provider
+        audioContext = new SilkAudioContext(windowProvider, config);
+
+        // Register as both interface and concrete type for flexibility
+        context.SetExtension<IAudioContext>(audioContext);
+        context.SetExtension(audioContext);
+
+        // Register backend-agnostic audio update system
+        context.AddSystem<AudioUpdateSystem>(SystemPhase.Update);
+    }
+
+    /// <inheritdoc />
+    public void Uninstall(IPluginContext context)
+    {
+        context.RemoveExtension<IAudioContext>();
+        context.RemoveExtension<SilkAudioContext>();
+        audioContext?.Dispose();
+        audioContext = null;
+    }
+}

--- a/src/KeenEyes.Audio.Silk/packages.lock.json
+++ b/src/KeenEyes.Audio.Silk/packages.lock.json
@@ -1,0 +1,139 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "Silk.NET.OpenAL": {
+        "type": "Direct",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "YpzIhYRcUZ8dHML8+DUHqEgu0exmZhouWYHGR4AXPtD63YbFuuO4aFqulWkCpIaOvjCdsIWtNKElLJreLxXvFw==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "NSmDw3K0ozNDgShSIpsZcbFIzBX4w28nDag+TfaQujkXGazBm+lid5onlWoCBy4VsLxqnnKjEBbGSJVWJMf43g=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "XbDilPmvsQIrvxZkeVCNNX3LyRtA3hN6UykAiyZjlu/JkYh68U3WQummpP+j7jsxlX8s/pOrrU3vbN8LnMl0VA==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "8.0.0"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "I1u6CmwwtD+5OIHditbMBVHRQUHZWhfW3Z38mvydxwkZpAvjs5BCxyen6ecOVpbYD6I0EOjZ42M3IsaZbwiYUg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "DZy30akJABBmTnn8OICik0TFEuXrkd7YCQvoq+oh50eJzXt8JgEYYa+sJYBib/Phs5WULZg/QR7fM8Gi1G3tXg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "LZPZT1e/RxnjKfkqlp2Wp8KJFP1Av/ErTCZ00EzZpFR1lhUSBgSmgJwXg6XlWoEJHyeJcsXV688zjoEe6YW0BA==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "ynasHSQ4jGrmpn/07UagE3qVNRLzWvg+fbM8uHI0d5LF95y++Kuno42QLkP/UEruC1YovI+NRhMfGJy0gDQaZg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Maths": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "hBNxNSLvx/jdfvbU6oCsXcgLfqf9hMlEc6Mq/rllJ0eUTLloacuOZHTM8V702QGf7hOR+Mo4bTFqTqBnC0CM7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.22.0",
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.audio": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.22.0, )",
+          "Silk.NET.Windowing": "[2.22.0, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "1gqbKHrKpBv2Vk983kVpMqXL4Uj36NaUIQ2YbQosFVa3pXJE8UMGiWqKtaeoMqnzItusZ1WYgDHKge37EvNm/w==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Input.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "W9b5UlUGCu5Ywb5f8ZyIWJ475ucY+mT/nEiSTo3JH098VxHaZS/02bYr9f29VWBaJhh3DwMkfxQvgTyXzTrHyw=="
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "yKGe/8REdm+T43LdtfUpFUx9eQARwx6wTmEoJ2bANVGQPCvWYC2Qi1+haT6n63dyNIX+iJWKg4++F4TFjg0/Fw==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Audio/KeenEyes.Audio.csproj
+++ b/src/KeenEyes.Audio/KeenEyes.Audio.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>KeenEyes.Audio</PackageId>
+    <Description>Backend-agnostic audio systems for KeenEyes ECS</Description>
+    <PackageTags>ecs;audio;sound;game</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Audio.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Audio.Abstractions\KeenEyes.Audio.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Audio/Systems/AudioUpdateSystem.cs
+++ b/src/KeenEyes.Audio/Systems/AudioUpdateSystem.cs
@@ -1,0 +1,58 @@
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio;
+
+/// <summary>
+/// System that updates the audio context each frame.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs in the Update phase and calls <see cref="IAudioContext.Update"/>
+/// to maintain the audio backend. The primary purpose is to recycle audio sources
+/// that have finished playing back to the source pool.
+/// </para>
+/// <para>
+/// Without this system, the source pool would eventually be exhausted as finished
+/// sources would not be returned to the pool for reuse.
+/// </para>
+/// <para>
+/// This system is backend-agnostic and works with any <see cref="IAudioContext"/>
+/// implementation registered as a world extension.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Typically added by the audio plugin, but can be added manually:
+/// world.AddSystem&lt;AudioUpdateSystem&gt;(SystemPhase.Update);
+/// </code>
+/// </example>
+public sealed class AudioUpdateSystem : ISystem
+{
+    private IWorld? world;
+    private IAudioContext? audioContext;
+
+    /// <inheritdoc />
+    public bool Enabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public void Initialize(IWorld world)
+    {
+        this.world = world;
+    }
+
+    /// <inheritdoc />
+    public void Update(float deltaTime)
+    {
+        // Lazy initialization - get audio context on first update
+        audioContext ??= world?.TryGetExtension<IAudioContext>(out var ctx) == true ? ctx : null;
+
+        // Call update to recycle finished sources
+        audioContext?.Update();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // No resources to dispose
+    }
+}

--- a/src/KeenEyes.Audio/packages.lock.json
+++ b/src/KeenEyes.Audio/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements Phase 1 of the audio system following established patterns from Graphics and Input subsystems
- Creates three new projects: `KeenEyes.Audio.Abstractions`, `KeenEyes.Audio`, and `KeenEyes.Audio.Silk`
- Adds OpenAL backend via Silk.NET for cross-platform audio support
- Provides WAV file loading, one-shot playback, and automatic source pool management

## New Projects

| Project | Purpose |
|---------|---------|
| `KeenEyes.Audio.Abstractions` | Backend-agnostic interfaces (`IAudioContext`, `IAudioDevice`), opaque handles, enums |
| `KeenEyes.Audio` | ECS integration with `AudioUpdateSystem` for source pool recycling |
| `KeenEyes.Audio.Silk` | OpenAL implementation via Silk.NET with `SilkAudioPlugin` |

## Key Features

- **WAV file loading** via `WavDecoder`
- **One-shot playback** (fire and forget) with efficient source pooling
- **Master volume control**
- **Automatic source pool recycling** via `AudioUpdateSystem`
- **Plugin registration** following `SilkInputPlugin` pattern

## Usage Example

```csharp
// Setup
world.InstallPlugin(new SilkWindowPlugin(windowConfig));
world.InstallPlugin(new SilkAudioPlugin(new SilkAudioConfig
{
    MaxOneShotSources = 64,
    InitialMasterVolume = 0.8f
}));

// Load and play
var audio = world.GetExtension<IAudioContext>();
var clip = audio.LoadClip("assets/sounds/explosion.wav");
audio.Play(clip);
```

## Test plan

- [x] All existing tests pass (4213 passed, 0 failed)
- [x] Full solution builds with 0 warnings, 0 errors
- [x] New projects added to solution and build correctly
- [ ] Manual testing with actual WAV files (requires audio device)
- [ ] Integration testing in sample project (deferred to follow-up)

## Related Issues

- Closes #419 (Phase 1: Core Infrastructure)
- Related: #420 (Phase 2: ECS Integration - AudioSource, AudioListener components)
- Related: #421 (Phase 3: Music streaming and mixer support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)