### PR TITLE
Add comprehensive BitReader and BitWriter test coverage

### DIFF
--- a/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
+++ b/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
@@ -148,4 +148,188 @@ public class BitReaderTests
         Assert.True(reader.ReadBool());
         Assert.Equal(-100, reader.ReadSignedBits(16));
     }
+
+    [Fact]
+    public void ReadFloat_ReturnsWrittenValue()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteFloat(3.14159f);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadFloat();
+
+        Assert.Equal(3.14159f, result);
+    }
+
+    [Fact]
+    public void ReadQuantized_ReturnsApproximateValue()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteQuantized(50.5f, 0f, 100f, 0.1f);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadQuantized(0f, 100f, 0.1f);
+
+        Assert.InRange(result, 50.4f, 50.6f);
+    }
+
+    [Fact]
+    public void ReadBytes_IntoSpan_FillsCorrectly()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteByte(0x11);
+        writer.WriteByte(0x22);
+        writer.WriteByte(0x33);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        Span<byte> result = stackalloc byte[3];
+        reader.ReadBytes(result);
+
+        Assert.Equal(0x11, result[0]);
+        Assert.Equal(0x22, result[1]);
+        Assert.Equal(0x33, result[2]);
+    }
+
+    [Fact]
+    public void ReadBytes_ReturnsNewArray()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteByte(0xAA);
+        writer.WriteByte(0xBB);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadBytes(2);
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(0xAA, result[0]);
+        Assert.Equal(0xBB, result[1]);
+    }
+
+    [Fact]
+    public void SkipBits_AdvancesPosition()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteByte(0xFF);
+        writer.WriteByte(0x42);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        reader.SkipBits(8);
+        var result = reader.ReadByte();
+
+        Assert.Equal(0x42, result);
+    }
+
+    [Fact]
+    public void BytePosition_AfterReading_ReturnsCorrectValue()
+    {
+        byte[] data = [0x11, 0x22, 0x33];
+        var reader = new BitReader(data);
+
+        Assert.Equal(0, reader.BytePosition);
+
+        reader.ReadByte();
+        Assert.Equal(1, reader.BytePosition);
+
+        reader.ReadByte();
+        Assert.Equal(2, reader.BytePosition);
+    }
+
+    [Fact]
+    public void BitOffset_AfterPartialRead_ReturnsCorrectValue()
+    {
+        byte[] data = [0xFF, 0xFF];
+        var reader = new BitReader(data);
+
+        Assert.Equal(0, reader.BitOffset);
+
+        reader.ReadBits(3);
+        Assert.Equal(3, reader.BitOffset);
+
+        reader.ReadBits(5);
+        Assert.Equal(0, reader.BitOffset); // Wrapped to next byte
+    }
+
+    [Fact]
+    public void TotalBitsRead_TracksCorrectly()
+    {
+        byte[] data = [0xFF, 0xFF, 0xFF];
+        var reader = new BitReader(data);
+
+        Assert.Equal(0, reader.TotalBitsRead);
+
+        reader.ReadBits(5);
+        Assert.Equal(5, reader.TotalBitsRead);
+
+        reader.ReadByte();
+        Assert.Equal(13, reader.TotalBitsRead);
+    }
+
+    [Fact]
+    public void ReadBits_ZeroBits_ThrowsArgumentOutOfRange()
+    {
+        byte[] data = [0xFF];
+        var reader = new BitReader(data);
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ReadBitsHelper(data, 0));
+        Assert.Equal("bits", ex.ParamName);
+    }
+
+    [Fact]
+    public void ReadBits_TooManyBits_ThrowsArgumentOutOfRange()
+    {
+        byte[] data = [0xFF];
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ReadBitsHelper(data, 33));
+        Assert.Equal("bits", ex.ParamName);
+    }
+
+    private static uint ReadBitsHelper(byte[] data, int bits)
+    {
+        var reader = new BitReader(data);
+        return reader.ReadBits(bits);
+    }
+
+    [Fact]
+    public void ReadSignedBits_PositiveValue_ReturnsCorrectly()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteSignedBits(42, 8);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadSignedBits(8);
+
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void ReadQuantized_MinValue_ReturnsMin()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteQuantized(-100f, -100f, 100f, 1f);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadQuantized(-100f, 100f, 1f);
+
+        Assert.Equal(-100f, result);
+    }
+
+    [Fact]
+    public void ReadQuantized_MaxValue_ReturnsApproximateMax()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteQuantized(100f, -100f, 100f, 1f);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadQuantized(-100f, 100f, 1f);
+
+        Assert.InRange(result, 99f, 101f);
+    }
 }

--- a/tests/KeenEyes.Network.Abstractions.Tests/BitWriterTests.cs
+++ b/tests/KeenEyes.Network.Abstractions.Tests/BitWriterTests.cs
@@ -124,4 +124,168 @@ public class BitWriterTests
         var array = writer.ToArray();
         Assert.Equal(4, array.Length);
     }
