### PR TITLE
feat: Add complete audio API and ECS components (Issues #419, #420, #421)

### DIFF
--- a/src/KeenEyes.Audio.Abstractions/AudioConfig.cs
+++ b/src/KeenEyes.Audio.Abstractions/AudioConfig.cs
@@ -1,0 +1,80 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Configuration options for the audio system.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this to configure global audio settings that affect all sounds.
+/// These values are typically set once when initializing the audio system.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var config = new AudioConfig
+/// {
+///     MaxSimultaneousSounds = 64,
+///     DefaultMinDistance = 2f,
+///     DefaultMaxDistance = 50f
+/// };
+/// </code>
+/// </example>
+public sealed class AudioConfig
+{
+    /// <summary>
+    /// Maximum number of sounds that can play simultaneously.
+    /// </summary>
+    /// <remarks>
+    /// Sounds beyond this limit will be silently ignored or oldest sounds
+    /// may be stopped to make room for new ones, depending on implementation.
+    /// </remarks>
+    public int MaxSimultaneousSounds { get; init; } = 32;
+
+    /// <summary>
+    /// Default minimum distance for 3D spatial audio sources.
+    /// </summary>
+    /// <remarks>
+    /// Within this distance, sound plays at full volume.
+    /// </remarks>
+    public float DefaultMinDistance { get; init; } = 1f;
+
+    /// <summary>
+    /// Default maximum distance for 3D spatial audio sources.
+    /// </summary>
+    /// <remarks>
+    /// Beyond this distance, sound is inaudible (for linear rolloff)
+    /// or attenuated to near-zero (for logarithmic/exponential rolloff).
+    /// </remarks>
+    public float DefaultMaxDistance { get; init; } = 100f;
+
+    /// <summary>
+    /// Default distance attenuation curve for 3D audio.
+    /// </summary>
+    public AudioRolloffMode DefaultRolloff { get; init; } = AudioRolloffMode.Logarithmic;
+
+    /// <summary>
+    /// Doppler effect intensity factor.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>0 = Doppler effect disabled</item>
+    /// <item>1 = Normal Doppler effect</item>
+    /// <item>2+ = Exaggerated Doppler effect</item>
+    /// </list>
+    /// </remarks>
+    public float DopplerFactor { get; init; } = 1f;
+
+    /// <summary>
+    /// Speed of sound in units per second (for Doppler calculations).
+    /// </summary>
+    /// <remarks>
+    /// The default value of 343 represents the speed of sound in air at 20°C
+    /// in meters per second. Adjust this to match your game's unit system.
+    /// </remarks>
+    public float SpeedOfSound { get; init; } = 343f;
+
+    /// <summary>
+    /// Default configuration with sensible defaults for most games.
+    /// </summary>
+    public static AudioConfig Default => new();
+}

--- a/src/KeenEyes.Audio.Abstractions/Enums/AudioChannel.cs
+++ b/src/KeenEyes.Audio.Abstractions/Enums/AudioChannel.cs
@@ -1,0 +1,38 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Audio channel categories for mixer control and volume grouping.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each channel can have its own volume level, allowing users to independently
+/// control different types of audio (e.g., mute music while keeping sound effects).
+/// </para>
+/// </remarks>
+public enum AudioChannel
+{
+    /// <summary>
+    /// Master channel affecting all audio output.
+    /// </summary>
+    Master,
+
+    /// <summary>
+    /// Background music and soundtrack.
+    /// </summary>
+    Music,
+
+    /// <summary>
+    /// Sound effects (explosions, footsteps, UI sounds).
+    /// </summary>
+    SFX,
+
+    /// <summary>
+    /// Voice and dialogue audio.
+    /// </summary>
+    Voice,
+
+    /// <summary>
+    /// Ambient and environmental sounds (wind, rain, crowd noise).
+    /// </summary>
+    Ambient
+}

--- a/src/KeenEyes.Audio.Abstractions/Enums/AudioEnums.cs
+++ b/src/KeenEyes.Audio.Abstractions/Enums/AudioEnums.cs
@@ -46,3 +46,49 @@ public enum AudioPlayState
     /// </summary>
     Paused
 }
+
+/// <summary>
+/// Distance attenuation curve for 3D spatial audio.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Controls how audio volume decreases as the listener moves away from the source.
+/// Different modes are suitable for different types of audio sources.
+/// </para>
+/// </remarks>
+public enum AudioRolloffMode
+{
+    /// <summary>
+    /// Linear falloff: Volume decreases linearly from MinDistance to MaxDistance.
+    /// </summary>
+    /// <remarks>
+    /// Volume = 1 - (distance - minDist) / (maxDist - minDist)
+    /// </remarks>
+    Linear,
+
+    /// <summary>
+    /// Logarithmic (inverse) falloff: Realistic sound propagation.
+    /// </summary>
+    /// <remarks>
+    /// Volume = minDist / (minDist + rolloff * (distance - minDist))
+    /// </remarks>
+    Logarithmic,
+
+    /// <summary>
+    /// Exponential falloff: Faster drop-off than logarithmic.
+    /// </summary>
+    /// <remarks>
+    /// Volume = pow(distance / minDist, -rolloff)
+    /// </remarks>
+    Exponential,
+
+    /// <summary>
+    /// User-defined custom attenuation curve.
+    /// </summary>
+    /// <remarks>
+    /// When using custom rolloff, the application must compute and set
+    /// the source gain manually based on distance. The audio backend
+    /// will not apply automatic distance attenuation.
+    /// </remarks>
+    Custom
+}

