### PR TITLE
refactor: Extract magic numbers to named constants in tests

### DIFF
--- a/tests/KeenEyes.Core.Tests/AddComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/AddComponentTests.cs
@@ -136,7 +136,7 @@ public class AddComponentTests
     public void Add_ThrowsInvalidOperationException_WhenEntityNotAlive()
     {
         using var world = new World();
-        var deadEntity = new Entity(999, 1);
+        var deadEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             world.Add(deadEntity, new TestPosition { X = 0f, Y = 0f }));

--- a/tests/KeenEyes.Core.Tests/ArchetypeManagerAdditionalTests.cs
+++ b/tests/KeenEyes.Core.Tests/ArchetypeManagerAdditionalTests.cs
@@ -206,7 +206,7 @@ public class ArchetypeManagerAdditionalTests
 
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             manager.AddComponentBoxed(entity, typeof(Position), new Position()));
@@ -242,7 +242,7 @@ public class ArchetypeManagerAdditionalTests
 
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             manager.SetBoxed(entity, typeof(Position), new Position()));
@@ -284,7 +284,7 @@ public class ArchetypeManagerAdditionalTests
 
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var removed = manager.RemoveComponent(entity, typeof(Position));
 
@@ -349,7 +349,7 @@ public class ArchetypeManagerAdditionalTests
 
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.False(manager.Has(entity, typeof(Position)));
     }
@@ -382,7 +382,7 @@ public class ArchetypeManagerAdditionalTests
         var registry = new ComponentRegistry();
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var found = manager.TryGetEntityLocation(entity, out var archetype, out var index);
 
@@ -418,7 +418,7 @@ public class ArchetypeManagerAdditionalTests
         var registry = new ComponentRegistry();
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             manager.GetEntityLocation(entity));
@@ -453,7 +453,7 @@ public class ArchetypeManagerAdditionalTests
         var registry = new ComponentRegistry();
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var removed = manager.RemoveEntity(entity);
 
@@ -535,7 +535,7 @@ public class ArchetypeManagerAdditionalTests
 
         using var manager = new ArchetypeManager(registry);
 
-        var entity = new Entity(999, 1);
+        var entity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             manager.AddComponent(entity, new Position()));

--- a/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
+++ b/tests/KeenEyes.Core.Tests/ArchetypeTests.cs
@@ -541,7 +541,7 @@ public class ArchetypeTests
         registry.Register<Position>();
         var manager = new ArchetypeManager(registry);
 
-        var result = manager.TryGetEntityLocation(new Entity(999, 1), out var archetype, out var index);
+        var result = manager.TryGetEntityLocation(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion), out var archetype, out var index);
 
         Assert.False(result);
         Assert.Null(archetype);
@@ -554,7 +554,7 @@ public class ArchetypeTests
         var registry = new ComponentRegistry();
         var manager = new ArchetypeManager(registry);
 
-        var types = manager.GetComponentTypes(new Entity(999, 1));
+        var types = manager.GetComponentTypes(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion));
 
         Assert.Empty(types);
     }
@@ -565,7 +565,7 @@ public class ArchetypeTests
         var registry = new ComponentRegistry();
         var manager = new ArchetypeManager(registry);
 
-        var components = manager.GetComponents(new Entity(999, 1)).ToList();
+        var components = manager.GetComponents(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)).ToList();
 
         Assert.Empty(components);
     }
@@ -576,7 +576,7 @@ public class ArchetypeTests
         var registry = new ComponentRegistry();
         var manager = new ArchetypeManager(registry);
 
-        Assert.False(manager.IsTracked(new Entity(999, 1)));
+        Assert.False(manager.IsTracked(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)));
     }
 
     [Fact]
@@ -607,7 +607,7 @@ public class ArchetypeTests
         registry.Register<Position>();
         var manager = new ArchetypeManager(registry);
 
-        Assert.False(manager.Has<Position>(new Entity(999, 1)));
+        Assert.False(manager.Has<Position>(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)));
     }
 
     #endregion
@@ -753,7 +753,7 @@ public class ArchetypeTests
         var manager = new ArchetypeManager(registry);
         var archetype = manager.GetOrCreateArchetype([typeof(Position)]);
 
-        var result = archetype.RemoveEntity(new Entity(999, 1));
+        var result = archetype.RemoveEntity(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion));
 
         Assert.Null(result);
     }
@@ -766,7 +766,7 @@ public class ArchetypeTests
         var manager = new ArchetypeManager(registry);
         var archetype = manager.GetOrCreateArchetype([typeof(Position)]);
 
-        var index = archetype.GetEntityIndex(new Entity(999, 1));
+        var index = archetype.GetEntityIndex(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion));
 
         Assert.Equal(-1, index);
     }
