### PR TITLE
docs: Update API documentation to match current codebase

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -188,9 +188,27 @@ int count = world.EntityCount;
 
 // Memory statistics
 var stats = world.GetMemoryStats();
-Console.WriteLine($"Total entities: {stats.TotalEntities}");
+Console.WriteLine($"Active entities: {stats.EntitiesActive}");
+Console.WriteLine($"Total allocated: {stats.EntitiesAllocated}");
 Console.WriteLine($"Archetypes: {stats.ArchetypeCount}");
+Console.WriteLine($"Query cache hit rate: {stats.QueryCacheHitRate:F1}%");
+Console.WriteLine($"Estimated storage: {stats.EstimatedComponentBytes / 1024.0:F1} KB");
 ```
+
+The `MemoryStats` struct includes:
+
+| Property | Description |
+|----------|-------------|
+| `EntitiesActive` | Number of currently alive entities |
+| `EntitiesAllocated` | Total entities ever allocated |
+| `EntitiesRecycled` | Entity IDs available for reuse |
+| `EntityRecycleCount` | Total recycling operations |
+| `ArchetypeCount` | Number of active archetypes |
+| `ComponentTypeCount` | Registered component types |
+| `SystemCount` | Registered systems |
+| `CachedQueryCount` | Cached query count |
+| `QueryCacheHits` / `QueryCacheMisses` | Cache statistics |
+| `EstimatedComponentBytes` | Estimated storage size |
 
 ## Null Entity
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,12 @@ Add the KeenEyes packages to your project:
 
 ```bash
 dotnet add package KeenEyes.Core
-dotnet add package KeenEyes.Generators.Attributes
+```
+
+The `KeenEyes.Core` package includes all necessary types. For plugin development or minimal dependencies, you may use:
+
+```bash
+dotnet add package KeenEyes.Abstractions
 ```
 
 ## Step 1: Define Components
@@ -166,7 +171,7 @@ Console.WriteLine("All particles expired!");
 KeenEyes provides source generators to reduce boilerplate. Add the `[Component]` attribute:
 
 ```csharp
-using KeenEyes.Generators.Attributes;
+using KeenEyes;
 
 [Component]
 public partial struct Position
@@ -195,7 +200,7 @@ world.Spawn()
 For entities with many components, use bundles to group related components:
 
 ```csharp
-using KeenEyes.Generators.Attributes;
+using KeenEyes;
 
 [Component]
 public partial struct Position { public float X, Y; }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -414,15 +414,17 @@ public void Install(IPluginContext context)
 
 ### Available Capabilities
 
-| Capability | Purpose | Methods |
-|------------|---------|---------|
-| `ISystemHookCapability` | Before/after system hooks | `AddSystemHook()` |
-| `IPersistenceCapability` | World save/load | `CreateSnapshot()`, `RestoreSnapshot()` |
-| `IHierarchyCapability` | Entity parent-child relationships | `SetParent()`, `GetChildren()`, `GetDescendants()` |
-| `IValidationCapability` | Component validation | `RegisterValidator<T>()`, `ValidationMode` |
-| `ITagCapability` | String-based entity tagging | `AddTag()`, `RemoveTag()`, `QueryByTag()` |
-| `IStatisticsCapability` | Memory profiling | `GetMemoryStats()` |
-| `IPrefabCapability` | Entity templates | `RegisterPrefab()`, `SpawnFromPrefab()` |
+| Capability | Purpose | Key Methods |
+|------------|---------|-------------|
+| `ISystemHookCapability` | Before/after system execution hooks | `AddSystemHook()` |
+| `IPersistenceCapability` | Configure save directory | `SaveDirectory` property |
+| `IHierarchyCapability` | Entity parent-child relationships | `SetParent()`, `GetChildren()`, `GetDescendants()`, `GetAncestors()`, `DespawnRecursive()` |
+| `IValidationCapability` | Component constraint validation | `RegisterValidator<T>()`, `ValidationMode` |
+| `ITagCapability` | String-based entity tagging | `AddTag()`, `RemoveTag()`, `HasTag()`, `QueryByTag()` |
+| `IStatisticsCapability` | Memory and performance statistics | `GetMemoryStats()` |
+| `IPrefabCapability` | Entity prefab templates | `RegisterPrefab()`, `SpawnFromPrefab()`, `HasPrefab()` |
+| `ISnapshotCapability` | World state serialization | `GetComponents()`, `GetAllSingletons()`, `SetSingleton()`, `Clear()` |
+| `IInspectionCapability` | Entity debugging and inspection | `GetName()`, `HasComponent()`, `GetRegisteredComponents()` |
 
 ### Requesting Capabilities
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -94,6 +94,39 @@ foreach (var entity in world.Query<Position, Velocity>()
 }
 ```
 
+### String Tag Filters
+
+In addition to component-based tags, you can filter by runtime string tags:
+
+```csharp
+// Entities with a specific string tag
+foreach (var entity in world.Query<Position>().WithTag("player"))
+{
+    // Player tagged entities
+}
+
+// Exclude entities with a string tag
+foreach (var entity in world.Query<Position>().WithoutTag("npc"))
+{
+    // Entities that are NOT tagged as "npc"
+}
+
+// Combine string tag filters
+foreach (var entity in world.Query<Position>()
+    .WithTag("enemy")
+    .WithoutTag("boss"))
+{
+    // Regular enemies (not bosses)
+}
+```
+
+String tags are useful for:
+- Runtime categorization that can change dynamically
+- Editor-driven tagging systems
+- Scenarios where you can't define component types ahead of time
+
+**Note:** String tag filtering is per-entity (O(entities)) rather than per-archetype, so prefer component-based tags when performance is critical.
+
 ## Query Results
 
 Queries return an enumerable of `Entity`:


### PR DESCRIPTION
## Summary
- Updated `IWorld`, `IPluginContext`, and `IEntityBuilder` interfaces in abstractions.md to match current implementations
- Added string tag filtering documentation (`WithTag`/`WithoutTag`) to queries.md
- Fixed `MemoryStats` properties in entities.md to match actual struct fields
- Added missing capabilities (`ISnapshotCapability`, `IInspectionCapability`) to plugins.md
- Updated messaging section in systems.md to use correct `World.Send`/`Subscribe` API
- Fixed package references in getting-started.md (removed nonexistent `KeenEyes.Generators.Attributes`)

## Test plan
- [ ] Documentation renders correctly in markdown preview
- [ ] Code examples in documentation are syntactically correct
- [ ] All interface definitions match actual source files in `src/KeenEyes.Abstractions/`