--- a/src/KeenEyes.Audio.Abstractions/Handles/SoundHandle.cs
+++ b/src/KeenEyes.Audio.Abstractions/Handles/SoundHandle.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// An opaque handle to a playing sound instance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sound handles reference active playback instances, allowing control over
+/// playing sounds (stop, pause, volume changes). Unlike <see cref="AudioClipHandle"/>
+/// which references loaded audio data, <see cref="SoundHandle"/> references a
+/// runtime playback state.
+/// </para>
+/// <para>
+/// A single <see cref="AudioClipHandle"/> can have multiple concurrent
+/// <see cref="SoundHandle"/> instances playing simultaneously.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var clip = audio.LoadClip("explosion.wav");
+/// var sound = audio.Play(clip, volume: 0.8f);
+///
+/// // Later, stop the specific sound instance
+/// audio.Stop(sound);
+/// </code>
+/// </example>
+/// <param name="Id">The internal identifier for this sound instance.</param>
+public readonly record struct SoundHandle(int Id)
+{
+    /// <summary>
+    /// An invalid sound handle representing no sound.
+    /// </summary>
+    public static readonly SoundHandle Invalid = new(-1);
+
+    /// <summary>
+    /// Gets whether this handle refers to a valid sound instance.
+    /// </summary>
+    public bool IsValid => Id >= 0;
+
+    /// <inheritdoc/>
+    public override string ToString() => IsValid ? $"Sound({Id})" : "Sound(Invalid)";
+}

--- a/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
+++ b/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace KeenEyes.Audio.Abstractions;
 
 /// <summary>
@@ -83,6 +85,18 @@ public interface IAudioContext : IDisposable
     /// <param name="handle">The clip handle.</param>
     void UnloadClip(AudioClipHandle handle);
 
+    /// <summary>
+    /// Gets the internal backend buffer ID for a clip handle.
+    /// </summary>
+    /// <param name="handle">The clip handle.</param>
+    /// <returns>The backend buffer ID, or 0 if the handle is invalid.</returns>
+    /// <remarks>
+    /// This is an advanced method for systems that manage their own audio sources
+    /// directly through <see cref="IAudioDevice"/>. Most applications should use
+    /// the <see cref="Play(AudioClipHandle, float)"/> methods instead.
+    /// </remarks>
+    uint GetBufferId(AudioClipHandle handle);
+
     #endregion
 
     #region Playback
@@ -90,18 +104,158 @@ public interface IAudioContext : IDisposable
     /// <summary>
     /// Plays an audio clip once (fire and forget).
     /// </summary>
-    /// <param name="handle">The clip to play.</param>
+    /// <param name="clip">The clip to play.</param>
     /// <param name="volume">The playback volume (0.0 to 1.0). Defaults to 1.0.</param>
+    /// <returns>A handle to the playing sound for optional control.</returns>
     /// <remarks>
     /// Uses an internal source pool for efficient one-shot playback.
     /// The source is automatically recycled when playback completes.
     /// </remarks>
-    void Play(AudioClipHandle handle, float volume = 1f);
+    SoundHandle Play(AudioClipHandle clip, float volume = 1f);
+
+    /// <summary>
+    /// Plays an audio clip with custom playback options.
+    /// </summary>
+    /// <param name="clip">The clip to play.</param>
+    /// <param name="options">Playback options (volume, pitch, loop, channel).</param>
+    /// <returns>A handle to the playing sound for optional control.</returns>
+    SoundHandle Play(AudioClipHandle clip, PlaybackOptions options);
+
+    /// <summary>
+    /// Plays an audio clip at a 3D position.
+    /// </summary>
+    /// <param name="clip">The clip to play.</param>
+    /// <param name="position">The world-space position of the sound.</param>
+    /// <param name="volume">The playback volume (0.0 to 1.0). Defaults to 1.0.</param>
+    /// <returns>A handle to the playing sound for optional control.</returns>
+    SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, float volume = 1f);
+
+    /// <summary>
+    /// Plays an audio clip at a 3D position with custom options.
+    /// </summary>
+    /// <param name="clip">The clip to play.</param>
+    /// <param name="position">The world-space position of the sound.</param>
+    /// <param name="options">Playback options (volume, pitch, loop, channel).</param>
+    /// <returns>A handle to the playing sound for optional control.</returns>
+    SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, PlaybackOptions options);
+
+    /// <summary>
+    /// Stops a specific playing sound.
+    /// </summary>
+    /// <param name="sound">The sound handle to stop.</param>
+    void Stop(SoundHandle sound);
+
+    /// <summary>
+    /// Pauses a specific playing sound.
+    /// </summary>
+    /// <param name="sound">The sound handle to pause.</param>
+    void Pause(SoundHandle sound);
+
+    /// <summary>
+    /// Resumes a paused sound.
+    /// </summary>
+    /// <param name="sound">The sound handle to resume.</param>
+    void Resume(SoundHandle sound);
+
+    /// <summary>
+    /// Sets the volume of a playing sound.
+    /// </summary>
+    /// <param name="sound">The sound handle.</param>
+    /// <param name="volume">The new volume (0.0 to 1.0).</param>
+    void SetVolume(SoundHandle sound, float volume);
+
+    /// <summary>
+    /// Sets the pitch of a playing sound.
+    /// </summary>
+    /// <param name="sound">The sound handle.</param>
+    /// <param name="pitch">The new pitch multiplier.</param>
+    void SetPitch(SoundHandle sound, float pitch);
+
+    /// <summary>
+    /// Sets the 3D position of a playing sound.
+    /// </summary>
+    /// <param name="sound">The sound handle.</param>
+    /// <param name="position">The new world-space position.</param>
+    void SetPosition(SoundHandle sound, Vector3 position);
+
+    /// <summary>
+    /// Checks whether a sound is currently playing.
+    /// </summary>
+    /// <param name="sound">The sound handle.</param>
+    /// <returns>True if the sound is playing, false otherwise.</returns>
+    bool IsPlaying(SoundHandle sound);
 
     /// <summary>
     /// Stops all currently playing sounds.
     /// </summary>
     void StopAll();