@@ -1074,7 +1074,7 @@ public class ArchetypeTests
         var manager = new ArchetypeManager(registry);
         var archetype = manager.GetOrCreateArchetype([typeof(Position)]);
 
-        var (chunkIndex, indexInChunk) = archetype.GetEntityLocation(new Entity(999, 1));
+        var (chunkIndex, indexInChunk) = archetype.GetEntityLocation(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion));
 
         Assert.Equal(-1, chunkIndex);
         Assert.Equal(-1, indexInChunk);
@@ -1511,7 +1511,7 @@ public class ArchetypeTests
     {
         var registry = new ComponentRegistry();
 
-        var result = registry.GetById(new ComponentId(999));
+        var result = registry.GetById(new ComponentId(TestConstants.InvalidComponentId));
 
         Assert.Null(result);
     }

--- a/tests/KeenEyes.Core.Tests/CommandBufferPoolTests.cs
+++ b/tests/KeenEyes.Core.Tests/CommandBufferPoolTests.cs
@@ -519,7 +519,7 @@ public class CommandBufferPoolTests
             {
                 for (var i = 0; i < iterations; i++)
                 {
-                    pool.Rent(i + 1000); // Use high IDs to avoid conflicts
+                    pool.Rent(i + TestConstants.ConcurrentTestHighIdOffset); // Use high IDs to avoid conflicts
                     Thread.SpinWait(10);
                 }
             }

--- a/tests/KeenEyes.Core.Tests/CommandBufferTests.cs
+++ b/tests/KeenEyes.Core.Tests/CommandBufferTests.cs
@@ -184,7 +184,7 @@ public class CommandBufferTests
         using var world = new World();
         var buffer = new CommandBuffer();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         buffer.Despawn(nonExistentEntity);
 
         // Should not throw
@@ -261,7 +261,7 @@ public class CommandBufferTests
         using var world = new World();
         var buffer = new CommandBuffer();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         buffer.AddComponent(nonExistentEntity, new TestVelocity { X = 1f, Y = 1f });
 
         // Should not throw
@@ -352,7 +352,7 @@ public class CommandBufferTests
         using var world = new World();
         var buffer = new CommandBuffer();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         buffer.RemoveComponent<TestVelocity>(nonExistentEntity);
 
         // Should not throw
@@ -1018,7 +1018,7 @@ public class CommandBufferTests
         using var world = new World();
         var buffer = new CommandBuffer();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         buffer.SetComponent(nonExistentEntity, new TestPosition { X = 100f, Y = 100f });
 
         // Should not throw

