### PR TITLE
feat(editor): Add dynamic plugin loading infrastructure

### DIFF
--- a/docs/adr/013-dynamic-plugin-loading.md
+++ b/docs/adr/013-dynamic-plugin-loading.md
@@ -1,0 +1,370 @@
+# ADR-013: Dynamic Plugin Loading
+
+**Status:** Proposed
+**Date:** 2026-01-02
+
+## Context
+
+KeenEyes Editor needs to support third-party plugins distributed as NuGet packages. Users should be able to:
+
+1. **Install plugins** via NuGet package manager or CLI
+2. **Load plugins** at editor startup (from installed packages)
+3. **Enable/disable plugins** at runtime without editor restart
+4. **Unload plugins** (optional hot reload) for development workflows
+5. **Upgrade plugins** with minimal disruption
+
+### Constraints
+
+1. **Editor is JIT-compiled** - Reflection is acceptable (unlike runtime AOT)
+2. **Plugins are NuGet packages** - Standard distribution mechanism
+3. **Isolation required** - Plugin crashes shouldn't take down the editor
+4. **Unloading is complex** - .NET's collectible AssemblyLoadContext has limitations
+
+### Prior Art
+
+| Editor | Plugin Loading | Hot Reload |
+|--------|---------------|------------|
+| Unity | Domain reload (full restart) | Yes (slow, ~2-5s) |
+| Unreal | DLL replacement + restart | Limited |
+| Godot | GDExtension (native) | No |
+| VS Code | Extension host process | Yes (process restart) |
+| Rider | Separate plugin process | Yes |
+
+## Decision
+
+Implement a **tiered plugin loading system** with three levels of dynamism:
+
+### Tier 1: Static Plugins (Default)
+- Loaded at startup, require editor restart to add/remove
+- Simplest, most stable approach
+- All plugins work at this tier
+
+### Tier 2: Enable/Disable at Runtime
+- Plugins can be enabled/disabled without restart
+- Plugin's `Initialize()` and `Shutdown()` called
+- Assembly stays loaded (no unload)
+- Requires plugin to properly clean up resources
+
+### Tier 3: Full Hot Reload (Opt-in)
+- Assembly can be unloaded and reloaded
+- Uses collectible `AssemblyLoadContext`
+- Plugin must declare `"supportsHotReload": true` in manifest
+- Requires careful resource management
+
+### Plugin Package Structure
+
+```
+MyPlugin.1.0.0.nupkg
+├── lib/net10.0/
+│   └── MyPlugin.dll
+├── content/
+│   └── keeneyes-plugin.json      # Plugin manifest (required)
+└── MyPlugin.nuspec
+```
+
+### Plugin Manifest (keeneyes-plugin.json)
+
+```json
+{
+  "$schema": "https://keeneyes.dev/schemas/plugin-manifest-v1.json",
+  "name": "My Awesome Plugin",
+  "id": "com.example.myawesomeplugin",
+  "version": "1.0.0",
+  "author": "Example Corp",
+  "description": "Adds awesome features to the editor",
+
+  "entryPoint": {
+    "assembly": "MyPlugin.dll",
+    "type": "MyPlugin.MyEditorPlugin"
+  },
+
+  "compatibility": {
+    "minEditorVersion": "1.0.0",
+    "maxEditorVersion": "2.0.0"
+  },
+
+  "capabilities": {
+    "supportsHotReload": false,
+    "supportsDisable": true
+  },
+
+  "dependencies": {
+    "com.keeneyes.physics-editor": ">=1.0.0"
+  },
+
+  "settings": {
+    "configFile": "myPlugin.config.json"
+  }
+}
+```
+
+### Architecture
+
+```
+EditorPluginManager
+├── PluginRepository           # Discovers installed plugins
+│   ├── Scan NuGet global cache
+│   ├── Scan local plugin folder
+│   └── Parse manifests
+│
+├── PluginLoader               # Loads/unloads assemblies
+│   ├── Create PluginLoadContext (collectible if hot-reload)
+│   ├── Load assembly + dependencies
+│   ├── Instantiate IEditorPlugin via reflection
+│   └── Unload context (if collectible)
+│
+├── PluginRegistry             # Tracks loaded plugins
+│   ├── Plugin metadata
+│   ├── Load state (Unloaded, Loaded, Enabled, Disabled)
+│   └── Dependency graph
+│
+└── PluginLifecycle            # Manages state transitions
+    ├── Load → Enable → Disable → Unload
+    ├── Dependency ordering
+    └── Error recovery
+```
+
+### PluginLoadContext
+
+```csharp
+internal sealed class PluginLoadContext : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver resolver;
+    private readonly HashSet<string> sharedAssemblies;
+
+    public PluginLoadContext(string pluginPath, bool isCollectible)
+        : base(name: Path.GetFileNameWithoutExtension(pluginPath),
+               isCollectible: isCollectible)
+    {
+        resolver = new AssemblyDependencyResolver(pluginPath);
+
+        // Assemblies that should come from the host, not the plugin
+        sharedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "KeenEyes.Core",
+            "KeenEyes.Abstractions",
+            "KeenEyes.Editor",
+            "KeenEyes.Editor.Abstractions",
+            // Framework assemblies handled by base class
+        };
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // Use host's version for shared assemblies (type identity)
+        if (sharedAssemblies.Contains(assemblyName.Name!))
+        {
+            return null; // Delegates to default context
+        }
+
+        // Resolve plugin's own dependencies
+        var path = resolver.ResolveAssemblyToPath(assemblyName);
+        if (path != null)
+        {
+            return LoadFromAssemblyPath(path);
+        }
+
+        return null;
+    }
+}
+```
+
+### Plugin States
+
+```
+                    ┌──────────────┐
+         install   │  Discovered  │   scan
+            ┌──────│   (on disk)  │◄──────┐
+            │      └──────────────┘       │
+            │                             │
+            ▼                             │
+    ┌──────────────┐              ┌───────┴──────┐
+    │    Loaded    │◄────────────►│   Unloaded   │
+    │  (in memory) │   unload*    │  (assembly   │
+    └──────┬───────┘              │   released)  │
+           │                      └──────────────┘
+           │ enable                     ▲
+           ▼                            │ unload*
+    ┌──────────────┐                    │
+    │   Enabled    │────────────────────┘
+    │  (running)   │     disable + unload*
+    └──────┬───────┘
+           │ disable
+           ▼
+    ┌──────────────┐
+    │   Disabled   │
+    │  (sleeping)  │
+    └──────────────┘
+
+    * Only for hot-reload plugins
+```
+
+### Dependency Resolution
+
+Plugins can depend on other plugins:
+
+```json
+{
+  "dependencies": {
+    "com.keeneyes.physics-editor": ">=1.0.0",
+    "com.keeneyes.ui-toolkit": "^2.0.0"
+  }
+}
+```
+
+The `PluginLifecycle` ensures:
+1. Dependencies are loaded before dependents
+2. Dependents are disabled before dependencies
+3. Version compatibility is checked at load time
+4. Circular dependencies are detected and rejected
+
+### Hot Reload Challenges
+
+For unloading to work, ALL references to plugin types must be released:
+
+1. **UI elements** - Plugin panels must be closed
+2. **Event handlers** - All subscriptions must be disposed
+3. **Cached types** - No `Type` or `MethodInfo` references retained
+4. **Static fields** - Plugin must not store in host statics
+
+The `EditorPluginContext` tracks all resources and disposes them on unload:
+
+```csharp
+public sealed class EditorPluginContext : IEditorContext, IDisposable
+{
+    private readonly List<EventSubscription> subscriptions = [];
+    private readonly List<Entity> createdPanels = [];
+    private readonly WeakReference<IEditorPlugin> pluginRef;
+
+    public void Dispose()
+    {
+        // Dispose subscriptions (removes event handlers)
+        foreach (var sub in subscriptions)
+            sub.Dispose();
+
+        // Destroy created UI entities
+        foreach (var entity in createdPanels)
+            EditorWorld.Despawn(entity);
+
+        // Clear capability registrations
+        // ...
+    }
+}
+```
+
+### Error Handling
+
+Plugin failures are isolated:
+
+```csharp
+public void EnablePlugin(string pluginId)
+{
+    var entry = registry.Get(pluginId);
+    var context = new EditorPluginContext(this, entry.Manifest);
+
+    try
+    {
+        entry.Plugin.Initialize(context);
+        entry.State = PluginState.Enabled;
+    }
+    catch (Exception ex)
+    {
+        // Log error, keep plugin in Loaded state
+        logger.Error($"Plugin {pluginId} failed to initialize: {ex}");
+        context.Dispose();
+        entry.State = PluginState.Failed;
+
+        // Optionally show user notification
+        notifications.Show($"Plugin '{entry.Manifest.Name}' failed to start");
+    }
+}
+```
+
+### Plugin Discovery Locations
+
+Plugins are discovered from:
+
+1. **NuGet global cache** - `~/.nuget/packages/<package-id>/<version>/`
+2. **Editor plugins folder** - `<editor-install>/plugins/`
+3. **Project plugins** - `<project>/.keeneyes/plugins/`
+4. **Development folder** - `<project>/Plugins/` (for local development)
+
+### API Surface
+
+```csharp
+// Plugin management
+editorPlugins.InstallFromNuGet("com.example.myplugin", "1.0.0");
+editorPlugins.InstallFromPath("/path/to/MyPlugin.dll");
+editorPlugins.UninstallPlugin("com.example.myplugin");
+
+// Enable/disable
+editorPlugins.EnablePlugin("com.example.myplugin");
+editorPlugins.DisablePlugin("com.example.myplugin");
+
+// Hot reload (opt-in plugins only)
+editorPlugins.ReloadPlugin("com.example.myplugin");
+
+// Query
+var plugin = editorPlugins.GetPlugin("com.example.myplugin");
+var all = editorPlugins.GetAllPlugins();
+var enabled = editorPlugins.GetEnabledPlugins();
+```
+
+### User Experience
+
+1. **Plugin Manager Panel** - UI for browsing, installing, enabling plugins
+2. **Restart Indicator** - Shows when restart is needed for full changes
+3. **Error Recovery** - Disable failing plugins, offer to uninstall
+4. **Development Mode** - Auto-reload on rebuild (for plugin developers)
+
+## Consequences
+
+### Positive
+
+1. **Standard distribution** - Uses NuGet, familiar to .NET developers
+2. **Isolated loading** - Plugins get their own AssemblyLoadContext
+3. **Tiered complexity** - Simple plugins just work; advanced features opt-in
+4. **Development workflow** - Hot reload for plugin authors
+5. **Version compatibility** - Manifests specify compatible editor versions
+
+### Negative
+
+1. **Complexity** - AssemblyLoadContext management is non-trivial
+2. **Hot reload limitations** - Many edge cases can prevent clean unload
+3. **Memory overhead** - Each plugin's ALC has some overhead
+4. **Testing burden** - Must test all three tiers
+
+### Neutral
+
+1. **Reflection in loader** - Acceptable since editor is JIT-compiled
+2. **Two-phase install** - NuGet install + editor enable are separate steps
+
+## Implementation Phases
+
+### Phase 1: Static Loading
+- Plugin manifest schema
+- Plugin discovery from NuGet cache
+- PluginLoadContext with dependency resolution
+- Basic PluginLoader (load-only)
+
+### Phase 2: Enable/Disable
+- PluginRegistry with state tracking
+- Enable/Disable API
+- Plugin Manager panel UI
+
+### Phase 3: Hot Reload
+- Collectible context support
+- Resource tracking in context
+- Unload API
+- Development mode auto-reload
+
+### Phase 4: NuGet Integration
+- `keeneyes plugin install <package>` CLI
+- In-editor package browser
+- Version upgrade handling
+
+## Related
+
+- [ADR-012: Editor Plugin Extension Architecture](012-editor-plugin-extension-architecture.md)
+- [ADR-007: Capability-Based Plugin Architecture](007-capability-based-plugin-architecture.md)
+- [.NET AssemblyLoadContext docs](https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext)

