### PR TITLE
fix: Address quick win issues #478, #476, #484

### DIFF
--- a/samples/KeenEyes.Sample.SaveLoad/Program.cs
+++ b/samples/KeenEyes.Sample.SaveLoad/Program.cs
@@ -325,7 +325,11 @@ static void PrintWorldState(World world, string label)
     Console.WriteLine($"Entities: {playerCount} players, {enemyCount} enemies, {npcCount} NPCs");
 
     var player = world.GetEntityByName("Player");
-    if (player.IsValid)
+    if (player.IsValid &&
+        world.Has<Position>(player) &&
+        world.Has<Health>(player) &&
+        world.Has<Experience>(player) &&
+        world.Has<Gold>(player))
     {
         ref readonly var pos = ref world.Get<Position>(player);
         ref readonly var health = ref world.Get<Health>(player);

--- a/samples/KeenEyes.Sample.Simulation/Systems.cs
+++ b/samples/KeenEyes.Sample.Simulation/Systems.cs
@@ -518,6 +518,9 @@ public partial class ShootingSystem : SystemBase
                     float dy = targetPos.Y - pos.Y;
                     float dist = MathF.Sqrt(dx * dx + dy * dy);
 
+                    // Note: Direct comparison is acceptable for threshold checks (> or <).
+                    // Unlike equality checks (==), small floating-point errors don't affect
+                    // the outcome - values near the boundary behave consistently.
                     if (dist > MinimumShootingDistance)
                     {
                         float vx = (dx / dist) * PlayerProjectileSpeed;

--- a/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
+++ b/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\editor\KeenEyes.Editor.Common\KeenEyes.Editor.Common.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Editor\KeenEyes.Editor.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\KeenEyes.Logging\KeenEyes.Logging.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add component existence checks (`Has<>`) before `Get<>` calls in SaveLoad sample (#478)
- Document why direct threshold comparison is acceptable for floats in Simulation sample (#476)
- Add query comprehension syntax detection to LinqHotPathAnalyzer (#484)
- Fix missing KeenEyes.Logging reference in Editor.Tests (pre-existing build issue)

## Details

### #478 - Missing Component Existence Check
The `PrintWorldState` function in the SaveLoad sample called `Get<>` without first checking if the entity has the required components. Added `Has<>` checks to prevent crashes when entity exists but lacks expected components.

### #476 - Float Comparison in Simulation Sample
Direct threshold comparisons (`>`, `<`) are acceptable for floats unlike equality checks. Added documentation comment explaining why small floating-point errors don't affect comparison outcomes near boundaries.

### #484 - LinqHotPathAnalyzer Incomplete Detection
Added detection for LINQ query comprehension syntax (`from x in collection where... select...`) which is compiled to LINQ method calls. The analyzer now warns about these in hot paths as well.

## Test plan
- [x] Build passes with zero warnings
- [x] All tests pass
- [x] Manual verification of analyzer changes

Closes #478
Closes #476
Closes #484