--- a/tests/KeenEyes.Core.Tests/EdgeCaseTests.cs
+++ b/tests/KeenEyes.Core.Tests/EdgeCaseTests.cs
@@ -703,7 +703,7 @@ public class EdgeCaseTests
     {
         var pool = new EntityPool();
 
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         var result = pool.Release(invalidEntity);
 
         Assert.False(result);
@@ -725,7 +725,7 @@ public class EdgeCaseTests
     {
         var pool = new EntityPool();
 
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         var result = pool.IsValid(invalidEntity);
 
         Assert.False(result);

--- a/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
@@ -385,7 +385,7 @@ public class WorldHasTests
     public void Has_InvalidEntity_ReturnsFalse()
     {
         using var world = new World();
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.False(world.Has<BuilderTestPosition>(invalidEntity));
     }
@@ -450,7 +450,7 @@ public class WorldDespawnTests
     public void Despawn_InvalidEntity_ReturnsFalse()
     {
         using var world = new World();
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var result = world.Despawn(invalidEntity);
 

--- a/tests/KeenEyes.Core.Tests/EntityNamingTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityNamingTests.cs
@@ -188,7 +188,7 @@ public class EntityNamingTests
     public void GetName_InvalidEntity_ReturnsNull()
     {
         using var world = new World();
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var name = world.GetName(invalidEntity);
 

--- a/tests/KeenEyes.Core.Tests/GetComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/GetComponentTests.cs
@@ -129,7 +129,7 @@ public class GetComponentTests
     {
         using var world = new World();
         world.Components.Register<TestPosition>();
-        var deadEntity = new Entity(999, 1);
+        var deadEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             world.Get<TestPosition>(deadEntity));

--- a/tests/KeenEyes.Core.Tests/GetComponentsTests.cs
+++ b/tests/KeenEyes.Core.Tests/GetComponentsTests.cs
@@ -114,7 +114,7 @@ public class GetComponentsTests
         using var world = new World();
         world.Components.Register<TestPosition>();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var components = world.GetComponents(nonExistentEntity);
 

--- a/tests/KeenEyes.Core.Tests/HasComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/HasComponentTests.cs
@@ -113,7 +113,7 @@ public class HasComponentTests
         using var world = new World();
         world.Components.Register<TestPosition>();
 
-        var nonExistentEntity = new Entity(999, 1);
+        var nonExistentEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var hasPosition = world.Has<TestPosition>(nonExistentEntity);
 

--- a/tests/KeenEyes.Core.Tests/InternalApiTests.cs
+++ b/tests/KeenEyes.Core.Tests/InternalApiTests.cs
@@ -110,7 +110,7 @@ public class InternalApiTests
         using var world = new World();
 
         // Create a fake entity that doesn't exist
-        var unknownEntity = new Entity(999, 1);
+        var unknownEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             world.ArchetypeManager.AddComponent(unknownEntity, new Position()));
@@ -135,7 +135,7 @@ public class InternalApiTests
     {
         using var world = new World();
 
-        var unknownEntity = new Entity(999, 1);
+        var unknownEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         Assert.Throws<InvalidOperationException>(() =>
             world.ArchetypeManager.GetEntityLocation(unknownEntity));
@@ -618,7 +618,7 @@ public class InternalApiTests
         pool.Acquire();
 
         // Try to release an entity with an ID beyond what was allocated
-        var outOfRangeEntity = new Entity(999, 1);
+        var outOfRangeEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
         var result = pool.Release(outOfRangeEntity);
 
         Assert.False(result);

--- a/tests/KeenEyes.Core.Tests/PoolingTests.cs
+++ b/tests/KeenEyes.Core.Tests/PoolingTests.cs
@@ -396,7 +396,7 @@ public class PoolingTests
                 // Wait for release
                 while (Interlocked.CompareExchange(ref releaseComplete, 0, 0) == 0)
                 {
-                    Thread.Sleep(1);
+                    Thread.Sleep(TestConstants.ThreadSleepShortMs);
                 }
 
                 // Check after release
@@ -1464,7 +1464,7 @@ public class PoolingTests
         chunk.AddComponent(new TestPosition());
 
         Assert.True(chunk.Contains(entity));
-        Assert.False(chunk.Contains(new Entity(999, 1)));
+        Assert.False(chunk.Contains(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)));
     }
 
     [Fact]
@@ -1477,7 +1477,7 @@ public class PoolingTests
         chunk.AddComponent(new TestPosition());
 
         Assert.Equal(0, chunk.GetEntityIndex(entity));
-        Assert.Equal(-1, chunk.GetEntityIndex(new Entity(999, 1)));
+        Assert.Equal(-1, chunk.GetEntityIndex(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)));
     }
 
     [Fact]
@@ -1598,7 +1598,7 @@ public class PoolingTests
         var archetypeId = new ArchetypeId([typeof(TestPosition)]);
         var chunk = new ArchetypeChunk(archetypeId, [testPositionInfo]);
 
-        var result = chunk.RemoveEntity(new Entity(999, 1));
+        var result = chunk.RemoveEntity(new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion));
 
         Assert.Null(result);
     }

--- a/tests/KeenEyes.Core.Tests/QueryCachingTests.cs
+++ b/tests/KeenEyes.Core.Tests/QueryCachingTests.cs
@@ -648,7 +648,7 @@ public class QueryCachingTests
         description.AddWrite<Position>();
 
         const int threadCount = 10;
-        const int iterationsPerThread = 1000;
+        const int iterationsPerThread = TestConstants.ConcurrentIterationsPerThread;
         var exceptions = new List<Exception>();
         var exceptionLock = new object();
 