--- a/editor/KeenEyes.Editor/KeenEyes.Editor.csproj
+++ b/editor/KeenEyes.Editor/KeenEyes.Editor.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Editor.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Editor.Abstractions\KeenEyes.Editor.Abstractions.csproj" />
     <ProjectReference Include="..\KeenEyes.Editor.Common\KeenEyes.Editor.Common.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />

--- a/editor/KeenEyes.Editor/Plugins/LoadedPlugin.cs
+++ b/editor/KeenEyes.Editor/Plugins/LoadedPlugin.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions;
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// Represents a plugin that has been loaded or discovered by the editor.
+/// </summary>
+/// <remarks>
+/// This class tracks the full lifecycle of a plugin from discovery through
+/// loading, enabling, disabling, and unloading.
+/// </remarks>
+public sealed class LoadedPlugin
+{
+    /// <summary>
+    /// Gets the plugin manifest.
+    /// </summary>
+    public PluginManifest Manifest { get; }
+
+    /// <summary>
+    /// Gets the path to the plugin's base directory.
+    /// </summary>
+    public string BasePath { get; }
+
+    /// <summary>
+    /// Gets the current state of the plugin.
+    /// </summary>
+    public PluginState State { get; internal set; }
+
+    /// <summary>
+    /// Gets the plugin instance, if loaded and enabled.
+    /// </summary>
+    public IEditorPlugin? Instance { get; internal set; }
+
+    /// <summary>
+    /// Gets the plugin context, if enabled.
+    /// </summary>
+    internal EditorPluginContext? Context { get; set; }
+
+    /// <summary>
+    /// Gets the assembly load context for this plugin.
+    /// </summary>
+    internal PluginLoadContext? LoadContext { get; set; }
+
+    /// <summary>
+    /// Gets the error message if the plugin is in a failed state.
+    /// </summary>
+    public string? ErrorMessage { get; internal set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the plugin supports hot reloading.
+    /// </summary>
+    public bool SupportsHotReload => Manifest.Capabilities.SupportsHotReload;
+
+    /// <summary>
+    /// Gets a value indicating whether the plugin can be disabled at runtime.
+    /// </summary>
+    public bool SupportsDisable => Manifest.Capabilities.SupportsDisable;
+
+    /// <summary>
+    /// Creates a new loaded plugin entry.
+    /// </summary>
+    /// <param name="manifest">The plugin manifest.</param>
+    /// <param name="basePath">The path to the plugin's base directory.</param>
+    public LoadedPlugin(PluginManifest manifest, string basePath)
+    {
+        Manifest = manifest;
+        BasePath = basePath;
+        State = PluginState.Discovered;
+    }
+
+    /// <summary>
+    /// Gets the full path to the plugin's main assembly.
+    /// </summary>
+    /// <returns>The assembly path.</returns>
+    public string GetAssemblyPath()
+    {
+        return Path.Combine(BasePath, Manifest.EntryPoint.Assembly);
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{Manifest.Name} ({Manifest.Id}) v{Manifest.Version} [{State}]";
+    }
+}

--- a/editor/KeenEyes.Editor/Plugins/PluginLoadContext.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginLoadContext.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// An isolated assembly load context for loading editor plugins.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each plugin is loaded into its own <see cref="PluginLoadContext"/> to provide:
+/// </para>
+/// <list type="bullet">
+/// <item>Assembly isolation - plugin dependencies don't conflict with other plugins</item>
+/// <item>Optional unloading - collectible contexts can be unloaded for hot reload</item>
+/// <item>Type identity - shared assemblies (KeenEyes.*) are loaded from the host</item>
+/// </list>
+/// </remarks>
+internal sealed class PluginLoadContext : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver resolver;
+    private readonly HashSet<string> sharedAssemblies;
+
+    /// <summary>
+    /// Gets the plugin ID this context was created for.
+    /// </summary>
+    public string PluginId { get; }
+
+    /// <summary>
+    /// Gets the path to the plugin's main assembly.
+    /// </summary>
+    public string PluginPath { get; }
+
+    /// <summary>
+    /// Creates a new plugin load context.
+    /// </summary>
+    /// <param name="pluginId">The plugin identifier.</param>
+    /// <param name="pluginPath">Path to the plugin's main assembly.</param>
+    /// <param name="isCollectible">
+    /// If true, the context can be unloaded. This is required for hot reload
+    /// but adds memory overhead.
+    /// </param>
+    public PluginLoadContext(string pluginId, string pluginPath, bool isCollectible)
+        : base(name: $"Plugin:{pluginId}", isCollectible: isCollectible)
+    {
+        PluginId = pluginId;
+        PluginPath = pluginPath;
+        resolver = new AssemblyDependencyResolver(pluginPath);
+
+        // Assemblies that should be loaded from the host context to ensure
+        // type identity across plugin boundaries. Plugins reference the same
+        // IEditorPlugin, IEditorContext, etc. as the host.
+        sharedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // KeenEyes assemblies
+            "KeenEyes.Core",
+            "KeenEyes.Abstractions",
+            "KeenEyes.Common",
+            "KeenEyes.Editor",
+            "KeenEyes.Editor.Abstractions",
+
+            // System assemblies are handled by the default context automatically
+        };
+    }
+
+    /// <inheritdoc/>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // For shared assemblies, delegate to the default context to ensure
+        // type identity. This means IEditorPlugin from the plugin is the same
+        // type as IEditorPlugin in the host.
+        if (assemblyName.Name != null && sharedAssemblies.Contains(assemblyName.Name))
+        {
+            // Return null to fall back to the default load context
+            return null;
+        }
+
+        // Try to resolve the assembly from the plugin's directory
+        var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
+        {
+            return LoadFromAssemblyPath(assemblyPath);
+        }
+
+        // Fall back to default context for other assemblies (framework, etc.)
+        return null;
+    }
+
+    /// <inheritdoc/>
+    protected override nint LoadUnmanagedDll(string unmanagedDllName)
+    {
+        // Try to resolve native libraries from the plugin's directory
+        var libraryPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (libraryPath != null)
+        {
+            return LoadUnmanagedDllFromPath(libraryPath);
+        }
+
+        return nint.Zero;
+    }
+
+    /// <summary>
+    /// Adds an assembly name to the shared assemblies list.
+    /// </summary>
+    /// <remarks>
+    /// Shared assemblies are loaded from the host context instead of the plugin's
+    /// directory. This is necessary for type identity across plugin boundaries.
+    /// </remarks>
+    /// <param name="assemblyName">The assembly name (without .dll extension).</param>
+    public void AddSharedAssembly(string assemblyName)
+    {
+        sharedAssemblies.Add(assemblyName);
+    }
+}