+
+    /// <summary>
+    /// Pauses all currently playing sounds.
+    /// </summary>
+    void PauseAll();
+
+    /// <summary>
+    /// Resumes all paused sounds.
+    /// </summary>
+    void ResumeAll();
+
+    #endregion
+
+    #region Channel Volume
+
+    /// <summary>
+    /// Gets the volume for a specific audio channel.
+    /// </summary>
+    /// <param name="channel">The audio channel.</param>
+    /// <returns>The channel volume (0.0 to 1.0).</returns>
+    float GetChannelVolume(AudioChannel channel);
+
+    /// <summary>
+    /// Sets the volume for a specific audio channel.
+    /// </summary>
+    /// <param name="channel">The audio channel.</param>
+    /// <param name="volume">The new volume (0.0 to 1.0).</param>
+    /// <remarks>
+    /// Channel volume is multiplied with individual sound volumes.
+    /// Setting a channel to 0 mutes all sounds on that channel.
+    /// </remarks>
+    void SetChannelVolume(AudioChannel channel, float volume);
+
+    #endregion
+
+    #region Listener
+
+    /// <summary>
+    /// Sets the listener position in 3D space.
+    /// </summary>
+    /// <param name="position">The world-space position of the listener.</param>
+    /// <remarks>
+    /// This is a convenience method that delegates to the underlying device.
+    /// For ECS-based audio, use the <c>AudioListener</c> component instead.
+    /// </remarks>
+    void SetListenerPosition(Vector3 position);
+
+    /// <summary>
+    /// Sets the listener orientation in 3D space.
+    /// </summary>
+    /// <param name="forward">The forward direction vector (normalized).</param>
+    /// <param name="up">The up direction vector (normalized).</param>
+    /// <remarks>
+    /// This is a convenience method that delegates to the underlying device.
+    /// For ECS-based audio, use the <c>AudioListener</c> component instead.
+    /// </remarks>
+    void SetListenerOrientation(Vector3 forward, Vector3 up);
+
+    /// <summary>
+    /// Sets the listener velocity for Doppler calculations.
+    /// </summary>
+    /// <param name="velocity">The velocity vector (units per second).</param>
+    /// <remarks>
+    /// This is a convenience method that delegates to the underlying device.
+    /// For ECS-based audio, use the <c>AudioListener</c> component instead.
+    /// </remarks>
+    void SetListenerVelocity(Vector3 velocity);
 
     #endregion
 

--- a/src/KeenEyes.Audio.Abstractions/IAudioDevice.cs
+++ b/src/KeenEyes.Audio.Abstractions/IAudioDevice.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace KeenEyes.Audio.Abstractions;
 
 /// <summary>
@@ -93,4 +95,108 @@ public interface IAudioDevice : IDisposable
     /// </summary>
     /// <param name="gain">The gain value (0.0 to 1.0+).</param>
     void SetListenerGain(float gain);
+
+    // === 3D Source Properties ===
+
+    /// <summary>
+    /// Sets the 3D position of an audio source.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="position">The position in world space.</param>
+    void SetSourcePosition(uint sourceId, Vector3 position);
+
+    /// <summary>
+    /// Sets the velocity of an audio source for Doppler effect calculations.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="velocity">The velocity vector.</param>
+    void SetSourceVelocity(uint sourceId, Vector3 velocity);
+
+    /// <summary>
+    /// Sets the pitch multiplier of an audio source.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="pitch">The pitch multiplier (1.0 = normal, 0.5 = octave down, 2.0 = octave up).</param>
+    void SetSourcePitch(uint sourceId, float pitch);
+
+    /// <summary>
+    /// Sets whether a source loops.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="loop">True to loop, false to play once.</param>
+    void SetSourceLooping(uint sourceId, bool loop);
+
+    /// <summary>
+    /// Sets the minimum distance for distance attenuation.
+    /// </summary>
+    /// <remarks>
+    /// Within this distance, the source plays at full volume.
+    /// </remarks>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="distance">The minimum distance.</param>
+    void SetSourceMinDistance(uint sourceId, float distance);
+
+    /// <summary>
+    /// Sets the maximum distance for distance attenuation.
+    /// </summary>
+    /// <remarks>
+    /// Beyond this distance, the source is inaudible (or clamped to minimum).
+    /// </remarks>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="distance">The maximum distance.</param>
+    void SetSourceMaxDistance(uint sourceId, float distance);
+
+    /// <summary>
+    /// Sets the rolloff factor for distance attenuation.
+    /// </summary>
+    /// <param name="sourceId">The source.</param>
+    /// <param name="rolloff">The rolloff factor (higher = faster falloff).</param>
+    void SetSourceRolloff(uint sourceId, float rolloff);
+
+    /// <summary>
+    /// Pauses a playing source.
+    /// </summary>
+    /// <param name="sourceId">The source to pause.</param>
+    void PauseSource(uint sourceId);
+
+    // === 3D Listener Properties ===
+
+    /// <summary>
+    /// Sets the listener position in 3D space.
+    /// </summary>
+    /// <param name="position">The position in world space.</param>
+    void SetListenerPosition(Vector3 position);
+
+    /// <summary>
+    /// Sets the listener velocity for Doppler effect calculations.
+    /// </summary>
+    /// <param name="velocity">The velocity vector.</param>
+    void SetListenerVelocity(Vector3 velocity);
+
+    /// <summary>
+    /// Sets the listener orientation in 3D space.
+    /// </summary>
+    /// <param name="forward">The forward direction vector (normalized).</param>
+    /// <param name="up">The up direction vector (normalized).</param>
+    void SetListenerOrientation(Vector3 forward, Vector3 up);
+
+    // === Global Settings ===
+
+    /// <summary>
+    /// Sets the global distance attenuation model.
+    /// </summary>
+    /// <param name="mode">The rolloff mode to use.</param>
+    void SetDistanceModel(AudioRolloffMode mode);
+
+    /// <summary>
+    /// Sets the speed of sound for Doppler effect calculations.
+    /// </summary>
+    /// <param name="speed">The speed of sound in units per second (default: 343 m/s).</param>
+    void SetSpeedOfSound(float speed);
+
+    /// <summary>
+    /// Sets the global Doppler effect factor.
+    /// </summary>
+    /// <param name="factor">The Doppler factor (0 = disabled, 1 = normal, 2+ = exaggerated).</param>
+    void SetDopplerFactor(float factor);
 }

