### PR TITLE
docs: Add GitHub CLI usage guidance for web sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1018,3 +1018,21 @@ download_pkg "TransitivePackage" "Version"
 ```
 
 Keep the script organized with comments grouping related packages.
+
+### GitHub CLI Usage
+
+In web sessions, the git remote uses a local proxy URL that the GitHub CLI doesn't recognize as a GitHub host. Always use the `--repo` flag to specify the repository explicitly:
+
+```bash
+# ❌ BAD: Will fail with "none of the git remotes configured for this repository point to a known GitHub host"
+gh issue list
+gh pr create
+
+# ✅ GOOD: Explicitly specify the repository
+gh issue list --repo orion-ecs/keen-eye
+gh pr create --repo orion-ecs/keen-eye --title "..." --body "..."
+gh issue close 123 --repo orion-ecs/keen-eye --comment "Fixed in PR #456"
+gh api repos/orion-ecs/keen-eye/issues/123
+```
+
+This applies to all `gh` commands that interact with the repository.


### PR DESCRIPTION
## Summary
- Added documentation to CLAUDE.md explaining how to use the GitHub CLI (`gh`) in web sessions
- Web sessions use a local proxy URL that `gh` doesn't recognize as a GitHub host
- Must use `--repo` flag to explicitly specify the repository

## Example
```bash
# Instead of: gh issue list
gh issue list --repo orion-ecs/keen-eye
```

## Test plan
- [x] Documentation only change
- [x] Build passes