### PR TITLE
fix: Address medium priority bugs #472, #470, #471

### DIFF
--- a/editor/KeenEyes.Generators/ComponentGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentGenerator.cs
@@ -163,13 +163,53 @@ public sealed class ComponentGenerator : IIncrementalGenerator
             TypedConstantKind.Primitive when constant.Value is string s => $"\"{s}\"",
             TypedConstantKind.Primitive when constant.Value is char c => $"'{c}'",
             TypedConstantKind.Primitive when constant.Value is bool b => b ? "true" : "false",
-            TypedConstantKind.Primitive when constant.Value is float f => $"{f}f",
-            TypedConstantKind.Primitive when constant.Value is double d => $"{d}d",
+            TypedConstantKind.Primitive when constant.Value is float f => FormatFloat(f),
+            TypedConstantKind.Primitive when constant.Value is double d => FormatDouble(d),
             TypedConstantKind.Primitive when constant.Value is decimal m => $"{m}m",
             TypedConstantKind.Primitive => constant.Value?.ToString() ?? "default",
             TypedConstantKind.Enum => $"({constant.Type!.ToDisplayString()}){constant.Value}",
             _ => "default"
         };
+    }
+
+    private static string FormatFloat(float f)
+    {
+        if (float.IsNaN(f))
+        {
+            return "float.NaN";
+        }
+
+        if (float.IsPositiveInfinity(f))
+        {
+            return "float.PositiveInfinity";
+        }
+
+        if (float.IsNegativeInfinity(f))
+        {
+            return "float.NegativeInfinity";
+        }
+
+        return $"{f}f";
+    }
+
+    private static string FormatDouble(double d)
+    {
+        if (double.IsNaN(d))
+        {
+            return "double.NaN";
+        }
+
+        if (double.IsPositiveInfinity(d))
+        {
+            return "double.PositiveInfinity";
+        }
+
+        if (double.IsNegativeInfinity(d))
+        {
+            return "double.NegativeInfinity";
+        }
+
+        return $"{d}d";
     }
 
     private static string GenerateComponentPartial(ComponentInfo info)

--- a/src/KeenEyes.Abstractions/Attributes/ComponentValidationAttribute.cs
+++ b/src/KeenEyes.Abstractions/Attributes/ComponentValidationAttribute.cs
@@ -14,8 +14,13 @@ namespace KeenEyes;
 /// </para>
 /// <para>
 /// Multiple <see cref="RequiresComponentAttribute"/> can be applied to the same component
-/// to express multiple dependencies. Dependencies are checked transitively - if A requires B
-/// and B requires C, then adding A will verify both B and C are present.
+/// to express multiple dependencies. Each dependency is validated independently when the
+/// component is added - required components must already be present on the entity.
+/// </para>
+/// <para>
+/// <b>Note:</b> Dependencies are checked directly, not transitively. If A requires B and
+/// B requires C, adding A only validates that B is present. To ensure C is also present,
+/// either add C explicitly or add a <c>[RequiresComponent(typeof(C))]</c> to A.
 /// </para>
 /// </remarks>
 /// <example>


### PR DESCRIPTION
## Summary
- Fix special float/double value handling in ComponentGenerator (#472)
- Update RequiresComponentAttribute documentation for accuracy (#470)
- Add circular dependency detection to SystemOrderingAnalyzer (#471)

## Details

### #472 - Component Default Value Edge Cases
Added `FormatFloat()` and `FormatDouble()` helpers to handle special values:
- `float.NaN` → `"float.NaN"` (was generating invalid `"NaNf"`)
- `float.PositiveInfinity` → `"float.PositiveInfinity"` (was generating `"∞f"`)
- `float.NegativeInfinity` → `"float.NegativeInfinity"` (was generating `"-∞f"`)

Same for double values.

### #470 - ComponentValidationAnalyzer Transitive Dependency Gap
Updated `RequiresComponentAttribute` documentation to accurately describe that dependencies are checked **directly**, not transitively. The previous documentation incorrectly claimed "if A requires B and B requires C, then adding A will verify both B and C are present."

### #471 - SystemOrderingAnalyzer Missing Circular Dependency Detection
Added `KEEN006` diagnostic that detects circular ordering dependencies at compile time:
- `A [RunBefore(B)]` + `B [RunBefore(A)]` → Error
- `A [RunAfter(B)]` + `B [RunAfter(A)]` → Error

This provides immediate feedback during development rather than runtime failures.

## Test plan
- [x] Build passes with zero warnings
- [x] All tests pass (9551 passed, 8 skipped)

Closes #472
Closes #470
Closes #471