### PR TITLE
docs: Add voxel game sample with biome-based terrain generation

### DIFF
--- a/samples/KeenEyes.Sample.Voxel/Blocks.cs
+++ b/samples/KeenEyes.Sample.Voxel/Blocks.cs
@@ -1,0 +1,138 @@
+namespace KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// BLOCK DEFINITIONS
+// =============================================================================
+
+/// <summary>
+/// Block type identifiers.
+/// </summary>
+public static class BlockId
+{
+    /// <summary>Empty block (no collision).</summary>
+    public const byte Air = 0;
+
+    /// <summary>Basic stone block.</summary>
+    public const byte Stone = 1;
+
+    /// <summary>Dirt block (subsurface layer).</summary>
+    public const byte Dirt = 2;
+
+    /// <summary>Grass-covered surface block.</summary>
+    public const byte Grass = 3;
+
+    /// <summary>Sand block (desert/beach).</summary>
+    public const byte Sand = 4;
+
+    /// <summary>Water block (liquid).</summary>
+    public const byte Water = 5;
+
+    /// <summary>Tree trunk block.</summary>
+    public const byte Wood = 6;
+
+    /// <summary>Tree foliage block.</summary>
+    public const byte Leaves = 7;
+
+    /// <summary>Snow-covered surface block.</summary>
+    public const byte Snow = 8;
+
+    /// <summary>Frozen water block.</summary>
+    public const byte Ice = 9;
+
+    /// <summary>Gravel block.</summary>
+    public const byte Gravel = 10;
+
+    /// <summary>Clay block (underwater).</summary>
+    public const byte Clay = 11;
+
+    /// <summary>Indestructible bedrock layer.</summary>
+    public const byte Bedrock = 12;
+
+    /// <summary>Cobblestone block.</summary>
+    public const byte Cobblestone = 13;
+
+    /// <summary>Desert cactus plant.</summary>
+    public const byte Cactus = 14;
+
+    /// <summary>Dead bush plant.</summary>
+    public const byte DeadBush = 15;
+}
+
+/// <summary>
+/// Properties of a block type.
+/// </summary>
+public readonly record struct BlockType(
+    byte Id,
+    string Name,
+    char Symbol,
+    ConsoleColor Color,
+    bool IsSolid,
+    bool IsTransparent,
+    bool IsLiquid
+);
+
+/// <summary>
+/// Registry of all block types and their properties.
+/// </summary>
+public sealed class BlockRegistry
+{
+    private readonly BlockType[] _blocks = new BlockType[256];
+
+    /// <summary>
+    /// Initializes the block registry with default block types.
+    /// </summary>
+    public BlockRegistry()
+    {
+        Register(new BlockType(BlockId.Air, "Air", ' ', ConsoleColor.Black, false, true, false));
+        Register(new BlockType(BlockId.Stone, "Stone", '#', ConsoleColor.DarkGray, true, false, false));
+        Register(new BlockType(BlockId.Dirt, "Dirt", '=', ConsoleColor.DarkYellow, true, false, false));
+        Register(new BlockType(BlockId.Grass, "Grass", '"', ConsoleColor.Green, true, false, false));
+        Register(new BlockType(BlockId.Sand, "Sand", '.', ConsoleColor.Yellow, true, false, false));
+        Register(new BlockType(BlockId.Water, "Water", '~', ConsoleColor.Blue, false, true, true));
+        Register(new BlockType(BlockId.Wood, "Wood", '|', ConsoleColor.DarkRed, true, false, false));
+        Register(new BlockType(BlockId.Leaves, "Leaves", '*', ConsoleColor.DarkGreen, true, true, false));
+        Register(new BlockType(BlockId.Snow, "Snow", 'o', ConsoleColor.White, true, false, false));
+        Register(new BlockType(BlockId.Ice, "Ice", '-', ConsoleColor.Cyan, true, true, false));
+        Register(new BlockType(BlockId.Gravel, "Gravel", ':', ConsoleColor.Gray, true, false, false));
+        Register(new BlockType(BlockId.Clay, "Clay", '%', ConsoleColor.DarkCyan, true, false, false));
+        Register(new BlockType(BlockId.Bedrock, "Bedrock", '@', ConsoleColor.DarkGray, true, false, false));
+        Register(new BlockType(BlockId.Cobblestone, "Cobblestone", '+', ConsoleColor.Gray, true, false, false));
+        Register(new BlockType(BlockId.Cactus, "Cactus", '!', ConsoleColor.Green, true, false, false));
+        Register(new BlockType(BlockId.DeadBush, "Dead Bush", 'v', ConsoleColor.DarkYellow, false, true, false));
+    }
+
+    private void Register(BlockType block)
+    {
+        _blocks[block.Id] = block;
+    }
+
+    /// <summary>
+    /// Gets the block type for the given ID.
+    /// </summary>
+    public ref readonly BlockType Get(byte id) => ref _blocks[id];
+
+    /// <summary>
+    /// Checks if a block is solid (blocks movement).
+    /// </summary>
+    public bool IsSolid(byte id) => _blocks[id].IsSolid;
+
+    /// <summary>
+    /// Checks if a block is transparent (can see through).
+    /// </summary>
+    public bool IsTransparent(byte id) => _blocks[id].IsTransparent;
+
+    /// <summary>
+    /// Checks if a block is a liquid.
+    /// </summary>
+    public bool IsLiquid(byte id) => _blocks[id].IsLiquid;
+
+    /// <summary>
+    /// Gets the display symbol for a block.
+    /// </summary>
+    public char GetSymbol(byte id) => _blocks[id].Symbol;
+
+    /// <summary>
+    /// Gets the display color for a block.
+    /// </summary>
+    public ConsoleColor GetColor(byte id) => _blocks[id].Color;
+}

