### PR TITLE
Add hot reload infrastructure for editor (#590)

### DIFF
--- a/editor/KeenEyes.Editor/HotReload/GameAssemblyContext.cs
+++ b/editor/KeenEyes.Editor/HotReload/GameAssemblyContext.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace KeenEyes.Editor.HotReload;
+
+/// <summary>
+/// A collectible assembly load context for loading game assemblies that can be unloaded.
+/// </summary>
+/// <remarks>
+/// This context enables hot reload by allowing the game assembly to be unloaded
+/// and replaced with a newly compiled version at runtime.
+/// </remarks>
+internal sealed class GameAssemblyContext : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver _resolver;
+
+    /// <summary>
+    /// Creates a new game assembly context.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the main game assembly.</param>
+    public GameAssemblyContext(string assemblyPath)
+        : base(name: "GameCode", isCollectible: true)
+    {
+        _resolver = new AssemblyDependencyResolver(assemblyPath);
+    }
+
+    /// <inheritdoc/>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // Try to resolve dependencies from the game assembly's directory
+        var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+
+        if (assemblyPath != null)
+        {
+            return LoadFromAssemblyPath(assemblyPath);
+        }
+
+        // Fall back to default context for framework assemblies
+        return null;
+    }
+
+    /// <inheritdoc/>
+    protected override nint LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+
+        if (libraryPath != null)
+        {
+            return LoadUnmanagedDllFromPath(libraryPath);
+        }
+
+        return nint.Zero;
+    }
+}