--- a/src/KeenEyes.Audio.Abstractions/PlaybackOptions.cs
+++ b/src/KeenEyes.Audio.Abstractions/PlaybackOptions.cs
@@ -1,0 +1,88 @@
+namespace KeenEyes.Audio.Abstractions;
+
+/// <summary>
+/// Options for audio playback, controlling volume, pitch, looping, and mixer channel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this to specify playback parameters when calling
+/// <c>Play(AudioClipHandle, PlaybackOptions)</c> or
+/// <c>PlayAt(AudioClipHandle, Vector3, PlaybackOptions)</c>.
+/// </para>
+/// <para>
+/// This is a value type for performance. Use <see cref="Default"/> for standard playback,
+/// or use <c>with</c> expressions to customize specific properties.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Play with default options
+/// audio.Play(clip, PlaybackOptions.Default);
+///
+/// // Play looped music at reduced volume
+/// audio.Play(musicClip, new PlaybackOptions
+/// {
+///     Volume = 0.5f,
+///     Loop = true,
+///     Channel = AudioChannel.Music
+/// });
+///
+/// // Modify defaults using 'with'
+/// audio.Play(clip, PlaybackOptions.Default with { Pitch = 1.5f });
+/// </code>
+/// </example>
+public readonly record struct PlaybackOptions
+{
+    /// <summary>
+    /// Playback volume (0.0 to 1.0, can exceed 1.0 for amplification).
+    /// </summary>
+    /// <remarks>
+    /// Values above 1.0 may cause clipping/distortion.
+    /// </remarks>
+    public float Volume { get; init; }
+
+    /// <summary>
+    /// Playback pitch multiplier.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>0.5 = One octave down</item>
+    /// <item>1.0 = Normal pitch</item>
+    /// <item>2.0 = One octave up</item>
+    /// </list>
+    /// </remarks>
+    public float Pitch { get; init; }
+
+    /// <summary>
+    /// Whether the sound should loop continuously.
+    /// </summary>
+    public bool Loop { get; init; }
+
+    /// <summary>
+    /// The mixer channel for volume grouping.
+    /// </summary>
+    /// <remarks>
+    /// Allows per-category volume control (e.g., mute music but keep sound effects).
+    /// </remarks>
+    public AudioChannel Channel { get; init; }
+
+    /// <summary>
+    /// Default playback options with standard values.
+    /// </summary>
+    /// <remarks>
+    /// Default values:
+    /// <list type="bullet">
+    /// <item>Volume: 1.0</item>
+    /// <item>Pitch: 1.0</item>
+    /// <item>Loop: false</item>
+    /// <item>Channel: SFX</item>
+    /// </list>
+    /// </remarks>
+    public static PlaybackOptions Default => new()
+    {
+        Volume = 1f,
+        Pitch = 1f,
+        Loop = false,
+        Channel = AudioChannel.SFX
+    };
+}

--- a/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
@@ -13,7 +13,11 @@ namespace KeenEyes.Audio.Silk;
 /// </para>
 /// <para>
 /// The plugin creates a <see cref="SilkAudioContext"/> extension that provides
-/// audio clip loading and one-shot playback functionality.
+/// audio clip loading, one-shot playback, and 3D spatial audio functionality.
+/// </para>
+/// <para>
+/// ECS components <see cref="AudioSource"/> and <see cref="AudioListener"/> are registered
+/// automatically, along with systems to synchronize them with the OpenAL backend.
 /// </para>
 /// </remarks>
 /// <example>
@@ -33,16 +37,25 @@ namespace KeenEyes.Audio.Silk;
 ///     InitialMasterVolume = 0.8f
 /// }));
 ///
-/// // Access audio context
+/// // Access audio context for one-shot playback
 /// var audio = world.GetExtension&lt;IAudioContext&gt;();
 /// var clip = audio.LoadClip("assets/sounds/explosion.wav");
 /// audio.Play(clip);