--- a/samples/KeenEyes.Sample.Voxel/Components.cs
+++ b/samples/KeenEyes.Sample.Voxel/Components.cs
@@ -1,0 +1,243 @@
+using KeenEyes;
+
+namespace KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// VOXEL GAME COMPONENTS
+// =============================================================================
+// Components for a voxel-based game demonstrating:
+// - Chunk-based world storage
+// - Block types and biomes
+// - Player movement with voxel collision
+// - ASCII visualization of voxel terrain
+// =============================================================================
+
+// =============================================================================
+// CHUNK COMPONENTS
+// =============================================================================
+
+/// <summary>
+/// Chunk position in chunk coordinates (not world coordinates).
+/// </summary>
+[Component]
+public partial struct ChunkCoord
+{
+    /// <summary>Chunk X coordinate.</summary>
+    public int X;
+
+    /// <summary>Chunk Y coordinate (vertical).</summary>
+    public int Y;
+
+    /// <summary>Chunk Z coordinate.</summary>
+    public int Z;
+}
+
+/// <summary>
+/// Voxel data storage for a chunk.
+/// Uses IComponent directly without generator to avoid array complexity.
+/// </summary>
+public struct VoxelData : IComponent
+{
+    /// <summary>Chunk size in blocks per axis.</summary>
+    public const int Size = 16;
+
+    /// <summary>Total blocks per chunk.</summary>
+    public const int Volume = Size * Size * Size;
+
+    /// <summary>Block type IDs (0 = air).</summary>
+    public byte[] Blocks;
+
+    /// <summary>
+    /// Gets the block at local coordinates.
+    /// </summary>
+    public readonly byte GetBlock(int x, int y, int z)
+    {
+        if (x < 0 || x >= Size || y < 0 || y >= Size || z < 0 || z >= Size)
+        {
+            return 0;
+        }
+
+        return Blocks[x + y * Size + z * Size * Size];
+    }
+
+    /// <summary>
+    /// Sets the block at local coordinates.
+    /// </summary>
+    public readonly void SetBlock(int x, int y, int z, byte blockId)
+    {
+        if (x < 0 || x >= Size || y < 0 || y >= Size || z < 0 || z >= Size)
+        {
+            return;
+        }
+
+        Blocks[x + y * Size + z * Size * Size] = blockId;
+    }
+}
+
+/// <summary>
+/// Biome identifier for a chunk.
+/// </summary>
+[Component]
+public partial struct ChunkBiome
+{
+    /// <summary>Biome type for this chunk.</summary>
+    public BiomeType Biome;
+}
+
+/// <summary>
+/// Height map cache for faster terrain queries.
+/// Uses IComponent directly without generator to avoid array complexity.
+/// </summary>
+public struct HeightMap : IComponent
+{
+    /// <summary>Cached height values for each XZ column.</summary>
+    public byte[] Heights;
+
+    /// <summary>
+    /// Gets the terrain height at local XZ coordinates.
+    /// </summary>
+    public readonly int GetHeight(int x, int z)
+    {
+        if (x < 0 || x >= VoxelData.Size || z < 0 || z >= VoxelData.Size)
+        {
+            return 0;
+        }
+
+        return Heights[x + z * VoxelData.Size];
+    }
+}
+
+// =============================================================================
+// PLAYER COMPONENTS
+// =============================================================================
+
+/// <summary>
+/// 3D position in world space.
+/// </summary>
+[Component]
+public partial struct Position3D
+{
+    /// <summary>X coordinate in world units.</summary>
+    public float X;
+
+    /// <summary>Y coordinate (vertical) in world units.</summary>
+    public float Y;
+
+    /// <summary>Z coordinate in world units.</summary>
+    public float Z;
+}
+
+/// <summary>
+/// 3D velocity for movement.
+/// </summary>
+[Component]
+public partial struct Velocity3D
+{
+    /// <summary>X velocity component.</summary>
+    public float X;
+
+    /// <summary>Y velocity component.</summary>
+    public float Y;
+
+    /// <summary>Z velocity component.</summary>
+    public float Z;
+}
+
+/// <summary>
+/// Axis-aligned bounding box for collision.
+/// </summary>
+[Component]
+public partial struct VoxelCollider
+{
+    /// <summary>Width (X axis).</summary>
+    public float Width;
+
+    /// <summary>Height (Y axis).</summary>
+    public float Height;
+
+    /// <summary>Depth (Z axis).</summary>
+    public float Depth;
+
+    /// <summary>Whether the entity is standing on ground.</summary>
+    public bool OnGround;
+}
+
+/// <summary>
+/// Camera rotation for viewing direction.
+/// </summary>
+[Component]
+public partial struct CameraRotation
+{
+    /// <summary>Yaw angle in radians (horizontal rotation).</summary>
+    public float Yaw;
+
+    /// <summary>Pitch angle in radians (vertical rotation).</summary>
+    public float Pitch;
+}
+
+/// <summary>
+/// View range for chunk loading.
+/// </summary>
+[Component]
+public partial struct ViewDistance
+{
+    /// <summary>Horizontal view distance in chunks.</summary>
+    [DefaultValue(4)]
+    public int Horizontal;
+
+    /// <summary>Vertical view distance in chunks.</summary>
+    [DefaultValue(2)]
+    public int Vertical;
+}
+
+// =============================================================================
+// TAG COMPONENTS
+// =============================================================================
+
+/// <summary>Marks an entity as the local player.</summary>
+[TagComponent]
+public partial struct LocalPlayer;
+
+/// <summary>Marks a chunk as loaded and ready.</summary>
+[TagComponent]
+public partial struct ChunkLoaded;
+
+/// <summary>Marks a chunk as needing mesh/display update.</summary>
+[TagComponent]
+public partial struct ChunkDirty;
+
+/// <summary>Marks a chunk as visible to the player.</summary>
+[TagComponent]
+public partial struct ChunkVisible;
+
+/// <summary>Marks a chunk as modified (needs saving).</summary>
+[TagComponent]
+public partial struct ChunkModified;
+
+// =============================================================================
+// BIOME TYPES
+// =============================================================================
+
+/// <summary>
+/// Available biome types.
+/// </summary>
+public enum BiomeType : byte
+{
+    /// <summary>Flat grassland with occasional trees.</summary>
+    Plains,
+
+    /// <summary>Dense tree coverage.</summary>
+    Forest,
+
+    /// <summary>Sandy terrain near water.</summary>
+    Desert,
+
+    /// <summary>Elevated rocky terrain.</summary>
+    Mountains,
+
+    /// <summary>Cold snowy terrain.</summary>
+    Tundra,
+
+    /// <summary>Water body.</summary>
+    Ocean
+}

