### PR TITLE
fix: Address bugs and code quality issues from nightly reviews

### DIFF
--- a/samples/KeenEyes.Sample.RenderingCulling/Program.cs
+++ b/samples/KeenEyes.Sample.RenderingCulling/Program.cs
@@ -208,6 +208,7 @@ public class CameraOrbitSystem(Entity cameraEntity) : SystemBase
 public class FrustumCullingRenderSystem(Entity cameraEntity, RenderingStats stats) : SystemBase
 {
     private SpatialQueryApi? spatial;
+    private readonly List<Entity> visibleEntities = [];  // Reused to avoid per-frame allocation
 
     protected override void OnInitialize()
     {
@@ -236,7 +237,7 @@ public class FrustumCullingRenderSystem(Entity cameraEntity, RenderingStats stat
         var frustum = Frustum.FromMatrix(viewProj);
 
         // Broadphase: query entities in frustum
-        var visibleEntities = new List<Entity>();
+        visibleEntities.Clear();  // Clear and reuse to avoid allocation
         foreach (var entity in spatial!.QueryFrustum<Renderable>(frustum))
         {
             stats.BroadphaseCandidates++;


### PR DESCRIPTION
## Summary

This PR addresses multiple bugs and code quality issues identified in nightly code reviews:

- **#465**: Fixed float comparison in Physics sample to use tolerance-based `IsApproximatelyZero()` method
- **#466**: Fixed BundleGenerator nested bundle flattening - ComponentTypes, Query, With/Without now properly expand nested bundles to component types. GetBundle and BundleRef skip generation for bundles with nesting (with explanatory comment)
- **#467**: Added documentation in AOT sample explaining both component definition approaches (`[Component]` attribute vs explicit `IComponent`)
- **#468**: Fixed MixinGenerator diamond dependency false positive by deduplicating fields by `(Name, Type, SourceMixin)` before conflict detection
- **#469**: Added KEEN032 diagnostic when bundles exceed the 4-component Query<T>() limit, guiding users to QueryBuilder API
- **Hot path allocation**: Fixed per-frame List<Entity> allocation in RenderingCulling sample by reusing a field

## Test plan

- [x] All 9,896 tests pass
- [x] Build succeeds with 0 warnings, 0 errors
- [x] Manual verification of each fix

## Related Issues

Closes #465
Closes #466
Closes #467
Closes #468
Closes #469