### PR TITLE
ci: Add 5-minute timeout to pre-push test task

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -17,7 +17,8 @@
          "name": "dotnet-test",
          "group": "pre-push",
          "command": "dotnet",
-         "args": ["test", "--no-build", "-c", "Release"]
+         "args": ["test", "--no-build", "-c", "Release"],
+         "timeout": 300000
       }
    ]
 }


### PR DESCRIPTION
## Summary
- Adds a 5-minute (300000ms) timeout to the `dotnet-test` task in the Husky pre-push hook
- Prevents indefinite hangs if tests get stuck during push

## Test plan
- [ ] Verify pre-push hook still runs tests normally
- [ ] Confirm timeout triggers after 5 minutes if tests hang