--- a/samples/KeenEyes.Sample.Voxel/KeenEyes.Sample.Voxel.csproj
+++ b/samples/KeenEyes.Sample.Voxel/KeenEyes.Sample.Voxel.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/KeenEyes.Sample.Voxel/Noise.cs
+++ b/samples/KeenEyes.Sample.Voxel/Noise.cs
@@ -1,0 +1,133 @@
+namespace KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// SIMPLEX NOISE IMPLEMENTATION
+// =============================================================================
+// A simple noise generator for terrain generation.
+// Based on Ken Perlin's improved noise algorithm.
+// =============================================================================
+
+/// <summary>
+/// Simplex noise generator for procedural terrain.
+/// </summary>
+public sealed class SimplexNoise
+{
+    private readonly int[] _perm = new int[512];
+    private readonly int[] _permMod12 = new int[512];
+
+    private static readonly int[] Grad3 =
+    [
+        1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1, 0,
+        1, 0, 1, -1, 0, 1, 1, 0, -1, -1, 0, -1,
+        0, 1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1
+    ];
+
+    /// <summary>
+    /// Creates a new noise generator with the specified seed.
+    /// </summary>
+    public SimplexNoise(int seed)
+    {
+        // Seeded random is required for deterministic procedural generation
+#pragma warning disable KEEN030
+        var random = new Random(seed);
+#pragma warning restore KEEN030
+        var p = new int[256];
+
+        for (int i = 0; i < 256; i++)
+        {
+            p[i] = i;
+        }
+
+        // Fisher-Yates shuffle
+        for (int i = 255; i > 0; i--)
+        {
+            int j = random.Next(i + 1);
+            (p[i], p[j]) = (p[j], p[i]);
+        }
+
+        for (int i = 0; i < 512; i++)
+        {
+            _perm[i] = p[i & 255];
+            _permMod12[i] = _perm[i] % 12;
+        }
+    }
+
+    /// <summary>
+    /// 2D simplex noise.
+    /// </summary>
+    public float Noise2D(float x, float y)
+    {
+        const float F2 = 0.5f * (1.732050808f - 1.0f); // (sqrt(3) - 1) / 2
+        const float G2 = (3.0f - 1.732050808f) / 6.0f; // (3 - sqrt(3)) / 6
+
+        float s = (x + y) * F2;
+        int i = FastFloor(x + s);
+        int j = FastFloor(y + s);
+
+        float t = (i + j) * G2;
+        float x0 = x - (i - t);
+        float y0 = y - (j - t);
+
+        int i1, j1;
+        if (x0 > y0) { i1 = 1; j1 = 0; }
+        else { i1 = 0; j1 = 1; }
+
+        float x1 = x0 - i1 + G2;
+        float y1 = y0 - j1 + G2;
+        float x2 = x0 - 1.0f + 2.0f * G2;
+        float y2 = y0 - 1.0f + 2.0f * G2;
+
+        int ii = i & 255;
+        int jj = j & 255;
+
+        float n0 = CalculateCorner(x0, y0, _permMod12[ii + _perm[jj]]);
+        float n1 = CalculateCorner(x1, y1, _permMod12[ii + i1 + _perm[jj + j1]]);
+        float n2 = CalculateCorner(x2, y2, _permMod12[ii + 1 + _perm[jj + 1]]);
+
+        return 70.0f * (n0 + n1 + n2);
+    }
+
+    /// <summary>
+    /// Fractal Brownian motion - layered noise for more natural terrain.
+    /// </summary>
+    public float FBM(float x, float y, int octaves, float persistence, float lacunarity)
+    {
+        float total = 0;
+        float amplitude = 1;
+        float frequency = 1;
+        float maxValue = 0;
+
+        for (int i = 0; i < octaves; i++)
+        {
+            total += Noise2D(x * frequency, y * frequency) * amplitude;
+            maxValue += amplitude;
+            amplitude *= persistence;
+            frequency *= lacunarity;
+        }
+
+        return total / maxValue;
+    }
+
+    private static float CalculateCorner(float x, float y, int gi)
+    {
+        float t = 0.5f - x * x - y * y;
+        if (t < 0)
+        {
+            return 0;
+        }
+
+        t *= t;
+        return t * t * Dot2D(Grad3, gi * 3, x, y);
+    }
+
+    private static float Dot2D(int[] g, int offset, float x, float y)
+    {
+        return g[offset] * x + g[offset + 1] * y;
+    }
+
+    private static int FastFloor(float x)
+    {
+        int xi = (int)x;
+        return x < xi ? xi - 1 : xi;
+    }
+}

