### PR TITLE
feat(editor): Add Phase 3 viewport, tool, and shortcut capabilities (#651, #652, #653)

### DIFF
--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IShortcutCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IShortcutCapability.cs
@@ -1,0 +1,542 @@
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for registering and managing keyboard shortcuts.
+/// Allows plugins to add custom shortcuts with conflict detection and rebinding support.
+/// </summary>
+public interface IShortcutCapability : IEditorCapability
+{
+    /// <summary>
+    /// Registers a new keyboard shortcut.
+    /// </summary>
+    /// <param name="actionId">The unique identifier for the action.</param>
+    /// <param name="displayName">The display name shown in the shortcut editor.</param>
+    /// <param name="category">The category for organizing shortcuts.</param>
+    /// <param name="defaultShortcut">The default keyboard shortcut (e.g., "Ctrl+S").</param>
+    /// <param name="action">The action to execute when the shortcut is triggered.</param>
+    /// <returns>The created shortcut binding.</returns>
+    ShortcutBinding RegisterShortcut(
+        string actionId,
+        string displayName,
+        string category,
+        string defaultShortcut,
+        Action action);
+
+    /// <summary>
+    /// Registers a new keyboard shortcut with a can-execute predicate.
+    /// </summary>
+    /// <param name="actionId">The unique identifier for the action.</param>
+    /// <param name="displayName">The display name shown in the shortcut editor.</param>
+    /// <param name="category">The category for organizing shortcuts.</param>
+    /// <param name="defaultShortcut">The default keyboard shortcut (e.g., "Ctrl+S").</param>
+    /// <param name="action">The action to execute when the shortcut is triggered.</param>
+    /// <param name="canExecute">A predicate that determines if the action can be executed.</param>
+    /// <returns>The created shortcut binding.</returns>
+    ShortcutBinding RegisterShortcut(
+        string actionId,
+        string displayName,
+        string category,
+        string defaultShortcut,
+        Action action,
+        Func<bool> canExecute);
+
+    /// <summary>
+    /// Unregisters a shortcut by its action ID.
+    /// </summary>
+    /// <param name="actionId">The action ID to unregister.</param>
+    /// <returns>True if the shortcut was found and unregistered.</returns>
+    bool UnregisterShortcut(string actionId);
+
+    /// <summary>
+    /// Gets a shortcut binding by its action ID.
+    /// </summary>
+    /// <param name="actionId">The action ID.</param>
+    /// <returns>The shortcut binding, or null if not found.</returns>
+    ShortcutBinding? GetShortcut(string actionId);
+
+    /// <summary>
+    /// Gets all shortcuts in a specific category.
+    /// </summary>
+    /// <param name="category">The category to filter by.</param>
+    /// <returns>The shortcuts in the specified category.</returns>
+    IEnumerable<ShortcutBinding> GetShortcutsInCategory(string category);
+
+    /// <summary>
+    /// Gets all registered shortcuts.
+    /// </summary>
+    /// <returns>All registered shortcuts.</returns>
+    IEnumerable<ShortcutBinding> GetAllShortcuts();
+
+    /// <summary>
+    /// Gets all shortcut categories.
+    /// </summary>
+    /// <returns>The category names.</returns>
+    IEnumerable<string> GetCategories();
+
+    /// <summary>
+    /// Rebinds a shortcut to a new key combination.
+    /// </summary>
+    /// <param name="actionId">The action ID to rebind.</param>
+    /// <param name="newShortcut">The new keyboard shortcut.</param>
+    /// <returns>True if the rebind was successful.</returns>
+    bool RebindShortcut(string actionId, string newShortcut);
+
+    /// <summary>
+    /// Resets a shortcut to its default key combination.
+    /// </summary>
+    /// <param name="actionId">The action ID to reset.</param>
+    /// <returns>True if the reset was successful.</returns>
+    bool ResetShortcut(string actionId);
+
+    /// <summary>
+    /// Resets all shortcuts to their default key combinations.
+    /// </summary>
+    void ResetAllShortcuts();
+
+    /// <summary>
+    /// Checks if a shortcut string conflicts with an existing binding.
+    /// </summary>
+    /// <param name="shortcut">The shortcut string to check.</param>
+    /// <param name="excludeActionId">An action ID to exclude from the conflict check.</param>
+    /// <returns>The conflicting shortcut binding, or null if no conflict.</returns>
+    ShortcutBinding? FindConflict(string shortcut, string? excludeActionId = null);
+
+    /// <summary>
+    /// Processes a key event and executes any matching shortcuts.
+    /// </summary>
+    /// <param name="keyEvent">The key event to process.</param>
+    /// <returns>True if a shortcut was executed.</returns>
+    bool ProcessKeyEvent(KeyEvent keyEvent);
+
+    /// <summary>
+    /// Event raised when a shortcut is registered.
+    /// </summary>
+    event Action<ShortcutBinding>? ShortcutRegistered;
+
+    /// <summary>
+    /// Event raised when a shortcut is unregistered.
+    /// </summary>
+    event Action<string>? ShortcutUnregistered;
+
+    /// <summary>
+    /// Event raised when a shortcut is rebound.
+    /// </summary>
+    event Action<string, string, string>? ShortcutRebound;
+}
+
+/// <summary>
+/// Represents a keyboard shortcut binding.
+/// </summary>
+public sealed class ShortcutBinding
+{
+    /// <summary>
+    /// Gets the unique identifier for the action.
+    /// </summary>
+    public required string ActionId { get; init; }
+
+    /// <summary>
+    /// Gets the display name shown in the shortcut editor.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the category for organizing shortcuts.
+    /// </summary>
+    public required string Category { get; init; }
+
+    /// <summary>
+    /// Gets the default keyboard shortcut.
+    /// </summary>
+    public required string DefaultShortcut { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current keyboard shortcut.
+    /// </summary>
+    public string CurrentShortcut { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the action to execute.
+    /// </summary>
+    public required Action Execute { get; init; }
+
+    /// <summary>
+    /// Gets the predicate that determines if the action can be executed.
+    /// </summary>
+    public Func<bool>? CanExecute { get; init; }
+
+    /// <summary>
+    /// Gets whether the shortcut has been modified from its default.
+    /// </summary>
+    public bool IsModified => CurrentShortcut != DefaultShortcut;
+
+    /// <summary>
+    /// Gets whether this shortcut is currently enabled.
+    /// </summary>
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets the parsed key combination for the current shortcut.
+    /// </summary>
+    public KeyCombination? ParsedShortcut { get; set; }
+}
+
+/// <summary>
+/// Represents a key combination for shortcuts.
+/// </summary>
+public readonly struct KeyCombination : IEquatable<KeyCombination>
+{
+    /// <summary>
+    /// Gets the key modifiers (Ctrl, Alt, Shift, etc.).
+    /// </summary>
+    public KeyModifiers Modifiers { get; init; }
+
+    /// <summary>
+    /// Gets the primary key.
+    /// </summary>
+    public Key Key { get; init; }
+
+    /// <summary>
+    /// Creates a new key combination.
+    /// </summary>
+    public KeyCombination(Key key, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        Key = key;
+        Modifiers = modifiers;
+    }
+
+    /// <summary>
+    /// Parses a shortcut string like "Ctrl+Shift+S" into a KeyCombination.
+    /// </summary>
+    /// <param name="shortcut">The shortcut string to parse.</param>
+    /// <returns>The parsed key combination, or null if invalid.</returns>
+    public static KeyCombination? Parse(string shortcut)
+    {
+        if (string.IsNullOrWhiteSpace(shortcut))
+        {
+            return null;
+        }
+
+        var parts = shortcut.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        var modifiers = KeyModifiers.None;
+        Key? key = null;
+
+        foreach (var part in parts)
+        {
+            var normalized = part.ToUpperInvariant();
+
+            // Check for modifiers
+            if (normalized is "CTRL" or "CONTROL")
+            {
+                modifiers |= KeyModifiers.Control;
+            }
+            else if (normalized is "ALT")
+            {
+                modifiers |= KeyModifiers.Alt;
+            }
+            else if (normalized is "SHIFT")
+            {
+                modifiers |= KeyModifiers.Shift;
+            }
+            else if (normalized is "CMD" or "COMMAND" or "META" or "WIN" or "SUPER")
+            {
+                modifiers |= KeyModifiers.Meta;
+            }
+            else if (Enum.TryParse<Key>(normalized, true, out var parsedKey))
+            {
+                key = parsedKey;
+            }
+            else
+            {
+                // Try single character keys
+                if (normalized.Length == 1 && char.IsLetterOrDigit(normalized[0]))
+                {
+                    if (Enum.TryParse<Key>(normalized, true, out var charKey))
+                    {
+                        key = charKey;
+                    }
+                }
+            }
+        }
+
+        if (key is null)
+        {
+            return null;
+        }
+
+        return new KeyCombination(key.Value, modifiers);
+    }
+
+    /// <summary>
+    /// Converts the key combination to a display string.
+    /// </summary>
+    public override string ToString()
+    {
+        var parts = new List<string>();
+
+        if (Modifiers.HasFlag(KeyModifiers.Control))
+        {
+            parts.Add("Ctrl");
+        }
+
+        if (Modifiers.HasFlag(KeyModifiers.Alt))
+        {
+            parts.Add("Alt");
+        }
+
+        if (Modifiers.HasFlag(KeyModifiers.Shift))
+        {
+            parts.Add("Shift");
+        }
+
+        if (Modifiers.HasFlag(KeyModifiers.Meta))
+        {
+            parts.Add("Cmd");
+        }
+
+        parts.Add(Key.ToString());
+
+        return string.Join("+", parts);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(KeyCombination other) =>
+        Key == other.Key && Modifiers == other.Modifiers;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is KeyCombination other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(Key, Modifiers);
+
+    /// <summary>
+    /// Equality operator.
+    /// </summary>
+    public static bool operator ==(KeyCombination left, KeyCombination right) =>
+        left.Equals(right);
+
+    /// <summary>
+    /// Inequality operator.
+    /// </summary>
+    public static bool operator !=(KeyCombination left, KeyCombination right) =>
+        !left.Equals(right);
+}
+
+/// <summary>
+/// Key modifier flags.
+/// </summary>
+[Flags]
+public enum KeyModifiers
+{
+    /// <summary>
+    /// No modifiers.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Control key (Ctrl on Windows/Linux, Control on macOS).
+    /// </summary>
+    Control = 1 << 0,
+
+    /// <summary>
+    /// Alt key (Alt on Windows/Linux, Option on macOS).
+    /// </summary>
+    Alt = 1 << 1,
+
+    /// <summary>
+    /// Shift key.
+    /// </summary>
+    Shift = 1 << 2,
+
+    /// <summary>
+    /// Meta key (Windows key on Windows, Command on macOS).
+    /// </summary>
+    Meta = 1 << 3
+}
+
+/// <summary>
+/// Represents a keyboard key event.
+/// </summary>
+public sealed class KeyEvent
+{
+    /// <summary>
+    /// Gets the key that was pressed or released.
+    /// </summary>
+    public required Key Key { get; init; }
+
+    /// <summary>
+    /// Gets the current modifiers.
+    /// </summary>
+    public required KeyModifiers Modifiers { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a key down event.
+    /// </summary>
+    public required bool IsDown { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a key repeat event.
+    /// </summary>
+    public bool IsRepeat { get; init; }
+
+    /// <summary>
+    /// Gets the key combination for this event.
+    /// </summary>
+    public KeyCombination Combination => new(Key, Modifiers);
+}
+
+/// <summary>
+/// Standard shortcut categories.
+/// </summary>
+public static class ShortcutCategories
+{
+    /// <summary>
+    /// File operations (save, open, etc.).
+    /// </summary>
+    public const string File = "File";
+
+    /// <summary>
+    /// Edit operations (undo, redo, copy, paste, etc.).
+    /// </summary>
+    public const string Edit = "Edit";
+
+    /// <summary>
+    /// View operations (toggle panels, zoom, etc.).
+    /// </summary>
+    public const string View = "View";
+
+    /// <summary>
+    /// Selection operations.
+    /// </summary>
+    public const string Selection = "Selection";
+
+    /// <summary>
+    /// Transform operations.
+    /// </summary>
+    public const string Transform = "Transform";
+
+    /// <summary>
+    /// Play mode operations.
+    /// </summary>
+    public const string PlayMode = "Play Mode";
+
+    /// <summary>
+    /// Navigation operations.
+    /// </summary>
+    public const string Navigation = "Navigation";
+
+    /// <summary>
+    /// Tool activation shortcuts.
+    /// </summary>
+    public const string Tools = "Tools";
+
+    /// <summary>
+    /// Custom plugin shortcuts.
+    /// </summary>
+    public const string Custom = "Custom";
+}
+
+/// <summary>
+/// Common keyboard keys.
+/// </summary>
+public enum Key
+{
+    /// <summary>Unknown key.</summary>
+    Unknown = 0,
+
+    // Letters
+    /// <summary>A key.</summary>
+    A, B, C, D, E, F, G, H, I, J, K, L, M,
+    /// <summary>N key.</summary>
+    N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+
+    // Numbers
+    /// <summary>0 key.</summary>
+    D0, D1, D2, D3, D4, D5, D6, D7, D8, D9,
+
+    // Function keys
+    /// <summary>F1 key.</summary>
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+
+    // Special keys
+    /// <summary>Escape key.</summary>
+    Escape,
+    /// <summary>Tab key.</summary>
+    Tab,
+    /// <summary>Space key.</summary>
+    Space,
+    /// <summary>Enter key.</summary>
+    Enter,
+    /// <summary>Backspace key.</summary>
+    Backspace,
+    /// <summary>Delete key.</summary>
+    Delete,
+    /// <summary>Insert key.</summary>
+    Insert,
+    /// <summary>Home key.</summary>
+    Home,
+    /// <summary>End key.</summary>
+    End,
+    /// <summary>Page Up key.</summary>
+    PageUp,
+    /// <summary>Page Down key.</summary>
+    PageDown,
+
+    // Arrow keys
+    /// <summary>Left arrow key.</summary>
+    Left,
+    /// <summary>Right arrow key.</summary>
+    Right,
+    /// <summary>Up arrow key.</summary>
+    Up,
+    /// <summary>Down arrow key.</summary>
+    Down,
+
+    // Numpad
+    /// <summary>Numpad 0.</summary>
+    NumPad0, NumPad1, NumPad2, NumPad3, NumPad4,
+    /// <summary>Numpad 5.</summary>
+    NumPad5, NumPad6, NumPad7, NumPad8, NumPad9,
+    /// <summary>Numpad Add.</summary>
+    NumPadAdd,
+    /// <summary>Numpad Subtract.</summary>
+    NumPadSubtract,
+    /// <summary>Numpad Multiply.</summary>
+    NumPadMultiply,
+    /// <summary>Numpad Divide.</summary>
+    NumPadDivide,
+    /// <summary>Numpad Decimal.</summary>
+    NumPadDecimal,
+    /// <summary>Numpad Enter.</summary>
+    NumPadEnter,
+
+    // Punctuation
+    /// <summary>Minus key.</summary>
+    Minus,
+    /// <summary>Equals key.</summary>
+    Equals,
+    /// <summary>Left bracket key.</summary>
+    LeftBracket,
+    /// <summary>Right bracket key.</summary>
+    RightBracket,
+    /// <summary>Backslash key.</summary>
+    Backslash,
+    /// <summary>Semicolon key.</summary>
+    Semicolon,
+    /// <summary>Apostrophe key.</summary>
+    Apostrophe,
+    /// <summary>Comma key.</summary>
+    Comma,
+    /// <summary>Period key.</summary>
+    Period,
+    /// <summary>Slash key.</summary>
+    Slash,
+    /// <summary>Grave accent key.</summary>
+    GraveAccent
+}

--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IToolCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IToolCapability.cs
@@ -1,0 +1,353 @@
+using System.Numerics;
+
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for registering and managing editor tools.
+/// Allows plugins to add custom tools for viewport interaction.
+/// </summary>
+public interface IToolCapability : IEditorCapability
+{
+    /// <summary>
+    /// Gets the currently active tool, or null if no tool is active.
+    /// </summary>
+    IEditorTool? ActiveTool { get; }
+
+    /// <summary>
+    /// Gets the ID of the currently active tool.
+    /// </summary>
+    string? ActiveToolId { get; }
+
+    /// <summary>
+    /// Registers a tool with the editor.
+    /// </summary>
+    /// <param name="id">The unique identifier for the tool.</param>
+    /// <param name="tool">The tool instance.</param>
+    void RegisterTool(string id, IEditorTool tool);
+
+    /// <summary>
+    /// Unregisters a tool from the editor.
+    /// </summary>
+    /// <param name="id">The tool ID to unregister.</param>
+    /// <returns>True if the tool was found and unregistered.</returns>
+    bool UnregisterTool(string id);
+
+    /// <summary>
+    /// Activates a tool by its ID.
+    /// </summary>
+    /// <param name="id">The tool ID to activate.</param>
+    /// <returns>True if the tool was found and activated.</returns>
+    bool ActivateTool(string id);
+
+    /// <summary>
+    /// Deactivates the current tool.
+    /// </summary>
+    void DeactivateTool();
+
+    /// <summary>
+    /// Gets a tool by its ID.
+    /// </summary>
+    /// <param name="id">The tool ID.</param>
+    /// <returns>The tool, or null if not found.</returns>
+    IEditorTool? GetTool(string id);
+
+    /// <summary>
+    /// Gets all registered tools.
+    /// </summary>
+    /// <returns>The registered tools with their IDs.</returns>
+    IEnumerable<(string Id, IEditorTool Tool)> GetTools();
+
+    /// <summary>
+    /// Gets all registered tools in a specific category.
+    /// </summary>
+    /// <param name="category">The category to filter by.</param>
+    /// <returns>The tools in the specified category.</returns>
+    IEnumerable<(string Id, IEditorTool Tool)> GetToolsInCategory(string category);
+
+    /// <summary>
+    /// Event raised when the active tool changes.
+    /// </summary>
+    event Action<ToolChangedEventArgs>? ActiveToolChanged;
+
+    /// <summary>
+    /// Event raised when a tool is registered.
+    /// </summary>
+    event Action<string, IEditorTool>? ToolRegistered;
+
+    /// <summary>
+    /// Event raised when a tool is unregistered.
+    /// </summary>
+    event Action<string>? ToolUnregistered;
+}
+
+/// <summary>
+/// Event arguments for when the active tool changes.
+/// </summary>
+public sealed class ToolChangedEventArgs
+{
+    /// <summary>
+    /// Gets the previously active tool ID, or null if no tool was active.
+    /// </summary>
+    public string? PreviousToolId { get; init; }
+
+    /// <summary>
+    /// Gets the previously active tool, or null if no tool was active.
+    /// </summary>
+    public IEditorTool? PreviousTool { get; init; }
+
+    /// <summary>
+    /// Gets the newly active tool ID, or null if no tool is now active.
+    /// </summary>
+    public string? NewToolId { get; init; }
+
+    /// <summary>
+    /// Gets the newly active tool, or null if no tool is now active.
+    /// </summary>
+    public IEditorTool? NewTool { get; init; }
+}
+
+/// <summary>
+/// Interface for editor tools that handle viewport interaction.
+/// </summary>
+public interface IEditorTool
+{
+    /// <summary>
+    /// Gets the display name of the tool.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the optional icon identifier for the tool.
+    /// </summary>
+    string? Icon { get; }
+
+    /// <summary>
+    /// Gets the category for organizing tools in the toolbar.
+    /// </summary>
+    string Category { get; }
+
+    /// <summary>
+    /// Gets the optional tooltip text.
+    /// </summary>
+    string? Tooltip { get; }
+
+    /// <summary>
+    /// Gets the optional keyboard shortcut to activate this tool.
+    /// </summary>
+    string? Shortcut { get; }
+
+    /// <summary>
+    /// Gets whether this tool is currently enabled.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Called when the tool is activated.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    void OnActivate(ToolContext context);
+
+    /// <summary>
+    /// Called when the tool is deactivated.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    void OnDeactivate(ToolContext context);
+
+    /// <summary>
+    /// Called every frame while the tool is active.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    /// <param name="deltaTime">Time since last update.</param>
+    void Update(ToolContext context, float deltaTime);
+
+    /// <summary>
+    /// Called when the mouse button is pressed in the viewport.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    /// <param name="button">The mouse button that was pressed.</param>
+    /// <param name="position">The mouse position in viewport-normalized coordinates.</param>
+    /// <returns>True if the tool handled the input.</returns>
+    bool OnMouseDown(ToolContext context, MouseButton button, Vector2 position);
+
+    /// <summary>
+    /// Called when the mouse button is released in the viewport.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    /// <param name="button">The mouse button that was released.</param>
+    /// <param name="position">The mouse position in viewport-normalized coordinates.</param>
+    /// <returns>True if the tool handled the input.</returns>
+    bool OnMouseUp(ToolContext context, MouseButton button, Vector2 position);
+
+    /// <summary>
+    /// Called when the mouse moves in the viewport.
+    /// </summary>
+    /// <param name="context">The tool context.</param>
+    /// <param name="position">The mouse position in viewport-normalized coordinates.</param>
+    /// <param name="delta">The mouse movement delta.</param>
+    /// <returns>True if the tool handled the input.</returns>
+    bool OnMouseMove(ToolContext context, Vector2 position, Vector2 delta);
+
+    /// <summary>
+    /// Called to render tool-specific overlays.
+    /// </summary>
+    /// <param name="context">The gizmo render context.</param>
+    void OnRender(GizmoRenderContext context);
+}
+
+/// <summary>
+/// Context provided to editor tools.
+/// </summary>
+public sealed class ToolContext
+{
+    /// <summary>
+    /// Gets the editor context for accessing editor services.
+    /// </summary>
+    public required IEditorContext EditorContext { get; init; }
+
+    /// <summary>
+    /// Gets the scene world, or null if no scene is open.
+    /// </summary>
+    public IWorld? SceneWorld { get; init; }
+
+    /// <summary>
+    /// Gets the currently selected entities.
+    /// </summary>
+    public required IReadOnlyList<Entity> SelectedEntities { get; init; }
+
+    /// <summary>
+    /// Gets the viewport bounds.
+    /// </summary>
+    public required ViewportBounds ViewportBounds { get; init; }
+
+    /// <summary>
+    /// Gets the view matrix.
+    /// </summary>
+    public required Matrix4x4 ViewMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the projection matrix.
+    /// </summary>
+    public required Matrix4x4 ProjectionMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the camera position.
+    /// </summary>
+    public required Vector3 CameraPosition { get; init; }
+
+    /// <summary>
+    /// Gets the camera forward direction.
+    /// </summary>
+    public required Vector3 CameraForward { get; init; }
+}
+
+/// <summary>
+/// Base class for editor tools that provides default implementations.
+/// </summary>
+public abstract class EditorToolBase : IEditorTool
+{
+    /// <inheritdoc/>
+    public abstract string DisplayName { get; }
+
+    /// <inheritdoc/>
+    public virtual string? Icon => null;
+
+    /// <inheritdoc/>
+    public virtual string Category => "General";
+
+    /// <inheritdoc/>
+    public virtual string? Tooltip => null;
+
+    /// <inheritdoc/>
+    public virtual string? Shortcut => null;
+
+    /// <inheritdoc/>
+    public virtual bool IsEnabled => true;
+
+    /// <inheritdoc/>
+    public virtual void OnActivate(ToolContext context) { }
+
+    /// <inheritdoc/>
+    public virtual void OnDeactivate(ToolContext context) { }
+
+    /// <inheritdoc/>
+    public virtual void Update(ToolContext context, float deltaTime) { }
+
+    /// <inheritdoc/>
+    public virtual bool OnMouseDown(ToolContext context, MouseButton button, Vector2 position) => false;
+
+    /// <inheritdoc/>
+    public virtual bool OnMouseUp(ToolContext context, MouseButton button, Vector2 position) => false;
+
+    /// <inheritdoc/>
+    public virtual bool OnMouseMove(ToolContext context, Vector2 position, Vector2 delta) => false;
+
+    /// <inheritdoc/>
+    public virtual void OnRender(GizmoRenderContext context) { }
+}
+
+/// <summary>
+/// Standard tool categories for organizing tools.
+/// </summary>
+public static class ToolCategories
+{
+    /// <summary>
+    /// Selection and navigation tools.
+    /// </summary>
+    public const string Selection = "Selection";
+
+    /// <summary>
+    /// Transform tools (move, rotate, scale).
+    /// </summary>
+    public const string Transform = "Transform";
+
+    /// <summary>
+    /// Creation and placement tools.
+    /// </summary>
+    public const string Creation = "Creation";
+
+    /// <summary>
+    /// Terrain editing tools.
+    /// </summary>
+    public const string Terrain = "Terrain";
+
+    /// <summary>
+    /// Physics debugging tools.
+    /// </summary>
+    public const string Physics = "Physics";
+
+    /// <summary>
+    /// Custom plugin tools.
+    /// </summary>
+    public const string Custom = "Custom";
+}
+
+/// <summary>
+/// Mouse button enumeration for tool input.
+/// </summary>
+public enum MouseButton
+{
+    /// <summary>
+    /// Left mouse button.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Right mouse button.
+    /// </summary>
+    Right,
+
+    /// <summary>
+    /// Middle mouse button (scroll wheel click).
+    /// </summary>
+    Middle,
+
+    /// <summary>
+    /// Extra button 1 (typically back).
+    /// </summary>
+    Button4,
+
+    /// <summary>
+    /// Extra button 2 (typically forward).
+    /// </summary>
+    Button5
+}

--- a/editor/KeenEyes.Editor.Abstractions/Capabilities/IViewportCapability.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Capabilities/IViewportCapability.cs
@@ -1,0 +1,351 @@
+using System.Numerics;
+
+namespace KeenEyes.Editor.Abstractions.Capabilities;
+
+/// <summary>
+/// Capability for customizing the viewport rendering and interaction.
+/// Allows plugins to add custom gizmo renderers, overlays, and pick handlers.
+/// </summary>
+public interface IViewportCapability : IEditorCapability
+{
+    /// <summary>
+    /// Adds a custom gizmo renderer to the viewport.
+    /// </summary>
+    /// <param name="renderer">The gizmo renderer to add.</param>
+    void AddGizmoRenderer(IGizmoRenderer renderer);
+
+    /// <summary>
+    /// Removes a custom gizmo renderer from the viewport.
+    /// </summary>
+    /// <param name="renderer">The gizmo renderer to remove.</param>
+    void RemoveGizmoRenderer(IGizmoRenderer renderer);
+
+    /// <summary>
+    /// Gets all registered gizmo renderers.
+    /// </summary>
+    /// <returns>The gizmo renderers.</returns>
+    IEnumerable<IGizmoRenderer> GetGizmoRenderers();
+
+    /// <summary>
+    /// Adds an overlay to the viewport.
+    /// </summary>
+    /// <param name="id">The unique identifier for the overlay.</param>
+    /// <param name="overlay">The overlay to add.</param>
+    void AddOverlay(string id, IViewportOverlay overlay);
+
+    /// <summary>
+    /// Removes an overlay from the viewport.
+    /// </summary>
+    /// <param name="id">The overlay ID to remove.</param>
+    /// <returns>True if the overlay was found and removed.</returns>
+    bool RemoveOverlay(string id);
+
+    /// <summary>
+    /// Sets the visibility of an overlay.
+    /// </summary>
+    /// <param name="id">The overlay ID.</param>
+    /// <param name="visible">Whether the overlay should be visible.</param>
+    void SetOverlayVisible(string id, bool visible);
+
+    /// <summary>
+    /// Gets whether an overlay is currently visible.
+    /// </summary>
+    /// <param name="id">The overlay ID.</param>
+    /// <returns>True if the overlay exists and is visible.</returns>
+    bool IsOverlayVisible(string id);
+
+    /// <summary>
+    /// Gets all registered overlay IDs.
+    /// </summary>
+    /// <returns>The overlay IDs.</returns>
+    IEnumerable<string> GetOverlayIds();
+
+    /// <summary>
+    /// Adds a pick handler for custom entity picking logic.
+    /// </summary>
+    /// <param name="handler">The pick handler to add.</param>
+    void AddPickHandler(IPickHandler handler);
+
+    /// <summary>
+    /// Removes a pick handler.
+    /// </summary>
+    /// <param name="handler">The pick handler to remove.</param>
+    void RemovePickHandler(IPickHandler handler);
+
+    /// <summary>
+    /// Gets all registered pick handlers.
+    /// </summary>
+    /// <returns>The pick handlers.</returns>
+    IEnumerable<IPickHandler> GetPickHandlers();
+
+    /// <summary>
+    /// Event raised when a gizmo renderer is added.
+    /// </summary>
+    event Action<IGizmoRenderer>? GizmoRendererAdded;
+
+    /// <summary>
+    /// Event raised when a gizmo renderer is removed.
+    /// </summary>
+    event Action<IGizmoRenderer>? GizmoRendererRemoved;
+}
+
+/// <summary>
+/// Interface for custom gizmo renderers that draw in the viewport.
+/// </summary>
+public interface IGizmoRenderer
+{
+    /// <summary>
+    /// Gets the unique identifier for this renderer.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the display name for this renderer.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Gets or sets whether this renderer is enabled.
+    /// </summary>
+    bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Gets the render order. Lower values render first (behind).
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Called to render the gizmo.
+    /// </summary>
+    /// <param name="context">The rendering context.</param>
+    void Render(GizmoRenderContext context);
+
+    /// <summary>
+    /// Called to check if this renderer should render for the given entity.
+    /// </summary>
+    /// <param name="entity">The entity to check.</param>
+    /// <param name="sceneWorld">The scene world.</param>
+    /// <returns>True if this renderer should render for the entity.</returns>
+    bool ShouldRender(Entity entity, IWorld sceneWorld);
+}
+
+/// <summary>
+/// Context provided to gizmo renderers during rendering.
+/// </summary>
+public sealed class GizmoRenderContext
+{
+    /// <summary>
+    /// Gets the scene world being rendered.
+    /// </summary>
+    public required IWorld SceneWorld { get; init; }
+
+    /// <summary>
+    /// Gets the currently selected entities.
+    /// </summary>
+    public required IReadOnlyList<Entity> SelectedEntities { get; init; }
+
+    /// <summary>
+    /// Gets the view matrix.
+    /// </summary>
+    public required Matrix4x4 ViewMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the projection matrix.
+    /// </summary>
+    public required Matrix4x4 ProjectionMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the camera position.
+    /// </summary>
+    public required Vector3 CameraPosition { get; init; }
+
+    /// <summary>
+    /// Gets the viewport bounds in screen coordinates.
+    /// </summary>
+    public required ViewportBounds Bounds { get; init; }
+
+    /// <summary>
+    /// Gets the delta time since last frame.
+    /// </summary>
+    public float DeltaTime { get; init; }
+}
+
+/// <summary>
+/// Represents viewport bounds in screen coordinates.
+/// </summary>
+public readonly struct ViewportBounds
+{
+    /// <summary>
+    /// Gets the X position of the viewport.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y position of the viewport.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the width of the viewport.
+    /// </summary>
+    public float Width { get; init; }
+
+    /// <summary>
+    /// Gets the height of the viewport.
+    /// </summary>
+    public float Height { get; init; }
+
+    /// <summary>
+    /// Gets the aspect ratio (width / height).
+    /// </summary>
+    public float AspectRatio => Height > 0 ? Width / Height : 1f;
+
+    /// <summary>
+    /// Creates a new viewport bounds instance.
+    /// </summary>
+    public ViewportBounds(float x, float y, float width, float height)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+}
+
+/// <summary>
+/// Interface for viewport overlays that render 2D content on top of the viewport.
+/// </summary>
+public interface IViewportOverlay
+{
+    /// <summary>
+    /// Gets whether this overlay is currently visible.
+    /// </summary>
+    bool IsVisible { get; set; }
+
+    /// <summary>
+    /// Gets the render order. Lower values render first (behind).
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Called to render the overlay.
+    /// </summary>
+    /// <param name="context">The overlay render context.</param>
+    void Render(OverlayRenderContext context);
+}
+
+/// <summary>
+/// Context provided to overlays during rendering.
+/// </summary>
+public sealed class OverlayRenderContext
+{
+    /// <summary>
+    /// Gets the editor world for creating UI entities.
+    /// </summary>
+    public required IWorld EditorWorld { get; init; }
+
+    /// <summary>
+    /// Gets the scene world being rendered.
+    /// </summary>
+    public IWorld? SceneWorld { get; init; }
+
+    /// <summary>
+    /// Gets the viewport bounds in screen coordinates.
+    /// </summary>
+    public required ViewportBounds Bounds { get; init; }
+
+    /// <summary>
+    /// Gets the delta time since last frame.
+    /// </summary>
+    public float DeltaTime { get; init; }
+}
+
+/// <summary>
+/// Interface for custom pick handlers that can intercept entity picking.
+/// </summary>
+public interface IPickHandler
+{
+    /// <summary>
+    /// Gets the priority of this handler. Higher values are checked first.
+    /// </summary>
+    int Priority { get; }
+
+    /// <summary>
+    /// Attempts to pick an entity at the given screen position.
+    /// </summary>
+    /// <param name="context">The pick context.</param>
+    /// <returns>The pick result, or null if this handler didn't pick anything.</returns>
+    PickResult? TryPick(PickContext context);
+}
+
+/// <summary>
+/// Context provided to pick handlers during picking.
+/// </summary>
+public sealed class PickContext
+{
+    /// <summary>
+    /// Gets the scene world being picked from.
+    /// </summary>
+    public required IWorld SceneWorld { get; init; }
+
+    /// <summary>
+    /// Gets the normalized screen X coordinate (0-1).
+    /// </summary>
+    public required float NormalizedX { get; init; }
+
+    /// <summary>
+    /// Gets the normalized screen Y coordinate (0-1).
+    /// </summary>
+    public required float NormalizedY { get; init; }
+
+    /// <summary>
+    /// Gets the ray origin (camera position).
+    /// </summary>
+    public required Vector3 RayOrigin { get; init; }
+
+    /// <summary>
+    /// Gets the ray direction.
+    /// </summary>
+    public required Vector3 RayDirection { get; init; }
+
+    /// <summary>
+    /// Gets the view matrix.
+    /// </summary>
+    public required Matrix4x4 ViewMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the projection matrix.
+    /// </summary>
+    public required Matrix4x4 ProjectionMatrix { get; init; }
+
+    /// <summary>
+    /// Gets the viewport bounds.
+    /// </summary>
+    public required ViewportBounds Bounds { get; init; }
+}
+
+/// <summary>
+/// Result of a pick operation.
+/// </summary>
+public sealed class PickResult
+{
+    /// <summary>
+    /// Gets the picked entity.
+    /// </summary>
+    public required Entity Entity { get; init; }
+
+    /// <summary>
+    /// Gets the world position of the pick point.
+    /// </summary>
+    public Vector3 WorldPosition { get; init; }
+
+    /// <summary>
+    /// Gets the distance from the camera to the pick point.
+    /// </summary>
+    public float Distance { get; init; }
+
+    /// <summary>
+    /// Gets optional additional data about the pick.
+    /// </summary>
+    public object? UserData { get; init; }
+}


### PR DESCRIPTION
## Summary
- Implements IViewportCapability (#651) for custom gizmo renderers, viewport overlays, and pick handlers
- Implements IToolCapability (#652) for editor tool registration, activation, and lifecycle management
- Implements IShortcutCapability (#653) for keyboard shortcut registration with conflict detection and rebinding support
- All capability interfaces extend IEditorCapability marker interface from Phase 1

## Key Types

### IViewportCapability
- `IGizmoRenderer` - Custom 3D gizmo rendering
- `IViewportOverlay` - 2D overlays on top of viewport
- `IPickHandler` - Custom entity picking logic
- `GizmoRenderContext`, `ViewportBounds`, `PickContext`, `PickResult`

### IToolCapability
- `IEditorTool` - Tool interface for viewport interaction
- `EditorToolBase` - Convenience base class
- `ToolContext`, `ToolChangedEventArgs`
- `ToolCategories` - Standard tool categories

### IShortcutCapability
- `ShortcutBinding` - Shortcut registration and state
- `KeyCombination` - Parsed key combinations with modifiers
- `KeyEvent`, `Key`, `KeyModifiers`
- `ShortcutCategories` - Standard shortcut categories

## Test plan
- [x] Build passes with zero warnings
- [x] All existing tests pass (510 editor tests, 2143 core tests)
- [ ] Integration tests for capabilities will be added when implementations are created

## Related Issues
Closes #651, closes #652, closes #653
Part of Epic #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)