### PR TITLE
feat: Add double support to FloatEqualityAnalyzer

### DIFF
--- a/editor/KeenEyes.Generators/FloatEqualityAnalyzer.cs
+++ b/editor/KeenEyes.Generators/FloatEqualityAnalyzer.cs
@@ -18,16 +18,17 @@ namespace KeenEyes.Generators;
 /// <para>
 /// This analyzer detects:
 /// <list type="bullet">
-/// <item><description><c>float == float</c> - Direct equality comparison</description></item>
-/// <item><description><c>float != float</c> - Direct inequality comparison</description></item>
-/// <item><description><c>float == 0</c> or <c>0 == float</c> - Zero comparison</description></item>
+/// <item><description><c>float == float</c> or <c>double == double</c> - Direct equality comparison</description></item>
+/// <item><description><c>float != float</c> or <c>double != double</c> - Direct inequality comparison</description></item>
+/// <item><description><c>float == 0</c> or <c>double == 0</c> - Zero comparison</description></item>
 /// </list>
 /// </para>
 /// <para>
-/// Instead of direct comparisons, use the extension methods from <c>KeenEyes.Common.FloatExtensions</c>:
+/// Instead of direct comparisons, use the extension methods from <c>KeenEyes.Common.FloatExtensions</c>
+/// or <c>KeenEyes.Common.DoubleExtensions</c>:
 /// <list type="bullet">
 /// <item><description><c>value.IsApproximatelyZero()</c> - Check if value is close to zero</description></item>
-/// <item><description><c>value.ApproximatelyEquals(other)</c> - Compare two floats for near-equality</description></item>
+/// <item><description><c>value.ApproximatelyEquals(other)</c> - Compare two values for near-equality</description></item>
 /// </list>
 /// </para>
 /// </remarks>
@@ -45,9 +46,9 @@ public sealed class FloatEqualityAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Direct equality comparisons (== and !=) with floating-point numbers are unreliable " +
-                     "due to precision limitations. Use the extension methods from KeenEyes.Common.FloatExtensions: " +
-                     "IsApproximatelyZero() to check if a value is close to zero, or " +
-                     "ApproximatelyEquals() to compare two floats for near-equality.");
+                     "due to precision limitations. Use the extension methods from KeenEyes.Common.FloatExtensions " +
+                     "or KeenEyes.Common.DoubleExtensions: IsApproximatelyZero() to check if a value is close to zero, or " +
+                     "ApproximatelyEquals() to compare two values for near-equality.");
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
@@ -117,8 +118,9 @@ public sealed class FloatEqualityAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Check for float (System.Single)
-        return type.SpecialType == SpecialType.System_Single;
+        // Check for float (System.Single) or double (System.Double)
+        return type.SpecialType == SpecialType.System_Single ||
+               type.SpecialType == SpecialType.System_Double;
     }
 
     /// <summary>
@@ -204,7 +206,9 @@ public sealed class FloatEqualityAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Check if this is the KeenEyes.Common.FloatExtensions class
-        return typeSymbol.ToDisplayString() == "KeenEyes.Common.FloatExtensions";
+        // Check if this is the KeenEyes.Common.FloatExtensions or DoubleExtensions class
+        var displayString = typeSymbol.ToDisplayString();
+        return displayString == "KeenEyes.Common.FloatExtensions" ||
+               displayString == "KeenEyes.Common.DoubleExtensions";
     }
 }