+///
+/// // Or use ECS components for 3D spatial audio
+/// var enemy = world.Spawn()
+///     .With(new Transform3D(new Vector3(10, 0, 0), Quaternion.Identity, Vector3.One))
+///     .With(AudioSource.Default with { Clip = clip, Spatial = true, PlayOnAwake = true })
+///     .Build();
 /// </code>
 /// </example>
 /// <param name="config">The audio configuration.</param>
 public sealed class SilkAudioPlugin(SilkAudioConfig config) : IWorldPlugin
 {
     private SilkAudioContext? audioContext;
+    private AudioSourceSystem? audioSourceSystem;
+    private EventSubscription? audioSourceRemovedSubscription;
+    private EventSubscription? entityDestroyedSubscription;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SilkAudioPlugin"/> class with default configuration.
@@ -73,16 +86,54 @@ public sealed class SilkAudioPlugin(SilkAudioConfig config) : IWorldPlugin
         context.SetExtension<IAudioContext>(audioContext);
         context.SetExtension(audioContext);
 
-        // Register backend-agnostic audio update system
-        context.AddSystem<AudioUpdateSystem>(SystemPhase.Update);
+        // Register ECS components
+        context.RegisterComponent<AudioSource>();
+        context.RegisterComponent<AudioListener>();
+
+        // Register systems
+        // AudioUpdateSystem: Recycles finished sources in the pool
+        context.AddSystem<AudioUpdateSystem>(SystemPhase.Update, order: 0);
+
+        // AudioListenerSystem: Syncs listener position/orientation (runs before source system)
+        context.AddSystem<AudioListenerSystem>(SystemPhase.Update, order: 5);
+
+        // AudioSourceSystem: Syncs source positions and playback state
+        audioSourceSystem = new AudioSourceSystem();
+        context.AddSystem(audioSourceSystem, SystemPhase.Update, order: 10);
+
+        // Subscribe to component lifecycle events
+        audioSourceRemovedSubscription = context.World.OnComponentRemoved<AudioSource>(OnAudioSourceRemoved);
+        entityDestroyedSubscription = context.World.OnEntityDestroyed(OnEntityDestroyed);
     }
 
     /// <inheritdoc />
     public void Uninstall(IPluginContext context)
     {
+        // Unsubscribe from events
+        audioSourceRemovedSubscription?.Dispose();
+        entityDestroyedSubscription?.Dispose();
+        audioSourceRemovedSubscription = null;
+        entityDestroyedSubscription = null;
+
+        // Remove extensions
         context.RemoveExtension<IAudioContext>();
         context.RemoveExtension<SilkAudioContext>();
+
+        // Dispose resources
         audioContext?.Dispose();
         audioContext = null;
+        audioSourceSystem = null;
+
+        // Systems are automatically cleaned up by PluginManager
+    }
+
+    private void OnAudioSourceRemoved(Entity entity)
+    {
+        audioSourceSystem?.OnAudioSourceRemoved(entity);
+    }
+
+    private void OnEntityDestroyed(Entity entity)
+    {
+        audioSourceSystem?.OnEntityDestroyed(entity);
     }
 }

--- a/src/KeenEyes.Audio.Silk/packages.lock.json
+++ b/src/KeenEyes.Audio.Silk/packages.lock.json
@@ -92,10 +92,17 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )",
-          "KeenEyes.Audio.Abstractions": "[1.0.0, )"
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
         }
       },
       "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.common": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"

--- a/src/KeenEyes.Audio/Components/AudioListener.cs
+++ b/src/KeenEyes.Audio/Components/AudioListener.cs
@@ -1,0 +1,93 @@
+namespace KeenEyes.Audio;
+
+/// <summary>
+/// ECS component marking an entity as the audio listener (the "ear" for 3D spatial audio).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only one listener should be active at a time. The audio system uses the entity's
+/// <c>Transform3D</c> component to position the listener in 3D space.
+/// </para>
+/// <para>
+/// Typically attached to the player character or camera entity. The listener's
+/// position and orientation determine how 3D sounds are spatialized.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Attach listener to player/camera
+/// var player = world.Spawn()
+///     .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+///     .With(AudioListener.Active)
+///     .Build();
+/// </code>
+/// </example>
+public struct AudioListener : IComponent
+{
+    /// <summary>
+    /// Whether this listener is active.
+    /// </summary>
+    /// <remarks>
+    /// Only one listener should be active at a time. If multiple listeners
+    /// are active, the first one found is used.
+    /// </remarks>
+    public bool IsActive;
+
+    /// <summary>
+    /// Doppler effect factor.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>0 = Doppler effect disabled</item>
+    /// <item>1 = Normal Doppler effect</item>
+    /// <item>2+ = Exaggerated Doppler effect</item>
+    /// </list>
+    /// </remarks>
+    public float DopplerFactor;
+
+    /// <summary>
+    /// Volume multiplier applied to all audio.
+    /// </summary>
+    public float VolumeMultiplier;
+
+    /// <summary>
+    /// Speed of sound in units per second (for Doppler calculations).
+    /// </summary>
+    /// <remarks>
+    /// The default value of 343 represents the speed of sound in air at 20°C
+    /// in meters per second. Adjust this to match your game's unit system.
+    /// For example, if your game uses 1 unit = 1 centimeter, use 34300.
+    /// </remarks>
+    public float SpeedOfSound;
+
+    /// <summary>
+    /// Creates an active listener with default settings.
+    /// </summary>
+    /// <remarks>
+    /// Default values:
+    /// <list type="bullet">
+    /// <item>IsActive: true</item>
+    /// <item>DopplerFactor: 1.0</item>
+    /// <item>VolumeMultiplier: 1.0</item>
+    /// <item>SpeedOfSound: 343.0 (m/s at 20°C)</item>
+    /// </list>
+    /// </remarks>
+    public static AudioListener Active => new()
+    {
+        IsActive = true,
+        DopplerFactor = 1f,
+        VolumeMultiplier = 1f,
+        SpeedOfSound = 343f
+    };
+
+    /// <summary>
+    /// Creates an inactive listener with default settings.
+    /// </summary>
+    public static AudioListener Inactive => new()
+    {
+        IsActive = false,
+        DopplerFactor = 1f,
+        VolumeMultiplier = 1f,
+        SpeedOfSound = 343f
+    };
+}

