### PR TITLE
feat: Add EditorExtensionGenerator for typed IEditorContext extensions

### DIFF
--- a/editor/KeenEyes.Editor.Abstractions/Attributes/EditorExtensionAttribute.cs
+++ b/editor/KeenEyes.Editor.Abstractions/Attributes/EditorExtensionAttribute.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace KeenEyes.Editor.Abstractions;
+
+/// <summary>
+/// Marks a class as an editor extension that should generate a typed accessor property on IEditorContext.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When applied to a class, the source generator will create a C# 13 extension member
+/// that provides direct property access instead of using IEditorContext.GetExtension.
+/// </para>
+/// <para>
+/// The generated extension allows code like <c>context.MyExtension</c> instead of
+/// <c>context.GetExtension&lt;MyExtensionClass&gt;()</c>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Mark the extension class
+/// [EditorExtension("SceneAnalyzer")]
+/// public sealed class SceneAnalyzerExtension
+/// {
+///     public IEnumerable&lt;Entity&gt; FindOrphanedEntities() { ... }
+/// }
+///
+/// // Usage in plugin code becomes:
+/// var orphans = context.SceneAnalyzer.FindOrphanedEntities();
+/// </code>
+/// </example>
+/// <param name="propertyName">The name of the property to generate on IEditorContext.</param>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+[ExcludeFromCodeCoverage]
+public sealed class EditorExtensionAttribute(string propertyName) : Attribute
+{
+    /// <summary>
+    /// Gets the property name to generate on IEditorContext.
+    /// </summary>
+    public string PropertyName { get; } = propertyName;
+
+    /// <summary>
+    /// Gets or sets whether the extension property is nullable.
+    /// When true, the property returns null if the extension is not registered.
+    /// When false (default), accessing the property throws if the extension is not registered.
+    /// </summary>
+    public bool Nullable { get; set; }
+}

