### PR TITLE
feat: Add multi-transport support to multiplayer sample

### DIFF
--- a/samples/KeenEyes.Sample.Multiplayer/KeenEyes.Sample.Multiplayer.csproj
+++ b/samples/KeenEyes.Sample.Multiplayer/KeenEyes.Sample.Multiplayer.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Network\KeenEyes.Network.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Network.Transport.Tcp\KeenEyes.Network.Transport.Tcp.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Network.Transport.Udp\KeenEyes.Network.Transport.Udp.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/samples/KeenEyes.Sample.Multiplayer/Program.cs
+++ b/samples/KeenEyes.Sample.Multiplayer/Program.cs
@@ -13,269 +13,522 @@ using KeenEyes.Sample.Multiplayer;
 // 4. Delta compression for bandwidth efficiency
 // 5. Full snapshot synchronization
 //
-// Note: This sample uses LocalTransport for in-process 1:1 testing.
-// For real multiplayer with multiple clients, implement INetworkTransport
-// using LiteNetLib, ENet, or WebSocket.
+// Supports three transport modes:
+// - Local:  In-process paired transport for quick testing (default)
+// - TCP:    Reliable ordered delivery over TCP sockets
+// - UDP:    Configurable reliability with multiple delivery modes
+//
+// Run with --help for usage information.
 // =============================================================================
+
+var options = TransportOptions.Parse(args);
+
+if (options.ShowHelp)
+{
+    TransportOptions.PrintHelp();
+    return;
+}
 
 Console.WriteLine("KeenEyes ECS - Multiplayer Networking Demo");
 Console.WriteLine(new string('=', 50));
+Console.WriteLine($"Transport: {options.Transport}");
 
-// Create serializer (shared between server and clients)
-var serializer = new GameSerializer();
-
-// =============================================================================
-// PART 1: Create Server
-// =============================================================================
-
-Console.WriteLine("\n[1] Creating Server\n");
-
-// LocalTransport creates a paired server/client for in-process testing
-var (serverTransport, clientTransport) = LocalTransport.CreatePair();
-
-// Create server world
-using var serverWorld = new World();
-
-var serverConfig = new ServerNetworkConfig
+switch (options.Transport)
 {
-    TickRate = 60,
-    MaxClients = 4,
-    Serializer = serializer,
-};
+    case TransportType.Local:
+        await RunLocalDemo();
+        break;
 
-var serverPlugin = new NetworkServerPlugin(serverTransport, serverConfig);
-serverWorld.InstallPlugin(serverPlugin);
-
-// Handle client input on server
-serverPlugin.ClientInputReceived += (clientId, tick, inputData) =>
-{
-    Console.WriteLine($"  Server received input from client {clientId} at tick {tick}");
-};
-
-// Start listening
-await serverTransport.ListenAsync(7777);
-Console.WriteLine("Server started (using LocalTransport for testing)");
-
-// =============================================================================
-// PART 2: Create Client
-// =============================================================================
-
-Console.WriteLine("\n[2] Creating Client\n");
-
-using var clientWorld = new World();
-
-// Pre-register component types so they exist before receiving network data
-// This is required because KeenEyes uses per-world component registries
-clientWorld.Components.Register<Position>();
-clientWorld.Components.Register<Velocity>();
-
-var clientConfig = new ClientNetworkConfig
-{
-    ServerAddress = "localhost",
-    ServerPort = 7777,
-    EnablePrediction = true,
-    Serializer = serializer,
-};
-var clientPlugin = new NetworkClientPlugin(clientTransport, clientConfig);
-clientWorld.InstallPlugin(clientPlugin);
-
-clientPlugin.Connected += () => Console.WriteLine("  Client connected!");
-clientPlugin.Disconnected += () => Console.WriteLine("  Client disconnected");
-
-// Connect to server
-Console.WriteLine("Connecting to server...");
-await clientTransport.ConnectAsync("localhost", 7777);
-
-// Process connection messages
-serverTransport.Update();
-clientTransport.Update();
-
-Console.WriteLine($"  Assigned Client ID: {clientPlugin.LocalClientId}");
-
-// =============================================================================
-// PART 3: Create Networked Entities on Server
-// =============================================================================
-
-Console.WriteLine("\n[3] Creating Networked Entities\n");
-
-// Create local player entity (owned by the connected client)
-var localPlayer = serverWorld.Spawn()
-    .WithPosition(x: 100, y: 100)
-    .WithVelocity(x: 0, y: 0)
-    .Build();
-var localPlayerNetId = serverPlugin.RegisterNetworkedEntity(localPlayer, ownerId: clientPlugin.LocalClientId);
-Console.WriteLine($"  Local Player: Entity={localPlayer}, NetworkId={localPlayerNetId.Value}, Owner={clientPlugin.LocalClientId}");
-
-// Create remote player entity (simulates another player, server-owned for this demo)
-var remotePlayer = serverWorld.Spawn()
-    .WithPosition(x: 200, y: 100)
-    .WithVelocity(x: -1, y: 0)
-    .Build();
-var remotePlayerNetId = serverPlugin.RegisterNetworkedEntity(remotePlayer, ownerId: 0);
-Console.WriteLine($"  Remote Player: Entity={remotePlayer}, NetworkId={remotePlayerNetId.Value}, Owner=Server");
-
-// Create NPC (server-owned)
-var npc = serverWorld.Spawn()
-    .WithPosition(x: 150, y: 200)
-    .WithVelocity(x: 1, y: 0)
-    .Build();
-var npcNetId = serverPlugin.RegisterNetworkedEntity(npc, ownerId: 0);
-Console.WriteLine($"  NPC: Entity={npc}, NetworkId={npcNetId.Value}, Owner=Server");
-
-// =============================================================================
-// PART 4: Send Full Snapshot to Client
-// =============================================================================
-
-Console.WriteLine("\n[4] Sending Full Snapshot\n");
-
-// Server sends full snapshot to the client
-serverPlugin.SendFullSnapshot(clientPlugin.LocalClientId);
-
-// Process messages
-serverTransport.Update();
-clientTransport.Update();
-
-// Verify entities replicated to client
-Console.WriteLine("  Entities received by client:");
-foreach (var entity in clientWorld.Query<Position>())
-{
-    ref readonly var pos = ref clientWorld.Get<Position>(entity);
-    var owner = clientWorld.Has<KeenEyes.Network.Components.NetworkOwner>(entity)
-        ? clientWorld.Get<KeenEyes.Network.Components.NetworkOwner>(entity).ClientId
-        : -1;
-    var isLocal = owner == clientPlugin.LocalClientId;
-    Console.WriteLine($"    {entity}: Position={pos}, Owner={owner} ({(isLocal ? "LOCAL" : "REMOTE")})");
+    case TransportType.Tcp:
+    case TransportType.Udp:
+        if (options.IsServer)
+        {
+            await RunServerDemo(options);
+        }
+        else
+        {
+            await RunClientDemo(options);
+        }
+        break;
 }
 
 // =============================================================================
