### PR TITLE
fix: Address bugs and code quality issues from nightly reviews

### DIFF
--- a/samples/KeenEyes.Sample.Aot/Program.cs
+++ b/samples/KeenEyes.Sample.Aot/Program.cs
@@ -118,6 +118,24 @@ Console.WriteLine("Native AOT sample completed successfully!");
 // ============================================================================
 // Component Definitions (AOT-compatible)
 // ============================================================================
+// Note: There are TWO ways to define components in KeenEyes:
+//
+// 1. [Component] attribute (RECOMMENDED):
+//    [Component]
+//    public partial struct Position { public float X, Y; }
+//
+//    The source generator will implement IComponent automatically and
+//    generate fluent builder methods like WithPosition().
+//
+// 2. Explicit IComponent (shown below):
+//    public struct Position : IComponent { public float X, Y; }
+//
+//    This is also AOT-compatible and demonstrates that no reflection is
+//    used. Useful when you want full control or minimal generated code.
+//
+// Both approaches are equally AOT-compatible. The [Component] attribute is
+// recommended for most use cases as it generates helpful extension methods.
+// ============================================================================
 
 /// <summary>Position component for 2D coordinates.</summary>
 public struct Position : IComponent

--- a/samples/KeenEyes.Sample.Physics/Program.cs
+++ b/samples/KeenEyes.Sample.Physics/Program.cs
@@ -126,7 +126,7 @@ void RunFallingObjectsDemo()
         simTime += dt;
 
         // Print positions every 0.5 seconds
-        if (Math.Abs(simTime % 0.5f) < dt)
+        if (Math.Abs(simTime % 0.5f).IsApproximatelyZero(dt))
         {
             Console.WriteLine($"  t={simTime:F1}s:");
             PrintEntityPosition(world, rubberBall, "    Rubber Ball");


### PR DESCRIPTION
## Summary

- **#465**: Fixed float comparison in Physics sample to use tolerance-based `IsApproximatelyZero()` method
- **#466**: Fixed BundleGenerator nested bundle flattening - ComponentTypes, Query, With/Without now properly expand nested bundles to component types
- **#467**: Added documentation in AOT sample explaining both component definition approaches
- **#468**: Fixed MixinGenerator diamond dependency false positive by deduplicating fields before conflict detection
- **#469**: Added KEEN032 diagnostic when bundles exceed the 4-component Query<T>() limit

## Test plan

- [x] All 9,896 tests pass
- [x] Build succeeds with 0 warnings, 0 errors
- [x] Manual verification of each fix

## Related Issues

Closes #465
Closes #466
Closes #467
Closes #468
Closes #469