### PR TITLE
feat(editor): Add Phase 2 capability interfaces (#648, #649, #650)

### DIFF
--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IInspectorCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IInspectorCapability.cs
@@ -1,0 +1,163 @@
+using KeenEyes.Editor.Abstractions.Inspector;
+
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for customizing the inspector panel.
+/// Allows plugins to register custom property drawers, component inspectors, and actions.
+/// </summary>
+public interface IInspectorCapability : IEditorCapability
+{
+    /// <summary>
+    /// Registers a property drawer for a specific field type.
+    /// </summary>
+    /// <param name="fieldType">The field type to handle.</param>
+    /// <param name="drawer">The drawer instance.</param>
+    void RegisterPropertyDrawer(Type fieldType, PropertyDrawer drawer);
+
+    /// <summary>
+    /// Registers a property drawer for a specific field type.
+    /// </summary>
+    /// <typeparam name="T">The field type to handle.</typeparam>
+    /// <param name="drawer">The drawer instance.</param>
+    void RegisterPropertyDrawer<T>(PropertyDrawer drawer);
+
+    /// <summary>
+    /// Registers a property drawer for fields decorated with a specific attribute.
+    /// </summary>
+    /// <typeparam name="TAttribute">The attribute type to match.</typeparam>
+    /// <param name="drawer">The drawer instance.</param>
+    void RegisterDrawerForAttribute<TAttribute>(PropertyDrawer drawer) where TAttribute : Attribute;
+
+    /// <summary>
+    /// Registers a custom inspector for a specific component type.
+    /// </summary>
+    /// <typeparam name="TComponent">The component type.</typeparam>
+    /// <param name="inspector">The custom inspector.</param>
+    void RegisterComponentInspector<TComponent>(IComponentInspector inspector) where TComponent : struct, IComponent;
+
+    /// <summary>
+    /// Registers context menu actions for a specific component type.
+    /// </summary>
+    /// <typeparam name="TComponent">The component type.</typeparam>
+    /// <param name="provider">The action provider.</param>
+    void RegisterComponentActions<TComponent>(IComponentActionProvider provider) where TComponent : struct, IComponent;
+
+    /// <summary>
+    /// Gets the property drawer registry for direct access.
+    /// </summary>
+    IPropertyDrawerRegistry PropertyDrawers { get; }
+}
+
+/// <summary>
+/// Interface for custom component inspectors that replace the default component display.
+/// </summary>
+public interface IComponentInspector
+{
+    /// <summary>
+    /// Creates the UI for inspecting a component instance.
+    /// </summary>
+    /// <param name="context">The inspector context.</param>
+    /// <param name="componentValue">The current component value.</param>
+    /// <returns>The root entity of the inspector UI.</returns>
+    Entity CreateUI(ComponentInspectorContext context, object componentValue);
+
+    /// <summary>
+    /// Updates the inspector UI with new component values.
+    /// </summary>
+    /// <param name="context">The inspector context.</param>
+    /// <param name="rootEntity">The root entity returned by CreateUI.</param>
+    /// <param name="componentValue">The new component value.</param>
+    void UpdateUI(ComponentInspectorContext context, Entity rootEntity, object componentValue);
+}
+
+/// <summary>
+/// Context provided to component inspectors for creating UI.
+/// </summary>
+public sealed class ComponentInspectorContext
+{
+    /// <summary>
+    /// Gets the editor world for creating UI entities.
+    /// </summary>
+    public required IWorld EditorWorld { get; init; }
+
+    /// <summary>
+    /// Gets the parent entity to add UI widgets to.
+    /// </summary>
+    public required Entity Parent { get; init; }
+
+    /// <summary>
+    /// Gets the entity being inspected.
+    /// </summary>
+    public required Entity InspectedEntity { get; init; }
+
+    /// <summary>
+    /// Gets the component type being inspected.
+    /// </summary>
+    public required Type ComponentType { get; init; }
+
+    /// <summary>
+    /// Called when the component value changes.
+    /// </summary>
+    public Action<object>? OnValueChanged { get; init; }
+}
+
+/// <summary>
+/// Interface for providing context menu actions for components in the inspector.
+/// </summary>
+public interface IComponentActionProvider
+{
+    /// <summary>
+    /// Gets the context menu actions for a component.
+    /// </summary>
+    /// <param name="context">The action context.</param>
+    /// <returns>The available actions.</returns>
+    IEnumerable<ComponentAction> GetActions(ComponentActionContext context);
+}
+
+/// <summary>
+/// Context for component actions.
+/// </summary>
+public sealed class ComponentActionContext
+{
+    /// <summary>
+    /// Gets the entity that has the component.
+    /// </summary>
+    public required Entity Entity { get; init; }
+
+    /// <summary>
+    /// Gets the current component value.
+    /// </summary>
+    public required object ComponentValue { get; init; }
+
+    /// <summary>
+    /// Gets the editor context for accessing editor services.
+    /// </summary>
+    public required IEditorContext EditorContext { get; init; }
+}
+
+/// <summary>
+/// Represents an action that can be performed on a component.
+/// </summary>
+public sealed class ComponentAction
+{
+    /// <summary>
+    /// Gets the display name of the action.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the action to execute.
+    /// </summary>
+    public required Action Execute { get; init; }
+
+    /// <summary>
+    /// Gets whether the action is currently enabled.
+    /// </summary>
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Gets the optional icon for the action.
+    /// </summary>
+    public string? Icon { get; init; }
+}

--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IMenuCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IMenuCapability.cs
@@ -1,0 +1,295 @@
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for customizing editor menus and toolbars.
+/// Allows plugins to add menu items, context menus, and toolbar buttons.
+/// </summary>
+public interface IMenuCapability : IEditorCapability
+{
+    /// <summary>
+    /// Adds a menu item to the main menu bar.
+    /// </summary>
+    /// <param name="path">The menu path (e.g., "File/Export/Scene").</param>
+    /// <param name="command">The command to execute when clicked.</param>
+    void AddMenuItem(MenuPath path, EditorCommand command);
+
+    /// <summary>
+    /// Adds a context menu item that appears when right-clicking on specific types.
+    /// </summary>
+    /// <typeparam name="T">The target type for the context menu.</typeparam>
+    /// <param name="path">The menu path within the context menu.</param>
+    /// <param name="command">The command to execute when clicked.</param>
+    void AddContextMenuItem<T>(MenuPath path, EditorCommand<T> command);
+
+    /// <summary>
+    /// Adds a button to the editor toolbar.
+    /// </summary>
+    /// <param name="section">The toolbar section to add to.</param>
+    /// <param name="command">The command to execute when clicked.</param>
+    void AddToolbarButton(ToolbarSection section, EditorCommand command);
+
+    /// <summary>
+    /// Removes a menu item.
+    /// </summary>
+    /// <param name="path">The menu path to remove.</param>
+    /// <returns>True if the menu item was found and removed.</returns>
+    bool RemoveMenuItem(MenuPath path);
+
+    /// <summary>
+    /// Removes a toolbar button.
+    /// </summary>
+    /// <param name="commandId">The ID of the command to remove.</param>
+    /// <returns>True if the button was found and removed.</returns>
+    bool RemoveToolbarButton(string commandId);
+
+    /// <summary>
+    /// Gets all menu items at a given path.
+    /// </summary>
+    /// <param name="parentPath">The parent menu path.</param>
+    /// <returns>The child menu items.</returns>
+    IEnumerable<MenuItemInfo> GetMenuItems(MenuPath parentPath);
+}
+
+/// <summary>
+/// Represents a path in the menu hierarchy.
+/// </summary>
+public readonly struct MenuPath : IEquatable<MenuPath>
+{
+    private readonly string[] segments;
+
+    /// <summary>
+    /// Creates a new menu path from segments.
+    /// </summary>
+    /// <param name="segments">The path segments.</param>
+    public MenuPath(params string[] segments)
+    {
+        this.segments = segments ?? [];
+    }
+
+    /// <summary>
+    /// Creates a menu path from a string like "File/Export/Scene".
+    /// </summary>
+    /// <param name="path">The path string.</param>
+    /// <returns>The parsed menu path.</returns>
+    public static MenuPath Parse(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return new MenuPath([]);
+        }
+
+        return new MenuPath(path.Split('/'));
+    }
+
+    /// <summary>
+    /// Gets the path segments.
+    /// </summary>
+    public ReadOnlySpan<string> Segments => segments ?? [];
+
+    /// <summary>
+    /// Gets the parent path (all segments except the last).
+    /// </summary>
+    public MenuPath Parent => segments.Length > 1
+        ? new MenuPath(segments[..^1])
+        : new MenuPath([]);
+
+    /// <summary>
+    /// Gets the final segment (the menu item name).
+    /// </summary>
+    public string Name => segments.Length > 0 ? segments[^1] : string.Empty;
+
+    /// <summary>
+    /// Gets whether this is a root-level menu.
+    /// </summary>
+    public bool IsRoot => segments.Length <= 1;
+
+    /// <summary>
+    /// Gets the full path as a string.
+    /// </summary>
+    public override string ToString() => string.Join("/", segments ?? []);
+
+    /// <inheritdoc/>
+    public bool Equals(MenuPath other) =>
+        segments.SequenceEqual(other.segments ?? []);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is MenuPath other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var segment in segments ?? [])
+        {
+            hash.Add(segment);
+        }
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Implicit conversion from string.
+    /// </summary>
+    public static implicit operator MenuPath(string path) => Parse(path);
+
+    /// <summary>
+    /// Equality operator.
+    /// </summary>
+    public static bool operator ==(MenuPath left, MenuPath right) => left.Equals(right);
+
+    /// <summary>
+    /// Inequality operator.
+    /// </summary>
+    public static bool operator !=(MenuPath left, MenuPath right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Represents an editor command that can be invoked from menus or buttons.
+/// </summary>
+public class EditorCommand
+{
+    /// <summary>
+    /// Gets the unique identifier for this command.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the display name of the command.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the action to execute.
+    /// </summary>
+    public required Action Execute { get; init; }
+
+    /// <summary>
+    /// Gets a function that determines if the command can be executed.
+    /// </summary>
+    public Func<bool>? CanExecute { get; init; }
+
+    /// <summary>
+    /// Gets the optional keyboard shortcut.
+    /// </summary>
+    public string? Shortcut { get; init; }
+
+    /// <summary>
+    /// Gets the optional icon identifier.
+    /// </summary>
+    public string? Icon { get; init; }
+
+    /// <summary>
+    /// Gets the optional tooltip text.
+    /// </summary>
+    public string? Tooltip { get; init; }
+}
+
+/// <summary>
+/// Represents an editor command that operates on a specific target type.
+/// Used for context menu commands where an action needs a target object.
+/// </summary>
+/// <typeparam name="T">The target type.</typeparam>
+public sealed class EditorCommand<T>
+{
+    /// <summary>
+    /// Gets the unique identifier for this command.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the display name of the command.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the action to execute with the target.
+    /// </summary>
+    public required Action<T> Execute { get; init; }
+
+    /// <summary>
+    /// Gets a function that determines if the command can be executed on a target.
+    /// </summary>
+    public Func<T, bool>? CanExecute { get; init; }
+
+    /// <summary>
+    /// Gets the optional keyboard shortcut.
+    /// </summary>
+    public string? Shortcut { get; init; }
+
+    /// <summary>
+    /// Gets the optional icon identifier.
+    /// </summary>
+    public string? Icon { get; init; }
+
+    /// <summary>
+    /// Gets the optional tooltip text.
+    /// </summary>
+    public string? Tooltip { get; init; }
+}
+
+/// <summary>
+/// Defines standard toolbar sections.
+/// </summary>
+public enum ToolbarSection
+{
+    /// <summary>
+    /// File operations (save, load, etc.).
+    /// </summary>
+    File,
+
+    /// <summary>
+    /// Edit operations (undo, redo, etc.).
+    /// </summary>
+    Edit,
+
+    /// <summary>
+    /// Play mode controls.
+    /// </summary>
+    PlayMode,
+
+    /// <summary>
+    /// Transform tools (move, rotate, scale).
+    /// </summary>
+    Tools,
+
+    /// <summary>
+    /// View options (grid, gizmos, etc.).
+    /// </summary>
+    View,
+
+    /// <summary>
+    /// Custom plugin section.
+    /// </summary>
+    Custom
+}
+
+/// <summary>
+/// Information about a registered menu item.
+/// </summary>
+public sealed class MenuItemInfo
+{
+    /// <summary>
+    /// Gets the menu path.
+    /// </summary>
+    public required MenuPath Path { get; init; }
+
+    /// <summary>
+    /// Gets the associated command.
+    /// </summary>
+    public required EditorCommand Command { get; init; }
+
+    /// <summary>
+    /// Gets whether this item has children (is a submenu).
+    /// </summary>
+    public bool HasChildren { get; init; }
+
+    /// <summary>
+    /// Gets the order priority for sorting.
+    /// </summary>
+    public int Priority { get; init; }
+
+    /// <summary>
+    /// Gets whether to show a separator before this item.
+    /// </summary>
+    public bool SeparatorBefore { get; init; }
+}

--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IPanelCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IPanelCapability.cs
@@ -1,0 +1,225 @@
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for registering and managing editor panels.
+/// Allows plugins to add custom panels to the editor layout.
+/// </summary>
+public interface IPanelCapability : IEditorCapability
+{
+    /// <summary>
+    /// Registers a panel type with the editor.
+    /// </summary>
+    /// <typeparam name="T">The panel type.</typeparam>
+    /// <param name="descriptor">The panel descriptor.</param>
+    void RegisterPanel<T>(PanelDescriptor descriptor) where T : IEditorPanel, new();
+
+    /// <summary>
+    /// Registers a panel type with the editor using a factory.
+    /// </summary>
+    /// <param name="descriptor">The panel descriptor.</param>
+    /// <param name="factory">Factory function to create the panel.</param>
+    void RegisterPanel(PanelDescriptor descriptor, Func<IEditorPanel> factory);
+
+    /// <summary>
+    /// Opens a panel by its ID.
+    /// </summary>
+    /// <param name="id">The panel ID.</param>
+    void OpenPanel(string id);
+
+    /// <summary>
+    /// Closes a panel by its ID.
+    /// </summary>
+    /// <param name="id">The panel ID.</param>
+    void ClosePanel(string id);
+
+    /// <summary>
+    /// Checks if a panel is currently open.
+    /// </summary>
+    /// <param name="id">The panel ID.</param>
+    /// <returns>True if the panel is open.</returns>
+    bool IsPanelOpen(string id);
+
+    /// <summary>
+    /// Focuses a panel, bringing it to the front.
+    /// </summary>
+    /// <param name="id">The panel ID.</param>
+    void FocusPanel(string id);
+
+    /// <summary>
+    /// Gets all registered panel descriptors.
+    /// </summary>
+    /// <returns>The panel descriptors.</returns>
+    IEnumerable<PanelDescriptor> GetPanelDescriptors();
+
+    /// <summary>
+    /// Gets the IDs of all currently open panels.
+    /// </summary>
+    /// <returns>The open panel IDs.</returns>
+    IEnumerable<string> GetOpenPanels();
+
+    /// <summary>
+    /// Event raised when a panel is opened.
+    /// </summary>
+    event Action<string>? PanelOpened;
+
+    /// <summary>
+    /// Event raised when a panel is closed.
+    /// </summary>
+    event Action<string>? PanelClosed;
+}
+
+/// <summary>
+/// Describes a panel that can be registered with the editor.
+/// </summary>
+public sealed class PanelDescriptor
+{
+    /// <summary>
+    /// Gets the unique identifier for this panel.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the display title of the panel.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets the optional icon identifier.
+    /// </summary>
+    public string? Icon { get; init; }
+
+    /// <summary>
+    /// Gets the default dock location for the panel.
+    /// </summary>
+    public PanelDockLocation DefaultLocation { get; init; } = PanelDockLocation.Right;
+
+    /// <summary>
+    /// Gets whether the panel should be open by default.
+    /// </summary>
+    public bool OpenByDefault { get; init; }
+
+    /// <summary>
+    /// Gets the minimum width of the panel.
+    /// </summary>
+    public float MinWidth { get; init; } = 200;
+
+    /// <summary>
+    /// Gets the minimum height of the panel.
+    /// </summary>
+    public float MinHeight { get; init; } = 100;
+
+    /// <summary>
+    /// Gets the default width of the panel.
+    /// </summary>
+    public float DefaultWidth { get; init; } = 300;
+
+    /// <summary>
+    /// Gets the default height of the panel.
+    /// </summary>
+    public float DefaultHeight { get; init; } = 400;
+
+    /// <summary>
+    /// Gets whether multiple instances of this panel can be opened.
+    /// </summary>
+    public bool AllowMultiple { get; init; }
+
+    /// <summary>
+    /// Gets the category for organizing panels in the View menu.
+    /// </summary>
+    public string? Category { get; init; }
+
+    /// <summary>
+    /// Gets the optional keyboard shortcut to toggle the panel.
+    /// </summary>
+    public string? ToggleShortcut { get; init; }
+}
+
+/// <summary>
+/// Default dock locations for panels.
+/// </summary>
+public enum PanelDockLocation
+{
+    /// <summary>
+    /// Left side of the editor.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Right side of the editor.
+    /// </summary>
+    Right,
+
+    /// <summary>
+    /// Bottom of the editor.
+    /// </summary>
+    Bottom,
+
+    /// <summary>
+    /// Top of the editor.
+    /// </summary>
+    Top,
+
+    /// <summary>
+    /// Center area (main content).
+    /// </summary>
+    Center,
+
+    /// <summary>
+    /// Floating window.
+    /// </summary>
+    Floating
+}
+
+/// <summary>
+/// Interface for editor panels.
+/// </summary>
+public interface IEditorPanel
+{
+    /// <summary>
+    /// Called when the panel is created.
+    /// </summary>
+    /// <param name="context">The panel context.</param>
+    void Initialize(PanelContext context);
+
+    /// <summary>
+    /// Called every frame to update the panel.
+    /// </summary>
+    /// <param name="deltaTime">Time since last update.</param>
+    void Update(float deltaTime);
+
+    /// <summary>
+    /// Called when the panel is closed.
+    /// </summary>
+    void Shutdown();
+
+    /// <summary>
+    /// Gets the root UI entity of the panel.
+    /// </summary>
+    Entity RootEntity { get; }
+}
+
+/// <summary>
+/// Context provided to panels during initialization.
+/// </summary>
+public sealed class PanelContext
+{
+    /// <summary>
+    /// Gets the editor context for accessing editor services.
+    /// </summary>
+    public required IEditorContext EditorContext { get; init; }
+
+    /// <summary>
+    /// Gets the editor world for creating UI entities.
+    /// </summary>
+    public required IWorld EditorWorld { get; init; }
+
+    /// <summary>
+    /// Gets the parent entity to add panel content to.
+    /// </summary>
+    public required Entity Parent { get; init; }
+
+    /// <summary>
+    /// Gets the panel descriptor.
+    /// </summary>
+    public required PanelDescriptor Descriptor { get; init; }
+}


### PR DESCRIPTION
## Summary
- Implements IInspectorCapability (#648) for custom property drawers, component inspectors, and context actions
- Implements IMenuCapability (#649) for main menus, context menus, and toolbar buttons
- Implements IPanelCapability (#650) for registering and managing editor panels
- All capability interfaces extend IEditorCapability marker interface from Phase 1

## Test plan
- [x] Build passes with zero warnings
- [x] All existing tests pass
- [ ] Integration tests for capabilities will be added when implementations are created

## Related Issues
Closes #648, closes #649, closes #650
Part of Epic #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)