--- a/samples/KeenEyes.Sample.Voxel/Program.cs
+++ b/samples/KeenEyes.Sample.Voxel/Program.cs
@@ -1,0 +1,362 @@
+using System.Diagnostics;
+using System.Text;
+using KeenEyes;
+using KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// KEEN EYES ECS - Voxel World Demo
+// =============================================================================
+// A procedural voxel world demonstrating:
+// - Chunk-based terrain generation with biomes
+// - Simplex noise for natural-looking terrain
+// - Player movement with voxel collision
+// - ASCII side-view visualization
+// =============================================================================
+
+Console.OutputEncoding = Encoding.UTF8;
+Console.CursorVisible = false;
+
+// Configuration
+const int ViewWidth = 80;
+const int ViewHeight = 24;
+const float TargetFps = 30f;
+const float FixedDeltaTime = 1f / 60f;
+const int WorldSeed = 12345;
+
+// Create world and services
+using var world = new World();
+var blockRegistry = new BlockRegistry();
+var worldGenerator = new WorldGenerator(WorldSeed);
+
+// Create systems
+var chunkLoader = new ChunkLoaderSystem
+{
+    Generator = worldGenerator,
+    MaxChunksPerFrame = 8
+};
+
+var inputSystem = new PlayerInputSystem
+{
+    MoveSpeed = 6f,
+    JumpVelocity = 8f
+};
+
+var physicsSystem = new VoxelPhysicsSystem
+{
+    ChunkLoader = chunkLoader,
+    Blocks = blockRegistry,
+    Gravity = 20f
+};
+
+var visibilitySystem = new ChunkVisibilitySystem();
+
+// Register systems
+world
+    .AddSystem(chunkLoader)
+    .AddSystem(inputSystem)
+    .AddSystem(physicsSystem)
+    .AddSystem(visibilitySystem);
+
+// Calculate spawn position - find ground level at origin
+int spawnX = 0;
+int spawnZ = 0;
+int spawnY = 64; // Start high and let physics bring us down
+
+// Create player
+var player = world.Spawn()
+    .WithPosition3D(x: spawnX + 0.5f, y: spawnY, z: spawnZ + 0.5f)
+    .WithVelocity3D(x: 0, y: 0, z: 0)
+    .WithVoxelCollider(width: 0.6f, height: 1.8f, depth: 0.6f, onGround: false)
+    .WithCameraRotation(yaw: 0, pitch: 0)
+    .WithViewDistance(horizontal: 3, vertical: 2)
+    .WithLocalPlayer()
+    .Build();
+
+// Frame buffer for rendering
+var frameBuffer = new char[ViewHeight, ViewWidth];
+var colorBuffer = new ConsoleColor[ViewHeight, ViewWidth];
+
+// Game state
+float gameTime = 0;
+var inputState = new PlayerInputState();
+
+// Clear screen and show header
+Console.Clear();
+Console.WriteLine("KeenEyes ECS - Voxel World Demo");
+Console.WriteLine(new string('=', ViewWidth));
+Console.WriteLine("WASD = Move | Q/E = Turn | Space = Jump | ESC = Exit");
+Console.WriteLine(new string('-', ViewWidth));
+
+const int HeaderLines = 4;
+int statsLine = HeaderLines + ViewHeight + 1;
+
+// Game loop
+var stopwatch = Stopwatch.StartNew();
+var lastFrameTime = stopwatch.Elapsed.TotalSeconds;
+var accumulator = 0.0;
+var running = true;
+
+Console.CancelKeyPress += (s, e) =>
+{
+    e.Cancel = true;
+    running = false;
+};
+
+while (running)
+{
+    var currentTime = stopwatch.Elapsed.TotalSeconds;
+    var frameTime = currentTime - lastFrameTime;
+    lastFrameTime = currentTime;
+
+    // Cap frame time
+    if (frameTime > 0.25)
+    {
+        frameTime = 0.25;
+    }
+
+    accumulator += frameTime;
+
+    // Read input
+    ReadInput();
+
+    if (inputState is { Forward: false, Backward: false, Left: false, Right: false, Jump: false, TurnLeft: false, TurnRight: false })
+    {
+        // Check for key without blocking
+        if (Console.KeyAvailable)
+        {
+            var key = Console.ReadKey(true);
+            if (key.Key == ConsoleKey.Escape)
+            {
+                running = false;
+                continue;
+            }
+        }
+    }
+
+    inputSystem.Input = inputState;
+
+    // Fixed timestep updates
+    while (accumulator >= FixedDeltaTime)
+    {
+        world.Update(FixedDeltaTime);
+        gameTime += FixedDeltaTime;
+        accumulator -= FixedDeltaTime;
+    }
+
+    // Render
+    RenderFrame();
+
+    // Sleep to cap frame rate
+    var elapsed = stopwatch.Elapsed.TotalSeconds - currentTime;
+    var sleepTime = (1.0 / TargetFps) - elapsed;
+    if (sleepTime > 0)
+    {
+        Thread.Sleep((int)(sleepTime * 1000));
+    }
+}
+
+Console.CursorVisible = true;
+Console.SetCursorPosition(0, statsLine + 2);
+Console.ResetColor();
+Console.WriteLine("\nExiting voxel world...");
+
+// =============================================================================
+// INPUT HANDLING
+// =============================================================================
+
+void ReadInput()
+{
+    inputState = new PlayerInputState();
+
+    while (Console.KeyAvailable)
+    {
+        var key = Console.ReadKey(true);
+
+        switch (key.Key)
+        {
+            case ConsoleKey.W:
+            case ConsoleKey.UpArrow:
+                inputState.Forward = true;
+                break;
+            case ConsoleKey.S:
+            case ConsoleKey.DownArrow:
+                inputState.Backward = true;
+                break;
+            case ConsoleKey.A:
+                inputState.Left = true;
+                break;
+            case ConsoleKey.D:
+                inputState.Right = true;
+                break;
+            case ConsoleKey.Q:
+            case ConsoleKey.LeftArrow:
+                inputState.TurnLeft = true;
+                break;
+            case ConsoleKey.E:
+            case ConsoleKey.RightArrow:
+                inputState.TurnRight = true;
+                break;
+            case ConsoleKey.Spacebar:
+                inputState.Jump = true;
+                break;
+            case ConsoleKey.Escape:
+                running = false;
+                break;
+        }
+    }
+}
+
+// =============================================================================
+// RENDERING - Side View (XY plane looking down Z axis)
+// =============================================================================
+
+void RenderFrame()
+{
+    // Clear buffers
+    for (int y = 0; y < ViewHeight; y++)
+    {
+        for (int x = 0; x < ViewWidth; x++)
+        {
+            frameBuffer[y, x] = ' ';
+            colorBuffer[y, x] = ConsoleColor.DarkBlue; // Sky color
+        }
+    }
+
+    // Get player position
+    ref readonly var playerPos = ref world.Get<Position3D>(player);
+    ref readonly var playerRot = ref world.Get<CameraRotation>(player);
+
+    int centerWorldX = (int)MathF.Floor(playerPos.X);
+    int centerWorldY = (int)MathF.Floor(playerPos.Y);
+    int centerWorldZ = (int)MathF.Floor(playerPos.Z);
+
+    // Render side view (XY plane at player's Z)
+    int halfWidth = ViewWidth / 2;
+    int halfHeight = ViewHeight / 2;
+
+    for (int screenY = 0; screenY < ViewHeight; screenY++)
+    {
+        for (int screenX = 0; screenX < ViewWidth; screenX++)
+        {
+            // Map screen to world coordinates
+            int worldX = centerWorldX + (screenX - halfWidth);
+            int worldY = centerWorldY + (halfHeight - screenY); // Flip Y
+
+            // Sample blocks at multiple Z depths for depth effect
+            byte blockId = BlockId.Air;
+            for (int dz = 0; dz <= 3; dz++)
+            {
+                int sampleZ = centerWorldZ + dz;
+                byte sampled = chunkLoader.GetBlock(worldX, worldY, sampleZ);
+
+                if (sampled != BlockId.Air)
+                {
+                    blockId = sampled;
+                    break;
+                }
+            }
+
+            // Get block visual
+            if (blockId != BlockId.Air)
+            {
+                frameBuffer[screenY, screenX] = blockRegistry.GetSymbol(blockId);
+                colorBuffer[screenY, screenX] = blockRegistry.GetColor(blockId);
+            }
+            else
+            {
+                // Sky gradient based on height
+                int worldHeight = centerWorldY + (halfHeight - screenY);
+                if (worldHeight < 32) // Below sea level
+                {
+                    frameBuffer[screenY, screenX] = '~';
+                    colorBuffer[screenY, screenX] = ConsoleColor.DarkBlue;
+                }
+                else if (worldHeight < 50)
+                {
+                    colorBuffer[screenY, screenX] = ConsoleColor.Blue;
+                }
+                else
+                {
+                    colorBuffer[screenY, screenX] = ConsoleColor.Cyan;
+                }
+            }
+        }
+    }
+
+    // Draw player marker at center
+    int playerScreenX = halfWidth;
+    int playerScreenY = halfHeight;
+    if (playerScreenX >= 0 && playerScreenX < ViewWidth &&
+        playerScreenY >= 0 && playerScreenY < ViewHeight)
+    {
+        frameBuffer[playerScreenY, playerScreenX] = '@';
+        colorBuffer[playerScreenY, playerScreenX] = ConsoleColor.Yellow;
+
+        // Draw player body (2 blocks tall)
+        if (playerScreenY + 1 < ViewHeight)
+        {
+            frameBuffer[playerScreenY + 1, playerScreenX] = 'O';
+            colorBuffer[playerScreenY + 1, playerScreenX] = ConsoleColor.Yellow;
+        }
+    }
+
+    // Draw direction indicator
+    float yaw = playerRot.Yaw;
+    char dirChar;
+    if (yaw >= -0.4f && yaw <= 0.4f)
+    {
+        dirChar = '^';
+    }
+    else if (yaw > 0.4f && yaw < 2.7f)
+    {
+        dirChar = '>';
+    }
+    else if (yaw >= 2.7f || yaw <= -2.7f)
+    {
+        dirChar = 'v';
+    }
+    else
+    {
+        dirChar = '<';
+    }
+
+    if (playerScreenY > 0)
+    {
+        frameBuffer[playerScreenY - 1, playerScreenX] = dirChar;
+        colorBuffer[playerScreenY - 1, playerScreenX] = ConsoleColor.White;
+    }
+
+    // Draw frame to console
+    for (int y = 0; y < ViewHeight; y++)
+    {
+        Console.SetCursorPosition(0, HeaderLines + y);
+        ConsoleColor lastColor = ConsoleColor.Black;
+
+        for (int x = 0; x < ViewWidth; x++)
+        {
+            var color = colorBuffer[y, x];
+            if (color != lastColor)
+            {
+                Console.ForegroundColor = color;
+                lastColor = color;
+            }
+            Console.Write(frameBuffer[y, x]);
+        }
+    }
+
+    // Draw stats
+    Console.SetCursorPosition(0, statsLine);
+    Console.ResetColor();
+
+    // Get current biome
+    var biome = worldGenerator.DetermineBiome(centerWorldX, centerWorldZ);
+    ref readonly var collider = ref world.Get<VoxelCollider>(player);
+
+    var groundStatus = collider.OnGround ? "Ground" : "Air   ";
+
+    Console.Write($"Pos: ({playerPos.X,6:F1}, {playerPos.Y,5:F1}, {playerPos.Z,6:F1}) | ");
+    Console.Write($"Biome: {biome,-10} | ");
+    Console.Write($"Chunks: {chunkLoader.LoadedChunkCount,3} | ");
+    Console.Write($"Status: {groundStatus} | ");
+    Console.Write($"Time: {gameTime,6:F1}s   ");
+}