-// PART 5: Simulate Game Loop with Movement
+// LOCAL DEMO - Server and Client in same process
 // =============================================================================
-
-Console.WriteLine("\n[5] Simulating Game Loop\n");
-
-const float deltaTime = 1f / 60f;
-const int simulationFrames = 10;
-
-Console.WriteLine($"Running {simulationFrames} frames of simulation...\n");
-
-for (int frame = 0; frame < simulationFrames; frame++)
+async Task RunLocalDemo()
 {
-    // --- Server Update ---
+    Console.WriteLine("Mode: Local (in-process server + client)\n");
 
-    // Move NPC in a pattern
+    var serializer = new GameSerializer();
+    var (serverTransport, clientTransport) = TransportOptions.CreateLocalTransportPair();
+
+    try
     {
-        ref var npcPos = ref serverWorld.Get<Position>(npc);
-        ref readonly var npcVel = ref serverWorld.Get<Velocity>(npc);
-        npcPos.X += npcVel.X * deltaTime * 60;
+        // --- Create Server ---
+        Console.WriteLine("[1] Creating Server\n");
+
+        using var serverWorld = new World();
+        var serverConfig = new ServerNetworkConfig
+        {
+            TickRate = 60,
+            MaxClients = 4,
+            Serializer = serializer,
+        };
+
+        var serverPlugin = new NetworkServerPlugin(serverTransport, serverConfig);
+        serverWorld.InstallPlugin(serverPlugin);
+
+        serverPlugin.ClientInputReceived += (clientId, tick, inputData) =>
+        {
+            Console.WriteLine($"  Server received input from client {clientId} at tick {tick}");
+        };
+
+        await serverTransport.ListenAsync(7777);
+        Console.WriteLine("Server started on port 7777");
+
+        // --- Create Client ---
+        Console.WriteLine("\n[2] Creating Client\n");
+
+        using var clientWorld = new World();
+        clientWorld.Components.Register<Position>();
+        clientWorld.Components.Register<Velocity>();
+
+        var clientConfig = new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            EnablePrediction = true,
+            Serializer = serializer,
+        };
+        var clientPlugin = new NetworkClientPlugin(clientTransport, clientConfig);
+        clientWorld.InstallPlugin(clientPlugin);
+
+        clientPlugin.Connected += () => Console.WriteLine("  Client connected!");
+        clientPlugin.Disconnected += () => Console.WriteLine("  Client disconnected");
+
+        Console.WriteLine("Connecting to server...");
+        await clientTransport.ConnectAsync("localhost", 7777);
+
+        serverTransport.Update();
+        clientTransport.Update();
+
+        Console.WriteLine($"  Assigned Client ID: {clientPlugin.LocalClientId}");
+
+        // --- Create Networked Entities ---
+        Console.WriteLine("\n[3] Creating Networked Entities\n");
+
+        var localPlayer = serverWorld.Spawn()
+            .WithPosition(x: 100, y: 100)
+            .WithVelocity(x: 0, y: 0)
+            .Build();
+        var localPlayerNetId = serverPlugin.RegisterNetworkedEntity(localPlayer, ownerId: clientPlugin.LocalClientId);
+        Console.WriteLine($"  Local Player: Entity={localPlayer}, NetworkId={localPlayerNetId.Value}, Owner={clientPlugin.LocalClientId}");
+
+        var remotePlayer = serverWorld.Spawn()
+            .WithPosition(x: 200, y: 100)
+            .WithVelocity(x: -1, y: 0)
+            .Build();
+        var remotePlayerNetId = serverPlugin.RegisterNetworkedEntity(remotePlayer, ownerId: 0);
+        Console.WriteLine($"  Remote Player: Entity={remotePlayer}, NetworkId={remotePlayerNetId.Value}, Owner=Server");
+
+        var npc = serverWorld.Spawn()
+            .WithPosition(x: 150, y: 200)
+            .WithVelocity(x: 1, y: 0)
+            .Build();
+        var npcNetId = serverPlugin.RegisterNetworkedEntity(npc, ownerId: 0);
+        Console.WriteLine($"  NPC: Entity={npc}, NetworkId={npcNetId.Value}, Owner=Server");
+
+        // --- Send Snapshot ---
+        Console.WriteLine("\n[4] Sending Full Snapshot\n");
+
+        serverPlugin.SendFullSnapshot(clientPlugin.LocalClientId);
+        serverTransport.Update();
+        clientTransport.Update();
+
+        Console.WriteLine("  Entities received by client:");
+        foreach (var entity in clientWorld.Query<Position>())
+        {
+            ref readonly var pos = ref clientWorld.Get<Position>(entity);
+            var owner = clientWorld.Has<KeenEyes.Network.Components.NetworkOwner>(entity)
+                ? clientWorld.Get<KeenEyes.Network.Components.NetworkOwner>(entity).ClientId
+                : -1;
+            var isLocal = owner == clientPlugin.LocalClientId;
+            Console.WriteLine($"    {entity}: Position={pos}, Owner={owner} ({(isLocal ? "LOCAL" : "REMOTE")})");
+        }
+
+        // --- Game Loop ---
+        Console.WriteLine("\n[5] Simulating Game Loop\n");
+
+        const float deltaTime = 1f / 60f;
+        const int simulationFrames = 10;
+
+        Console.WriteLine($"Running {simulationFrames} frames of simulation...\n");
+
+        for (int frame = 0; frame < simulationFrames; frame++)
+        {
+            // Move entities
+            {
+                ref var npcPos = ref serverWorld.Get<Position>(npc);
+                ref readonly var npcVel = ref serverWorld.Get<Velocity>(npc);
+                npcPos.X += npcVel.X * deltaTime * 60;
+            }
+
+            {
+                ref var remotePos = ref serverWorld.Get<Position>(remotePlayer);
+                ref readonly var remoteVel = ref serverWorld.Get<Velocity>(remotePlayer);
+                remotePos.X += remoteVel.X * deltaTime * 60;
+            }
+
+            {
+                ref var localPos = ref serverWorld.Get<Position>(localPlayer);
+                localPos.X += 2.0f;
+            }
+
+            if (serverPlugin.Tick(deltaTime))
+            {
+                serverWorld.Update(deltaTime);
+            }
+
+            clientWorld.Update(deltaTime);
+            serverTransport.Update();
+            clientTransport.Update();
+
+            if (frame % 3 == 0)
+            {
+                ref readonly var serverLocalPos = ref serverWorld.Get<Position>(localPlayer);
+                ref readonly var serverRemotePos = ref serverWorld.Get<Position>(remotePlayer);
+                ref readonly var serverNpcPos = ref serverWorld.Get<Position>(npc);
+                Console.WriteLine($"  Frame {frame}:");
+                Console.WriteLine($"    Server: Local={serverLocalPos}, Remote={serverRemotePos}, NPC={serverNpcPos}");
+            }
+        }
+
+        // --- Delta Compression Demo ---
+        Console.WriteLine("\n[6] Delta Compression Demo\n");
+
+        var baseline = new Position { X = 100, Y = 100 };
+        var current = new Position { X = 110, Y = 100 };
+
+        var dirtyMask = current.GetDirtyMask(baseline);
+        Console.WriteLine($"  Baseline: {baseline}");
+        Console.WriteLine($"  Current:  {current}");
+        Console.WriteLine($"  Dirty Mask: 0b{Convert.ToString(dirtyMask, 2).PadLeft(2, '0')} (bit 0=X, bit 1=Y)");
+        Console.WriteLine($"  Result: Only X is sent over network, saving 50% bandwidth!");
+
+        // --- Hierarchy Demo ---
+        Console.WriteLine("\n[7] Entity Hierarchy Demo\n");
+
+        var weapon = serverWorld.Spawn()
+            .WithPosition(x: 10, y: 0)
+            .Build();
+        var weaponNetId = serverPlugin.RegisterNetworkedEntity(weapon);
+
+        serverWorld.SetParent(weapon, localPlayer);
+        serverPlugin.SendHierarchyChange(weapon, localPlayer);
+        serverTransport.Update();
+        clientTransport.Update();
+
+        Console.WriteLine($"  Created weapon (NetworkId={weaponNetId.Value}) attached to LocalPlayer");
+        Console.WriteLine($"  Server: weapon parent = {serverWorld.GetParent(weapon)}");
+
+        if (clientPlugin.NetworkIds.TryGetLocalEntity(weaponNetId.Value, out var clientWeapon))
+        {
+            var clientWeaponParent = clientWorld.GetParent(clientWeapon);
+            Console.WriteLine($"  Client: weapon parent = {clientWeaponParent}");
+        }
+
+        // --- Cleanup ---
+        Console.WriteLine("\n[8] Cleanup\n");
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        clientWorld.UninstallPlugin("NetworkClient");
+    }
+    finally
+    {
+        serverTransport.Dispose();
+        clientTransport.Dispose();
     }
 