--- a/editor/KeenEyes.Editor/HotReload/HotReloadManager.cs
+++ b/editor/KeenEyes.Editor/HotReload/HotReloadManager.cs
@@ -1,0 +1,465 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace KeenEyes.Editor.HotReload;
+
+/// <summary>
+/// Manages hot reloading of game assemblies during development.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Uses <see cref="AssemblyLoadContext"/> to load game assemblies into a collectible
+/// context that can be unloaded and replaced when source files change.
+/// </para>
+/// <para>
+/// The hot reload process:
+/// <list type="number">
+/// <item>Detect source file changes via <see cref="FileSystemWatcher"/></item>
+/// <item>Unregister all game systems from the world</item>
+/// <item>Unload the previous assembly context</item>
+/// <item>Rebuild the project via dotnet build</item>
+/// <item>Load the new assembly into a fresh context</item>
+/// <item>Re-register systems from the new assembly</item>
+/// </list>
+/// </para>
+/// <para>
+/// Component data survives reload as it's stored as bytes in archetypes.
+/// Only system logic is replaced.
+/// </para>
+/// </remarks>
+public sealed class HotReloadManager : IDisposable
+{
+    private readonly string _projectPath;
+    private readonly string _outputDirectory;
+    private readonly World _sceneWorld;
+    private readonly TimeSpan _debounceDelay;
+    private readonly List<ISystem> _registeredSystems = [];
+
+    private GameAssemblyContext? _gameContext;
+    private Assembly? _gameAssembly;
+    private FileSystemWatcher? _sourceWatcher;
+    private CancellationTokenSource? _debounceCts;
+    private bool _isReloading;
+    private bool _disposed;
+
+    /// <summary>
+    /// Raised when a reload operation starts.
+    /// </summary>
+    public event Action? ReloadStarted;
+
+    /// <summary>
+    /// Raised when a reload operation completes successfully.
+    /// </summary>
+    public event Action? ReloadCompleted;
+
+    /// <summary>
+    /// Raised when compilation fails during reload.
+    /// </summary>
+    public event Action<BuildResult>? CompilationFailed;
+
+    /// <summary>
+    /// Raised when a source file change is detected.
+    /// </summary>
+    public event Action<string>? SourceFileChanged;
+
+    /// <summary>
+    /// Gets whether a reload is currently in progress.
+    /// </summary>
+    public bool IsReloading => _isReloading;
+
+    /// <summary>
+    /// Gets whether file watching is enabled.
+    /// </summary>
+    public bool IsWatching => _sourceWatcher?.EnableRaisingEvents ?? false;
+
+    /// <summary>
+    /// Gets the currently loaded game assembly, if any.
+    /// </summary>
+    public Assembly? GameAssembly => _gameAssembly;
+
+    /// <summary>
+    /// Gets the list of systems registered from the game assembly.
+    /// </summary>
+    public IReadOnlyList<ISystem> RegisteredSystems => _registeredSystems;
+
+    /// <summary>
+    /// Creates a new hot reload manager.
+    /// </summary>
+    /// <param name="projectPath">Path to the game's .csproj file.</param>
+    /// <param name="sceneWorld">The scene world to register systems to.</param>
+    /// <param name="debounceDelay">Delay before triggering rebuild after file change.</param>
+    public HotReloadManager(
+        string projectPath,
+        World sceneWorld,
+        TimeSpan? debounceDelay = null)
+    {
+        ArgumentNullException.ThrowIfNull(sceneWorld);
+
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            throw new ArgumentException("Project path cannot be empty", nameof(projectPath));
+        }
+
+        if (!File.Exists(projectPath))
+        {
+            throw new FileNotFoundException("Project file not found", projectPath);
+        }
+
+        _projectPath = Path.GetFullPath(projectPath);
+        _outputDirectory = Path.Combine(
+            Path.GetDirectoryName(_projectPath)!,
+            "bin", "Debug", "net10.0");
+        _sceneWorld = sceneWorld;
+        _debounceDelay = debounceDelay ?? TimeSpan.FromMilliseconds(500);
+    }
+
+    /// <summary>
+    /// Starts watching for source file changes.
+    /// </summary>
+    public void StartWatching()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(HotReloadManager));
+        }
+
+        if (_sourceWatcher != null)
+        {
+            return;
+        }
+
+        var projectDir = Path.GetDirectoryName(_projectPath)!;
+
+        _sourceWatcher = new FileSystemWatcher(projectDir, "*.cs")
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName
+        };
+
+        _sourceWatcher.Changed += OnSourceChanged;
+        _sourceWatcher.Created += OnSourceChanged;
+        _sourceWatcher.Renamed += OnSourceRenamed;
+        _sourceWatcher.EnableRaisingEvents = true;
+    }
+
+    /// <summary>
+    /// Stops watching for source file changes.
+    /// </summary>
+    public void StopWatching()
+    {
+        if (_sourceWatcher != null)
+        {
+            _sourceWatcher.EnableRaisingEvents = false;
+            _sourceWatcher.Changed -= OnSourceChanged;
+            _sourceWatcher.Created -= OnSourceChanged;
+            _sourceWatcher.Renamed -= OnSourceRenamed;
+            _sourceWatcher.Dispose();
+            _sourceWatcher = null;
+        }
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = null;
+    }
+
+    /// <summary>
+    /// Performs a hot reload of the game assembly.
+    /// </summary>
+    /// <returns>The result of the reload operation.</returns>
+    public async Task<HotReloadResult> ReloadAsync()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(HotReloadManager));
+        }
+
+        if (_isReloading)
+        {
+            return new HotReloadResult(false, "Reload already in progress");
+        }
+
+        _isReloading = true;
+        ReloadStarted?.Invoke();
+
+        try
+        {
+            // 1. Unregister all game systems
+            foreach (var system in _registeredSystems)
+            {
+                _sceneWorld.RemoveSystem(system);
+            }
+            _registeredSystems.Clear();
+
+            // 2. Unload previous assembly context
+            await UnloadGameContextAsync();
+
+            // 3. Rebuild the project
+            var buildResult = await BuildProjectAsync();
+            if (!buildResult.Success)
+            {
+                CompilationFailed?.Invoke(buildResult);
+                return new HotReloadResult(false, "Compilation failed", buildResult);
+            }
+
+            // 4. Load the new assembly
+            var loadResult = LoadGameAssembly(buildResult.OutputPath!);
+            if (!loadResult.Success)
+            {
+                return loadResult;
+            }
+
+            // 5. Register systems from the new assembly
+            RegisterSystemsFromAssembly();
+
+            ReloadCompleted?.Invoke();
+            return new HotReloadResult(true, "Reload successful");
+        }
+        catch (Exception ex)
+        {
+            var failedResult = new BuildResult(false, null, [$"Exception: {ex.Message}"]);
+            CompilationFailed?.Invoke(failedResult);
+            return new HotReloadResult(false, ex.Message);
+        }
+        finally
+        {
+            _isReloading = false;
+        }
+    }
+
+    /// <summary>
+    /// Loads a game assembly without file watching.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the assembly DLL.</param>
+    /// <returns>Result of the load operation.</returns>
+    public HotReloadResult LoadGameAssembly(string assemblyPath)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(HotReloadManager));
+        }
+
+        if (!File.Exists(assemblyPath))
+        {
+            return new HotReloadResult(false, $"Assembly not found: {assemblyPath}");
+        }
+
+        try
+        {
+            _gameContext = new GameAssemblyContext(assemblyPath);
+            _gameAssembly = _gameContext.LoadFromAssemblyPath(assemblyPath);
+            return new HotReloadResult(true, "Assembly loaded");
+        }
+        catch (Exception ex)
+        {
+            return new HotReloadResult(false, $"Failed to load assembly: {ex.Message}");
+        }
+    }
+
+    private async Task UnloadGameContextAsync()
+    {
+        if (_gameContext == null)
+        {
+            return;
+        }
+
+        var contextRef = new WeakReference(_gameContext);
+        _gameContext.Unload();
+        _gameContext = null;
+        _gameAssembly = null;
+
+        // Force garbage collection to fully unload the context
+        for (int i = 0; i < 10 && contextRef.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(10);
+        }
+
+        if (contextRef.IsAlive)
+        {
+            Console.Error.WriteLine("[HotReload] Warning: Previous context may not have fully unloaded");
+        }
+    }
+
+    private async Task<BuildResult> BuildProjectAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"build \"{_projectPath}\" -c Debug --no-restore",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            process.Start();
+
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
+            await process.WaitForExitAsync();
+
+            var output = await outputTask;
+            var error = await errorTask;
+
+            if (process.ExitCode == 0)
+            {
+                var assemblyName = Path.GetFileNameWithoutExtension(_projectPath) + ".dll";
+                var outputPath = Path.Combine(_outputDirectory, assemblyName);
+                return new BuildResult(true, outputPath, []);
+            }
+
+            var errors = ParseBuildErrors(error + "\n" + output);
+            return new BuildResult(false, null, errors);
+        }
+        catch (Exception ex)
+        {
+            return new BuildResult(false, null, [$"Build process failed: {ex.Message}"]);
+        }
+    }
+
+    private void RegisterSystemsFromAssembly()
+    {
+        if (_gameAssembly == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var systemTypes = _gameAssembly.GetTypes()
+                .Where(t => typeof(ISystem).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface);
+
+            foreach (var systemType in systemTypes)
+            {
+                try
+                {
+                    var system = (ISystem)Activator.CreateInstance(systemType)!;
+                    _sceneWorld.AddSystem(system);
+                    _registeredSystems.Add(system);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[HotReload] Failed to create system {systemType.Name}: {ex.Message}");
+                }
+            }
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            Console.Error.WriteLine($"[HotReload] Failed to load types: {ex.Message}");
+            foreach (var loaderEx in ex.LoaderExceptions)
+            {
+                if (loaderEx != null)
+                {
+                    Console.Error.WriteLine($"  {loaderEx.Message}");
+                }
+            }
+        }
+    }
+
+    private static string[] ParseBuildErrors(string output)
+    {
+        var errors = new List<string>();
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Contains(": error ") || trimmed.Contains(": warning "))
+            {
+                errors.Add(trimmed);
+            }
+        }
+
+        return errors.Count > 0 ? [.. errors] : ["Build failed with unknown error"];
+    }
+
+    private async void OnSourceChanged(object sender, FileSystemEventArgs e)
+    {
+        await HandleFileChangeAsync(e.FullPath);
+    }
+
+    private async void OnSourceRenamed(object sender, RenamedEventArgs e)
+    {
+        await HandleFileChangeAsync(e.FullPath);
+    }
+
+    private async Task HandleFileChangeAsync(string filePath)
+    {
+        if (_disposed || _isReloading)
+        {
+            return;
+        }
+
+        // Skip hidden files and obj/bin directories
+        if (filePath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+            filePath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+        {
+            return;
+        }
+
+        SourceFileChanged?.Invoke(filePath);
+
+        // Cancel any pending debounce
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = new CancellationTokenSource();
+
+        try
+        {
+            await Task.Delay(_debounceDelay, _debounceCts.Token);
+            await ReloadAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Debounce was cancelled by a newer change
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        StopWatching();
+
+        // Unregister systems
+        foreach (var system in _registeredSystems)
+        {
+            _sceneWorld.RemoveSystem(system);
+        }
+        _registeredSystems.Clear();
+
+        // Unload context synchronously
+        _gameContext?.Unload();
+        _gameContext = null;
+        _gameAssembly = null;
+    }
+}
+
+/// <summary>
+/// Result of a build operation.
+/// </summary>
+/// <param name="Success">Whether the build succeeded.</param>
+/// <param name="OutputPath">Path to the output assembly if successful.</param>
+/// <param name="Errors">Build errors if failed.</param>
+public sealed record BuildResult(bool Success, string? OutputPath, string[] Errors);
+
+/// <summary>
+/// Result of a hot reload operation.
+/// </summary>
+/// <param name="Success">Whether the reload succeeded.</param>
+/// <param name="Message">Status message.</param>
+/// <param name="BuildResult">The build result if a build was attempted.</param>
+public sealed record HotReloadResult(bool Success, string Message, BuildResult? BuildResult = null);

--- a/src/KeenEyes.Core/SystemManager.cs
+++ b/src/KeenEyes.Core/SystemManager.cs
@@ -209,7 +209,8 @@ internal sealed class SystemManager
     /// Removes a system from this manager.
     /// </summary>
     /// <param name="system">The system to remove.</param>
-    internal void RemoveSystem(ISystem system)
+    /// <returns>True if the system was found and removed; false otherwise.</returns>
+    internal bool RemoveSystem(ISystem system)
     {
         for (int i = systems.Count - 1; i >= 0; i--)
         {
@@ -217,9 +218,10 @@ internal sealed class SystemManager
             {
                 systems.RemoveAt(i);
                 systemsSorted = false;
-                return;
+                return true;
             }
         }
+        return false;
     }
 
     /// <summary>

--- a/src/KeenEyes.Core/World.Systems.cs
+++ b/src/KeenEyes.Core/World.Systems.cs
@@ -280,5 +280,57 @@ public sealed partial class World
     public bool DisableSystem<T>() where T : class, ISystem
         => systemManager.DisableSystem<T>();
 
+    /// <summary>
+    /// Removes a system instance from this world.
+    /// </summary>
+    /// <param name="system">The system instance to remove.</param>
+    /// <returns>True if the system was found and removed; false otherwise.</returns>
+    /// <remarks>
+    /// <para>
+    /// The system will no longer receive update calls after removal.
+    /// Any resources held by the system should be disposed by the caller if needed.
+    /// </para>
+    /// <para>
+    /// This method is primarily intended for hot reload scenarios where systems
+    /// need to be unregistered before loading new versions.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var physics = world.GetSystem&lt;PhysicsSystem&gt;();
+    /// if (physics is not null)
+    /// {
+    ///     world.RemoveSystem(physics);
+    /// }
+    /// </code>
+    /// </example>
+    public bool RemoveSystem(ISystem system)
+        => systemManager.RemoveSystem(system);
+
+    /// <summary>
+    /// Removes a system of the specified type from this world.
+    /// </summary>
+    /// <typeparam name="T">The type of system to remove.</typeparam>
+    /// <returns>True if the system was found and removed; false otherwise.</returns>
+    /// <remarks>
+    /// <para>
+    /// If multiple systems of the same type exist, only the first match is removed.
+    /// </para>
+    /// <para>
+    /// The system will no longer receive update calls after removal.
+    /// Any resources held by the system should be disposed by the caller if needed.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// world.RemoveSystem&lt;PhysicsSystem&gt;();
+    /// </code>
+    /// </example>
+    public bool RemoveSystem<T>() where T : class, ISystem
+    {
+        var system = GetSystem<T>();
+        return system != null && RemoveSystem(system);
+    }
+
     #endregion
 }

