### PR TITLE
fix(benchmarks): Ensure benchmark methods consume ref return values

### DIFF
--- a/benchmarks/KeenEyes.Benchmarks/ComponentBenchmarks.cs
+++ b/benchmarks/KeenEyes.Benchmarks/ComponentBenchmarks.cs
@@ -49,9 +49,10 @@ public class ComponentBenchmarks
     /// Measures the cost of getting a component by reference.
     /// </summary>
     [Benchmark]
-    public ref Position GetComponent()
+    public float GetComponent()
     {
-        return ref world.Get<Position>(entity);
+        ref var pos = ref world.Get<Position>(entity);
+        return pos.X; // Force actual memory access to prevent JIT optimization
     }
 
     /// <summary>
@@ -252,27 +253,30 @@ public class ComponentSizeBenchmarks
     /// Measures Get performance for small components (4 bytes).
     /// </summary>
     [Benchmark(Baseline = true)]
-    public ref SmallComponent GetSmallComponent()
+    public int GetSmallComponent()
     {
-        return ref world.Get<SmallComponent>(smallEntity);
+        ref var component = ref world.Get<SmallComponent>(smallEntity);
+        return component.Value; // Force actual memory access to prevent JIT optimization
     }
 
     /// <summary>
     /// Measures Get performance for medium components (64 bytes).
     /// </summary>
     [Benchmark]
-    public ref MediumComponent GetMediumComponent()
+    public long GetMediumComponent()
     {
-        return ref world.Get<MediumComponent>(mediumEntity);
+        ref var component = ref world.Get<MediumComponent>(mediumEntity);
+        return component.A; // Force actual memory access to prevent JIT optimization
     }
 
     /// <summary>
     /// Measures Get performance for large components (256 bytes).
     /// </summary>
     [Benchmark]
-    public ref LargeComponent GetLargeComponent()
+    public long GetLargeComponent()
     {
-        return ref world.Get<LargeComponent>(largeEntity);
+        ref var component = ref world.Get<LargeComponent>(largeEntity);
+        return component.A0; // Force actual memory access to prevent JIT optimization
     }
 }
 

--- a/benchmarks/KeenEyes.Benchmarks/SmokeTestBenchmarks.cs
+++ b/benchmarks/KeenEyes.Benchmarks/SmokeTestBenchmarks.cs
@@ -73,9 +73,10 @@ public class SmokeTestBenchmarks
     /// Get component by ref - critical hot path.
     /// </summary>
     [Benchmark]
-    public ref Position Component_GetByRef()
+    public float Component_GetByRef()
     {
-        return ref world.Get<Position>(singleEntity);
+        ref var pos = ref world.Get<Position>(singleEntity);
+        return pos.X; // Force actual memory access to prevent JIT optimization
     }
 
     /// <summary>
@@ -147,9 +148,10 @@ public class SmokeTestBenchmarks
     /// Get singleton - global game state access pattern.
     /// </summary>
     [Benchmark]
-    public ref GameTime Singleton_Get()
+    public float Singleton_Get()
     {
-        return ref world.GetSingleton<GameTime>();
+        ref var gameTime = ref world.GetSingleton<GameTime>();
+        return gameTime.DeltaTime; // Force actual memory access to prevent JIT optimization
     }
 
     [IterationSetup(Target = nameof(Singleton_Get))]


### PR DESCRIPTION
## Summary
- Fixed 6 benchmark methods that returned ref values without consuming them
- JIT optimizer could potentially skip actual memory access since the ref was never used
- Changed methods to return actual field values, forcing memory access during benchmarking

## Methods Fixed
- `ComponentBenchmarks.GetComponent()` - now returns `pos.X`
- `ComponentBenchmarks.GetSmallComponent()` - now returns `component.Value`
- `ComponentBenchmarks.GetMediumComponent()` - now returns `component.A`
- `ComponentBenchmarks.GetLargeComponent()` - now returns `component.A0`
- `SmokeTestBenchmarks.Component_GetByRef()` - now returns `pos.X`
- `SmokeTestBenchmarks.Singleton_Get()` - now returns `gameTime.DeltaTime`

## Test plan
- [x] Build succeeds with zero warnings
- [x] All 10,457 tests pass
- [ ] Benchmarks run successfully

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)