-    // Move remote player
-    {
-        ref var remotePos = ref serverWorld.Get<Position>(remotePlayer);
-        ref readonly var remoteVel = ref serverWorld.Get<Velocity>(remotePlayer);
-        remotePos.X += remoteVel.X * deltaTime * 60;
-    }
-
-    // Simulate local player input (would normally come from client)
-    {
-        ref var localPos = ref serverWorld.Get<Position>(localPlayer);
-        localPos.X += 2.0f; // Move right
-    }
-
-    // Server tick
-    if (serverPlugin.Tick(deltaTime))
-    {
-        serverWorld.Update(deltaTime);
-    }
-
-    // --- Client Update ---
-    clientWorld.Update(deltaTime);
-
-    // Process network messages
-    serverTransport.Update();
-    clientTransport.Update();
-
-    // Print state every few frames
-    if (frame % 3 == 0)
-    {
-        ref readonly var serverLocalPos = ref serverWorld.Get<Position>(localPlayer);
-        ref readonly var serverRemotePos = ref serverWorld.Get<Position>(remotePlayer);
-        ref readonly var serverNpcPos = ref serverWorld.Get<Position>(npc);
-        Console.WriteLine($"  Frame {frame}:");
-        Console.WriteLine($"    Server: Local={serverLocalPos}, Remote={serverRemotePos}, NPC={serverNpcPos}");
-    }
+    PrintSummary();
 }
 
 // =============================================================================
