### PR TITLE
fix: Remove unused IsRef field from QueryGenerator

### DIFF
--- a/editor/KeenEyes.Generators/QueryGenerator.cs
+++ b/editor/KeenEyes.Generators/QueryGenerator.cs
@@ -83,13 +83,11 @@ public sealed class QueryGenerator : IIncrementalGenerator
             }
 
             var fieldType = field.Type;
-            var isRef = false;
             var isReadOnly = false;
 
             // Check for ref/ref readonly field types
             if (fieldType is IPointerTypeSymbol || field.RefKind != RefKind.None)
             {
-                isRef = true;
                 isReadOnly = field.RefKind == RefKind.RefReadOnly;
             }
 
@@ -153,8 +151,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
             fields.Add(new QueryFieldInfo(
                 field.Name,
                 componentType,
-                accessType,
-                isRef));
+                accessType));
         }
 
         return new QueryInfo(
@@ -250,8 +247,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
     private sealed record QueryFieldInfo(
         string Name,
         string ComponentType,
-        QueryAccessType AccessType,
-        bool IsRef);
+        QueryAccessType AccessType);
 
     private sealed record QueryDiagnosticInfo(
         DiagnosticDescriptor Descriptor,


### PR DESCRIPTION
## Summary
- **L4**: Removed unused `IsRef` property from `QueryFieldInfo` record in QueryGenerator
  - The property was set but never read
  - The `AccessType` enum already captures whether the field is read-only or writable
  - Simplifies the code by removing dead state

## Items not included
Other low priority items can be addressed separately:
- L1 (Archetype.cs): Add removal timeline to Obsolete attributes
- L2 (ComponentRegistry.cs): Add IComponent constraint  
- L3 (World.Entities.cs): Clarify Remove<T>() documentation
- L5 (SystemGenerator.cs): Extract shared helper method
- L6 (LoaderTests.cs): Rename tests to follow convention
- L7 (Diagnostic IDs): Document grouping conventions

## Test plan
- [x] Generator builds successfully
- [x] No compilation errors

Fixes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)