### PR TITLE
fix: Address code quality issues from nightly review

### DIFF
--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -446,16 +446,22 @@ public sealed class Archetype : IDisposable
 
     private void UpdateLocationsAfterChunkRemoval(int removedChunkIndex)
     {
-        // Update all entity locations that were in chunks after the removed one
-        // We iterate through the dictionary's entries and only update when necessary
-        // to avoid allocating a list copy
+        // Collect entity IDs that need their chunk index decremented.
+        // We must not modify dictionary values during enumeration as it's undefined behavior.
+        var entityIdsToUpdate = new List<int>();
         foreach (var kvp in entityLocations)
         {
-            var (chunkIdx, indexInChunk) = kvp.Value;
-            if (chunkIdx > removedChunkIndex)
+            if (kvp.Value.ChunkIndex > removedChunkIndex)
             {
-                entityLocations[kvp.Key] = (chunkIdx - 1, indexInChunk);
+                entityIdsToUpdate.Add(kvp.Key);
             }
+        }
+
+        // Now update the locations for collected entities
+        foreach (var entityId in entityIdsToUpdate)
+        {
+            var (chunkIndex, indexInChunk) = entityLocations[entityId];
+            entityLocations[entityId] = (chunkIndex - 1, indexInChunk);
         }
     }
 }

--- a/src/KeenEyes.Core/TagManager.cs
+++ b/src/KeenEyes.Core/TagManager.cs
@@ -39,10 +39,12 @@ internal sealed class TagManager
     /// <returns>
     /// <c>true</c> if the tag was added; <c>false</c> if the entity already had the tag.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="entityId"/> is negative.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="tag"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="tag"/> is empty or whitespace.</exception>
     internal bool AddTag(int entityId, string tag)
     {
+        ValidateEntityId(entityId);
         ValidateTag(tag);
 
         // Get or create the entity's tag set
@@ -77,10 +79,12 @@ internal sealed class TagManager
     /// <returns>
     /// <c>true</c> if the tag was removed; <c>false</c> if the entity didn't have the tag.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="entityId"/> is negative.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="tag"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="tag"/> is empty or whitespace.</exception>
     internal bool RemoveTag(int entityId, string tag)
     {
+        ValidateEntityId(entityId);
         ValidateTag(tag);
 
         // Remove from entity's tags
@@ -116,10 +120,12 @@ internal sealed class TagManager
     /// <param name="entityId">The entity ID to check.</param>
     /// <param name="tag">The tag to check for.</param>
     /// <returns><c>true</c> if the entity has the tag; <c>false</c> otherwise.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="entityId"/> is negative.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="tag"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="tag"/> is empty or whitespace.</exception>
     internal bool HasTag(int entityId, string tag)
     {
+        ValidateEntityId(entityId);
         ValidateTag(tag);
         return entityTags.TryGetValue(entityId, out var tags) && tags.Contains(tag);
     }
@@ -132,8 +138,11 @@ internal sealed class TagManager
     /// A read-only collection of tags on the entity. Returns an empty collection
     /// if the entity has no tags.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="entityId"/> is negative.</exception>
     internal IReadOnlyCollection<string> GetTags(int entityId)
     {
+        ValidateEntityId(entityId);
+
         if (entityTags.TryGetValue(entityId, out var tags))
         {
             return tags;
@@ -217,5 +226,13 @@ internal sealed class TagManager
         {
             throw new ArgumentException("Tag cannot be empty or whitespace.", nameof(tag));
         }
+    }
+
+    /// <summary>
+    /// Validates that an entity ID is non-negative.
+    /// </summary>
+    private static void ValidateEntityId(int entityId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(entityId);
     }
 }


### PR DESCRIPTION
## Summary
- Fix unsafe dictionary modification during iteration in Archetype
- Add input validation to TagManager for entity IDs

## Details

### Archetype Dictionary Modification Fix
The `UpdateLocationsAfterChunkRemoval` method was modifying dictionary values during enumeration, which is undefined behavior in .NET and could cause runtime exceptions in future versions.

**Before:** Modified `entityLocations[key]` while iterating over the dictionary
**After:** Collects entity IDs first, then updates in separate loop

### TagManager Input Validation
Added `ValidateEntityId()` method to prevent negative entity IDs from corrupting internal state.

Updated methods:
- `AddTag(entityId, tag)` 
- `RemoveTag(entityId, tag)`
- `HasTag(entityId, tag)`
- `GetTags(entityId)`

All now throw `ArgumentOutOfRangeException` for negative entityId values.

## Test plan
- [x] Build passes with zero warnings
- [x] All tests pass (9774 passed, 8 skipped)

## Related
Addresses findings from nightly code review #604