-// PART 6: Delta Compression Demo
+// SERVER DEMO - Standalone server for TCP/UDP
 // =============================================================================
-
-Console.WriteLine("\n[6] Delta Compression Demo\n");
-
-// Position supports delta serialization via INetworkDeltaSerializable
-var baseline = new Position { X = 100, Y = 100 };
-var current = new Position { X = 110, Y = 100 }; // Only X changed
-
-var dirtyMask = current.GetDirtyMask(baseline);
-Console.WriteLine($"  Baseline: {baseline}");
-Console.WriteLine($"  Current:  {current}");
-Console.WriteLine($"  Dirty Mask: 0b{Convert.ToString(dirtyMask, 2).PadLeft(2, '0')} (bit 0=X, bit 1=Y)");
-Console.WriteLine($"  Result: Only X is sent over network, saving 50% bandwidth!");
-
-// =============================================================================
-// PART 7: Entity Hierarchy Demo
-// =============================================================================
-
-Console.WriteLine("\n[7] Entity Hierarchy Demo\n");
-
-// Create a weapon attached to local player
-var weapon = serverWorld.Spawn()
-    .WithPosition(x: 10, y: 0) // Offset from player
-    .Build();
-var weaponNetId = serverPlugin.RegisterNetworkedEntity(weapon);
-
-// Set parent-child relationship
-serverWorld.SetParent(weapon, localPlayer);
-
-// Send hierarchy change to client
-serverPlugin.SendHierarchyChange(weapon, localPlayer);
-serverTransport.Update();
-clientTransport.Update();
-
-Console.WriteLine($"  Created weapon (NetworkId={weaponNetId.Value}) attached to LocalPlayer");
-Console.WriteLine($"  Server: weapon parent = {serverWorld.GetParent(weapon)}");
-
-// Verify on client
-if (clientPlugin.NetworkIds.TryGetLocalEntity(weaponNetId.Value, out var clientWeapon))
+async Task RunServerDemo(TransportOptions opts)
 {
-    var clientWeaponParent = clientWorld.GetParent(clientWeapon);
-    Console.WriteLine($"  Client: weapon parent = {clientWeaponParent}");
+    Console.WriteLine($"Mode: {opts.Transport} Server on port {opts.Port}\n");
+
+    var serializer = new GameSerializer();
+    var transport = opts.CreateTransport();
+
+    try
+    {
+        using var world = new World();
+        var config = new ServerNetworkConfig
+        {
+            TickRate = 60,
+            MaxClients = 4,
+            Serializer = serializer,
+        };
+
+        var serverPlugin = new NetworkServerPlugin(transport, config);
+        world.InstallPlugin(serverPlugin);
+
+        var clientEntities = new Dictionary<int, Entity>();
+
+        serverPlugin.ClientInputReceived += (clientId, tick, inputData) =>
+        {
+            Console.WriteLine($"  Received input from client {clientId} at tick {tick}");
+        };
+
+        transport.ClientConnected += clientId =>
+        {
+            Console.WriteLine($"\n  Client {clientId} connected!");
+
+            // Create player entity for this client
+            var player = world.Spawn()
+                .WithPosition(x: 100 + clientId * 50, y: 100)
+                .WithVelocity(x: 0, y: 0)
+                .Build();
+            var netId = serverPlugin.RegisterNetworkedEntity(player, ownerId: clientId);
+            clientEntities[clientId] = player;
+
+            Console.WriteLine($"  Created player for client {clientId}: Entity={player}, NetworkId={netId.Value}");
+
+            // Send full snapshot to new client
+            serverPlugin.SendFullSnapshot(clientId);
+            Console.WriteLine($"  Sent full snapshot to client {clientId}");
+        };
+
+        transport.ClientDisconnected += clientId =>
+        {
+            Console.WriteLine($"\n  Client {clientId} disconnected");
+
+            if (clientEntities.TryGetValue(clientId, out var entity))
+            {
+                world.Despawn(entity);
+                clientEntities.Remove(clientId);
+                Console.WriteLine($"  Removed player entity for client {clientId}");
+            }
+        };
+
+        // Create NPC
+        var npc = world.Spawn()
+            .WithPosition(x: 200, y: 200)
+            .WithVelocity(x: 1, y: 0)
+            .Build();
+        serverPlugin.RegisterNetworkedEntity(npc, ownerId: 0);
+        Console.WriteLine($"Created NPC: {npc}");
+
+        // Start listening
+        await transport.ListenAsync(opts.Port);
+        Console.WriteLine($"\nServer listening on port {opts.Port}");
+        Console.WriteLine("Waiting for clients... (Press Ctrl+C to stop)\n");
+
+        // Game loop
+        const float deltaTime = 1f / 60f;
+        var lastTime = DateTime.UtcNow;
+        var running = true;
+
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            running = false;
+            Console.WriteLine("\nShutting down server...");
+        };
+
+        while (running)
+        {
+            var now = DateTime.UtcNow;
+            var elapsed = (float)(now - lastTime).TotalSeconds;
+
+            if (elapsed >= deltaTime)
+            {
+                lastTime = now;
+
+                // Move NPC
+                ref var npcPos = ref world.Get<Position>(npc);
+                ref readonly var npcVel = ref world.Get<Velocity>(npc);
+                npcPos.X += npcVel.X;
+
+                // Bounce NPC
+                if (npcPos.X > 300 || npcPos.X < 100)
+                {
+                    ref var vel = ref world.Get<Velocity>(npc);
+                    vel.X = -vel.X;
+                }
+
+                if (serverPlugin.Tick(deltaTime))
+                {
+                    world.Update(deltaTime);
+                }
+
+                transport.Update();
+            }
+
+            await Task.Delay(1);
+        }
+
+        world.UninstallPlugin("NetworkServer");
+    }
+    finally
+    {
+        transport.Dispose();
+    }
+
+    Console.WriteLine("Server stopped.");
 }
 
 // =============================================================================