@@ -750,9 +750,9 @@ public class QueryCachingTests
         {
             try
             {
-                Thread.Sleep(10); // Let readers start first
+                Thread.Sleep(TestConstants.ThreadSleepMediumMs); // Let readers start first
                 manager.GetOrCreateArchetype([typeof(Position), typeof(Velocity)]);
-                Thread.Sleep(10);
+                Thread.Sleep(TestConstants.ThreadSleepMediumMs);
                 manager.GetOrCreateArchetype([typeof(Position), typeof(Health)]);
             }
             catch (Exception ex)

--- a/tests/KeenEyes.Core.Tests/RemoveComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/RemoveComponentTests.cs
@@ -148,7 +148,7 @@ public class RemoveComponentTests
     public void Remove_ReturnsFalse_WhenEntityNotAlive()
     {
         using var world = new World();
-        var deadEntity = new Entity(999, 1);
+        var deadEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         bool removed = world.Remove<TestPosition>(deadEntity);
 

--- a/tests/KeenEyes.Core.Tests/SaveManagerTests.cs
+++ b/tests/KeenEyes.Core.Tests/SaveManagerTests.cs
@@ -107,7 +107,7 @@ public class SaveManagerTests : IDisposable
         var createdAt = info1.CreatedAt;
 
         // Wait a bit and save again
-        Thread.Sleep(50);
+        Thread.Sleep(TestConstants.ThreadSleepLongMs);
         var info2 = world.SaveToSlot("slot1", serializer);
 
         Assert.Equal(createdAt.ToUnixTimeMilliseconds(), info2.CreatedAt.ToUnixTimeMilliseconds());

--- a/tests/KeenEyes.Core.Tests/SetComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/SetComponentTests.cs
@@ -146,7 +146,7 @@ public class SetComponentTests
     {
         using var world = new World();
         world.Components.Register<TestPosition>();
-        var deadEntity = new Entity(999, 1);
+        var deadEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             world.Set(deadEntity, new TestPosition { X = 0f, Y = 0f }));

--- a/tests/KeenEyes.Core.Tests/StringTagTests.cs
+++ b/tests/KeenEyes.Core.Tests/StringTagTests.cs
@@ -328,7 +328,7 @@ public class StringTagTests
     public void GetTags_InvalidEntity_ReturnsEmptyCollection()
     {
         using var world = new World();
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var tags = world.GetTags(invalidEntity);
 

--- a/tests/KeenEyes.Core.Tests/TestConstants.cs
+++ b/tests/KeenEyes.Core.Tests/TestConstants.cs
@@ -1,0 +1,68 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Constants used throughout the test suite to replace magic numbers
+/// and provide meaningful context for test values.
+/// </summary>
+public static class TestConstants
+{
+    /// <summary>
+    /// An entity ID that is guaranteed to not exist in any test world.
+    /// Used to test operations against non-existent entities.
+    /// </summary>
+    public const int InvalidEntityId = 999;
+
+    /// <summary>
+    /// Default version number for entities, typically used when creating
+    /// Entity instances that represent non-existent or dead entities.
+    /// </summary>
+    public const int DefaultEntityVersion = 1;
+
+    /// <summary>
+    /// A ComponentId value that is guaranteed to not exist in any test registry.
+    /// Used to test operations against non-existent component types.
+    /// </summary>
+    public const int InvalidComponentId = 999;
+
+    /// <summary>
+    /// High ID offset used in concurrent tests to avoid ID conflicts
+    /// between threads allocating from different ranges.
+    /// </summary>
+    public const int ConcurrentTestHighIdOffset = 1000;
+
+    /// <summary>
+    /// Number of entities to create for standard batch operations in tests.
+    /// Used when testing iteration, bulk operations, or moderate scale.
+    /// </summary>
+    public const int StandardBatchSize = 100;
+
+    /// <summary>
+    /// Number of entities for small-scale tests or quick iterations.
+    /// </summary>
+    public const int SmallBatchSize = 10;
+
+    /// <summary>
+    /// Number of entities for large-scale stress tests or performance scenarios.
+    /// </summary>
+    public const int LargeBatchSize = 1000;
+
+    /// <summary>
+    /// Short delay in milliseconds for thread synchronization in tests.
+    /// </summary>
+    public const int ThreadSleepShortMs = 1;
+
+    /// <summary>
+    /// Medium delay in milliseconds for thread synchronization in tests.
+    /// </summary>
+    public const int ThreadSleepMediumMs = 10;
+
+    /// <summary>
+    /// Longer delay in milliseconds for ensuring operations complete in tests.
+    /// </summary>
+    public const int ThreadSleepLongMs = 50;
+
+    /// <summary>
+    /// Number of iterations per thread in concurrent tests.
+    /// </summary>
+    public const int ConcurrentIterationsPerThread = 1000;
+}

--- a/tests/KeenEyes.Core.Tests/WorldTests.cs
+++ b/tests/KeenEyes.Core.Tests/WorldTests.cs
@@ -43,7 +43,7 @@ public class WorldTests
     public void World_IsAlive_ReturnsFalse_ForInvalidEntity()
     {
         using var world = new World();
-        var invalidEntity = new Entity(999, 1);
+        var invalidEntity = new Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion);
 
         var isAlive = world.IsAlive(invalidEntity);
 


### PR DESCRIPTION
## Summary
- Create `TestConstants.cs` with meaningful constants to replace unexplained magic numbers
- Replace `Entity(999, 1)` pattern with `Entity(TestConstants.InvalidEntityId, TestConstants.DefaultEntityVersion)` across 19 test files
- Replace `ComponentId(999)` with `TestConstants.InvalidComponentId`
- Replace Thread.Sleep magic values with named constants
- Replace concurrent test high ID offset (1000) with `TestConstants.ConcurrentTestHighIdOffset`

## Test plan
- [x] All 2131 tests pass
- [x] Build succeeds with zero warnings
- [x] Code formatted correctly

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)