--- a/tests/KeenEyes.Core.Tests/WorldSystemRemovalTests.cs
+++ b/tests/KeenEyes.Core.Tests/WorldSystemRemovalTests.cs
@@ -1,0 +1,169 @@
+namespace KeenEyes.Tests;
+
+public class WorldSystemRemovalTests
+{
+    #region Test Systems
+
+    private sealed class TestSystem : ISystem
+    {
+        public bool Enabled { get; set; } = true;
+        public int UpdateCount { get; private set; }
+
+        public void Initialize(IWorld world) { }
+
+        public void Update(float deltaTime)
+        {
+            UpdateCount++;
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class AnotherTestSystem : ISystem
+    {
+        public bool Enabled { get; set; } = true;
+        public int UpdateCount { get; private set; }
+
+        public void Initialize(IWorld world) { }
+
+        public void Update(float deltaTime)
+        {
+            UpdateCount++;
+        }
+
+        public void Dispose() { }
+    }
+
+    #endregion
+
+    #region RemoveSystem(ISystem) Tests
+
+    [Fact]
+    public void RemoveSystem_WithExistingSystem_ReturnsTrue()
+    {
+        using var world = new World();
+        var system = new TestSystem();
+        world.AddSystem(system);
+
+        var result = world.RemoveSystem(system);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void RemoveSystem_WithNonExistingSystem_ReturnsFalse()
+    {
+        using var world = new World();
+        var system = new TestSystem();
+
+        var result = world.RemoveSystem(system);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void RemoveSystem_RemovedSystemDoesNotReceiveUpdates()
+    {
+        using var world = new World();
+        var system = new TestSystem();
+        world.AddSystem(system);
+
+        world.Update(0.016f);
+        Assert.Equal(1, system.UpdateCount);
+
+        world.RemoveSystem(system);
+
+        world.Update(0.016f);
+        Assert.Equal(1, system.UpdateCount); // Should not have incremented
+    }
+
+    [Fact]
+    public void RemoveSystem_DoesNotAffectOtherSystems()
+    {
+        using var world = new World();
+        var system1 = new TestSystem();
+        var system2 = new AnotherTestSystem();
+        world.AddSystem(system1);
+        world.AddSystem(system2);
+
+        world.RemoveSystem(system1);
+
+        world.Update(0.016f);
+        Assert.Equal(0, system1.UpdateCount);
+        Assert.Equal(1, system2.UpdateCount);
+    }
+
+    [Fact]
+    public void RemoveSystem_CalledTwice_SecondCallReturnsFalse()
+    {
+        using var world = new World();
+        var system = new TestSystem();
+        world.AddSystem(system);
+
+        var firstResult = world.RemoveSystem(system);
+        var secondResult = world.RemoveSystem(system);
+
+        Assert.True(firstResult);
+        Assert.False(secondResult);
+    }
+
+    #endregion
+
+    #region RemoveSystem<T>() Tests
+
+    [Fact]
+    public void RemoveSystemGeneric_WithExistingSystem_ReturnsTrue()
+    {
+        using var world = new World();
+        world.AddSystem<TestSystem>();
+
+        var result = world.RemoveSystem<TestSystem>();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void RemoveSystemGeneric_WithNonExistingSystem_ReturnsFalse()
+    {
+        using var world = new World();
+
+        var result = world.RemoveSystem<TestSystem>();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void RemoveSystemGeneric_RemovedSystemDoesNotReceiveUpdates()
+    {
+        using var world = new World();
+        world.AddSystem<TestSystem>();
+
+        world.Update(0.016f);
+        var systemBefore = world.GetSystem<TestSystem>();
+        Assert.NotNull(systemBefore);
+        Assert.Equal(1, systemBefore.UpdateCount);
+
+        world.RemoveSystem<TestSystem>();
+
+        world.Update(0.016f);
+        var systemAfter = world.GetSystem<TestSystem>();
+        Assert.Null(systemAfter);
+    }
+
+    [Fact]
+    public void RemoveSystemGeneric_DoesNotAffectOtherSystems()
+    {
+        using var world = new World();
+        world.AddSystem<TestSystem>();
+        world.AddSystem<AnotherTestSystem>();
+
+        world.RemoveSystem<TestSystem>();
+
+        world.Update(0.016f);
+        Assert.Null(world.GetSystem<TestSystem>());
+        Assert.NotNull(world.GetSystem<AnotherTestSystem>());
+        Assert.Equal(1, world.GetSystem<AnotherTestSystem>()!.UpdateCount);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
@@ -1,0 +1,379 @@
+using KeenEyes.Editor.HotReload;
+
+namespace KeenEyes.Editor.Tests.HotReload;
+
+public class HotReloadManagerTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithValidPath_Succeeds()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            Assert.NotNull(manager);
+            Assert.False(manager.IsReloading);
+            Assert.False(manager.IsWatching);
+            Assert.Null(manager.GameAssembly);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullWorld_ThrowsArgumentNullException()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            Assert.Throws<ArgumentNullException>(() => new HotReloadManager(tempProject, null!));
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyPath_ThrowsArgumentException()
+    {
+        using var world = new World();
+        Assert.Throws<ArgumentException>(() => new HotReloadManager("", world));
+    }
+
+    [Fact]
+    public void Constructor_WithNonExistentPath_ThrowsFileNotFoundException()
+    {
+        using var world = new World();
+        Assert.Throws<FileNotFoundException>(() =>
+            new HotReloadManager("/nonexistent/path/project.csproj", world));
+    }
+
+    #endregion
+
+    #region File Watching Tests
+
+    [Fact]
+    public void StartWatching_EnablesWatching()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            manager.StartWatching();
+
+            Assert.True(manager.IsWatching);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void StopWatching_DisablesWatching()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            manager.StartWatching();
+            manager.StopWatching();
+
+            Assert.False(manager.IsWatching);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void StartWatching_CalledTwice_IsIdempotent()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            manager.StartWatching();
+            manager.StartWatching(); // Should not throw
+
+            Assert.True(manager.IsWatching);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void StartWatching_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            var manager = new HotReloadManager(tempProject, world);
+            manager.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => manager.StartWatching());
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region LoadGameAssembly Tests
+
+    [Fact]
+    public void LoadGameAssembly_WithNonExistentPath_ReturnsFalse()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            var result = manager.LoadGameAssembly("/nonexistent/assembly.dll");
+
+            Assert.False(result.Success);
+            Assert.Contains("not found", result.Message);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void LoadGameAssembly_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            var manager = new HotReloadManager(tempProject, world);
+            manager.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+                manager.LoadGameAssembly("/some/path.dll"));
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region Reload Tests
+
+    [Fact]
+    public async Task ReloadAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            var manager = new HotReloadManager(tempProject, world);
+            manager.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => manager.ReloadAsync());
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public async Task ReloadAsync_RaisesReloadStartedEvent()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+            var startedEventRaised = false;
+
+            manager.ReloadStarted += () => startedEventRaised = true;
+
+            await manager.ReloadAsync();
+
+            Assert.True(startedEventRaised);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WithInvalidProject_RaisesCompilationFailedEvent()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+            BuildResult? failedResult = null;
+
+            manager.CompilationFailed += result => failedResult = result;
+
+            await manager.ReloadAsync();
+
+            // The temp project is not a valid .NET project, so build should fail
+            Assert.NotNull(failedResult);
+            Assert.False(failedResult.Success);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region Event Tests
+
+    [Fact]
+    public void SourceFileChanged_RaisesEvent()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world, TimeSpan.FromSeconds(10));
+            string? changedFile = null;
+
+            manager.SourceFileChanged += path => changedFile = path;
+            manager.StartWatching();
+
+            // Create a .cs file to trigger the event
+            var csFile = Path.Combine(Path.GetDirectoryName(tempProject)!, "Test.cs");
+            File.WriteAllText(csFile, "// test");
+
+            // Give the watcher time to detect the change
+            Thread.Sleep(100);
+
+            // Note: Due to debouncing, the actual reload won't happen immediately
+            // We just verify the event was raised
+            Assert.NotNull(changedFile);
+            Assert.Contains("Test.cs", changedFile);
+
+            File.Delete(csFile);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region RegisteredSystems Tests
+
+    [Fact]
+    public void RegisteredSystems_InitiallyEmpty()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            using var manager = new HotReloadManager(tempProject, world);
+
+            Assert.Empty(manager.RegisteredSystems);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region Dispose Tests
+
+    [Fact]
+    public void Dispose_StopsWatching()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            var manager = new HotReloadManager(tempProject, world);
+            manager.StartWatching();
+            manager.Dispose();
+
+            Assert.False(manager.IsWatching);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_IsIdempotent()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            var manager = new HotReloadManager(tempProject, world);
+
+            manager.Dispose();
+            manager.Dispose(); // Should not throw
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string CreateTempProjectFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "HotReloadTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var projectPath = Path.Combine(tempDir, "TestProject.csproj");
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>");
+        return projectPath;
+    }
+
+    private static void CleanupTempProject(string projectPath)
+    {
+        var dir = Path.GetDirectoryName(projectPath);
+        if (dir != null && Directory.Exists(dir))
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+                // Ignore cleanup failures in tests
+            }
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `HotReloadManager` that manages hot reloading of game assemblies during development using `AssemblyLoadContext`
- Add `GameAssemblyContext` - a collectible AssemblyLoadContext for loading game assemblies that can be unloaded and replaced
- Add `World.RemoveSystem(ISystem)` and `World.RemoveSystem<T>()` APIs for hot reload to unregister systems before reloading

## Hot Reload Workflow
1. `FileSystemWatcher` detects `.cs` file changes in the project directory
2. Debounce multiple rapid changes (configurable delay, default 500ms)
3. Unregister all game systems from the world
4. Unload previous `AssemblyLoadContext`
5. Rebuild project via `dotnet build`
6. Load new assembly into fresh collectible context
7. Re-register systems from new assembly

Component data survives reload since it's stored as bytes in archetypes - only system logic is replaced.

## Files Changed
- **New:** `editor/KeenEyes.Editor/HotReload/GameAssemblyContext.cs` - Collectible AssemblyLoadContext wrapper
- **New:** `editor/KeenEyes.Editor/HotReload/HotReloadManager.cs` - Main hot reload manager (~460 lines)
- **Modified:** `src/KeenEyes.Core/World.Systems.cs` - Add RemoveSystem APIs
- **Modified:** `src/KeenEyes.Core/SystemManager.cs` - Support system removal with bool return

## Test plan
- [x] Added 17 unit tests for HotReloadManager covering:
  - Constructor validation
  - File watching start/stop
  - LoadGameAssembly error handling
  - ReloadAsync events and lifecycle
  - Dispose behavior
- [x] Added 9 unit tests for World.RemoveSystem APIs
- [x] All 9840 existing tests pass

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)