-// PART 8: Cleanup
+// CLIENT DEMO - Standalone client for TCP/UDP
 // =============================================================================
+async Task RunClientDemo(TransportOptions opts)
+{
+    Console.WriteLine($"Mode: {opts.Transport} Client connecting to {opts.Address}:{opts.Port}\n");
 
-Console.WriteLine("\n[8] Cleanup\n");
+    var serializer = new GameSerializer();
+    var transport = opts.CreateTransport();
 
-serverWorld.UninstallPlugin("NetworkServer");
-clientWorld.UninstallPlugin("NetworkClient");
+    try
+    {
+        using var world = new World();
 
-serverTransport.Dispose();
-clientTransport.Dispose();
+        // Pre-register components
+        world.Components.Register<Position>();
+        world.Components.Register<Velocity>();
 
-Console.WriteLine("All connections closed.");
+        var config = new ClientNetworkConfig
+        {
+            ServerAddress = opts.Address,
+            ServerPort = opts.Port,
+            EnablePrediction = true,
+            Serializer = serializer,
+        };
 
-Console.WriteLine("\n" + new string('=', 50));
-Console.WriteLine("Multiplayer Demo Complete!");
-Console.WriteLine("\nKey Features Demonstrated:");
-Console.WriteLine("  - Server-authoritative entity replication");
-Console.WriteLine("  - Network ID assignment and mapping");
-Console.WriteLine("  - Full snapshot sync for clients");
-Console.WriteLine("  - Entity hierarchy replication (parent-child)");
-Console.WriteLine("  - Delta compression for bandwidth efficiency");
-Console.WriteLine("  - Component pre-registration for network types");
-Console.WriteLine("\nFor real multiplayer, replace LocalTransport with:");
-Console.WriteLine("  - TcpTransport (built-in, reliable ordered)");
-Console.WriteLine("  - UdpTransport (built-in, configurable reliability)");
-Console.WriteLine("  - WebSocket (for browser clients)");
+        var clientPlugin = new NetworkClientPlugin(transport, config);
+        world.InstallPlugin(clientPlugin);
+
+        var connected = false;
+
+        clientPlugin.Connected += () =>
+        {
+            connected = true;
+            Console.WriteLine($"  Connected! Client ID: {clientPlugin.LocalClientId}");
+        };
+
+        clientPlugin.Disconnected += () =>
+        {
+            connected = false;
+            Console.WriteLine("  Disconnected from server");
+        };
+
+        // Connect to server
+        Console.WriteLine($"Connecting to {opts.Address}:{opts.Port}...");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            await transport.ConnectAsync(opts.Address, opts.Port, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Console.WriteLine("Connection timed out.");
+            return;
+        }
+
+        transport.Update();
+
+        if (!connected)
+        {
+            Console.WriteLine("Failed to connect.");
+            return;
+        }
+
+        Console.WriteLine("\nConnected to server! (Press Ctrl+C to disconnect)\n");
+
+        // Game loop
+        const float deltaTime = 1f / 60f;
+        var lastTime = DateTime.UtcNow;
+        var lastPrintTime = DateTime.UtcNow;
+        var running = true;
+
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            running = false;
+            Console.WriteLine("\nDisconnecting...");
+        };
+
+        while (running && connected)
+        {
+            var now = DateTime.UtcNow;
+            var elapsed = (float)(now - lastTime).TotalSeconds;
+
+            if (elapsed >= deltaTime)
+            {
+                lastTime = now;
+                world.Update(deltaTime);
+                transport.Update();
+
+                // Print entity status periodically
+                if ((now - lastPrintTime).TotalSeconds >= 1.0)
+                {
+                    lastPrintTime = now;
+                    var entityCount = 0;
+
+                    foreach (var entity in world.Query<Position>())
+                    {
+                        entityCount++;
+                        ref readonly var pos = ref world.Get<Position>(entity);
+                        var owner = world.Has<KeenEyes.Network.Components.NetworkOwner>(entity)
+                            ? world.Get<KeenEyes.Network.Components.NetworkOwner>(entity).ClientId
+                            : -1;
+                        var isLocal = owner == clientPlugin.LocalClientId;
+                        Console.WriteLine($"  {entity}: {pos} ({(isLocal ? "LOCAL" : "REMOTE")})");
+                    }
+
+                    if (entityCount == 0)
+                    {
+                        Console.WriteLine("  (waiting for entities from server...)");
+                    }
+                }
+            }
+
+            await Task.Delay(1);
+        }
+
+        transport.Disconnect();
+        world.UninstallPlugin("NetworkClient");
+    }
+    finally
+    {
+        transport.Dispose();
+    }
+
+    Console.WriteLine("Client stopped.");
+}
+
+// =============================================================================
+// Summary
+// =============================================================================
+void PrintSummary()
+{
+    Console.WriteLine("All connections closed.");
+
+    Console.WriteLine("\n" + new string('=', 50));
+    Console.WriteLine("Multiplayer Demo Complete!");
+    Console.WriteLine("\nKey Features Demonstrated:");
+    Console.WriteLine("  - Server-authoritative entity replication");
+    Console.WriteLine("  - Network ID assignment and mapping");
+    Console.WriteLine("  - Full snapshot sync for clients");
+    Console.WriteLine("  - Entity hierarchy replication (parent-child)");
+    Console.WriteLine("  - Delta compression for bandwidth efficiency");
+    Console.WriteLine("  - Component pre-registration for network types");
+    Console.WriteLine("\nTransport Options:");
+    Console.WriteLine("  - Local:  In-process testing (this demo)");
+    Console.WriteLine("  - TCP:    dotnet run -- -t tcp -s  (server)");
+    Console.WriteLine("            dotnet run -- -t tcp -c  (client)");
+    Console.WriteLine("  - UDP:    dotnet run -- -t udp -s  (server)");
+    Console.WriteLine("            dotnet run -- -t udp -c  (client)");
+}