--- a/editor/KeenEyes.Generators/EditorExtensionGenerator.cs
+++ b/editor/KeenEyes.Generators/EditorExtensionGenerator.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using KeenEyes.Generators.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace KeenEyes.Generators;
+
+/// <summary>
+/// Generates C# 13 extension members on IEditorContext for classes marked with [EditorExtension].
+/// This allows typed property access like <c>context.SceneAnalyzer</c> instead of
+/// <c>context.GetExtension&lt;SceneAnalyzerExtension&gt;()</c>.
+/// </summary>
+[Generator]
+public sealed class EditorExtensionGenerator : IIncrementalGenerator
+{
+    private const string EditorExtensionAttribute = "KeenEyes.Editor.Abstractions.EditorExtensionAttribute";
+
+    /// <summary>
+    /// KEEN090: EditorExtension property name cannot be null.
+    /// </summary>
+    public static readonly DiagnosticDescriptor NullPropertyName = new(
+        id: "KEEN090",
+        title: "EditorExtension property name cannot be null",
+        messageFormat: "The property name for [EditorExtension] on '{0}' cannot be null",
+        category: "KeenEyes.Editor.Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [EditorExtension] attribute requires a non-null property name to generate the IEditorContext extension property.");
+
+    /// <inheritdoc />
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Find all classes with [EditorExtension] attribute
+        var extensionProvider = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                EditorExtensionAttribute,
+                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                transform: static (ctx, _) => GetExtensionInfo(ctx));
+
+        // Collect all extensions
+        var allExtensions = extensionProvider.Collect();
+
+        // Single output registration handles both diagnostics and code generation
+        context.RegisterSourceOutput(allExtensions, static (ctx, extensions) =>
+        {
+            // Report all diagnostics first
+            foreach (var ext in extensions)
+            {
+                foreach (var diag in ext.Diagnostics)
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(
+                        diag.Descriptor,
+                        diag.Location,
+                        diag.Args));
+                }
+            }
+
+            // Generate code only for valid extensions
+            var validExtensions = extensions.Where(static e => e.IsValid).ToImmutableArray();
+            if (validExtensions.Length == 0)
+            {
+                return;
+            }
+
+            var source = GenerateEditorContextExtensions(validExtensions);
+            ctx.AddSource("EditorContext.Extensions.g.cs", SourceText.From(source, Encoding.UTF8));
+        });
+    }
+
+    private static ExtensionInfo GetExtensionInfo(GeneratorAttributeSyntaxContext context)
+    {
+        // Predicate guarantees ClassDeclarationSyntax, which always has INamedTypeSymbol
+        if (context.TargetSymbol is not INamedTypeSymbol typeSymbol)
+        {
+            return CreateInvalidExtensionInfo();
+        }
+
+        // ForAttributeWithMetadataName guarantees the attribute exists, but use FirstOrDefault for safety
+        var attributeData = context.Attributes.FirstOrDefault(
+            a => a.AttributeClass?.ToDisplayString() == EditorExtensionAttribute);
+
+        if (attributeData is null)
+        {
+            return CreateInvalidExtensionInfo();
+        }
+
+        // Get property name from constructor argument
+        if (attributeData.ConstructorArguments.Length == 0 ||
+            attributeData.ConstructorArguments[0].Value is not string propertyName)
+        {
+            // Report error for null property name
+            var diagnostics = ImmutableArray.Create(new DiagnosticInfo(
+                NullPropertyName,
+                context.TargetNode.GetLocation(),
+                [typeSymbol.Name]));
+
+            return new ExtensionInfo(
+                typeSymbol.Name,
+                typeSymbol.ContainingNamespace.ToDisplayString(),
+                typeSymbol.ToDisplayString(),
+                string.Empty,
+                false,
+                diagnostics,
+                IsValid: false);
+        }
+
+        // Get Nullable property from named arguments
+        var isNullable = false;
+        foreach (var namedArg in attributeData.NamedArguments)
+        {
+            if (namedArg.Key == "Nullable" && namedArg.Value.Value is bool nullable)
+            {
+                isNullable = nullable;
+            }
+        }
+
+        return new ExtensionInfo(
+            typeSymbol.Name,
+            typeSymbol.ContainingNamespace.ToDisplayString(),
+            typeSymbol.ToDisplayString(),
+            propertyName,
+            isNullable,
+            ImmutableArray<DiagnosticInfo>.Empty,
+            IsValid: true);
+    }
+
+    private static ExtensionInfo CreateInvalidExtensionInfo()
+    {
+        return new ExtensionInfo(
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            false,
+            ImmutableArray<DiagnosticInfo>.Empty,
+            IsValid: false);
+    }
+
+    private static string GenerateEditorContextExtensions(ImmutableArray<ExtensionInfo> extensions)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("namespace KeenEyes.Editor.Abstractions;");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Generated extension members providing typed access to editor extensions on IEditorContext.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("/// <remarks>");
+        sb.AppendLine("/// <para>");
+        sb.AppendLine("/// These extension members are generated from classes marked with <see cref=\"EditorExtensionAttribute\"/>.");
+        sb.AppendLine("/// They provide convenient typed property access instead of using <see cref=\"IEditorContext.GetExtension{T}\"/>.");
+        sb.AppendLine("/// </para>");
+        sb.AppendLine("/// </remarks>");
+        sb.AppendLine("public static class EditorContextExtensions");
+        sb.AppendLine("{");
+        sb.AppendLine("    extension(global::KeenEyes.Editor.Abstractions.IEditorContext context)");
+        sb.AppendLine("    {");
+
+        foreach (var ext in extensions)
+        {
+            var fullTypeName = StringHelpers.IsValidNamespace(ext.Namespace)
+                ? $"global::{ext.FullName}"
+                : ext.Name;
+
+            sb.AppendLine($"        /// <summary>");
+            sb.AppendLine($"        /// Gets the <see cref=\"{ext.FullName}\"/> extension from this editor context.");
+            sb.AppendLine($"        /// </summary>");
+
+            if (ext.IsNullable)
+            {
+                sb.AppendLine($"        /// <returns>The extension instance if registered; otherwise, null.</returns>");
+                sb.AppendLine($"        public {fullTypeName}? {ext.PropertyName} => context.TryGetExtension<{fullTypeName}>(out var ext) ? ext : null;");
+            }
+            else
+            {
+                sb.AppendLine($"        /// <exception cref=\"global::System.InvalidOperationException\">Thrown when the extension is not registered.</exception>");
+                sb.AppendLine($"        public {fullTypeName} {ext.PropertyName} => context.GetExtension<{fullTypeName}>();");
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Information about a diagnostic to report, captured for incremental pipeline.
+    /// </summary>
+    private sealed record DiagnosticInfo(
+        DiagnosticDescriptor Descriptor,
+        Location Location,
+        object[] Args);
+
+    /// <summary>
+    /// Information about an editor extension class.
+    /// </summary>
+    private sealed record ExtensionInfo(
+        string Name,
+        string Namespace,
+        string FullName,
+        string PropertyName,
+        bool IsNullable,
+        ImmutableArray<DiagnosticInfo> Diagnostics,
+        bool IsValid);
+}


### PR DESCRIPTION
## Summary
- Adds `EditorExtensionAttribute` for marking classes as editor extensions
- Implements `EditorExtensionGenerator` source generator that generates C# 13 extension members on `IEditorContext`
- Mirrors the runtime `PluginExtensionGenerator` pattern for editor plugins

## Example Usage
```csharp
[EditorExtension("Physics")]
public class PhysicsEditorExtension { ... }

// Generated extension allows:
context.Physics.DoSomething();  // instead of:
context.GetExtension<PhysicsEditorExtension>().DoSomething();
```

## Test plan
- [x] Build passes with zero warnings
- [x] All existing tests pass (10028 passed)
- [x] Generator follows existing PluginExtensionGenerator patterns

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)