--- a/src/KeenEyes.Audio/Components/AudioSource.cs
+++ b/src/KeenEyes.Audio/Components/AudioSource.cs
@@ -1,0 +1,148 @@
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio;
+
+/// <summary>
+/// ECS component for audio emitters. Attach to entities to play sounds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The audio system synchronizes this component with a backend audio source.
+/// For 3D spatialization, ensure the entity also has a <c>Transform3D</c> component
+/// from <c>KeenEyes.Common</c>.
+/// </para>
+/// <para>
+/// Use <see cref="Default"/> to create an audio source with sensible defaults,
+/// then set the <see cref="Clip"/> property to the audio clip to play.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var clip = audio.LoadClip("explosion.wav");
+/// var entity = world.Spawn()
+///     .With(new Transform3D(...))
+///     .With(AudioSource.Default with { Clip = clip, Spatial = true, PlayOnAwake = true })
+///     .Build();
+/// </code>
+/// </example>
+public struct AudioSource : IComponent
+{
+    /// <summary>
+    /// The audio clip to play.
+    /// </summary>
+    public AudioClipHandle Clip;
+
+    /// <summary>
+    /// Playback volume (0.0 to 1.0, can exceed 1.0 for amplification).
+    /// </summary>
+    public float Volume;
+
+    /// <summary>
+    /// Playback pitch multiplier (0.5 to 2.0 typical range).
+    /// </summary>
+    /// <remarks>
+    /// Values below 1.0 lower the pitch, values above 1.0 raise the pitch.
+    /// A value of 0.5 is one octave down, 2.0 is one octave up.
+    /// </remarks>
+    public float Pitch;
+
+    /// <summary>
+    /// Whether to loop the audio when it reaches the end.
+    /// </summary>
+    public bool Loop;
+
+    /// <summary>
+    /// Whether to start playing immediately when the component is added.
+    /// </summary>
+    /// <remarks>
+    /// This flag is consumed (set to false) after the first play.
+    /// </remarks>
+    public bool PlayOnAwake;
+
+    /// <summary>
+    /// The mixer channel for volume grouping.
+    /// </summary>
+    public AudioChannel Channel;
+
+    /// <summary>
+    /// Whether this is a 3D spatial source.
+    /// </summary>
+    /// <remarks>
+    /// When true, the audio position is taken from the entity's <c>Transform3D</c> component.
+    /// When false, the audio plays at full volume regardless of listener position.
+    /// </remarks>
+    public bool Spatial;
+
+    /// <summary>
+    /// Distance at which sound is at full volume (for spatial audio).
+    /// </summary>
+    public float MinDistance;
+
+    /// <summary>
+    /// Distance at which sound becomes inaudible (for spatial audio).
+    /// </summary>
+    public float MaxDistance;
+
+    /// <summary>
+    /// Distance attenuation curve (for spatial audio).
+    /// </summary>
+    public AudioRolloffMode RolloffMode;
+
+    /// <summary>
+    /// Current playback state (managed by the audio system).
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="AudioPlayState.Playing"/> to start playback,
+    /// or <see cref="AudioPlayState.Stopped"/> to stop. The system updates
+    /// this value to reflect actual playback state.
+    /// </remarks>
+    public AudioPlayState State;
+
+    /// <summary>
+    /// Handle to the currently playing sound (managed by the audio system).
+    /// </summary>
+    /// <remarks>
+    /// This handle can be used with <see cref="IAudioContext"/> methods to control
+    /// the playing sound (e.g., adjust volume, pitch, or position dynamically).
+    /// Returns <see cref="SoundHandle.Invalid"/> when no sound is playing.
+    /// </remarks>
+    public SoundHandle CurrentSound;
+
+    /// <summary>
+    /// Internal backend source handle (managed by the audio system).
+    /// </summary>
+    internal int BackendSourceId;
+
+    /// <summary>
+    /// Creates a new audio source with sensible default settings.
+    /// </summary>
+    /// <remarks>
+    /// Default values:
+    /// <list type="bullet">
+    /// <item>Volume: 1.0</item>
+    /// <item>Pitch: 1.0</item>
+    /// <item>Loop: false</item>
+    /// <item>Channel: SFX</item>
+    /// <item>Spatial: false</item>
+    /// <item>MinDistance: 1.0</item>
+    /// <item>MaxDistance: 100.0</item>
+    /// <item>RolloffMode: Logarithmic</item>
+    /// </list>
+    /// </remarks>
+    public static AudioSource Default => new()
+    {
+        Clip = AudioClipHandle.Invalid,
+        Volume = 1f,
+        Pitch = 1f,
+        Loop = false,
+        PlayOnAwake = false,
+        Channel = AudioChannel.SFX,
+        Spatial = false,
+        MinDistance = 1f,
+        MaxDistance = 100f,
+        RolloffMode = AudioRolloffMode.Logarithmic,
+        State = AudioPlayState.Stopped,
+        CurrentSound = SoundHandle.Invalid,
+        BackendSourceId = -1
+    };
+}