--- a/samples/KeenEyes.Sample.Multiplayer/README.md
+++ b/samples/KeenEyes.Sample.Multiplayer/README.md
@@ -13,9 +13,60 @@ This sample demonstrates the KeenEyes networking system with server-authoritativ
 
 ## Running the Sample
 
+The sample supports three transport modes: Local, TCP, and UDP.
+
+### Local Mode (Default)
+
+Runs both server and client in a single process for quick testing:
+
 ```bash
 cd samples/KeenEyes.Sample.Multiplayer
 dotnet run
+```
+
+### TCP Mode
+
+For real network testing, run server and client in separate terminals:
+
+```bash
+# Terminal 1: Start server
+dotnet run -- --transport tcp --server
+
+# Terminal 2: Start client
+dotnet run -- --transport tcp --client
+```
+
+### UDP Mode
+
+Same pattern as TCP, with configurable reliability:
+
+```bash
+# Terminal 1: Start server
+dotnet run -- --transport udp --server --port 8888
+
+# Terminal 2: Start client
+dotnet run -- --transport udp --client --port 8888
+```
+
+### Command-Line Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--transport` | `-t` | Transport type: `local`, `tcp`, `udp` |
+| `--server` | `-s` | Run as server |
+| `--client` | `-c` | Run as client |
+| `--address` | `-a` | Server address (default: `localhost`) |
+| `--port` | `-p` | Port number (default: `7777`) |
+| `--help` | `-h` | Show help |
+
+### Examples
+
+```bash
+# Connect to remote server
+dotnet run -- -t tcp -c -a 192.168.1.100 -p 7777
+
+# UDP server on custom port
+dotnet run -- -t udp -s -p 9999
 ```
 
 ## Architecture Overview