+
+    [Fact]
+    public void WriteFloat_WritesFullPrecision()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        writer.WriteFloat(3.14159f);
+
+        Assert.Equal(4, writer.BytesRequired);
+    }
+
+    [Fact]
+    public void WriteQuantized_ReturnsCorrectBitCount()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        // Range 0-100 with resolution 1 = 101 values = 7 bits
+        var bitsWritten = writer.WriteQuantized(50f, 0f, 100f, 1f);
+
+        Assert.Equal(7, bitsWritten);
+    }
+
+    [Fact]
+    public void WriteQuantized_ClampsToRange()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        // Value outside range should be clamped
+        writer.WriteQuantized(200f, 0f, 100f, 1f);
+
+        var reader = new BitReader(writer.GetWrittenSpan());
+        var result = reader.ReadQuantized(0f, 100f, 1f);
+
+        Assert.InRange(result, 99f, 101f);
+    }
+
+    [Fact]
+    public void WriteBytes_WritesAllBytes()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        byte[] data = [0x11, 0x22, 0x33, 0x44];
+        writer.WriteBytes(data);
+
+        Assert.Equal(4, writer.BytesRequired);
+        var span = writer.GetWrittenSpan();
+        Assert.Equal(0x11, span[0]);
+        Assert.Equal(0x22, span[1]);
+        Assert.Equal(0x33, span[2]);
+        Assert.Equal(0x44, span[3]);
+    }
+
+    [Fact]
+    public void BytePosition_TracksCorrectly()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        Assert.Equal(0, writer.BytePosition);
+
+        writer.WriteByte(0x42);
+        Assert.Equal(1, writer.BytePosition);
+
+        writer.WriteByte(0x43);
+        Assert.Equal(2, writer.BytePosition);
+    }
+
+    [Fact]
+    public void BitOffset_TracksPartialBytes()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        Assert.Equal(0, writer.BitOffset);
+
+        writer.WriteBits(0b111, 3);
+        Assert.Equal(3, writer.BitOffset);
+
+        writer.WriteBits(0b11111, 5);
+        Assert.Equal(0, writer.BitOffset); // Wrapped to next byte
+    }
+
+    [Fact]
+    public void TotalBitsWritten_TracksCorrectly()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        Assert.Equal(0, writer.TotalBitsWritten);
+
+        writer.WriteBits(0b101, 3);
+        Assert.Equal(3, writer.TotalBitsWritten);
+
+        writer.WriteByte(0xFF);
+        Assert.Equal(11, writer.TotalBitsWritten);
+    }
+
+    [Fact]
+    public void WriteBits_ZeroBits_ThrowsArgumentOutOfRange()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => WriteBitsHelper(0, 0));
+        Assert.Equal("bits", ex.ParamName);
+    }
+
+    [Fact]
+    public void WriteBits_TooManyBits_ThrowsArgumentOutOfRange()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => WriteBitsHelper(0, 33));
+        Assert.Equal("bits", ex.ParamName);
+    }
+
+    private static void WriteBitsHelper(uint value, int bits)
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+        writer.WriteBits(value, bits);
+    }
+
+    [Fact]
+    public void BytesRequired_WithPartialByte_RoundsUp()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        writer.WriteBits(0b1, 1);
+
+        Assert.Equal(1, writer.BytesRequired);
+        Assert.Equal(0, writer.BytePosition);
+        Assert.Equal(1, writer.BitOffset);
+    }
+
+    [Fact]
+    public void WriteBits_32Bits_WritesCorrectly()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new BitWriter(buffer);
+
+        writer.WriteBits(0xFFFFFFFF, 32);
+
+        Assert.Equal(4, writer.BytesRequired);
+        var span = writer.GetWrittenSpan();
+        Assert.Equal(0xFF, span[0]);
+        Assert.Equal(0xFF, span[1]);
+        Assert.Equal(0xFF, span[2]);
+        Assert.Equal(0xFF, span[3]);
+    }
+
+    [Fact]
+    public void Constructor_ClearsBuffer()
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        buffer[0] = 0xFF;
+        buffer[1] = 0xFF;
+
+        var writer = new BitWriter(buffer);
+        writer.WriteBits(0, 8);
+
+        var span = writer.GetWrittenSpan();
+        Assert.Equal(0, span[0]);
+    }
 }


### PR DESCRIPTION
## Summary
- Add tests for ReadFloat, ReadQuantized, ReadBytes, SkipBits in BitReader
- Add tests for WriteFloat, WriteQuantized, WriteBytes in BitWriter
- Add property tracking tests (BytePosition, BitOffset, TotalBitsRead/Written)
- Add error condition tests for invalid bit counts
- Use helper methods to work around ref struct lambda limitations

## Test plan
- [x] All 196 Network.Abstractions tests pass
- [x] Build succeeds without warnings
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)