--- a/src/KeenEyes.Common/DoubleExtensions.cs
+++ b/src/KeenEyes.Common/DoubleExtensions.cs
@@ -1,0 +1,109 @@
+using System;
+
+namespace KeenEyes.Common;
+
+/// <summary>
+/// Extension methods for <see cref="double"/> providing tolerance-based comparisons.
+/// </summary>
+/// <remarks>
+/// Direct equality comparisons (==) with floating-point numbers can be unreliable due to
+/// precision issues. These methods provide well-established idioms for comparing doubles
+/// using a small tolerance (epsilon).
+/// </remarks>
+public static class DoubleExtensions
+{
+    /// <summary>
+    /// Default epsilon value for double comparisons.
+    /// </summary>
+    /// <remarks>
+    /// This value (1e-9) provides higher precision than float comparisons,
+    /// suitable for most scientific and game development scenarios.
+    /// For specific use cases requiring different precision, use the overload
+    /// that accepts a custom epsilon.
+    /// </remarks>
+    public const double DefaultEpsilon = 1e-9;
+
+    /// <summary>
+    /// Determines whether the double value is approximately zero within the default tolerance.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns><c>true</c> if the absolute value is less than <see cref="DefaultEpsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// double threshold = 0.0000000001;
+    /// if (threshold.IsApproximatelyZero())
+    /// {
+    ///     // Treat as zero
+    /// }
+    /// </code>
+    /// </example>
+    public static bool IsApproximatelyZero(this double value)
+    {
+        return Math.Abs(value) < DefaultEpsilon;
+    }
+
+    /// <summary>
+    /// Determines whether the double value is approximately zero within the specified tolerance.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="epsilon">The tolerance for the comparison. Must be positive.</param>
+    /// <returns><c>true</c> if the absolute value is less than <paramref name="epsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// double threshold = 0.0001;
+    /// const double customEpsilon = 1e-3;
+    /// if (threshold.IsApproximatelyZero(customEpsilon))
+    /// {
+    ///     // Treat as zero with custom precision
+    /// }
+    /// </code>
+    /// </example>
+    public static bool IsApproximatelyZero(this double value, double epsilon)
+    {
+        return Math.Abs(value) < epsilon;
+    }
+
+    /// <summary>
+    /// Determines whether two double values are approximately equal within the default tolerance.
+    /// </summary>
+    /// <param name="value">The first value to compare.</param>
+    /// <param name="other">The second value to compare.</param>
+    /// <returns><c>true</c> if the absolute difference is less than <see cref="DefaultEpsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// double a = 1.0;
+    /// double b = 1.0000000001;
+    /// if (a.ApproximatelyEquals(b))
+    /// {
+    ///     // Values are considered equal
+    /// }
+    /// </code>
+    /// </example>
+    public static bool ApproximatelyEquals(this double value, double other)
+    {
+        return Math.Abs(value - other) < DefaultEpsilon;
+    }
+
+    /// <summary>
+    /// Determines whether two double values are approximately equal within the specified tolerance.
+    /// </summary>
+    /// <param name="value">The first value to compare.</param>
+    /// <param name="other">The second value to compare.</param>
+    /// <param name="epsilon">The tolerance for the comparison. Must be positive.</param>
+    /// <returns><c>true</c> if the absolute difference is less than <paramref name="epsilon"/>; otherwise, <c>false</c>.</returns>
+    /// <example>
+    /// <code>
+    /// double a = 1.0;
+    /// double b = 1.001;
+    /// const double customEpsilon = 0.01;
+    /// if (a.ApproximatelyEquals(b, customEpsilon))
+    /// {
+    ///     // Values are considered equal with custom precision
+    /// }
+    /// </code>
+    /// </example>
+    public static bool ApproximatelyEquals(this double value, double other, double epsilon)
+    {
+        return Math.Abs(value - other) < epsilon;
+    }
+}


### PR DESCRIPTION
## Summary
- Extend FloatEqualityAnalyzer to detect double equality comparisons
- Add DoubleExtensions class with tolerance-based comparison methods

## Details

### FloatEqualityAnalyzer Enhancement
The analyzer now detects equality comparisons (`==` and `!=`) for both:
- `float` (System.Single)
- `double` (System.Double)

Previously only `float` comparisons were detected, leaving `double` comparisons unchecked.

### DoubleExtensions Class
Added new extension methods for `double` type in `KeenEyes.Common.DoubleExtensions`:

| Method | Description |
|--------|-------------|
| `IsApproximatelyZero()` | Check if value is close to zero (epsilon: 1e-9) |
| `IsApproximatelyZero(epsilon)` | Check with custom tolerance |
| `ApproximatelyEquals(other)` | Compare two doubles for near-equality |
| `ApproximatelyEquals(other, epsilon)` | Compare with custom tolerance |

The default epsilon (1e-9) provides higher precision than float (1e-6).

## Test plan
- [x] Build passes with zero warnings
- [x] All tests pass (9806 passed, 8 skipped)

## Related
Addresses HIGH priority finding from nightly code review #604