@@ -41,7 +92,8 @@ dotnet run
 
 | File | Description |
 |------|-------------|
-| `Program.cs` | Main demo showing server/client setup and game loop |
+| `Program.cs` | Main demo with Local, TCP, and UDP modes |
+| `TransportOptions.cs` | Command-line argument parsing and transport factory |
 | `Components.cs` | Networked components (Position, Velocity, PlayerInput) |
 | `GameSerializer.cs` | Network serializer for component replication |
 
@@ -109,27 +161,37 @@ serverPlugin.SendFullSnapshot(clientId);
 
 ## Transport Layer
 
-This sample uses `LocalTransport` for in-process testing. For production networking, KeenEyes provides optional transport packages:
+This sample demonstrates all built-in transports. Use `--help` to see available options.
 
-| Package | Transport | Use Case |
-|---------|-----------|----------|
-| `KeenEyes.Network.Transport.Tcp` | `TcpTransport` | Reliable ordered delivery, NAT-friendly |
-| `KeenEyes.Network.Transport.Udp` | `UdpTransport` | Low-latency, configurable reliability |
+| Transport | Package | Use Case |
+|-----------|---------|----------|
+| `LocalTransport` | `KeenEyes.Network` | In-process testing, unit tests |
+| `TcpTransport` | `KeenEyes.Network.Transport.Tcp` | Reliable ordered delivery, NAT-friendly |
+| `UdpTransport` | `KeenEyes.Network.Transport.Udp` | Low-latency, configurable reliability |
 
-Example with `TcpTransport`:
+### Choosing a Transport
+
+- **Local**: Quick testing without network overhead. Great for development.
+- **TCP**: Simple and reliable. Works through NAT/firewalls. Good for turn-based or slower-paced games.
+- **UDP**: Lower latency, but requires reliability handling. Best for fast-paced games.
+
+### Bring Your Own Transport
+
+Implement `INetworkTransport` to integrate third-party networking libraries:
+
 ```csharp
-using KeenEyes.Network.Transport.Tcp;
+using KeenEyes.Network.Transport;
 
-// Server
-var serverTransport = new TcpTransport();
-await serverTransport.ListenAsync(7777);
-
-// Client
-var clientTransport = new TcpTransport();
-await clientTransport.ConnectAsync("game.example.com", 7777);
+public class SteamTransport : INetworkTransport
+{
+    // Implement interface using Steamworks.NET
+}
 ```
 
-Or bring your own transport by implementing `INetworkTransport` (Steam, LiteNetLib, etc.).
+Popular options:
+- **Steam Networking** - Steamworks.NET for Steam games
+- **LiteNetLib** - Lightweight reliable UDP
+- **ENet** - Fast, reliable UDP with channels
 
 ## See Also
 

