### PR TITLE
Fix calendar test helper to create correct number of day cells

### DIFF
--- a/tests/KeenEyes.UI.Tests/UIDatePickerSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIDatePickerSystemTests.cs
@@ -2148,8 +2148,9 @@ public class UIDatePickerSystemTests
 
         world.SetParent(picker, canvas);
 
-        // Create some calendar day cells
-        for (int day = 1; day <= 30; day++)
+        // Create calendar day cells for all days in the month
+        var daysInMonth = DateTime.DaysInMonth(initialValue.Year, initialValue.Month);
+        for (int day = 1; day <= daysInMonth; day++)
         {
             var dayCell = world.Spawn()
                 .With(UIElement.Default)
@@ -2291,8 +2292,9 @@ public class UIDatePickerSystemTests
 
         world.SetParent(picker, canvas);
 
-        // Create calendar day cells with styles
-        for (int day = 1; day <= 30; day++)
+        // Create calendar day cells with styles for all days in the month
+        var daysInMonth = DateTime.DaysInMonth(initialValue.Year, initialValue.Month);
+        for (int day = 1; day <= daysInMonth; day++)
         {
             var dayCell = world.Spawn()
                 .With(UIElement.Default)


### PR DESCRIPTION
## Summary
- Fixed `CreateDatePickerWithDays` and `CreateDatePickerWithStyledDays` helper methods to create the correct number of day cells based on the month
- The helpers were hardcoded to create only 30 day cells, causing `CalendarDay_UpdateDayCell_SetsIsTodayCorrectly` to fail on day 31 of any month (e.g., December 31)
- Changed loop bounds to use `DateTime.DaysInMonth()` to dynamically determine the correct number of days

## Test plan
- [x] Verified the specific failing test now passes
- [x] Confirmed all 86 UIDatePickerSystem tests pass