--- a/src/KeenEyes.Audio/KeenEyes.Audio.csproj
+++ b/src/KeenEyes.Audio/KeenEyes.Audio.csproj
@@ -9,11 +9,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="KeenEyes.Audio.Tests" />
+    <InternalsVisibleTo Include="KeenEyes.Audio.Silk" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
     <ProjectReference Include="..\KeenEyes.Audio.Abstractions\KeenEyes.Audio.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.Audio/Systems/AudioListenerSystem.cs
+++ b/src/KeenEyes.Audio/Systems/AudioListenerSystem.cs
@@ -1,0 +1,91 @@
+using System.Numerics;
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Common;
+
+namespace KeenEyes.Audio;
+
+/// <summary>
+/// System that synchronizes the <see cref="AudioListener"/> component with the backend listener.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs in the Update phase and updates the backend audio listener
+/// position, orientation, and velocity based on the entity's <see cref="Transform3D"/>.
+/// </para>
+/// <para>
+/// Only one active listener is supported. If multiple entities have active
+/// <see cref="AudioListener"/> components, the first one found is used.
+/// </para>
+/// </remarks>
+public sealed class AudioListenerSystem : ISystem
+{
+    private IWorld? world;
+    private IAudioContext? audioContext;
+    private Vector3 previousPosition;
+
+    /// <inheritdoc />
+    public bool Enabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public void Initialize(IWorld world)
+    {
+        this.world = world;
+    }
+
+    /// <inheritdoc />
+    public void Update(float deltaTime)
+    {
+        // Lazy initialization
+        audioContext ??= world?.TryGetExtension<IAudioContext>(out var ctx) == true ? ctx : null;
+
+        if (audioContext?.Device is null || world is null)
+        {
+            return;
+        }
+
+        var device = audioContext.Device;
+
+        foreach (var entity in world.Query<AudioListener, Transform3D>())
+        {
+            ref readonly var listener = ref world.Get<AudioListener>(entity);
+            if (!listener.IsActive)
+            {
+                continue;
+            }
+
+            ref readonly var transform = ref world.Get<Transform3D>(entity);
+
+            // Update listener position
+            device.SetListenerPosition(transform.Position);
+
+            // Compute velocity from position delta for Doppler effect
+            if (deltaTime > 0)
+            {
+                var velocity = (transform.Position - previousPosition) / deltaTime;
+                device.SetListenerVelocity(velocity);
+            }
+            previousPosition = transform.Position;
+
+            // Update orientation from rotation quaternion
+            var forward = Vector3.Transform(-Vector3.UnitZ, transform.Rotation);
+            var up = Vector3.Transform(Vector3.UnitY, transform.Rotation);
+            device.SetListenerOrientation(forward, up);
+
+            // Apply volume multiplier
+            device.SetListenerGain(listener.VolumeMultiplier);
+
+            // Configure global Doppler settings
+            device.SetDopplerFactor(listener.DopplerFactor);
+            device.SetSpeedOfSound(listener.SpeedOfSound);
+
+            // Only process first active listener
+            break;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // No resources to dispose
+    }
+}

--- a/src/KeenEyes.Audio/Systems/AudioSourceSystem.cs
+++ b/src/KeenEyes.Audio/Systems/AudioSourceSystem.cs
@@ -1,0 +1,201 @@
+using System.Numerics;
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Common;
+
+namespace KeenEyes.Audio;
+
+/// <summary>
+/// System that synchronizes <see cref="AudioSource"/> components with backend audio sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system handles:
+/// </para>
+/// <list type="bullet">
+/// <item>Creating backend sources when AudioSource components need to play</item>
+/// <item>Updating 3D positions from Transform3D each frame</item>
+/// <item>Managing playback state (play/pause/stop)</item>
+/// <item>Detecting when non-looping sounds finish</item>
+/// </list>
+/// <para>
+/// Backend sources are allocated on-demand when playback is requested and cleaned up
+/// when the component is removed or the entity is destroyed.
+/// </para>
+/// </remarks>
+public sealed class AudioSourceSystem : ISystem
+{
+    private IWorld? world;
+    private IAudioContext? audioContext;
+    private readonly Dictionary<Entity, uint> entitySources = [];
+    private int nextSoundId = 1;
+
+    /// <inheritdoc />
+    public bool Enabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public void Initialize(IWorld world)
+    {
+        this.world = world;
+    }
+
+    /// <inheritdoc />
+    public void Update(float deltaTime)
+    {
+        // Lazy initialization
+        audioContext ??= world?.TryGetExtension<IAudioContext>(out var ctx) == true ? ctx : null;
+
+        if (audioContext?.Device is null || world is null)
+        {
+            return;
+        }
+
+        var device = audioContext.Device;
+
+        foreach (var entity in world.Query<AudioSource>())
+        {
+            ref var source = ref world.Get<AudioSource>(entity);
+
+            // Handle PlayOnAwake
+            if (source.PlayOnAwake && source.Clip.IsValid)
+            {
+                source.PlayOnAwake = false;
+                source.State = AudioPlayState.Playing;
+            }
+
+            // Check if we need a backend source
+            bool needsSource = source.State == AudioPlayState.Playing && source.Clip.IsValid;
+
+            if (!entitySources.TryGetValue(entity, out var backendId))
+            {
+                if (!needsSource)
+                {
+                    continue;
+                }
+
+                // Create backend source
+                backendId = device.CreateSource();
+                entitySources[entity] = backendId;
+                source.BackendSourceId = (int)backendId;
+
+                // Assign a sound handle for tracking
+                source.CurrentSound = new SoundHandle(nextSoundId++);
+
+                // Configure the source
+                ConfigureSource(device, backendId, ref source);
+
+                // Start playback
+                device.PlaySource(backendId);
+            }
+            else
+            {
+                // Source exists, sync state
+                var actualState = device.GetSourceState(backendId);
+
+                // Handle state transitions
+                if (source.State == AudioPlayState.Playing && actualState == AudioPlayState.Stopped)
+                {
+                    if (!source.Loop)
+                    {
+                        // Non-looping sound finished naturally
+                        source.State = AudioPlayState.Stopped;
+                        source.CurrentSound = SoundHandle.Invalid;
+                    }
+                    else
+                    {
+                        // Looping sound stopped unexpectedly, restart
+                        device.PlaySource(backendId);
+                    }
+                }
+                else if (source.State == AudioPlayState.Stopped && actualState == AudioPlayState.Playing)
+                {
+                    // User requested stop
+                    device.StopSource(backendId);
+                    source.CurrentSound = SoundHandle.Invalid;
+                }
+                else if (source.State == AudioPlayState.Paused && actualState == AudioPlayState.Playing)
+                {
+                    // User requested pause
+                    device.PauseSource(backendId);
+                }
+                else if (source.State == AudioPlayState.Playing && actualState == AudioPlayState.Paused)
+                {
+                    // User requested resume
+                    device.PlaySource(backendId);
+                }
+
+                // Update volume and pitch (they might have changed)
+                device.SetSourceGain(backendId, source.Volume);
+                device.SetSourcePitch(backendId, source.Pitch);
+            }
+
+            // Update 3D position if spatial
+            if (source.Spatial && world.Has<Transform3D>(entity))
+            {
+                ref readonly var transform = ref world.Get<Transform3D>(entity);
+                device.SetSourcePosition(backendId, transform.Position);
+
+                // Update velocity for Doppler if available
+                if (world.Has<Velocity3D>(entity))
+                {
+                    ref readonly var velocity = ref world.Get<Velocity3D>(entity);
+                    device.SetSourceVelocity(backendId, velocity.Value);
+                }
+            }
+        }
+    }
+
+    private void ConfigureSource(IAudioDevice device, uint sourceId, ref AudioSource source)
+    {
+        // Set initial properties
+        device.SetSourceGain(sourceId, source.Volume);
+        device.SetSourcePitch(sourceId, source.Pitch);
+        device.SetSourceLooping(sourceId, source.Loop);
+        device.SetSourceMinDistance(sourceId, source.MinDistance);
+        device.SetSourceMaxDistance(sourceId, source.MaxDistance);
+        device.SetSourceRolloff(sourceId, 1f); // Default rolloff factor
+
+        // Get buffer ID and attach to source
+        var bufferId = audioContext?.GetBufferId(source.Clip) ?? 0;
+        if (bufferId != 0)
+        {
+            device.SetSourceBuffer(sourceId, bufferId);
+        }
+    }
+
+    /// <summary>
+    /// Called when an AudioSource component is removed from an entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    internal void OnAudioSourceRemoved(Entity entity)
+    {
+        if (entitySources.Remove(entity, out var sourceId))
+        {
+            audioContext?.Device?.StopSource(sourceId);
+            audioContext?.Device?.DeleteSource(sourceId);
+        }
+    }
+
+    /// <summary>
+    /// Called when an entity is destroyed.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    internal void OnEntityDestroyed(Entity entity)
+    {
+        OnAudioSourceRemoved(entity);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Clean up all tracked sources
+        if (audioContext?.Device is not null)
+        {
+            foreach (var (_, sourceId) in entitySources)
+            {
+                audioContext.Device.StopSource(sourceId);
+                audioContext.Device.DeleteSource(sourceId);
+            }
+        }
+        entitySources.Clear();
+    }
+}

--- a/src/KeenEyes.Audio/packages.lock.json
+++ b/src/KeenEyes.Audio/packages.lock.json
@@ -16,6 +16,12 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Implements the complete audio system for KeenEyes ECS, covering Issues #419, #420, and #421.

### New Types (KeenEyes.Audio.Abstractions)
- **AudioConfig**: Global audio settings (max simultaneous sounds, default distances, rolloff, Doppler)
- **PlaybackOptions**: Per-sound options (volume, pitch, loop, channel)
- **SoundHandle**: Opaque handle for controlling playing sounds
- **AudioChannel**: Mixer channels (Master, Music, SFX, Voice, Ambient)

### ECS Components (KeenEyes.Audio)
- **AudioSource**: Component for entity-attached audio emitters with 3D spatial support
- **AudioListener**: Component for spatial audio receiver (the "ear")

### IAudioContext Extensions
- `Play()` now returns `SoundHandle` for optional control
- `PlayAt()` for 3D positioned one-shot sounds
- `Stop/Pause/Resume(SoundHandle)` for individual sound control
- `SetVolume/SetPitch/SetPosition(SoundHandle)` for dynamic properties
- `PauseAll()/ResumeAll()` for global control
- Per-channel volume control (`Get/SetChannelVolume`)
- Listener convenience methods

### IAudioDevice Extensions
- `SetSpeedOfSound()` for Doppler calculations
- `SetDopplerFactor()` for Doppler intensity
- `Custom` rolloff mode support

### ECS Systems
- **AudioSourceSystem**: Syncs AudioSource components with backend
- **AudioListenerSystem**: Syncs AudioListener with 3D listener settings

## Test plan
- [x] Build succeeds with 0 warnings, 0 errors
- [x] All audio-related code compiles
- [x] Existing tests pass (4212 tests, 1 pre-existing failure in Parallelism unrelated to audio)

## Related Issues
Closes #419, #420, #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)