--- a/samples/KeenEyes.Sample.Multiplayer/TransportOptions.cs
+++ b/samples/KeenEyes.Sample.Multiplayer/TransportOptions.cs
@@ -1,0 +1,197 @@
+using KeenEyes.Network;
+using KeenEyes.Network.Transport;
+using KeenEyes.Network.Transport.Tcp;
+using KeenEyes.Network.Transport.Udp;
+
+namespace KeenEyes.Sample.Multiplayer;
+
+/// <summary>
+/// Supported transport types for the multiplayer demo.
+/// </summary>
+public enum TransportType
+{
+    /// <summary>
+    /// In-process transport for testing. Runs both server and client in one process.
+    /// </summary>
+    Local,
+
+    /// <summary>
+    /// TCP transport. Reliable ordered delivery over TCP sockets.
+    /// </summary>
+    Tcp,
+
+    /// <summary>
+    /// UDP transport. Configurable reliability with multiple delivery modes.
+    /// </summary>
+    Udp
+}
+
+/// <summary>
+/// Parsed command-line options for transport configuration.
+/// </summary>
+public sealed class TransportOptions
+{
+    /// <summary>
+    /// The transport type to use.
+    /// </summary>
+    public TransportType Transport { get; init; } = TransportType.Local;
+
+    /// <summary>
+    /// Whether to run as server (true) or client (false).
+    /// Only applies to TCP/UDP transports.
+    /// </summary>
+    public bool IsServer { get; init; }
+
+    /// <summary>
+    /// Server address to connect to (client mode only).
+    /// </summary>
+    public string Address { get; init; } = "localhost";
+
+    /// <summary>
+    /// Port number for server/client.
+    /// </summary>
+    public int Port { get; init; } = 7777;
+
+    /// <summary>
+    /// Whether to show help information.
+    /// </summary>
+    public bool ShowHelp { get; init; }
+
+    /// <summary>
+    /// Parses command-line arguments into transport options.
+    /// </summary>
+    public static TransportOptions Parse(string[] args)
+    {
+        var transport = TransportType.Local;
+        var isServer = false;
+        var address = "localhost";
+        var port = 7777;
+        var showHelp = false;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i].ToLowerInvariant();
+
+            switch (arg)
+            {
+                case "--help":
+                case "-h":
+                case "-?":
+                    showHelp = true;
+                    break;
+
+                case "--transport":
+                case "-t":
+                    if (i + 1 < args.Length)
+                    {
+                        transport = args[++i].ToLowerInvariant() switch
+                        {
+                            "local" => TransportType.Local,
+                            "tcp" => TransportType.Tcp,
+                            "udp" => TransportType.Udp,
+                            _ => throw new ArgumentException($"Unknown transport: {args[i]}")
+                        };
+                    }
+                    break;
+
+                case "--server":
+                case "-s":
+                    isServer = true;
+                    break;
+
+                case "--client":
+                case "-c":
+                    isServer = false;
+                    break;
+
+                case "--address":
+                case "-a":
+                    if (i + 1 < args.Length)
+                    {
+                        address = args[++i];
+                    }
+                    break;
+
+                case "--port":
+                case "-p":
+                    if (i + 1 < args.Length)
+                    {
+                        port = int.Parse(args[++i]);
+                    }
+                    break;
+            }
+        }
+
+        return new TransportOptions
+        {
+            Transport = transport,
+            IsServer = isServer,
+            Address = address,
+            Port = port,
+            ShowHelp = showHelp
+        };
+    }
+
+    /// <summary>
+    /// Prints usage information to the console.
+    /// </summary>
+    public static void PrintHelp()
+    {
+        Console.WriteLine("""
+            KeenEyes Multiplayer Sample - Transport Options
+
+            Usage:
+              dotnet run                                    # Local transport (default, in-process)
+              dotnet run -- --transport tcp --server        # TCP server
+              dotnet run -- --transport tcp --client        # TCP client
+              dotnet run -- --transport udp --server        # UDP server
+              dotnet run -- --transport udp --client        # UDP client
+
+            Options:
+              -t, --transport <type>   Transport type: local, tcp, udp (default: local)
+              -s, --server             Run as server (TCP/UDP only)
+              -c, --client             Run as client (TCP/UDP only)
+              -a, --address <host>     Server address for client mode (default: localhost)
+              -p, --port <port>        Port number (default: 7777)
+              -h, --help               Show this help message
+
+            Examples:
+              # Quick test with local transport (both server and client in one process)
+              dotnet run
+
+              # TCP networking - start server first, then client
+              Terminal 1: dotnet run -- -t tcp -s
+              Terminal 2: dotnet run -- -t tcp -c
+
+              # UDP networking with custom port
+              Terminal 1: dotnet run -- -t udp -s -p 8888
+              Terminal 2: dotnet run -- -t udp -c -p 8888
+
+              # Connect to remote server
+              dotnet run -- -t tcp -c -a 192.168.1.100 -p 7777
+            """);
+    }
+
+    /// <summary>
+    /// Creates a transport instance based on the configured options.
+    /// For Local transport, returns a paired server/client.
+    /// For TCP/UDP, returns a single transport in the appropriate mode.
+    /// </summary>
+    public INetworkTransport CreateTransport()
+    {
+        return Transport switch
+        {
+            TransportType.Tcp => new TcpTransport(),
+            TransportType.Udp => new UdpTransport(),
+            _ => throw new InvalidOperationException("Use CreateLocalTransportPair for Local transport")
+        };
+    }
+
+    /// <summary>
+    /// Creates a paired local transport for in-process testing.
+    /// </summary>
+    public static (INetworkTransport Server, INetworkTransport Client) CreateLocalTransportPair()
+    {
+        return LocalTransport.CreatePair();
+    }
+}

--- a/samples/KeenEyes.Sample.Multiplayer/packages.lock.json
+++ b/samples/KeenEyes.Sample.Multiplayer/packages.lock.json
@@ -23,6 +23,18 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.network.transport.tcp": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.transport.udp": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Rework the multiplayer sample to demonstrate all built-in transports (Local, TCP, UDP)
- Add command-line argument parsing for transport selection (`--transport`, `--server`, `--client`, etc.)
- Support three operating modes: Local (in-process), Server, and Client
- Update README with comprehensive usage documentation

## Changes

### New File: `TransportOptions.cs`
- Command-line argument parser with support for transport type, server/client mode, address, and port
- Factory methods for creating transport instances
- Help text with usage examples

### Updated: `Program.cs`
- Refactored into three demo modes:
  - **Local mode** (default): Runs server + client in same process
  - **Server mode**: Standalone TCP/UDP server with game loop
  - **Client mode**: Connects to running server via TCP/UDP
- Proper Ctrl+C handling for graceful shutdown

### Updated: `README.md`
- Comprehensive usage documentation for all transport modes
- Command-line options table
- Transport selection guide

## Usage Examples

```bash
# Local mode (default, in-process testing)
dotnet run

# TCP networking
Terminal 1: dotnet run -- -t tcp -s
Terminal 2: dotnet run -- -t tcp -c

# UDP networking with custom port
Terminal 1: dotnet run -- -t udp -s -p 8888
Terminal 2: dotnet run -- -t udp -c -p 8888
```

## Test plan

- [x] Build succeeds with zero warnings
- [x] All 6914 tests pass (20 skipped for UDP in sandboxed environment)
- [x] Sample runs in local mode and produces expected output
- [x] `--help` displays usage information correctly