### PR TITLE
fix: Address low priority issues #477, #481

### DIFF
--- a/editor/KeenEyes.Generators/BundleGenerator.cs
+++ b/editor/KeenEyes.Generators/BundleGenerator.cs
@@ -522,11 +522,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         // Generate partial struct with IBundle implementation and constructor
         sb.AppendLine($"partial struct {info.Name} : global::KeenEyes.IBundle");
@@ -734,11 +730,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         // Generate ref struct with refs to all components
         sb.AppendLine("/// <summary>");

--- a/editor/KeenEyes.Generators/ComponentGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentGenerator.cs
@@ -220,11 +220,7 @@ public sealed class ComponentGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         var interfaceType = info.IsTag ? "ITagComponent" : "IComponent";
 
@@ -394,7 +390,7 @@ public sealed class ComponentGenerator : IIncrementalGenerator
     private static string GenerateNamespaceSuffix(string namespaceName)
     {
         // Handle empty or global namespace
-        if (string.IsNullOrEmpty(namespaceName) || namespaceName == "<global namespace>")
+        if (!StringHelpers.IsValidNamespace(namespaceName))
         {
             return "Global";
         }

--- a/editor/KeenEyes.Generators/MixinGenerator.cs
+++ b/editor/KeenEyes.Generators/MixinGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -323,11 +324,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         sb.AppendLine($"// Mixin fields from: {string.Join(", ", info.MixinTypes.Select(m => m.Name))}");
         sb.AppendLine($"partial struct {info.Name}");

--- a/editor/KeenEyes.Generators/PluginExtensionGenerator.cs
+++ b/editor/KeenEyes.Generators/PluginExtensionGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -137,9 +138,9 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
 
         foreach (var ext in extensions)
         {
-            var fullTypeName = ext.Namespace == "<global namespace>"
-                ? ext.Name
-                : $"global::{ext.FullName}";
+            var fullTypeName = StringHelpers.IsValidNamespace(ext.Namespace)
+                ? $"global::{ext.FullName}"
+                : ext.Name;
 
             sb.AppendLine($"        /// <summary>");
             sb.AppendLine($"        /// Gets the <see cref=\"{ext.FullName}\"/> extension from this world.");

--- a/editor/KeenEyes.Generators/QueryGenerator.cs
+++ b/editor/KeenEyes.Generators/QueryGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -112,11 +113,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         // Generate the query struct partial
         sb.AppendLine($"partial struct {info.Name}");

--- a/editor/KeenEyes.Generators/SystemGenerator.cs
+++ b/editor/KeenEyes.Generators/SystemGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -122,11 +123,7 @@ public sealed class SystemGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
 
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
         var groupStr = info.Group is not null ? $"\"{info.Group}\"" : "null";
 
@@ -171,15 +168,9 @@ public sealed class SystemGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // Use the same namespace as the system for discoverability
-        if (!string.IsNullOrEmpty(info.Namespace) && info.Namespace != "<global namespace>")
-        {
-            sb.AppendLine($"namespace {info.Namespace};");
-            sb.AppendLine();
-        }
+        StringHelpers.AppendNamespaceDeclaration(sb, info.Namespace);
 
-        var fullTypeName = info.Namespace is "<global namespace>" or ""
-            ? $"global::{info.Name}"
-            : $"global::{info.Namespace}.{info.Name}";
+        var fullTypeName = StringHelpers.GetFullTypeName(info.Namespace, info.Name);
 
         // Generate RunsBefore array
         var runsBeforeStr = info.RunsBefore.Count > 0

--- a/editor/KeenEyes.Generators/Utilities/StringHelpers.cs
+++ b/editor/KeenEyes.Generators/Utilities/StringHelpers.cs
@@ -1,5 +1,7 @@
 // Copyright (c) KeenEyes Contributors. Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Text;
+
 namespace KeenEyes.Generators.Utilities;
 
 /// <summary>
@@ -7,6 +9,52 @@ namespace KeenEyes.Generators.Utilities;
 /// </summary>
 internal static class StringHelpers
 {
+    /// <summary>
+    /// The string used by Roslyn to represent the global namespace.
+    /// </summary>
+    public const string GlobalNamespace = "<global namespace>";
+
+    /// <summary>
+    /// Determines if a namespace string represents a valid namespace that should be emitted.
+    /// </summary>
+    /// <param name="ns">The namespace string to check.</param>
+    /// <returns><c>true</c> if the namespace should be emitted; <c>false</c> if it's empty or global.</returns>
+    public static bool IsValidNamespace(string? ns)
+    {
+        return !string.IsNullOrEmpty(ns) && ns != GlobalNamespace;
+    }
+
+    /// <summary>
+    /// Appends a file-scoped namespace declaration if the namespace is valid.
+    /// </summary>
+    /// <param name="sb">The StringBuilder to append to.</param>
+    /// <param name="ns">The namespace string.</param>
+    /// <remarks>
+    /// Does nothing if the namespace is null, empty, or the global namespace.
+    /// Appends a file-scoped namespace declaration (e.g., "namespace Foo;") followed by a newline.
+    /// </remarks>
+    public static void AppendNamespaceDeclaration(StringBuilder sb, string? ns)
+    {
+        if (IsValidNamespace(ns))
+        {
+            sb.AppendLine($"namespace {ns};");
+            sb.AppendLine();
+        }
+    }
+
+    /// <summary>
+    /// Gets the fully qualified type name with global:: prefix.
+    /// </summary>
+    /// <param name="ns">The namespace (may be null, empty, or global namespace).</param>
+    /// <param name="typeName">The type name.</param>
+    /// <returns>The fully qualified name like "global::Namespace.Type" or "global::Type" for global namespace.</returns>
+    public static string GetFullTypeName(string? ns, string typeName)
+    {
+        return IsValidNamespace(ns)
+            ? $"global::{ns}.{typeName}"
+            : $"global::{typeName}";
+    }
+
     /// <summary>
     /// Converts a PascalCase string to camelCase.
     /// </summary>

--- a/samples/KeenEyes.Sample.SaveLoad/Program.cs
+++ b/samples/KeenEyes.Sample.SaveLoad/Program.cs
@@ -149,10 +149,20 @@ Console.WriteLine("\n[5] Restoring from Snapshot\n");
 Console.WriteLine("Loading saved state...");
 
 // Parse the JSON back to a snapshot
-var loadedSnapshot = SnapshotManager.FromJson(json);
-if (loadedSnapshot == null)
+WorldSnapshot? loadedSnapshot;
+try
 {
-    Console.WriteLine("Failed to load snapshot!");
+    loadedSnapshot = SnapshotManager.FromJson(json);
+    if (loadedSnapshot == null)
+    {
+        Console.WriteLine("Failed to load snapshot: SnapshotManager.FromJson returned null");
+        return;
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Failed to load snapshot: {ex.Message}");
+    Console.WriteLine($"Stack trace: {ex.StackTrace}");
     return;
 }
 


### PR DESCRIPTION
## Summary
- Add error handling to SaveLoad sample for better debugging (#477)
- Extract namespace handling to shared StringHelpers utility (#481)

## Details

### #477 - SaveLoad Sample Error Handling
Added try-catch block around `SnapshotManager.FromJson()` call to provide detailed error messages when snapshot loading fails. This improves the educational value of the sample for users learning the API.

### #481 - Namespace Handling Duplication
Extracted duplicate `"<global namespace>"` handling code to shared utilities in `StringHelpers.cs`:

- `GlobalNamespace` constant - the string Roslyn uses for global namespace
- `IsValidNamespace(ns)` - checks if namespace should be emitted  
- `AppendNamespaceDeclaration(sb, ns)` - appends file-scoped namespace if valid
- `GetFullTypeName(ns, name)` - gets fully qualified type name with `global::` prefix

Updated 7 generators to use these shared utilities:
- ComponentGenerator
- SystemGenerator
- BundleGenerator
- QueryGenerator
- MixinGenerator
- PluginExtensionGenerator

## Test plan
- [x] Build passes with zero warnings
- [x] All tests pass (9662 passed, 8 skipped)

Closes #477
Closes #481