--- a/editor/KeenEyes.Editor/Plugins/PluginLoader.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginLoader.cs
@@ -1,0 +1,252 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Runtime.Loader;
+using KeenEyes.Editor.Abstractions;
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// Handles loading and unloading of plugin assemblies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The plugin loader is responsible for:
+/// </para>
+/// <list type="bullet">
+/// <item>Creating isolated <see cref="PluginLoadContext"/> for each plugin</item>
+/// <item>Loading plugin assemblies and instantiating plugin types</item>
+/// <item>Unloading plugin assemblies (for hot-reloadable plugins)</item>
+/// <item>Managing shared assembly references</item>
+/// </list>
+/// </remarks>
+internal sealed class PluginLoader
+{
+    private readonly IEditorPluginLogger? logger;
+
+    /// <summary>
+    /// Creates a new plugin loader.
+    /// </summary>
+    /// <param name="logger">Optional logger for diagnostic output.</param>
+    public PluginLoader(IEditorPluginLogger? logger = null)
+    {
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Loads a plugin assembly into an isolated context.
+    /// </summary>
+    /// <param name="plugin">The plugin entry to load.</param>
+    /// <returns>True if loading succeeded; false otherwise.</returns>
+    public bool Load(LoadedPlugin plugin)
+    {
+        if (plugin.State != PluginState.Discovered && plugin.State != PluginState.Failed)
+        {
+            logger?.LogWarning($"Plugin '{plugin.Manifest.Id}' is already loaded (state: {plugin.State})");
+            return plugin.State == PluginState.Loaded;
+        }
+
+        var assemblyPath = plugin.GetAssemblyPath();
+        if (!File.Exists(assemblyPath))
+        {
+            plugin.State = PluginState.Failed;
+            plugin.ErrorMessage = $"Assembly not found: {assemblyPath}";
+            logger?.LogError($"Failed to load plugin '{plugin.Manifest.Id}': {plugin.ErrorMessage}");
+            return false;
+        }
+
+        try
+        {
+            // Create an isolated load context for this plugin
+            var isCollectible = plugin.SupportsHotReload;
+            var loadContext = new PluginLoadContext(
+                plugin.Manifest.Id,
+                assemblyPath,
+                isCollectible);
+
+            plugin.LoadContext = loadContext;
+
+            // Load the assembly
+            var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+
+            // Find the plugin type
+            var pluginType = assembly.GetType(plugin.Manifest.EntryPoint.Type);
+            if (pluginType == null)
+            {
+                throw new TypeLoadException(
+                    $"Type '{plugin.Manifest.EntryPoint.Type}' not found in assembly");
+            }
+
+            // Verify it implements IEditorPlugin
+            if (!typeof(IEditorPlugin).IsAssignableFrom(pluginType))
+            {
+                throw new TypeLoadException(
+                    $"Type '{pluginType.FullName}' does not implement IEditorPlugin");
+            }
+
+            // Create the plugin instance
+            var instance = Activator.CreateInstance(pluginType) as IEditorPlugin;
+            if (instance == null)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to create instance of '{pluginType.FullName}'");
+            }
+
+            plugin.Instance = instance;
+            plugin.State = PluginState.Loaded;
+            plugin.ErrorMessage = null;
+
+            logger?.LogInfo($"Loaded plugin '{plugin.Manifest.Id}' v{plugin.Manifest.Version}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            plugin.State = PluginState.Failed;
+            plugin.ErrorMessage = ex.Message;
+            plugin.Instance = null;
+
+            // Clean up the load context if it was created
+            if (plugin.LoadContext != null)
+            {
+                TryUnloadContext(plugin.LoadContext);
+                plugin.LoadContext = null;
+            }
+
+            logger?.LogError($"Failed to load plugin '{plugin.Manifest.Id}': {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Unloads a plugin assembly.
+    /// </summary>
+    /// <param name="plugin">The plugin to unload.</param>
+    /// <returns>True if unloading succeeded; false if the plugin doesn't support unloading.</returns>
+    /// <remarks>
+    /// Only plugins with <see cref="PluginManifest.Capabilities"/> set to support
+    /// hot reload can be unloaded. Other plugins require an editor restart.
+    /// </remarks>
+    public bool Unload(LoadedPlugin plugin)
+    {
+        if (plugin.State == PluginState.Discovered)
+        {
+            // Nothing to unload
+            return true;
+        }
+
+        if (!plugin.SupportsHotReload)
+        {
+            logger?.LogWarning(
+                $"Plugin '{plugin.Manifest.Id}' does not support hot reload. " +
+                "Restart the editor to fully unload.");
+            return false;
+        }
+
+        if (plugin.LoadContext == null)
+        {
+            logger?.LogWarning($"Plugin '{plugin.Manifest.Id}' has no load context to unload");
+            return false;
+        }
+
+        plugin.State = PluginState.Unloading;
+
+        try
+        {
+            // Clear references to the plugin instance
+            plugin.Instance = null;
+            plugin.Context = null;
+
+            // Unload the context
+            var weakRef = TryUnloadContext(plugin.LoadContext);
+            plugin.LoadContext = null;
+
+            // Wait for GC to collect the assembly (with timeout)
+            if (weakRef != null)
+            {
+                WaitForUnload(weakRef, plugin.Manifest.Id);
+            }
+
+            plugin.State = PluginState.Discovered;
+            logger?.LogInfo($"Unloaded plugin '{plugin.Manifest.Id}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            plugin.State = PluginState.Failed;
+            plugin.ErrorMessage = $"Unload failed: {ex.Message}";
+            logger?.LogError($"Failed to unload plugin '{plugin.Manifest.Id}': {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reloads a plugin by unloading and loading it again.
+    /// </summary>
+    /// <param name="plugin">The plugin to reload.</param>
+    /// <returns>True if reloading succeeded; false otherwise.</returns>
+    public bool Reload(LoadedPlugin plugin)
+    {
+        if (!plugin.SupportsHotReload)
+        {
+            logger?.LogWarning($"Plugin '{plugin.Manifest.Id}' does not support hot reload");
+            return false;
+        }
+
+        if (!Unload(plugin))
+        {
+            return false;
+        }
+
+        if (!Load(plugin))
+        {
+            return false;
+        }
+
+        // Note: The caller is responsible for re-enabling the plugin if it was enabled
+        return true;
+    }
+
+    private WeakReference? TryUnloadContext(PluginLoadContext context)
+    {
+        if (!context.IsCollectible)
+        {
+            return null;
+        }
+
+        var weakRef = new WeakReference(context);
+        context.Unload();
+        return weakRef;
+    }
+
+    private void WaitForUnload(WeakReference weakRef, string pluginId, int maxAttempts = 10)
+    {
+        for (int i = 0; i < maxAttempts && weakRef.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        if (weakRef.IsAlive)
+        {
+            logger?.LogWarning(
+                $"Plugin '{pluginId}' assembly may not have fully unloaded. " +
+                "There may be lingering references.");
+        }
+    }
+}
+
+/// <summary>
+/// Interface for plugin loader diagnostic logging.
+/// </summary>
+internal interface IEditorPluginLogger
+{
+    /// <summary>Logs an informational message.</summary>
+    void LogInfo(string message);
+
+    /// <summary>Logs a warning message.</summary>
+    void LogWarning(string message);
+
+    /// <summary>Logs an error message.</summary>
+    void LogError(string message);
+}

--- a/editor/KeenEyes.Editor/Plugins/PluginManifest.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginManifest.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// Represents the metadata and configuration for an editor plugin.
+/// </summary>
+/// <remarks>
+/// Plugin manifests are loaded from <c>keeneyes-plugin.json</c> files in plugin packages.
+/// </remarks>
+public sealed class PluginManifest
+{
+    /// <summary>
+    /// Gets or sets the display name of the plugin.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier for the plugin.
+    /// </summary>
+    /// <remarks>
+    /// Should follow reverse domain notation (e.g., "com.example.myplugin").
+    /// </remarks>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin version.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public required string Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin author.
+    /// </summary>
+    [JsonPropertyName("author")]
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin entry point configuration.
+    /// </summary>
+    [JsonPropertyName("entryPoint")]
+    public required PluginEntryPoint EntryPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the editor version compatibility requirements.
+    /// </summary>
+    [JsonPropertyName("compatibility")]
+    public PluginCompatibility? Compatibility { get; set; }
+
+    /// <summary>
+    /// Gets or sets the plugin capabilities.
+    /// </summary>
+    [JsonPropertyName("capabilities")]
+    public PluginCapabilities Capabilities { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the plugin dependencies.
+    /// </summary>
+    /// <remarks>
+    /// Keys are plugin IDs, values are version constraints (e.g., ">=1.0.0", "^2.0.0").
+    /// </remarks>
+    [JsonPropertyName("dependencies")]
+    public Dictionary<string, string> Dependencies { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets optional settings configuration.
+    /// </summary>
+    [JsonPropertyName("settings")]
+    public PluginSettings? Settings { get; set; }
+
+    /// <summary>
+    /// Parses a plugin manifest from JSON.
+    /// </summary>
+    /// <param name="json">The JSON content.</param>
+    /// <returns>The parsed manifest.</returns>
+    /// <exception cref="JsonException">Thrown if the JSON is invalid.</exception>
+    public static PluginManifest Parse(string json)
+    {
+        return JsonSerializer.Deserialize<PluginManifest>(json, JsonOptions)
+            ?? throw new JsonException("Failed to parse plugin manifest: result was null");
+    }
+
+    /// <summary>
+    /// Parses a plugin manifest from a stream.
+    /// </summary>
+    /// <param name="stream">The stream containing JSON content.</param>
+    /// <returns>The parsed manifest.</returns>
+    /// <exception cref="JsonException">Thrown if the JSON is invalid.</exception>
+    public static PluginManifest Parse(Stream stream)
+    {
+        return JsonSerializer.Deserialize<PluginManifest>(stream, JsonOptions)
+            ?? throw new JsonException("Failed to parse plugin manifest: result was null");
+    }
+
+    /// <summary>
+    /// Attempts to parse a plugin manifest from JSON.
+    /// </summary>
+    /// <param name="json">The JSON content.</param>
+    /// <param name="manifest">The parsed manifest, if successful.</param>
+    /// <returns>True if parsing succeeded; false otherwise.</returns>
+    public static bool TryParse(string json, out PluginManifest? manifest)
+    {
+        try
+        {
+            manifest = Parse(json);
+            return true;
+        }
+        catch (JsonException)
+        {
+            manifest = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Serializes the manifest to JSON.
+    /// </summary>
+    /// <returns>The JSON representation.</returns>
+    public string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonOptions);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+/// <summary>
+/// Specifies the entry point for a plugin.
+/// </summary>
+public sealed class PluginEntryPoint
+{
+    /// <summary>
+    /// Gets or sets the assembly file name (e.g., "MyPlugin.dll").
+    /// </summary>
+    [JsonPropertyName("assembly")]
+    public required string Assembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fully qualified type name of the plugin class.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+}
+
+/// <summary>
+/// Specifies editor version compatibility requirements.
+/// </summary>
+public sealed class PluginCompatibility
+{
+    /// <summary>
+    /// Gets or sets the minimum compatible editor version.
+    /// </summary>
+    [JsonPropertyName("minEditorVersion")]
+    public string? MinEditorVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum compatible editor version.
+    /// </summary>
+    [JsonPropertyName("maxEditorVersion")]
+    public string? MaxEditorVersion { get; set; }
+}
+
+/// <summary>
+/// Specifies plugin runtime capabilities.
+/// </summary>
+public sealed class PluginCapabilities
+{
+    /// <summary>
+    /// Gets or sets whether the plugin supports hot reloading.
+    /// </summary>
+    /// <remarks>
+    /// Hot-reloadable plugins can be unloaded and reloaded without editor restart.
+    /// This requires the plugin to properly clean up all resources on shutdown.
+    /// </remarks>
+    [JsonPropertyName("supportsHotReload")]
+    public bool SupportsHotReload { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the plugin can be disabled at runtime.
+    /// </summary>
+    /// <remarks>
+    /// If false, the plugin can only be enabled/disabled by restarting the editor.
+    /// </remarks>
+    [JsonPropertyName("supportsDisable")]
+    public bool SupportsDisable { get; set; } = true;
+}
+
+/// <summary>
+/// Specifies plugin settings configuration.
+/// </summary>
+public sealed class PluginSettings
+{
+    /// <summary>
+    /// Gets or sets the settings configuration file name.
+    /// </summary>
+    [JsonPropertyName("configFile")]
+    public string? ConfigFile { get; set; }
+}

--- a/editor/KeenEyes.Editor/Plugins/PluginRepository.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginRepository.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// Discovers and manages installed plugins from various sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The plugin repository scans the following locations for plugins:
+/// </para>
+/// <list type="bullet">
+/// <item><b>NuGet global cache</b> - ~/.nuget/packages/</item>
+/// <item><b>Editor plugins folder</b> - {editor}/plugins/</item>
+/// <item><b>Project plugins</b> - {project}/.keeneyes/plugins/</item>
+/// <item><b>Development folder</b> - {project}/Plugins/ (for local dev)</item>
+/// </list>
+/// </remarks>
+internal sealed class PluginRepository
+{
+    private const string ManifestFileName = "keeneyes-plugin.json";
+    private const string NuGetPackagesFolderName = "packages";
+
+    private readonly List<string> searchPaths = [];
+    private readonly Dictionary<string, LoadedPlugin> discoveredPlugins = [];
+    private readonly IEditorPluginLogger? logger;
+
+    /// <summary>
+    /// Gets all discovered plugins.
+    /// </summary>
+    public IReadOnlyDictionary<string, LoadedPlugin> Plugins => discoveredPlugins;
+
+    /// <summary>
+    /// Creates a new plugin repository.
+    /// </summary>
+    /// <param name="logger">Optional logger for diagnostic output.</param>
+    public PluginRepository(IEditorPluginLogger? logger = null)
+    {
+        this.logger = logger;
+        InitializeDefaultSearchPaths();
+    }
+
+    /// <summary>
+    /// Adds a search path for plugin discovery.
+    /// </summary>
+    /// <param name="path">The path to search.</param>
+    public void AddSearchPath(string path)
+    {
+        if (!string.IsNullOrWhiteSpace(path) && !searchPaths.Contains(path))
+        {
+            searchPaths.Add(path);
+        }
+    }
+
+    /// <summary>
+    /// Scans all search paths for plugins.
+    /// </summary>
+    /// <returns>The number of plugins discovered.</returns>
+    public int Scan()
+    {
+        discoveredPlugins.Clear();
+        var count = 0;
+
+        foreach (var path in searchPaths)
+        {
+            if (Directory.Exists(path))
+            {
+                count += ScanDirectory(path);
+            }
+        }
+
+        // Also scan NuGet global cache
+        count += ScanNuGetCache();
+
+        logger?.LogInfo($"Discovered {count} plugin(s) from {searchPaths.Count} search path(s)");
+        return count;
+    }
+
+    /// <summary>
+    /// Gets a discovered plugin by ID.
+    /// </summary>
+    /// <param name="pluginId">The plugin ID.</param>
+    /// <returns>The plugin, or null if not found.</returns>
+    public LoadedPlugin? GetPlugin(string pluginId)
+    {
+        return discoveredPlugins.TryGetValue(pluginId, out var plugin) ? plugin : null;
+    }
+
+    /// <summary>
+    /// Checks if a plugin with the specified ID exists.
+    /// </summary>
+    /// <param name="pluginId">The plugin ID.</param>
+    /// <returns>True if the plugin exists; false otherwise.</returns>
+    public bool HasPlugin(string pluginId)
+    {
+        return discoveredPlugins.ContainsKey(pluginId);
+    }
+
+    private void InitializeDefaultSearchPaths()
+    {
+        // Editor plugins folder (next to editor executable)
+        var editorDir = AppDomain.CurrentDomain.BaseDirectory;
+        var editorPluginsPath = Path.Combine(editorDir, "plugins");
+        if (Directory.Exists(editorPluginsPath))
+        {
+            searchPaths.Add(editorPluginsPath);
+        }
+    }
+
+    private int ScanDirectory(string directory)
+    {
+        var count = 0;
+
+        try
+        {
+            // Look for manifest files in immediate subdirectories
+            foreach (var subDir in Directory.GetDirectories(directory))
+            {
+                var manifestPath = Path.Combine(subDir, ManifestFileName);
+                if (File.Exists(manifestPath))
+                {
+                    if (TryLoadManifest(manifestPath, subDir, out var plugin))
+                    {
+                        RegisterPlugin(plugin);
+                        count++;
+                    }
+                }
+
+                // Also check lib/net10.0 structure (NuGet package layout)
+                var libPath = Path.Combine(subDir, "lib", "net10.0");
+                manifestPath = Path.Combine(subDir, "content", ManifestFileName);
+                if (Directory.Exists(libPath) && File.Exists(manifestPath))
+                {
+                    if (TryLoadManifest(manifestPath, libPath, out var plugin2))
+                    {
+                        RegisterPlugin(plugin2);
+                        count++;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning($"Error scanning directory '{directory}': {ex.Message}");
+        }
+
+        return count;
+    }
+
+    private int ScanNuGetCache()
+    {
+        var count = 0;
+        var nugetCache = GetNuGetPackagesPath();
+
+        if (string.IsNullOrEmpty(nugetCache) || !Directory.Exists(nugetCache))
+        {
+            return 0;
+        }
+
+        try
+        {
+            // NuGet packages are stored as: ~/.nuget/packages/{package-id}/{version}/
+            foreach (var packageDir in Directory.GetDirectories(nugetCache))
+            {
+                // Check each version
+                foreach (var versionDir in Directory.GetDirectories(packageDir))
+                {
+                    // Look for manifest in content folder
+                    var manifestPath = Path.Combine(versionDir, "content", ManifestFileName);
+                    var libPath = Path.Combine(versionDir, "lib", "net10.0");
+
+                    if (File.Exists(manifestPath) && Directory.Exists(libPath))
+                    {
+                        if (TryLoadManifest(manifestPath, libPath, out var plugin))
+                        {
+                            // Only register if we don't have a newer version
+                            if (!discoveredPlugins.TryGetValue(plugin.Manifest.Id, out var existing) ||
+                                IsNewerVersion(plugin.Manifest.Version, existing.Manifest.Version))
+                            {
+                                RegisterPlugin(plugin);
+                                count++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning($"Error scanning NuGet cache: {ex.Message}");
+        }
+
+        return count;
+    }
+
+    private static string? GetNuGetPackagesPath()
+    {
+        // Check NUGET_PACKAGES environment variable first
+        var envPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(envPath) && Directory.Exists(envPath))
+        {
+            return envPath;
+        }
+
+        // Default location: ~/.nuget/packages
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var defaultPath = Path.Combine(home, ".nuget", NuGetPackagesFolderName);
+
+        return Directory.Exists(defaultPath) ? defaultPath : null;
+    }
+
+    private bool TryLoadManifest(string manifestPath, string basePath, out LoadedPlugin plugin)
+    {
+        plugin = null!;
+
+        try
+        {
+            var json = File.ReadAllText(manifestPath);
+            var manifest = PluginManifest.Parse(json);
+
+            // Verify the assembly exists
+            var assemblyPath = Path.Combine(basePath, manifest.EntryPoint.Assembly);
+            if (!File.Exists(assemblyPath))
+            {
+                logger?.LogWarning(
+                    $"Plugin manifest at '{manifestPath}' references missing assembly: {manifest.EntryPoint.Assembly}");
+                return false;
+            }
+
+            plugin = new LoadedPlugin(manifest, basePath);
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            logger?.LogWarning($"Failed to parse plugin manifest '{manifestPath}': {ex.Message}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning($"Error loading plugin manifest '{manifestPath}': {ex.Message}");
+            return false;
+        }
+    }
+
+    private void RegisterPlugin(LoadedPlugin plugin)
+    {
+        discoveredPlugins[plugin.Manifest.Id] = plugin;
+        logger?.LogInfo($"Discovered plugin: {plugin.Manifest.Name} ({plugin.Manifest.Id}) v{plugin.Manifest.Version}");
+    }
+
+    private static bool IsNewerVersion(string version1, string version2)
+    {
+        // Simple version comparison - could be enhanced with proper SemVer parsing
+        if (Version.TryParse(version1, out var v1) && Version.TryParse(version2, out var v2))
+        {
+            return v1 > v2;
+        }
+
+        return string.Compare(version1, version2, StringComparison.Ordinal) > 0;
+    }
+}

--- a/editor/KeenEyes.Editor/Plugins/PluginState.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginState.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+namespace KeenEyes.Editor.Plugins;
+
+/// <summary>
+/// Represents the lifecycle state of a plugin.
+/// </summary>
+public enum PluginState
+{
+    /// <summary>
+    /// The plugin has been discovered but not loaded into memory.
+    /// </summary>
+    Discovered,
+
+    /// <summary>
+    /// The plugin assembly is loaded but the plugin is not initialized.
+    /// </summary>
+    Loaded,
+
+    /// <summary>
+    /// The plugin is fully initialized and running.
+    /// </summary>
+    Enabled,
+
+    /// <summary>
+    /// The plugin was disabled by the user but remains in memory.
+    /// </summary>
+    Disabled,
+
+    /// <summary>
+    /// The plugin failed to load or initialize.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The plugin is being unloaded.
+    /// </summary>
+    Unloading
+}

--- a/tests/KeenEyes.Editor.Tests/Plugins/LoadedPluginTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/LoadedPluginTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Plugins;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="LoadedPlugin"/>.
+/// </summary>
+public sealed class LoadedPluginTests
+{
+    private static PluginManifest CreateTestManifest(
+        string name = "Test Plugin",
+        string id = "com.example.test",
+        bool supportsHotReload = false,
+        bool supportsDisable = true) => new()
+        {
+            Name = name,
+            Id = id,
+            Version = "1.0.0",
+            EntryPoint = new PluginEntryPoint
+            {
+                Assembly = "TestPlugin.dll",
+                Type = "TestPlugin.TestEditorPlugin"
+            },
+            Capabilities = new PluginCapabilities
+            {
+                SupportsHotReload = supportsHotReload,
+                SupportsDisable = supportsDisable
+            }
+        };
+
+    [Fact]
+    public void Constructor_InitializesWithDiscoveredState()
+    {
+        // Arrange
+        var manifest = CreateTestManifest();
+
+        // Act
+        var loadedPlugin = new LoadedPlugin(manifest, "/path/to/plugin");
+
+        // Assert
+        Assert.Equal(PluginState.Discovered, loadedPlugin.State);
+        Assert.Null(loadedPlugin.Instance);
+        Assert.Null(loadedPlugin.ErrorMessage);
+    }
+
+    [Fact]
+    public void GetAssemblyPath_CombinesBasePathAndAssembly()
+    {
+        // Arrange
+        var manifest = CreateTestManifest();
+        var basePath = "/plugins/myplugin";
+        var loadedPlugin = new LoadedPlugin(manifest, basePath);
+
+        // Act
+        var assemblyPath = loadedPlugin.GetAssemblyPath();
+
+        // Assert
+        Assert.Equal("/plugins/myplugin/TestPlugin.dll", assemblyPath);
+    }
+
+    [Fact]
+    public void SupportsHotReload_ReflectsManifestCapabilities()
+    {
+        // Arrange
+        var hotReloadManifest = CreateTestManifest(supportsHotReload: true);
+        var noHotReloadManifest = CreateTestManifest(supportsHotReload: false);
+
+        // Act
+        var hotReloadPlugin = new LoadedPlugin(hotReloadManifest, "/path");
+        var noHotReloadPlugin = new LoadedPlugin(noHotReloadManifest, "/path");
+
+        // Assert
+        Assert.True(hotReloadPlugin.SupportsHotReload);
+        Assert.False(noHotReloadPlugin.SupportsHotReload);
+    }
+
+    [Fact]
+    public void SupportsDisable_ReflectsManifestCapabilities()
+    {
+        // Arrange
+        var disableManifest = CreateTestManifest(supportsDisable: true);
+        var noDisableManifest = CreateTestManifest(supportsDisable: false);
+
+        // Act
+        var disablePlugin = new LoadedPlugin(disableManifest, "/path");
+        var noDisablePlugin = new LoadedPlugin(noDisableManifest, "/path");
+
+        // Assert
+        Assert.True(disablePlugin.SupportsDisable);
+        Assert.False(noDisablePlugin.SupportsDisable);
+    }
+
+    [Fact]
+    public void ToString_IncludesNameIdVersionAndState()
+    {
+        // Arrange
+        var manifest = CreateTestManifest(name: "My Plugin", id: "com.example.myplugin");
+        var loadedPlugin = new LoadedPlugin(manifest, "/path");
+
+        // Act
+        var str = loadedPlugin.ToString();
+
+        // Assert
+        Assert.Contains("My Plugin", str);
+        Assert.Contains("com.example.myplugin", str);
+        Assert.Contains("1.0.0", str);
+        Assert.Contains("Discovered", str);
+    }
+
+    [Fact]
+    public void State_CanBeUpdated()
+    {
+        // Arrange
+        var manifest = CreateTestManifest();
+        var loadedPlugin = new LoadedPlugin(manifest, "/path");
+
+        // Act & Assert - state transitions
+        Assert.Equal(PluginState.Discovered, loadedPlugin.State);
+
+        loadedPlugin.State = PluginState.Loaded;
+        Assert.Equal(PluginState.Loaded, loadedPlugin.State);
+
+        loadedPlugin.State = PluginState.Enabled;
+        Assert.Equal(PluginState.Enabled, loadedPlugin.State);
+
+        loadedPlugin.State = PluginState.Disabled;
+        Assert.Equal(PluginState.Disabled, loadedPlugin.State);
+    }
+
+    [Fact]
+    public void ErrorMessage_CanBeSet()
+    {
+        // Arrange
+        var manifest = CreateTestManifest();
+        var loadedPlugin = new LoadedPlugin(manifest, "/path")
+        {
+            State = PluginState.Failed,
+            ErrorMessage = "Assembly not found"
+        };
+
+        // Assert
+        Assert.Equal(PluginState.Failed, loadedPlugin.State);
+        Assert.Equal("Assembly not found", loadedPlugin.ErrorMessage);
+    }
+}

--- a/tests/KeenEyes.Editor.Tests/Plugins/PluginManifestTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/PluginManifestTests.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Plugins;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="PluginManifest"/> JSON parsing.
+/// </summary>
+public sealed class PluginManifestTests
+{
+    #region Parse Tests
+
+    [Fact]
+    public void Parse_WithValidJson_ReturnsManifest()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "author": "Test Author",
+                "description": "A test plugin",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.TestEditorPlugin"
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.Equal("Test Plugin", manifest.Name);
+        Assert.Equal("com.example.test", manifest.Id);
+        Assert.Equal("1.0.0", manifest.Version);
+        Assert.Equal("Test Author", manifest.Author);
+        Assert.Equal("A test plugin", manifest.Description);
+        Assert.Equal("TestPlugin.dll", manifest.EntryPoint.Assembly);
+        Assert.Equal("TestPlugin.TestEditorPlugin", manifest.EntryPoint.Type);
+    }
+
+    [Fact]
+    public void Parse_WithCapabilities_ParsesHotReloadFlag()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Hot Reload Plugin",
+                "id": "com.example.hotreload",
+                "version": "2.0.0",
+                "entryPoint": {
+                    "assembly": "HotReloadPlugin.dll",
+                    "type": "HotReloadPlugin.Plugin"
+                },
+                "capabilities": {
+                    "supportsHotReload": true,
+                    "supportsDisable": true
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.True(manifest.Capabilities.SupportsHotReload);
+        Assert.True(manifest.Capabilities.SupportsDisable);
+    }
+
+    [Fact]
+    public void Parse_WithCompatibility_ParsesVersions()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Versioned Plugin",
+                "id": "com.example.versioned",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "VersionedPlugin.dll",
+                    "type": "VersionedPlugin.Plugin"
+                },
+                "compatibility": {
+                    "minEditorVersion": "1.0.0",
+                    "maxEditorVersion": "2.0.0"
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.NotNull(manifest.Compatibility);
+        Assert.Equal("1.0.0", manifest.Compatibility.MinEditorVersion);
+        Assert.Equal("2.0.0", manifest.Compatibility.MaxEditorVersion);
+    }
+
+    [Fact]
+    public void Parse_WithDependencies_ParsesDependencyMap()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Dependent Plugin",
+                "id": "com.example.dependent",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "DependentPlugin.dll",
+                    "type": "DependentPlugin.Plugin"
+                },
+                "dependencies": {
+                    "com.example.base": ">=1.0.0",
+                    "com.example.utils": "^2.0.0"
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.Equal(2, manifest.Dependencies.Count);
+        Assert.Equal(">=1.0.0", manifest.Dependencies["com.example.base"]);
+        Assert.Equal("^2.0.0", manifest.Dependencies["com.example.utils"]);
+    }
+
+    [Fact]
+    public void Parse_WithSettings_ParsesConfigFile()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Configurable Plugin",
+                "id": "com.example.configurable",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "ConfigurablePlugin.dll",
+                    "type": "ConfigurablePlugin.Plugin"
+                },
+                "settings": {
+                    "configFile": "config.json"
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.NotNull(manifest.Settings);
+        Assert.Equal("config.json", manifest.Settings.ConfigFile);
+    }
+
+    [Fact]
+    public void Parse_WithMinimalJson_UsesDefaults()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Minimal Plugin",
+                "id": "com.example.minimal",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "MinimalPlugin.dll",
+                    "type": "MinimalPlugin.Plugin"
+                }
+            }
+            """;
+
+        // Act
+        var manifest = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.Null(manifest.Author);
+        Assert.Null(manifest.Description);
+        Assert.Null(manifest.Compatibility);
+        Assert.Null(manifest.Settings);
+        Assert.False(manifest.Capabilities.SupportsHotReload);
+        Assert.True(manifest.Capabilities.SupportsDisable); // Default is true
+        Assert.Empty(manifest.Dependencies);
+    }
+
+    [Fact]
+    public void Parse_WithInvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        var json = "{ invalid json }";
+
+        // Act & Assert
+        Assert.ThrowsAny<System.Text.Json.JsonException>(() => PluginManifest.Parse(json));
+    }
+
+    [Fact]
+    public void Parse_WithMissingRequiredFields_ThrowsJsonException()
+    {
+        // Arrange - missing entryPoint
+        var json = """
+            {
+                "name": "Incomplete Plugin",
+                "id": "com.example.incomplete",
+                "version": "1.0.0"
+            }
+            """;
+
+        // Act & Assert
+        Assert.ThrowsAny<System.Text.Json.JsonException>(() => PluginManifest.Parse(json));
+    }
+
+    #endregion
+
+    #region TryParse Tests
+
+    [Fact]
+    public void TryParse_WithValidJson_ReturnsTrue()
+    {
+        // Arrange
+        var json = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.Plugin"
+                }
+            }
+            """;
+
+        // Act
+        var result = PluginManifest.TryParse(json, out var manifest);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(manifest);
+        Assert.Equal("Test Plugin", manifest.Name);
+    }
+
+    [Fact]
+    public void TryParse_WithInvalidJson_ReturnsFalse()
+    {
+        // Arrange
+        var json = "{ invalid json }";
+
+        // Act
+        var result = PluginManifest.TryParse(json, out var manifest);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(manifest);
+    }
+
+    #endregion
+
+    #region ToJson Tests
+
+    [Fact]
+    public void ToJson_SerializesCorrectly()
+    {
+        // Arrange
+        var manifest = new PluginManifest
+        {
+            Name = "Test Plugin",
+            Id = "com.example.test",
+            Version = "1.0.0",
+            Author = "Test Author",
+            EntryPoint = new PluginEntryPoint
+            {
+                Assembly = "TestPlugin.dll",
+                Type = "TestPlugin.Plugin"
+            }
+        };
+
+        // Act
+        var json = manifest.ToJson();
+
+        // Assert
+        Assert.Contains("\"name\": \"Test Plugin\"", json);
+        Assert.Contains("\"id\": \"com.example.test\"", json);
+        Assert.Contains("\"version\": \"1.0.0\"", json);
+    }
+
+    [Fact]
+    public void ToJson_AndParse_RoundTrips()
+    {
+        // Arrange
+        var original = new PluginManifest
+        {
+            Name = "Round Trip Plugin",
+            Id = "com.example.roundtrip",
+            Version = "1.2.3",
+            Author = "Test Author",
+            Description = "A test description",
+            EntryPoint = new PluginEntryPoint
+            {
+                Assembly = "RoundTrip.dll",
+                Type = "RoundTrip.Plugin"
+            },
+            Capabilities = new PluginCapabilities
+            {
+                SupportsHotReload = true,
+                SupportsDisable = true
+            }
+        };
+
+        // Act
+        var json = original.ToJson();
+        var parsed = PluginManifest.Parse(json);
+
+        // Assert
+        Assert.Equal(original.Name, parsed.Name);
+        Assert.Equal(original.Id, parsed.Id);
+        Assert.Equal(original.Version, parsed.Version);
+        Assert.Equal(original.Author, parsed.Author);
+        Assert.Equal(original.Description, parsed.Description);
+        Assert.Equal(original.EntryPoint.Assembly, parsed.EntryPoint.Assembly);
+        Assert.Equal(original.EntryPoint.Type, parsed.EntryPoint.Type);
+        Assert.Equal(original.Capabilities.SupportsHotReload, parsed.Capabilities.SupportsHotReload);
+        Assert.Equal(original.Capabilities.SupportsDisable, parsed.Capabilities.SupportsDisable);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Editor.Tests/Plugins/PluginRepositoryTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/PluginRepositoryTests.cs
@@ -1,0 +1,358 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Plugins;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="PluginRepository"/>.
+/// </summary>
+public sealed class PluginRepositoryTests : IDisposable
+{
+    private readonly string testDirectory;
+
+    public PluginRepositoryTests()
+    {
+        // Create a unique temp directory for each test
+        testDirectory = Path.Combine(Path.GetTempPath(), $"KeenEyesPluginTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(testDirectory);
+    }
+
+    public void Dispose()
+    {
+        // Clean up test directory
+        if (Directory.Exists(testDirectory))
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    private string CreatePluginDirectory(string pluginId, string manifestJson)
+    {
+        var pluginDir = Path.Combine(testDirectory, pluginId);
+        Directory.CreateDirectory(pluginDir);
+
+        // Write manifest
+        File.WriteAllText(Path.Combine(pluginDir, "keeneyes-plugin.json"), manifestJson);
+
+        // Create dummy assembly file
+        File.WriteAllText(Path.Combine(pluginDir, "TestPlugin.dll"), "");
+
+        return pluginDir;
+    }
+
+    [Fact]
+    public void Constructor_CreatesEmptyRepository()
+    {
+        // Act
+        var repository = new PluginRepository();
+
+        // Assert
+        Assert.Empty(repository.Plugins);
+    }
+
+    [Fact]
+    public void AddSearchPath_AddsPath()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        var searchPath = Path.Combine(testDirectory, "search");
+        Directory.CreateDirectory(searchPath);
+
+        // Act
+        repository.AddSearchPath(searchPath);
+
+        // No direct way to verify, but Scan() should include this path
+        Assert.NotNull(repository);
+    }
+
+    [Fact]
+    public void AddSearchPath_IgnoresNullOrWhitespace()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+
+        // Act - should not throw
+        repository.AddSearchPath(null!);
+        repository.AddSearchPath("");
+        repository.AddSearchPath("   ");
+
+        // Assert - no exception
+        Assert.NotNull(repository);
+    }
+
+    [Fact]
+    public void Scan_DiscoversPluginWithValidManifest()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var manifestJson = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.TestEditorPlugin"
+                }
+            }
+            """;
+        CreatePluginDirectory("test-plugin", manifestJson);
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(1, count);
+        Assert.Single(repository.Plugins);
+        Assert.True(repository.HasPlugin("com.example.test"));
+    }
+
+    [Fact]
+    public void Scan_IgnoresDirectoriesWithoutManifest()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        // Create directory without manifest
+        var pluginDir = Path.Combine(testDirectory, "no-manifest");
+        Directory.CreateDirectory(pluginDir);
+        File.WriteAllText(Path.Combine(pluginDir, "SomePlugin.dll"), "");
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(0, count);
+        Assert.Empty(repository.Plugins);
+    }
+
+    [Fact]
+    public void Scan_IgnoresInvalidManifests()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var pluginDir = Path.Combine(testDirectory, "invalid-manifest");
+        Directory.CreateDirectory(pluginDir);
+        File.WriteAllText(Path.Combine(pluginDir, "keeneyes-plugin.json"), "{ invalid json }");
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(0, count);
+        Assert.Empty(repository.Plugins);
+    }
+
+    [Fact]
+    public void Scan_IgnoresManifestWithMissingAssembly()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var manifestJson = """
+            {
+                "name": "Missing Assembly Plugin",
+                "id": "com.example.missing",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "NonExistent.dll",
+                    "type": "NonExistent.Plugin"
+                }
+            }
+            """;
+
+        var pluginDir = Path.Combine(testDirectory, "missing-assembly");
+        Directory.CreateDirectory(pluginDir);
+        File.WriteAllText(Path.Combine(pluginDir, "keeneyes-plugin.json"), manifestJson);
+        // Note: Not creating the assembly file
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(0, count);
+        Assert.Empty(repository.Plugins);
+    }
+
+    [Fact]
+    public void Scan_DiscoversMultiplePlugins()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        for (int i = 1; i <= 3; i++)
+        {
+            var manifestJson = $$"""
+                {
+                    "name": "Plugin {{i}}",
+                    "id": "com.example.plugin{{i}}",
+                    "version": "1.0.0",
+                    "entryPoint": {
+                        "assembly": "TestPlugin.dll",
+                        "type": "Plugin{{i}}.Plugin"
+                    }
+                }
+                """;
+            CreatePluginDirectory($"plugin{i}", manifestJson);
+        }
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(3, count);
+        Assert.Equal(3, repository.Plugins.Count);
+        Assert.True(repository.HasPlugin("com.example.plugin1"));
+        Assert.True(repository.HasPlugin("com.example.plugin2"));
+        Assert.True(repository.HasPlugin("com.example.plugin3"));
+    }
+
+    [Fact]
+    public void GetPlugin_ReturnsPluginById()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var manifestJson = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.TestEditorPlugin"
+                }
+            }
+            """;
+        CreatePluginDirectory("test-plugin", manifestJson);
+        repository.Scan();
+
+        // Act
+        var plugin = repository.GetPlugin("com.example.test");
+
+        // Assert
+        Assert.NotNull(plugin);
+        Assert.Equal("Test Plugin", plugin.Manifest.Name);
+        Assert.Equal("com.example.test", plugin.Manifest.Id);
+    }
+
+    [Fact]
+    public void GetPlugin_ReturnsNullForUnknownId()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+
+        // Act
+        var plugin = repository.GetPlugin("com.example.nonexistent");
+
+        // Assert
+        Assert.Null(plugin);
+    }
+
+    [Fact]
+    public void HasPlugin_ReturnsTrueForExistingPlugin()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var manifestJson = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.TestEditorPlugin"
+                }
+            }
+            """;
+        CreatePluginDirectory("test-plugin", manifestJson);
+        repository.Scan();
+
+        // Act & Assert
+        Assert.True(repository.HasPlugin("com.example.test"));
+        Assert.False(repository.HasPlugin("com.example.nonexistent"));
+    }
+
+    [Fact]
+    public void Scan_ClearsPreviousResults()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var manifestJson = """
+            {
+                "name": "Test Plugin",
+                "id": "com.example.test",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "TestPlugin.dll",
+                    "type": "TestPlugin.TestEditorPlugin"
+                }
+            }
+            """;
+        CreatePluginDirectory("test-plugin", manifestJson);
+
+        // First scan
+        repository.Scan();
+        Assert.Single(repository.Plugins);
+
+        // Remove the plugin directory
+        Directory.Delete(Path.Combine(testDirectory, "test-plugin"), recursive: true);
+
+        // Second scan
+        repository.Scan();
+
+        // Assert - plugins cleared
+        Assert.Empty(repository.Plugins);
+    }
+
+    [Fact]
+    public void Scan_HandlesNuGetPackageLayout()
+    {
+        // Arrange
+        var repository = new PluginRepository();
+        repository.AddSearchPath(testDirectory);
+
+        var packageDir = Path.Combine(testDirectory, "mypackage");
+        var contentDir = Path.Combine(packageDir, "content");
+        var libDir = Path.Combine(packageDir, "lib", "net10.0");
+
+        Directory.CreateDirectory(contentDir);
+        Directory.CreateDirectory(libDir);
+
+        var manifestJson = """
+            {
+                "name": "NuGet Plugin",
+                "id": "com.example.nuget",
+                "version": "1.0.0",
+                "entryPoint": {
+                    "assembly": "NuGetPlugin.dll",
+                    "type": "NuGetPlugin.Plugin"
+                }
+            }
+            """;
+
+        File.WriteAllText(Path.Combine(contentDir, "keeneyes-plugin.json"), manifestJson);
+        File.WriteAllText(Path.Combine(libDir, "NuGetPlugin.dll"), "");
+
+        // Act
+        var count = repository.Scan();
+
+        // Assert
+        Assert.Equal(1, count);
+        Assert.True(repository.HasPlugin("com.example.nuget"));
+    }
+}


### PR DESCRIPTION
## Summary

- Implement three-tier plugin loading system (static, enable/disable, hot reload)
- Add `PluginManifest` for `keeneyes-plugin.json` schema
- Add `PluginLoadContext` for isolated assembly loading per plugin
- Add `PluginLoader` for assembly load/unload lifecycle
- Add `PluginRepository` for discovering plugins from NuGet cache
- Extend `EditorPluginManager` with dynamic loading APIs

## Details

Plugins can now be distributed as NuGet packages with a `keeneyes-plugin.json` manifest:

```json
{
  "name": "My Plugin",
  "id": "com.example.myplugin",
  "version": "1.0.0",
  "entryPoint": {
    "assembly": "MyPlugin.dll",
    "type": "MyPlugin.MyEditorPlugin"
  },
  "capabilities": {
    "supportsHotReload": false,
    "supportsDisable": true
  }
}
```

### API

```csharp
// Discover plugins from NuGet cache and search paths
editorPlugins.DiscoverPlugins();

// Load and enable a plugin
editorPlugins.LoadDynamicPlugin("com.example.myplugin");

// Toggle at runtime (Tier 2)
editorPlugins.DisableDynamicPlugin("com.example.myplugin");
editorPlugins.EnableDynamicPlugin("com.example.myplugin");

// Hot reload for development (Tier 3, opt-in)
editorPlugins.ReloadDynamicPlugin("com.example.myplugin");
```

### Architecture

See [ADR-013](docs/adr/013-dynamic-plugin-loading.md) for detailed design decisions.

## Test plan

- [x] Unit tests for manifest parsing (valid, invalid, minimal, full)
- [x] Unit tests for LoadedPlugin state management
- [x] Unit tests for PluginRepository discovery
- [x] Build passes with zero warnings
- [ ] Manual testing with real plugin assembly (future)

## Related

- Closes #671
- Related to #654 (IAssetCapability)