--- a/samples/KeenEyes.Sample.Voxel/Systems.cs
+++ b/samples/KeenEyes.Sample.Voxel/Systems.cs
@@ -1,0 +1,427 @@
+using KeenEyes;
+
+namespace KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// VOXEL GAME SYSTEMS
+// =============================================================================
+
+/// <summary>
+/// Manages chunk loading and unloading based on player position.
+/// </summary>
+[System(Phase = SystemPhase.EarlyUpdate, Order = 0)]
+public partial class ChunkLoaderSystem : SystemBase
+{
+    private readonly Dictionary<(int, int, int), Entity> _loadedChunks = [];
+    private readonly HashSet<(int, int, int)> _chunksToLoad = [];
+    private readonly HashSet<(int, int, int)> _chunksToUnload = [];
+
+    /// <summary>Reference to the world generator.</summary>
+    public WorldGenerator Generator { get; init; } = null!;
+
+    /// <summary>Maximum chunks to load per frame.</summary>
+    public int MaxChunksPerFrame { get; set; } = 4;
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        // Find player and their view distance
+        foreach (var entity in World.Query<Position3D, ViewDistance>().With<LocalPlayer>())
+        {
+            ref readonly var pos = ref World.Get<Position3D>(entity);
+            ref readonly var view = ref World.Get<ViewDistance>(entity);
+
+            int playerChunkX = (int)MathF.Floor(pos.X / VoxelData.Size);
+            int playerChunkY = (int)MathF.Floor(pos.Y / VoxelData.Size);
+            int playerChunkZ = (int)MathF.Floor(pos.Z / VoxelData.Size);
+
+            // Determine chunks that should be loaded
+            _chunksToLoad.Clear();
+            for (int dy = -view.Vertical; dy <= view.Vertical; dy++)
+            {
+                for (int dz = -view.Horizontal; dz <= view.Horizontal; dz++)
+                {
+                    for (int dx = -view.Horizontal; dx <= view.Horizontal; dx++)
+                    {
+                        var coord = (playerChunkX + dx, playerChunkY + dy, playerChunkZ + dz);
+                        if (!_loadedChunks.ContainsKey(coord))
+                        {
+                            _chunksToLoad.Add(coord);
+                        }
+                    }
+                }
+            }
+
+            // Determine chunks to unload
+            _chunksToUnload.Clear();
+            foreach (var coord in _loadedChunks.Keys)
+            {
+                int dx = Math.Abs(coord.Item1 - playerChunkX);
+                int dy = Math.Abs(coord.Item2 - playerChunkY);
+                int dz = Math.Abs(coord.Item3 - playerChunkZ);
+
+                if (dx > view.Horizontal + 1 || dy > view.Vertical + 1 || dz > view.Horizontal + 1)
+                {
+                    _chunksToUnload.Add(coord);
+                }
+            }
+
+            // Unload distant chunks
+            foreach (var coord in _chunksToUnload)
+            {
+                if (_loadedChunks.TryGetValue(coord, out var chunkEntity))
+                {
+                    World.Despawn(chunkEntity);
+                    _loadedChunks.Remove(coord);
+                }
+            }
+
+            // Load new chunks (limited per frame)
+            int loaded = 0;
+            foreach (var coord in _chunksToLoad)
+            {
+                if (loaded >= MaxChunksPerFrame)
+                {
+                    break;
+                }
+
+                LoadChunk(coord.Item1, coord.Item2, coord.Item3);
+                loaded++;
+            }
+        }
+    }
+
+    private void LoadChunk(int cx, int cy, int cz)
+    {
+        var voxelData = Generator.GenerateChunk(cx, cy, cz, out var biome, out var heightMap);
+
+        var chunk = World.Spawn()
+            .WithChunkCoord(x: cx, y: cy, z: cz)
+            .With(voxelData)
+            .WithChunkBiome(biome: biome)
+            .With(heightMap)
+            .WithChunkLoaded()
+            .WithChunkDirty()
+            .Build();
+
+        _loadedChunks[(cx, cy, cz)] = chunk;
+    }
+
+    /// <summary>
+    /// Gets a loaded chunk entity by coordinates.
+    /// </summary>
+    public Entity? GetChunk(int cx, int cy, int cz)
+    {
+        return _loadedChunks.TryGetValue((cx, cy, cz), out var entity) ? entity : null;
+    }
+
+    /// <summary>
+    /// Gets the block at world coordinates.
+    /// </summary>
+    public byte GetBlock(int worldX, int worldY, int worldZ)
+    {
+        int cx = (int)MathF.Floor(worldX / (float)VoxelData.Size);
+        int cy = (int)MathF.Floor(worldY / (float)VoxelData.Size);
+        int cz = (int)MathF.Floor(worldZ / (float)VoxelData.Size);
+
+        if (!_loadedChunks.TryGetValue((cx, cy, cz), out var chunk))
+        {
+            return BlockId.Air;
+        }
+
+        if (!World.IsAlive(chunk))
+        {
+            return BlockId.Air;
+        }
+
+        ref readonly var voxels = ref World.Get<VoxelData>(chunk);
+
+        int lx = ((worldX % VoxelData.Size) + VoxelData.Size) % VoxelData.Size;
+        int ly = ((worldY % VoxelData.Size) + VoxelData.Size) % VoxelData.Size;
+        int lz = ((worldZ % VoxelData.Size) + VoxelData.Size) % VoxelData.Size;
+
+        return voxels.GetBlock(lx, ly, lz);
+    }
+
+    /// <summary>
+    /// Gets the number of loaded chunks.
+    /// </summary>
+    public int LoadedChunkCount => _loadedChunks.Count;
+}
+
+/// <summary>
+/// Handles player movement input and applies velocity.
+/// </summary>
+[System(Phase = SystemPhase.Update, Order = 0)]
+public partial class PlayerInputSystem : SystemBase
+{
+    /// <summary>Movement speed in blocks per second.</summary>
+    public float MoveSpeed { get; set; } = 8f;
+
+    /// <summary>Jump velocity.</summary>
+    public float JumpVelocity { get; set; } = 10f;
+
+    /// <summary>Current input state.</summary>
+    public PlayerInputState Input { get; set; }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Position3D, Velocity3D, VoxelCollider, CameraRotation>().With<LocalPlayer>())
+        {
+            ref var velocity = ref World.Get<Velocity3D>(entity);
+            ref readonly var collider = ref World.Get<VoxelCollider>(entity);
+            ref readonly var rotation = ref World.Get<CameraRotation>(entity);
+
+            // Calculate movement direction based on camera yaw
+            float cos = MathF.Cos(rotation.Yaw);
+            float sin = MathF.Sin(rotation.Yaw);
+
+            float moveX = 0;
+            float moveZ = 0;
+
+            if (Input.Forward)
+            {
+                moveX += sin;
+                moveZ += cos;
+            }
+
+            if (Input.Backward)
+            {
+                moveX -= sin;
+                moveZ -= cos;
+            }
+
+            if (Input.Left)
+            {
+                moveX += cos;
+                moveZ -= sin;
+            }
+
+            if (Input.Right)
+            {
+                moveX -= cos;
+                moveZ += sin;
+            }
+
+            // Normalize diagonal movement
+            float length = MathF.Sqrt(moveX * moveX + moveZ * moveZ);
+            if (length > 0.01f)
+            {
+                moveX /= length;
+                moveZ /= length;
+            }
+
+            // Apply horizontal velocity
+            velocity.X = moveX * MoveSpeed;
+            velocity.Z = moveZ * MoveSpeed;
+
+            // Jump if on ground
+            if (Input.Jump && collider.OnGround)
+            {
+                velocity.Y = JumpVelocity;
+            }
+
+            // Camera rotation (simplified for demo)
+            if (Input.TurnLeft || Input.TurnRight)
+            {
+                ref var rot = ref World.Get<CameraRotation>(entity);
+                rot.Yaw += (Input.TurnLeft ? -1 : 1) * 2f * deltaTime;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Input state for player control.
+/// </summary>
+public struct PlayerInputState
+{
+    /// <summary>Moving forward (W key).</summary>
+    public bool Forward;
+
+    /// <summary>Moving backward (S key).</summary>
+    public bool Backward;
+
+    /// <summary>Strafing left (A key).</summary>
+    public bool Left;
+
+    /// <summary>Strafing right (D key).</summary>
+    public bool Right;
+
+    /// <summary>Jumping (Space key).</summary>
+    public bool Jump;
+
+    /// <summary>Turning left (Q key).</summary>
+    public bool TurnLeft;
+
+    /// <summary>Turning right (E key).</summary>
+    public bool TurnRight;
+}
+
+/// <summary>
+/// Applies gravity and handles voxel collision.
+/// </summary>
+[System(Phase = SystemPhase.FixedUpdate, Order = 0)]
+public partial class VoxelPhysicsSystem : SystemBase
+{
+    /// <summary>Reference to chunk loader for block queries.</summary>
+    public ChunkLoaderSystem ChunkLoader { get; init; } = null!;
+
+    /// <summary>Reference to block registry.</summary>
+    public BlockRegistry Blocks { get; init; } = null!;
+
+    /// <summary>Gravity acceleration.</summary>
+    public float Gravity { get; set; } = 25f;
+
+    /// <summary>Maximum fall speed.</summary>
+    public float TerminalVelocity { get; set; } = 50f;
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Position3D, Velocity3D, VoxelCollider>())
+        {
+            ref var pos = ref World.Get<Position3D>(entity);
+            ref var vel = ref World.Get<Velocity3D>(entity);
+            ref var collider = ref World.Get<VoxelCollider>(entity);
+
+            // Apply gravity
+            vel.Y -= Gravity * deltaTime;
+            vel.Y = MathF.Max(vel.Y, -TerminalVelocity);
+
+            // Calculate movement
+            float dx = vel.X * deltaTime;
+            float dy = vel.Y * deltaTime;
+            float dz = vel.Z * deltaTime;
+
+            // Sweep collision (simplified axis-aligned)
+            collider.OnGround = false;
+
+            // X axis
+            if (MathF.Abs(dx) > 0.001f)
+            {
+                if (CheckCollision(pos.X + dx, pos.Y, pos.Z, collider))
+                {
+                    dx = 0;
+                    vel.X = 0;
+                }
+            }
+
+            // Z axis
+            if (MathF.Abs(dz) > 0.001f)
+            {
+                if (CheckCollision(pos.X + dx, pos.Y, pos.Z + dz, collider))
+                {
+                    dz = 0;
+                    vel.Z = 0;
+                }
+            }
+
+            // Y axis
+            if (MathF.Abs(dy) > 0.001f)
+            {
+                if (CheckCollision(pos.X + dx, pos.Y + dy, pos.Z + dz, collider))
+                {
+                    if (dy < 0)
+                    {
+                        collider.OnGround = true;
+                    }
+
+                    dy = 0;
+                    vel.Y = 0;
+                }
+            }
+
+            // Apply movement
+            pos.X += dx;
+            pos.Y += dy;
+            pos.Z += dz;
+        }
+    }
+
+    private bool CheckCollision(float x, float y, float z, VoxelCollider collider)
+    {
+        float halfWidth = collider.Width * 0.5f;
+        float halfDepth = collider.Depth * 0.5f;
+
+        // Check all blocks the AABB overlaps
+        int minX = (int)MathF.Floor(x - halfWidth);
+        int maxX = (int)MathF.Floor(x + halfWidth);
+        int minY = (int)MathF.Floor(y);
+        int maxY = (int)MathF.Floor(y + collider.Height);
+        int minZ = (int)MathF.Floor(z - halfDepth);
+        int maxZ = (int)MathF.Floor(z + halfDepth);
+
+        for (int by = minY; by <= maxY; by++)
+        {
+            for (int bz = minZ; bz <= maxZ; bz++)
+            {
+                for (int bx = minX; bx <= maxX; bx++)
+                {
+                    byte block = ChunkLoader.GetBlock(bx, by, bz);
+                    if (Blocks.IsSolid(block))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Updates visible chunk list based on player position.
+/// </summary>
+[System(Phase = SystemPhase.LateUpdate, Order = 0)]
+public partial class ChunkVisibilitySystem : SystemBase
+{
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        // Find player position
+        float playerX = 0, playerY = 0, playerZ = 0;
+        int viewHorizontal = 4, viewVertical = 2;
+
+        foreach (var entity in World.Query<Position3D, ViewDistance>().With<LocalPlayer>())
+        {
+            ref readonly var pos = ref World.Get<Position3D>(entity);
+            ref readonly var view = ref World.Get<ViewDistance>(entity);
+            playerX = pos.X;
+            playerY = pos.Y;
+            playerZ = pos.Z;
+            viewHorizontal = view.Horizontal;
+            viewVertical = view.Vertical;
+            break;
+        }
+
+        int playerChunkX = (int)MathF.Floor(playerX / VoxelData.Size);
+        int playerChunkY = (int)MathF.Floor(playerY / VoxelData.Size);
+        int playerChunkZ = (int)MathF.Floor(playerZ / VoxelData.Size);
+
+        // Update visibility for all chunks
+        foreach (var entity in World.Query<ChunkCoord>().With<ChunkLoaded>())
+        {
+            ref readonly var coord = ref World.Get<ChunkCoord>(entity);
+
+            int dx = Math.Abs(coord.X - playerChunkX);
+            int dy = Math.Abs(coord.Y - playerChunkY);
+            int dz = Math.Abs(coord.Z - playerChunkZ);
+
+            bool shouldBeVisible = dx <= viewHorizontal && dy <= viewVertical && dz <= viewHorizontal;
+
+            bool isVisible = World.Has<ChunkVisible>(entity);
+
+            if (shouldBeVisible && !isVisible)
+            {
+                World.Add(entity, default(ChunkVisible));
+            }
+            else if (!shouldBeVisible && isVisible)
+            {
+                World.Remove<ChunkVisible>(entity);
+            }
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.Voxel/WorldGeneration.cs
+++ b/samples/KeenEyes.Sample.Voxel/WorldGeneration.cs
@@ -1,0 +1,324 @@
+namespace KeenEyes.Sample.Voxel;
+
+// =============================================================================
+// WORLD GENERATION
+// =============================================================================
+// Procedural terrain generation with biomes using layered noise.
+// =============================================================================
+
+/// <summary>
+/// Biome properties for terrain generation.
+/// </summary>
+public readonly record struct BiomeProperties(
+    BiomeType Type,
+    int MinHeight,
+    int MaxHeight,
+    byte SurfaceBlock,
+    byte SubsurfaceBlock,
+    float TreeDensity,
+    float PlantDensity
+);
+
+/// <summary>
+/// World generator using simplex noise for terrain and biome distribution.
+/// </summary>
+/// <param name="seed">World seed for reproducible generation.</param>
+public sealed class WorldGenerator(int seed)
+{
+    private readonly SimplexNoise _heightNoise = new(seed);
+    private readonly SimplexNoise _temperatureNoise = new(seed + 2);
+    private readonly SimplexNoise _moistureNoise = new(seed + 3);
+    private readonly SimplexNoise _detailNoise = new(seed + 4);
+
+    /// <summary>World seed for reproducible generation.</summary>
+    public int Seed { get; } = seed;
+
+    /// <summary>Sea level height.</summary>
+    public int SeaLevel { get; } = 32;
+
+    /// <summary>Bedrock layer height.</summary>
+    public int BedrockHeight { get; } = 1;
+
+    private static readonly BiomeProperties[] BiomeData =
+    [
+        new(BiomeType.Plains, 28, 40, BlockId.Grass, BlockId.Dirt, 0.02f, 0.15f),
+        new(BiomeType.Forest, 30, 45, BlockId.Grass, BlockId.Dirt, 0.25f, 0.3f),
+        new(BiomeType.Desert, 26, 38, BlockId.Sand, BlockId.Sand, 0.005f, 0.02f),
+        new(BiomeType.Mountains, 40, 80, BlockId.Stone, BlockId.Stone, 0.01f, 0.05f),
+        new(BiomeType.Tundra, 28, 42, BlockId.Snow, BlockId.Dirt, 0.01f, 0.02f),
+        new(BiomeType.Ocean, 10, 30, BlockId.Sand, BlockId.Clay, 0f, 0f)
+    ];
+
+    /// <summary>
+    /// Generates chunk voxel data at the given chunk coordinates.
+    /// </summary>
+    public VoxelData GenerateChunk(int chunkX, int chunkY, int chunkZ, out BiomeType biome, out HeightMap heightMap)
+    {
+        var voxels = new VoxelData { Blocks = new byte[VoxelData.Volume] };
+        heightMap = new HeightMap { Heights = new byte[VoxelData.Size * VoxelData.Size] };
+
+        // Determine biome at chunk center
+        int centerX = chunkX * VoxelData.Size + VoxelData.Size / 2;
+        int centerZ = chunkZ * VoxelData.Size + VoxelData.Size / 2;
+        biome = DetermineBiome(centerX, centerZ);
+        var biomeProps = BiomeData[(int)biome];
+
+        // Generate terrain for each column
+        for (int lz = 0; lz < VoxelData.Size; lz++)
+        {
+            for (int lx = 0; lx < VoxelData.Size; lx++)
+            {
+                int worldX = chunkX * VoxelData.Size + lx;
+                int worldZ = chunkZ * VoxelData.Size + lz;
+
+                // Get local biome (may differ from chunk center)
+                var localBiome = DetermineBiome(worldX, worldZ);
+                var localBiomeProps = BiomeData[(int)localBiome];
+
+                // Calculate terrain height
+                int terrainHeight = CalculateTerrainHeight(worldX, worldZ, localBiomeProps);
+                heightMap.Heights[lx + lz * VoxelData.Size] = (byte)Math.Clamp(terrainHeight, 0, 255);
+
+                // Fill blocks for this column within chunk bounds
+                int worldBaseY = chunkY * VoxelData.Size;
+
+                for (int ly = 0; ly < VoxelData.Size; ly++)
+                {
+                    int worldY = worldBaseY + ly;
+                    byte blockId = GetBlockForPosition(worldX, worldY, worldZ, terrainHeight, localBiome, localBiomeProps);
+                    voxels.SetBlock(lx, ly, lz, blockId);
+                }
+            }
+        }
+
+        // Add features (trees, plants) - only in surface chunks
+        if (chunkY >= 0 && chunkY <= 5)
+        {
+            AddFeatures(ref voxels, chunkX, chunkY, chunkZ, biome, biomeProps, heightMap);
+        }
+
+        return voxels;
+    }
+
+    /// <summary>
+    /// Determines the biome at the given world coordinates.
+    /// </summary>
+    public BiomeType DetermineBiome(int worldX, int worldZ)
+    {
+        float scale = 0.005f;
+        float temperature = _temperatureNoise.Noise2D(worldX * scale, worldZ * scale);
+        float moisture = _moistureNoise.Noise2D(worldX * scale * 1.5f, worldZ * scale * 1.5f);
+
+        // Normalize to 0-1 range
+        temperature = (temperature + 1) * 0.5f;
+        moisture = (moisture + 1) * 0.5f;
+
+        // Check for ocean first (low elevation areas)
+        float elevation = _heightNoise.FBM(worldX * 0.01f, worldZ * 0.01f, 3, 0.5f, 2.0f);
+        if (elevation < -0.3f)
+        {
+            return BiomeType.Ocean;
+        }
+
+        // Temperature-moisture based biome selection
+        if (temperature < 0.25f)
+        {
+            return BiomeType.Tundra;
+        }
+        else if (temperature > 0.75f && moisture < 0.35f)
+        {
+            return BiomeType.Desert;
+        }
+        else if (elevation > 0.4f)
+        {
+            return BiomeType.Mountains;
+        }
+        else if (moisture > 0.55f)
+        {
+            return BiomeType.Forest;
+        }
+        else
+        {
+            return BiomeType.Plains;
+        }
+    }
+
+    private int CalculateTerrainHeight(int worldX, int worldZ, BiomeProperties biome)
+    {
+        // Base terrain using FBM
+        float baseHeight = _heightNoise.FBM(worldX * 0.02f, worldZ * 0.02f, 4, 0.5f, 2.0f);
+
+        // Detail noise for local variation
+        float detail = _detailNoise.Noise2D(worldX * 0.1f, worldZ * 0.1f) * 0.2f;
+
+        // Combine and scale to biome height range
+        float normalized = (baseHeight + detail + 1) * 0.5f;
+        int height = (int)(biome.MinHeight + normalized * (biome.MaxHeight - biome.MinHeight));
+
+        return Math.Clamp(height, 1, 127);
+    }
+
+    private byte GetBlockForPosition(int worldX, int worldY, int worldZ, int terrainHeight, BiomeType biome, BiomeProperties biomeProps)
+    {
+        // Bedrock layer
+        if (worldY <= BedrockHeight)
+        {
+            return BlockId.Bedrock;
+        }
+
+        // Underground
+        if (worldY < terrainHeight - 4)
+        {
+            return BlockId.Stone;
+        }
+
+        // Subsurface layer (3-4 blocks below surface)
+        if (worldY < terrainHeight)
+        {
+            return biomeProps.SubsurfaceBlock;
+        }
+
+        // Surface layer
+        if (worldY == terrainHeight)
+        {
+            // Water covers low areas
+            if (terrainHeight < SeaLevel && biome != BiomeType.Desert)
+            {
+                return biomeProps.SubsurfaceBlock; // Sand/clay under water
+            }
+
+            return biomeProps.SurfaceBlock;
+        }
+
+        // Water filling
+        if (worldY <= SeaLevel && worldY > terrainHeight)
+        {
+            if (biome == BiomeType.Tundra && worldY == SeaLevel)
+            {
+                return BlockId.Ice;
+            }
+
+            return BlockId.Water;
+        }
+
+        // Air above
+        return BlockId.Air;
+    }
+
+    private void AddFeatures(ref VoxelData voxels, int chunkX, int chunkY, int chunkZ, BiomeType biome, BiomeProperties biomeProps, HeightMap heightMap)
+    {
+        // Use deterministic random based on chunk position via noise
+        int worldBaseY = chunkY * VoxelData.Size;
+
+        for (int lz = 1; lz < VoxelData.Size - 1; lz++)
+        {
+            for (int lx = 1; lx < VoxelData.Size - 1; lx++)
+            {
+                int terrainHeight = heightMap.GetHeight(lx, lz);
+                int localY = terrainHeight - worldBaseY;
+
+                // Skip if surface is not in this chunk
+                if (localY < 0 || localY >= VoxelData.Size - 4)
+                {
+                    continue;
+                }
+
+                // Skip underwater areas
+                if (terrainHeight < 32) // Sea level
+                {
+                    continue;
+                }
+
+                // Use noise for deterministic feature placement
+                int worldX = chunkX * VoxelData.Size + lx;
+                int worldZ = chunkZ * VoxelData.Size + lz;
+                float roll = (_detailNoise.Noise2D(worldX * 0.5f, worldZ * 0.5f) + 1) * 0.5f;
+
+                // Trees
+                if (roll < biomeProps.TreeDensity && localY < VoxelData.Size - 6)
+                {
+                    PlaceTree(ref voxels, lx, localY + 1, lz, biome, worldX, worldZ);
+                }
+                // Plants
+                else if (roll < biomeProps.TreeDensity + biomeProps.PlantDensity)
+                {
+                    PlacePlant(ref voxels, lx, localY + 1, lz, biome);
+                }
+            }
+        }
+    }
+
+    private void PlaceTree(ref VoxelData voxels, int x, int y, int z, BiomeType biome, int worldX, int worldZ)
+    {
+        if (biome == BiomeType.Desert)
+        {
+            // Cactus in desert - use noise for height variation
+            int height = 2 + (int)((_detailNoise.Noise2D(worldX * 0.7f, worldZ * 0.7f) + 1) * 1.5f);
+            height = Math.Clamp(height, 2, 4);
+            for (int i = 0; i < height && y + i < VoxelData.Size; i++)
+            {
+                voxels.SetBlock(x, y + i, z, BlockId.Cactus);
+            }
+        }
+        else
+        {
+            // Regular tree - use noise for trunk height
+            int trunkHeight = 4 + (int)((_detailNoise.Noise2D(worldX * 0.3f, worldZ * 0.3f) + 1) * 1.5f);
+            trunkHeight = Math.Clamp(trunkHeight, 4, 7);
+
+            // Trunk
+            for (int i = 0; i < trunkHeight && y + i < VoxelData.Size; i++)
+            {
+                voxels.SetBlock(x, y + i, z, BlockId.Wood);
+            }
+
+            // Leaves (simple sphere-ish shape)
+            int leafStart = trunkHeight - 2;
+            for (int ly = leafStart; ly < trunkHeight + 2; ly++)
+            {
+                int radius = ly < trunkHeight ? 2 : 1;
+                for (int lx = -radius; lx <= radius; lx++)
+                {
+                    for (int lz = -radius; lz <= radius; lz++)
+                    {
+                        if (lx == 0 && lz == 0 && ly < trunkHeight)
+                        {
+                            continue; // Skip trunk
+                        }
+
+                        int px = x + lx;
+                        int py = y + ly;
+                        int pz = z + lz;
+
+                        if (px >= 0 && px < VoxelData.Size &&
+                            py >= 0 && py < VoxelData.Size &&
+                            pz >= 0 && pz < VoxelData.Size &&
+                            voxels.GetBlock(px, py, pz) == BlockId.Air)
+                        {
+                            voxels.SetBlock(px, py, pz, BlockId.Leaves);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void PlacePlant(ref VoxelData voxels, int x, int y, int z, BiomeType biome)
+    {
+        if (y >= VoxelData.Size)
+        {
+            return;
+        }
+
+        byte plantBlock = biome switch
+        {
+            BiomeType.Desert => BlockId.DeadBush,
+            _ => BlockId.Air // Just grass block is enough for plains/forest
+        };
+
+        if (plantBlock != BlockId.Air)
+        {
+            voxels.SetBlock(x, y, z, plantBlock);
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.Voxel/packages.lock.json
+++ b/samples/KeenEyes.Sample.Voxel/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This sample demonstrates how to build a voxel-based game using KeenEyes ECS:

- Chunk-based world storage with 16x16x16 voxel chunks
- Simplex noise terrain generation with multiple biomes (Plains, Forest, Desert, Mountains, Tundra, Ocean)
- Temperature and moisture-based biome selection
- Feature placement (trees, cacti, plants) using deterministic noise
- Player movement with AABB collision against voxel terrain
- Chunk loading/unloading based on player view distance
- ASCII side-view visualization for terminal output

Key architecture patterns shown:
- Complex component types (VoxelData, HeightMap) using IComponent directly
- System dependencies via property injection
- Seeded procedural generation for reproducible worlds
- Chunk coordinate to world coordinate transformations