### PR TITLE
feat(navigation): Add KeenEyes.Navigation.Abstractions package

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -67,6 +67,7 @@
     <Project Path="src/KeenEyes.Replay/KeenEyes.Replay.csproj" />
     <Project Path="src/KeenEyes.Spatial/KeenEyes.Spatial.csproj" />
     <Project Path="src/KeenEyes.Testing/KeenEyes.Testing.csproj" />
+    <Project Path="src/KeenEyes.Navigation.Abstractions/KeenEyes.Navigation.Abstractions.csproj" />
     <Project Path="src/KeenEyes.UI.Abstractions/KeenEyes.UI.Abstractions.csproj" />
     <Project Path="src/KeenEyes.UI/KeenEyes.UI.csproj" />
   </Folder>
@@ -88,6 +89,7 @@
     <Project Path="tests/KeenEyes.Graphics.Tests/KeenEyes.Graphics.Tests.csproj" />
     <Project Path="tests/KeenEyes.Input.Abstractions.Tests/KeenEyes.Input.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Logging.Tests/KeenEyes.Logging.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Navigation.Abstractions.Tests/KeenEyes.Navigation.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Network.Abstractions.Tests/KeenEyes.Network.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Network.Tests/KeenEyes.Network.Tests.csproj" />
     <Project Path="tests/KeenEyes.Parallelism.Tests/KeenEyes.Parallelism.Tests.csproj" />

--- a/src/KeenEyes.Navigation.Abstractions/AgentSettings.cs
+++ b/src/KeenEyes.Navigation.Abstractions/AgentSettings.cs
@@ -1,0 +1,85 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Configuration settings for a navigation agent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Agent settings define the physical characteristics that affect pathfinding,
+/// such as the agent's size and movement capabilities. These settings determine
+/// which areas the agent can traverse and how paths are computed.
+/// </para>
+/// <para>
+/// Use <see cref="Default"/> for typical humanoid characters or create custom
+/// settings for vehicles, large creatures, or other agent types.
+/// </para>
+/// </remarks>
+/// <param name="Radius">
+/// The radius of the agent's collision cylinder in world units.
+/// Used to determine navigable areas and obstacle avoidance.
+/// </param>
+/// <param name="Height">
+/// The height of the agent's collision cylinder in world units.
+/// Used for overhead clearance checks.
+/// </param>
+/// <param name="MaxSlopeAngle">
+/// The maximum slope angle the agent can walk up, in degrees.
+/// Surfaces steeper than this are considered unwalkable.
+/// </param>
+/// <param name="StepHeight">
+/// The maximum step height the agent can climb without jumping.
+/// Used for stair traversal and small obstacles.
+/// </param>
+public readonly record struct AgentSettings(
+    float Radius,
+    float Height,
+    float MaxSlopeAngle,
+    float StepHeight)
+{
+    /// <summary>
+    /// Default settings for a typical humanoid character.
+    /// </summary>
+    /// <remarks>
+    /// Radius: 0.5m, Height: 2.0m, MaxSlope: 45 degrees, StepHeight: 0.4m
+    /// </remarks>
+    public static AgentSettings Default => new(0.5f, 2.0f, 45f, 0.4f);
+
+    /// <summary>
+    /// Settings for a small agent (child, pet, etc.).
+    /// </summary>
+    /// <remarks>
+    /// Radius: 0.3m, Height: 1.0m, MaxSlope: 50 degrees, StepHeight: 0.25m
+    /// </remarks>
+    public static AgentSettings Small => new(0.3f, 1.0f, 50f, 0.25f);
+
+    /// <summary>
+    /// Settings for a large agent (vehicle, large creature, etc.).
+    /// </summary>
+    /// <remarks>
+    /// Radius: 1.5m, Height: 3.0m, MaxSlope: 30 degrees, StepHeight: 0.6m
+    /// </remarks>
+    public static AgentSettings Large => new(1.5f, 3.0f, 30f, 0.6f);
+
+    /// <summary>
+    /// Creates agent settings with the specified radius, using default values for other properties.
+    /// </summary>
+    /// <param name="radius">The agent radius.</param>
+    /// <returns>New agent settings with the specified radius.</returns>
+    public static AgentSettings WithRadius(float radius)
+        => Default with { Radius = radius };
+
+    /// <summary>
+    /// Gets the diameter of the agent (twice the radius).
+    /// </summary>
+    public float Diameter => Radius * 2f;
+
+    /// <summary>
+    /// Validates that the settings are physically reasonable.
+    /// </summary>
+    /// <returns>True if settings are valid, false otherwise.</returns>
+    public bool IsValid()
+        => Radius > 0f
+           && Height > 0f
+           && MaxSlopeAngle > 0f && MaxSlopeAngle < 90f
+           && StepHeight >= 0f && StepHeight < Height;
+}

--- a/src/KeenEyes.Navigation.Abstractions/Components/NavMeshAgent.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Components/NavMeshAgent.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions.Components;
+
+/// <summary>
+/// Component for entities that use navigation mesh pathfinding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attach this component to entities that should navigate using the
+/// navigation system. The navigation system will compute paths and
+/// provide movement targets for these entities.
+/// </para>
+/// <para>
+/// Use <see cref="SetDestination"/> to request a new path, and check
+/// <see cref="HasPath"/> to determine if a valid path exists.
+/// </para>
+/// </remarks>
+public struct NavMeshAgent : IComponent
+{
+    /// <summary>
+    /// The agent's physical settings for pathfinding.
+    /// </summary>
+    public AgentSettings Settings;
+
+    /// <summary>
+    /// The area mask determining which areas this agent can traverse.
+    /// </summary>
+    public NavAreaMask AreaMask;
+
+    /// <summary>
+    /// The maximum movement speed of the agent in units per second.
+    /// </summary>
+    public float Speed;
+
+    /// <summary>
+    /// The acceleration rate when changing velocity.
+    /// </summary>
+    public float Acceleration;
+
+    /// <summary>
+    /// The angular speed for turning in degrees per second.
+    /// </summary>
+    public float AngularSpeed;
+
+    /// <summary>
+    /// The distance from the destination at which the agent is considered to have arrived.
+    /// </summary>
+    public float StoppingDistance;
+
+    /// <summary>
+    /// Whether the agent should automatically brake when approaching the destination.
+    /// </summary>
+    public bool AutoBraking;
+
+    /// <summary>
+    /// The current destination the agent is navigating to.
+    /// </summary>
+    public Vector3 Destination;
+
+    /// <summary>
+    /// The next position the agent should move toward.
+    /// </summary>
+    /// <remarks>
+    /// Updated by the navigation system based on the current path.
+    /// </remarks>
+    public Vector3 SteeringTarget;
+
+    /// <summary>
+    /// The desired velocity computed by the navigation system.
+    /// </summary>
+    public Vector3 DesiredVelocity;
+
+    /// <summary>
+    /// The remaining distance to the destination along the current path.
+    /// </summary>
+    public float RemainingDistance;
+
+    /// <summary>
+    /// Whether this agent currently has a valid path.
+    /// </summary>
+    public bool HasPath;
+
+    /// <summary>
+    /// Whether a path is currently being computed for this agent.
+    /// </summary>
+    public bool PathPending;
+
+    /// <summary>
+    /// Whether the agent is currently on the navigation mesh.
+    /// </summary>
+    public bool IsOnNavMesh;
+
+    /// <summary>
+    /// Whether the agent is stopped (not actively navigating).
+    /// </summary>
+    public bool IsStopped;
+
+    /// <summary>
+    /// Creates a new NavMeshAgent with default settings.
+    /// </summary>
+    /// <returns>A new NavMeshAgent component.</returns>
+    public static NavMeshAgent Create()
+        => new()
+        {
+            Settings = AgentSettings.Default,
+            AreaMask = NavAreaMask.All,
+            Speed = 3.5f,
+            Acceleration = 8f,
+            AngularSpeed = 120f,
+            StoppingDistance = 0.1f,
+            AutoBraking = true,
+            IsStopped = true
+        };
+
+    /// <summary>
+    /// Creates a new NavMeshAgent with the specified settings.
+    /// </summary>
+    /// <param name="settings">The agent's physical settings.</param>
+    /// <param name="speed">The movement speed.</param>
+    /// <returns>A new NavMeshAgent component.</returns>
+    public static NavMeshAgent Create(AgentSettings settings, float speed = 3.5f)
+        => Create() with { Settings = settings, Speed = speed };
+
+    /// <summary>
+    /// Sets the agent's destination, triggering path computation.
+    /// </summary>
+    /// <param name="destination">The target position to navigate to.</param>
+    public void SetDestination(Vector3 destination)
+    {
+        Destination = destination;
+        PathPending = true;
+        IsStopped = false;
+    }
+
+    /// <summary>
+    /// Stops the agent and clears its current path.
+    /// </summary>
+    public void Stop()
+    {
+        HasPath = false;
+        PathPending = false;
+        IsStopped = true;
+        DesiredVelocity = Vector3.Zero;
+        RemainingDistance = 0f;
+    }
+
+    /// <summary>
+    /// Resumes navigation if the agent was stopped.
+    /// </summary>
+    public void Resume()
+    {
+        if (HasPath)
+        {
+            IsStopped = false;
+        }
+    }
+}

--- a/src/KeenEyes.Navigation.Abstractions/Components/NavMeshObstacle.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Components/NavMeshObstacle.cs
@@ -1,0 +1,119 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions.Components;
+
+/// <summary>
+/// Component for dynamic obstacles that affect navigation mesh carving.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attach this component to entities that should dynamically block
+/// navigation paths. The navigation system will carve holes in the
+/// navmesh around these obstacles.
+/// </para>
+/// <para>
+/// Use <see cref="Carving"/> to enable/disable runtime navmesh modification.
+/// Carving is more expensive but provides more accurate pathfinding.
+/// Non-carving obstacles are used for local avoidance only.
+/// </para>
+/// </remarks>
+public struct NavMeshObstacle : IComponent
+{
+    /// <summary>
+    /// The shape of the obstacle.
+    /// </summary>
+    public ObstacleShape Shape;
+
+    /// <summary>
+    /// The center offset from the entity's position.
+    /// </summary>
+    public Vector3 Center;
+
+    /// <summary>
+    /// The size of a box-shaped obstacle (width, height, depth).
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="Shape"/> is <see cref="ObstacleShape.Box"/>.
+    /// </remarks>
+    public Vector3 Size;
+
+    /// <summary>
+    /// The radius of a cylindrical obstacle.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="Shape"/> is <see cref="ObstacleShape.Cylinder"/>.
+    /// </remarks>
+    public float Radius;
+
+    /// <summary>
+    /// The height of a cylindrical obstacle.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="Shape"/> is <see cref="ObstacleShape.Cylinder"/>.
+    /// </remarks>
+    public float Height;
+
+    /// <summary>
+    /// Whether this obstacle should carve holes in the navigation mesh.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When true, the navmesh is dynamically modified around this obstacle.
+    /// Paths will avoid the carved area entirely.
+    /// </para>
+    /// <para>
+    /// When false, the obstacle is only used for local avoidance.
+    /// Agents will still attempt to path through the area but avoid
+    /// collisions at runtime.
+    /// </para>
+    /// </remarks>
+    public bool Carving;
+
+    /// <summary>
+    /// The time in seconds to wait before carving after the obstacle moves.
+    /// </summary>
+    /// <remarks>
+    /// Higher values reduce carving updates for moving obstacles but
+    /// may cause temporary path inaccuracies.
+    /// </remarks>
+    public float CarvingMoveThreshold;
+
+    /// <summary>
+    /// The distance the obstacle must move before the carve is updated.
+    /// </summary>
+    public float CarvingTimeToStationary;
+
+    /// <summary>
+    /// Creates a box-shaped obstacle.
+    /// </summary>
+    /// <param name="size">The size (width, height, depth) of the box.</param>
+    /// <param name="carving">Whether the obstacle carves the navmesh.</param>
+    /// <returns>A new NavMeshObstacle component.</returns>
+    public static NavMeshObstacle Box(Vector3 size, bool carving = true)
+        => new()
+        {
+            Shape = ObstacleShape.Box,
+            Size = size,
+            Carving = carving,
+            CarvingMoveThreshold = 0.1f,
+            CarvingTimeToStationary = 0.5f
+        };
+
+    /// <summary>
+    /// Creates a cylindrical obstacle.
+    /// </summary>
+    /// <param name="radius">The radius of the cylinder.</param>
+    /// <param name="height">The height of the cylinder.</param>
+    /// <param name="carving">Whether the obstacle carves the navmesh.</param>
+    /// <returns>A new NavMeshObstacle component.</returns>
+    public static NavMeshObstacle Cylinder(float radius, float height, bool carving = true)
+        => new()
+        {
+            Shape = ObstacleShape.Cylinder,
+            Radius = radius,
+            Height = height,
+            Carving = carving,
+            CarvingMoveThreshold = 0.1f,
+            CarvingTimeToStationary = 0.5f
+        };
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/NavAreaMask.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/NavAreaMask.cs
@@ -1,0 +1,93 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Bitmask for filtering navigable area types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this mask to specify which <see cref="NavAreaType"/> values an agent
+/// can traverse. Combine flags using bitwise OR to allow multiple area types.
+/// </para>
+/// <para>
+/// Example: <c>NavAreaMask.Walkable | NavAreaMask.Road</c> allows traversal
+/// of both walkable terrain and roads.
+/// </para>
+/// </remarks>
+[Flags]
+public enum NavAreaMask : uint
+{
+    /// <summary>
+    /// No areas are traversable.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Standard walkable terrain.
+    /// </summary>
+    Walkable = 1u << NavAreaType.Walkable,
+
+    /// <summary>
+    /// Water areas.
+    /// </summary>
+    Water = 1u << NavAreaType.Water,
+
+    /// <summary>
+    /// Road surfaces.
+    /// </summary>
+    Road = 1u << NavAreaType.Road,
+
+    /// <summary>
+    /// Grass areas.
+    /// </summary>
+    Grass = 1u << NavAreaType.Grass,
+
+    /// <summary>
+    /// Door areas.
+    /// </summary>
+    Door = 1u << NavAreaType.Door,
+
+    /// <summary>
+    /// Sand areas.
+    /// </summary>
+    Sand = 1u << NavAreaType.Sand,
+
+    /// <summary>
+    /// Mud areas.
+    /// </summary>
+    Mud = 1u << NavAreaType.Mud,
+
+    /// <summary>
+    /// Ice areas.
+    /// </summary>
+    Ice = 1u << NavAreaType.Ice,
+
+    /// <summary>
+    /// Hazard areas.
+    /// </summary>
+    Hazard = 1u << NavAreaType.Hazard,
+
+    /// <summary>
+    /// Jump links.
+    /// </summary>
+    Jump = 1u << NavAreaType.Jump,
+
+    /// <summary>
+    /// Climb surfaces.
+    /// </summary>
+    Climb = 1u << NavAreaType.Climb,
+
+    /// <summary>
+    /// Off-mesh links.
+    /// </summary>
+    OffMeshLink = 1u << NavAreaType.OffMeshLink,
+
+    /// <summary>
+    /// All standard ground-based areas (Walkable, Road, Grass, Sand).
+    /// </summary>
+    Ground = Walkable | Road | Grass | Sand,
+
+    /// <summary>
+    /// All traversable areas (excludes NotWalkable).
+    /// </summary>
+    All = uint.MaxValue & ~(1u << NavAreaType.NotWalkable)
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/NavAreaType.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/NavAreaType.cs
@@ -1,0 +1,83 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Defines the type of navigation area for pathfinding cost calculations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Area types determine traversal costs and whether certain agents can
+/// navigate through specific regions. Use <see cref="NavAreaMask"/> to
+/// filter which areas an agent can traverse.
+/// </para>
+/// <para>
+/// The numeric values correspond to bit positions for use with
+/// <see cref="NavAreaMask"/> bitmask operations.
+/// </para>
+/// </remarks>
+public enum NavAreaType
+{
+    /// <summary>
+    /// Standard walkable terrain (default cost multiplier: 1.0).
+    /// </summary>
+    Walkable = 0,
+
+    /// <summary>
+    /// Water areas that may require swimming or special traversal.
+    /// </summary>
+    Water = 1,
+
+    /// <summary>
+    /// Road or paved surface with reduced movement cost.
+    /// </summary>
+    Road = 2,
+
+    /// <summary>
+    /// Grass or vegetation that may slow movement slightly.
+    /// </summary>
+    Grass = 3,
+
+    /// <summary>
+    /// Door or gate that may require interaction to traverse.
+    /// </summary>
+    Door = 4,
+
+    /// <summary>
+    /// Sand or soft terrain with increased movement cost.
+    /// </summary>
+    Sand = 5,
+
+    /// <summary>
+    /// Mud or difficult terrain with high movement cost.
+    /// </summary>
+    Mud = 6,
+
+    /// <summary>
+    /// Ice or slippery surface affecting movement.
+    /// </summary>
+    Ice = 7,
+
+    /// <summary>
+    /// Lava or hazardous terrain (may cause damage).
+    /// </summary>
+    Hazard = 8,
+
+    /// <summary>
+    /// Jump link requiring a jump action to traverse.
+    /// </summary>
+    Jump = 9,
+
+    /// <summary>
+    /// Ladder or climbable surface requiring climb action.
+    /// </summary>
+    Climb = 10,
+
+    /// <summary>
+    /// Off-mesh link for custom traversal behavior.
+    /// </summary>
+    OffMeshLink = 11,
+
+    /// <summary>
+    /// Not walkable - completely blocks navigation.
+    /// </summary>
+    NotWalkable = 31
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/NavigationStrategy.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/NavigationStrategy.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Specifies the navigation strategy used for pathfinding.
+/// </summary>
+/// <remarks>
+/// Different strategies offer trade-offs between accuracy, memory usage,
+/// and computational cost. Choose based on your game's specific needs.
+/// </remarks>
+public enum NavigationStrategy
+{
+    /// <summary>
+    /// Navigation mesh-based pathfinding using connected polygons.
+    /// </summary>
+    /// <remarks>
+    /// Best for complex 3D environments with varied terrain.
+    /// Offers high accuracy and smooth paths.
+    /// </remarks>
+    NavMesh,
+
+    /// <summary>
+    /// Grid-based pathfinding using discrete cells.
+    /// </summary>
+    /// <remarks>
+    /// Simpler than NavMesh, well-suited for 2D games or
+    /// environments with uniform tile-based layouts.
+    /// </remarks>
+    Grid,
+
+    /// <summary>
+    /// Hierarchical pathfinding with multi-level abstraction.
+    /// </summary>
+    /// <remarks>
+    /// Uses a coarse high-level path refined by local detailed paths.
+    /// Excellent for large open worlds where long-distance paths are common.
+    /// </remarks>
+    Hierarchical,
+
+    /// <summary>
+    /// Custom user-defined navigation strategy.
+    /// </summary>
+    /// <remarks>
+    /// Allows integration of custom pathfinding algorithms.
+    /// The implementation must handle all path computation.
+    /// </remarks>
+    Custom
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/ObstacleShape.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/ObstacleShape.cs
@@ -1,0 +1,23 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Shape of a dynamic navigation obstacle for navmesh carving.
+/// </summary>
+public enum ObstacleShape
+{
+    /// <summary>
+    /// A box-shaped obstacle defined by width, height, and depth.
+    /// </summary>
+    /// <remarks>
+    /// Use for rectangular objects like crates, buildings, or walls.
+    /// </remarks>
+    Box,
+
+    /// <summary>
+    /// A cylindrical obstacle defined by radius and height.
+    /// </summary>
+    /// <remarks>
+    /// Use for round objects like barrels, pillars, or characters.
+    /// </remarks>
+    Cylinder
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/PathRequestStatus.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/PathRequestStatus.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Status of an asynchronous path computation request.
+/// </summary>
+public enum PathRequestStatus
+{
+    /// <summary>
+    /// The request is queued but computation has not started.
+    /// </summary>
+    Pending,
+
+    /// <summary>
+    /// Path computation is currently in progress.
+    /// </summary>
+    Computing,
+
+    /// <summary>
+    /// Path computation completed successfully.
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// Path computation failed (no valid path found).
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The request was cancelled before completion.
+    /// </summary>
+    Cancelled
+}

--- a/src/KeenEyes.Navigation.Abstractions/INavigationMesh.cs
+++ b/src/KeenEyes.Navigation.Abstractions/INavigationMesh.cs
@@ -1,0 +1,107 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Represents navigation mesh data for pathfinding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A navigation mesh (navmesh) is a data structure that describes the walkable
+/// surfaces in a game environment. It consists of connected convex polygons
+/// that agents can traverse.
+/// </para>
+/// <para>
+/// Implementations should support serialization for efficient loading and
+/// runtime modification for dynamic environments.
+/// </para>
+/// </remarks>
+public interface INavigationMesh
+{
+    /// <summary>
+    /// Gets the unique identifier for this navigation mesh.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the axis-aligned bounding box encompassing all navmesh geometry.
+    /// </summary>
+    (Vector3 Min, Vector3 Max) Bounds { get; }
+
+    /// <summary>
+    /// Gets the number of polygons in the navigation mesh.
+    /// </summary>
+    int PolygonCount { get; }
+
+    /// <summary>
+    /// Gets the total number of vertices in the navigation mesh.
+    /// </summary>
+    int VertexCount { get; }
+
+    /// <summary>
+    /// Gets the agent settings this navmesh was built for.
+    /// </summary>
+    /// <remarks>
+    /// Agents with significantly different settings may not navigate correctly.
+    /// </remarks>
+    AgentSettings BuiltForAgent { get; }
+
+    /// <summary>
+    /// Finds the nearest point on the navmesh to the specified position.
+    /// </summary>
+    /// <param name="position">The query position.</param>
+    /// <param name="searchRadius">Maximum distance to search for a valid point.</param>
+    /// <returns>
+    /// The nearest point on the navmesh, or null if no point is within the search radius.
+    /// </returns>
+    NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f);
+
+    /// <summary>
+    /// Finds a random point on the navmesh.
+    /// </summary>
+    /// <param name="areaMask">Optional area mask to filter valid areas.</param>
+    /// <returns>A random point on the navmesh, or null if no valid points exist.</returns>
+    NavPoint? GetRandomPoint(NavAreaMask areaMask = NavAreaMask.All);
+
+    /// <summary>
+    /// Finds a random point on the navmesh within a sphere.
+    /// </summary>
+    /// <param name="center">The center of the search sphere.</param>
+    /// <param name="radius">The radius of the search sphere.</param>
+    /// <param name="areaMask">Optional area mask to filter valid areas.</param>
+    /// <returns>
+    /// A random point within the specified sphere, or null if no valid points exist.
+    /// </returns>
+    NavPoint? GetRandomPointInRadius(Vector3 center, float radius, NavAreaMask areaMask = NavAreaMask.All);
+
+    /// <summary>
+    /// Gets the area type at the specified position.
+    /// </summary>
+    /// <param name="position">The position to query.</param>
+    /// <returns>
+    /// The area type at the position, or <see cref="NavAreaType.NotWalkable"/>
+    /// if the position is not on the navmesh.
+    /// </returns>
+    NavAreaType GetAreaType(Vector3 position);
+
+    /// <summary>
+    /// Checks whether a position is on the navigation mesh.
+    /// </summary>
+    /// <param name="position">The position to check.</param>
+    /// <param name="tolerance">Vertical tolerance for the check.</param>
+    /// <returns>True if the position is on the navmesh within tolerance.</returns>
+    bool IsOnNavMesh(Vector3 position, float tolerance = 0.5f);
+
+    /// <summary>
+    /// Serializes the navigation mesh to a byte array.
+    /// </summary>
+    /// <returns>The serialized navmesh data.</returns>
+    byte[] Serialize();
+
+    /// <summary>
+    /// Gets the vertices of a specific polygon.
+    /// </summary>
+    /// <param name="polygonId">The polygon identifier.</param>
+    /// <returns>The vertices of the polygon, or an empty span if invalid.</returns>
+    ReadOnlySpan<Vector3> GetPolygonVertices(uint polygonId);
+}

--- a/src/KeenEyes.Navigation.Abstractions/INavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Abstractions/INavigationProvider.cs
@@ -1,0 +1,189 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Provides navigation and pathfinding services.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The navigation provider is the main entry point for pathfinding operations.
+/// It supports both synchronous (blocking) and asynchronous path computation,
+/// as well as raycast queries for line-of-sight checks.
+/// </para>
+/// <para>
+/// Implementations may use various strategies (navmesh, grid, hierarchical)
+/// depending on the game's requirements.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Synchronous pathfinding
+/// var path = navigator.FindPath(start, destination, AgentSettings.Default);
+/// if (path.IsValid)
+/// {
+///     foreach (var waypoint in path)
+///     {
+///         // Follow waypoints
+///     }
+/// }
+///
+/// // Asynchronous pathfinding
+/// using var request = navigator.RequestPath(start, destination, AgentSettings.Default);
+/// var asyncPath = await request.AsTask();
+/// </code>
+/// </example>
+public interface INavigationProvider : IDisposable
+{
+    /// <summary>
+    /// Gets the navigation strategy used by this provider.
+    /// </summary>
+    NavigationStrategy Strategy { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the provider is initialized and ready for queries.
+    /// </summary>
+    bool IsReady { get; }
+
+    /// <summary>
+    /// Gets the currently active navigation mesh, if any.
+    /// </summary>
+    INavigationMesh? ActiveMesh { get; }
+
+    #region Pathfinding
+
+    /// <summary>
+    /// Computes a path synchronously (blocking).
+    /// </summary>
+    /// <param name="start">The starting position.</param>
+    /// <param name="end">The destination position.</param>
+    /// <param name="agent">The agent settings for path computation.</param>
+    /// <param name="areaMask">Optional mask to filter traversable areas.</param>
+    /// <returns>
+    /// The computed path, or <see cref="NavPath.Empty"/> if no path exists.
+    /// </returns>
+    /// <remarks>
+    /// This method blocks until path computation is complete.
+    /// For long paths or complex environments, consider using
+    /// <see cref="RequestPath"/> instead.
+    /// </remarks>
+    NavPath FindPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All);
+
+    /// <summary>
+    /// Requests a path computation asynchronously.
+    /// </summary>
+    /// <param name="start">The starting position.</param>
+    /// <param name="end">The destination position.</param>
+    /// <param name="agent">The agent settings for path computation.</param>
+    /// <param name="areaMask">Optional mask to filter traversable areas.</param>
+    /// <returns>A path request object to track computation progress.</returns>
+    /// <remarks>
+    /// The returned request should be disposed when no longer needed.
+    /// </remarks>
+    IPathRequest RequestPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All);
+
+    /// <summary>
+    /// Cancels all pending path requests.
+    /// </summary>
+    void CancelAllRequests();
+
+    #endregion
+
+    #region Raycasting
+
+    /// <summary>
+    /// Performs a raycast on the navigation mesh.
+    /// </summary>
+    /// <param name="start">The start position of the ray.</param>
+    /// <param name="end">The end position of the ray.</param>
+    /// <param name="hitPosition">
+    /// When this method returns true, contains the hit position.
+    /// When false, contains the end position.
+    /// </param>
+    /// <returns>True if the ray hit an obstacle or edge, false if clear.</returns>
+    /// <remarks>
+    /// Use this for line-of-sight checks and steering behavior.
+    /// The raycast is performed on the navmesh surface, not in 3D space.
+    /// </remarks>
+    bool Raycast(Vector3 start, Vector3 end, out Vector3 hitPosition);
+
+    /// <summary>
+    /// Performs a raycast with area filtering.
+    /// </summary>
+    /// <param name="start">The start position of the ray.</param>
+    /// <param name="end">The end position of the ray.</param>
+    /// <param name="areaMask">Mask specifying traversable areas.</param>
+    /// <param name="hitPosition">The hit or end position.</param>
+    /// <param name="hitAreaType">The area type at the hit position.</param>
+    /// <returns>True if the ray hit an obstacle, edge, or forbidden area.</returns>
+    bool Raycast(
+        Vector3 start,
+        Vector3 end,
+        NavAreaMask areaMask,
+        out Vector3 hitPosition,
+        out NavAreaType hitAreaType);
+
+    #endregion
+
+    #region Point Queries
+
+    /// <summary>
+    /// Finds the nearest point on the navmesh to the given position.
+    /// </summary>
+    /// <param name="position">The query position.</param>
+    /// <param name="searchRadius">Maximum distance to search.</param>
+    /// <returns>The nearest navmesh point, or null if none found.</returns>
+    NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f);
+
+    /// <summary>
+    /// Checks if a position is navigable for the given agent.
+    /// </summary>
+    /// <param name="position">The position to check.</param>
+    /// <param name="agent">The agent settings.</param>
+    /// <returns>True if the position is navigable.</returns>
+    bool IsNavigable(Vector3 position, AgentSettings agent);
+
+    /// <summary>
+    /// Projects a position onto the navmesh surface.
+    /// </summary>
+    /// <param name="position">The position to project.</param>
+    /// <param name="maxDistance">Maximum projection distance.</param>
+    /// <returns>The projected position, or null if projection failed.</returns>
+    Vector3? ProjectToNavMesh(Vector3 position, float maxDistance = 5f);
+
+    #endregion
+
+    #region Area Costs
+
+    /// <summary>
+    /// Gets the traversal cost multiplier for an area type.
+    /// </summary>
+    /// <param name="areaType">The area type to query.</param>
+    /// <returns>The cost multiplier (default is 1.0).</returns>
+    float GetAreaCost(NavAreaType areaType);
+
+    /// <summary>
+    /// Sets the traversal cost multiplier for an area type.
+    /// </summary>
+    /// <param name="areaType">The area type to configure.</param>
+    /// <param name="cost">
+    /// The cost multiplier. Higher values make the area less preferred.
+    /// Use 0 to make the area unwalkable.
+    /// </param>
+    void SetAreaCost(NavAreaType areaType, float cost);
+
+    #endregion
+
+    #region Updates
+
+    /// <summary>
+    /// Updates the navigation provider (processes pending requests, etc.).
+    /// </summary>
+    /// <param name="deltaTime">Time elapsed since the last update.</param>
+    /// <remarks>
+    /// Call this once per frame to process asynchronous path requests.
+    /// </remarks>
+    void Update(float deltaTime);
+
+    #endregion
+}

--- a/src/KeenEyes.Navigation.Abstractions/IPathRequest.cs
+++ b/src/KeenEyes.Navigation.Abstractions/IPathRequest.cs
@@ -1,0 +1,96 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Represents an asynchronous path computation request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Path requests allow non-blocking path computation. Use
+/// <see cref="INavigationProvider.RequestPath"/> to create a request,
+/// then poll <see cref="Status"/> or await completion.
+/// </para>
+/// <para>
+/// Always dispose of path requests when no longer needed to allow
+/// the navigation system to recycle resources.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var request = navigationProvider.RequestPath(start, end, agentSettings);
+///
+/// // Poll for completion
+/// while (request.Status == PathRequestStatus.Pending ||
+///        request.Status == PathRequestStatus.Computing)
+/// {
+///     await Task.Delay(10);
+/// }
+///
+/// if (request.Status == PathRequestStatus.Completed)
+/// {
+///     var path = request.Result;
+///     // Use the path
+/// }
+///
+/// request.Dispose();
+/// </code>
+/// </example>
+public interface IPathRequest : IDisposable
+{
+    /// <summary>
+    /// Gets the unique identifier for this path request.
+    /// </summary>
+    int Id { get; }
+
+    /// <summary>
+    /// Gets the current status of the path computation.
+    /// </summary>
+    PathRequestStatus Status { get; }
+
+    /// <summary>
+    /// Gets the starting position of the path request.
+    /// </summary>
+    Vector3 Start { get; }
+
+    /// <summary>
+    /// Gets the destination position of the path request.
+    /// </summary>
+    Vector3 End { get; }
+
+    /// <summary>
+    /// Gets the agent settings used for this path request.
+    /// </summary>
+    AgentSettings Agent { get; }
+
+    /// <summary>
+    /// Gets the computed path result.
+    /// </summary>
+    /// <remarks>
+    /// Only valid when <see cref="Status"/> is <see cref="PathRequestStatus.Completed"/>.
+    /// Returns <see cref="NavPath.Empty"/> if the path computation failed or is incomplete.
+    /// </remarks>
+    NavPath Result { get; }
+
+    /// <summary>
+    /// Cancels the path request if it is still pending or computing.
+    /// </summary>
+    /// <remarks>
+    /// After cancellation, <see cref="Status"/> will be <see cref="PathRequestStatus.Cancelled"/>
+    /// and <see cref="Result"/> will be <see cref="NavPath.Empty"/>.
+    /// </remarks>
+    void Cancel();
+
+    /// <summary>
+    /// Blocks until the path computation completes or times out.
+    /// </summary>
+    /// <param name="timeout">Maximum time to wait for completion.</param>
+    /// <returns>True if the path completed within the timeout, false otherwise.</returns>
+    bool Wait(TimeSpan timeout);
+
+    /// <summary>
+    /// Gets a task that completes when the path computation finishes.
+    /// </summary>
+    /// <returns>A task that completes with the computed path.</returns>
+    Task<NavPath> AsTask();
+}

--- a/src/KeenEyes.Navigation.Abstractions/KeenEyes.Navigation.Abstractions.csproj
+++ b/src/KeenEyes.Navigation.Abstractions/KeenEyes.Navigation.Abstractions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>KeenEyes.Navigation.Abstractions</PackageId>
+    <Description>Backend-agnostic navigation and pathfinding abstractions for KeenEyes ECS</Description>
+    <PackageTags>ecs;navigation;pathfinding;navmesh;abstractions</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/KeenEyes.Navigation.Abstractions/NavPath.cs
+++ b/src/KeenEyes.Navigation.Abstractions/NavPath.cs
@@ -1,0 +1,162 @@
+using System.Collections;
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Represents a computed navigation path with waypoints and metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="NavPath"/> contains the result of a pathfinding query,
+/// including the sequence of waypoints to follow and information about
+/// whether the path is complete or partial.
+/// </para>
+/// <para>
+/// Use <see cref="IsValid"/> to check if the path was successfully computed
+/// before attempting to follow it.
+/// </para>
+/// </remarks>
+/// <param name="waypoints">The waypoints comprising the path.</param>
+/// <param name="isComplete">
+/// Whether the path reaches the destination.
+/// False indicates a partial path to the closest reachable point.
+/// </param>
+/// <param name="totalCost">The total traversal cost of the path.</param>
+public sealed class NavPath(NavPoint[] waypoints, bool isComplete, float totalCost) : IReadOnlyList<NavPoint>
+{
+    private readonly NavPoint[] waypoints = waypoints ?? [];
+
+    /// <summary>
+    /// Gets an empty path representing a failed or invalid path query.
+    /// </summary>
+    public static NavPath Empty { get; } = new([], false, 0f);
+
+    /// <summary>
+    /// Gets a value indicating whether this path is valid (has waypoints).
+    /// </summary>
+    public bool IsValid => waypoints.Length > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether this path reaches the intended destination.
+    /// </summary>
+    /// <remarks>
+    /// When false, this is a partial path to the closest reachable point.
+    /// </remarks>
+    public bool IsComplete { get; } = isComplete;
+
+    /// <summary>
+    /// Gets the total traversal cost of this path.
+    /// </summary>
+    /// <remarks>
+    /// Cost is computed based on distance and area type cost multipliers.
+    /// </remarks>
+    public float TotalCost { get; } = totalCost;
+
+    /// <summary>
+    /// Gets the total length of the path in world units.
+    /// </summary>
+    public float Length
+    {
+        get
+        {
+            if (waypoints.Length < 2)
+            {
+                return 0f;
+            }
+
+            float total = 0f;
+            for (int i = 1; i < waypoints.Length; i++)
+            {
+                total += waypoints[i - 1].DistanceTo(waypoints[i]);
+            }
+
+            return total;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of waypoints in this path.
+    /// </summary>
+    public int Count => waypoints.Length;
+
+    /// <summary>
+    /// Gets the starting point of the path.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the path is empty.</exception>
+    public NavPoint Start => waypoints.Length > 0
+        ? waypoints[0]
+        : throw new InvalidOperationException("Cannot get start of empty path.");
+
+    /// <summary>
+    /// Gets the ending point of the path.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the path is empty.</exception>
+    public NavPoint End => waypoints.Length > 0
+        ? waypoints[^1]
+        : throw new InvalidOperationException("Cannot get end of empty path.");
+
+    /// <summary>
+    /// Gets the waypoint at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the waypoint.</param>
+    /// <returns>The waypoint at the specified index.</returns>
+    public NavPoint this[int index] => waypoints[index];
+
+    /// <summary>
+    /// Gets the waypoints as a read-only span.
+    /// </summary>
+    /// <returns>A span containing all waypoints.</returns>
+    public ReadOnlySpan<NavPoint> AsSpan() => waypoints;
+
+    /// <summary>
+    /// Samples a position along the path at the specified distance from the start.
+    /// </summary>
+    /// <param name="distance">The distance from the start of the path.</param>
+    /// <returns>
+    /// The interpolated position at the specified distance.
+    /// Returns the end position if distance exceeds path length.
+    /// </returns>
+    public Vector3 SamplePosition(float distance)
+    {
+        if (waypoints.Length == 0)
+        {
+            return Vector3.Zero;
+        }
+
+        if (waypoints.Length == 1 || distance <= 0)
+        {
+            return waypoints[0].Position;
+        }
+
+        float accumulated = 0f;
+        for (int i = 1; i < waypoints.Length; i++)
+        {
+            float segmentLength = waypoints[i - 1].DistanceTo(waypoints[i]);
+            if (accumulated + segmentLength >= distance)
+            {
+                float t = (distance - accumulated) / segmentLength;
+                return Vector3.Lerp(waypoints[i - 1].Position, waypoints[i].Position, t);
+            }
+
+            accumulated += segmentLength;
+        }
+
+        return waypoints[^1].Position;
+    }
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the waypoints.
+    /// </summary>
+    /// <returns>An enumerator for the waypoints.</returns>
+    public IEnumerator<NavPoint> GetEnumerator()
+    {
+        for (int i = 0; i < waypoints.Length; i++)
+        {
+            yield return waypoints[i];
+        }
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
+++ b/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Represents a point on a navigation mesh or grid.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="NavPoint"/> combines a 3D position with metadata about
+/// the navigation surface at that location. Use this to represent
+/// waypoints in computed paths.
+/// </para>
+/// </remarks>
+/// <param name="Position">The 3D world-space position of the point.</param>
+/// <param name="AreaType">The navigation area type at this point.</param>
+/// <param name="PolygonId">
+/// Optional identifier of the navmesh polygon containing this point.
+/// Zero if not applicable (e.g., for grid-based navigation).
+/// </param>
+public readonly record struct NavPoint(
+    Vector3 Position,
+    NavAreaType AreaType = NavAreaType.Walkable,
+    uint PolygonId = 0)
+{
+    /// <summary>
+    /// Creates a NavPoint at the specified position with default area type.
+    /// </summary>
+    /// <param name="position">The 3D position.</param>
+    /// <returns>A new NavPoint at the specified position.</returns>
+    public static NavPoint At(Vector3 position) => new(position);
+
+    /// <summary>
+    /// Creates a NavPoint at the specified coordinates with default area type.
+    /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
+    /// <param name="z">The Z coordinate.</param>
+    /// <returns>A new NavPoint at the specified coordinates.</returns>
+    public static NavPoint At(float x, float y, float z) => new(new Vector3(x, y, z));
+
+    /// <summary>
+    /// Calculates the distance to another NavPoint.
+    /// </summary>
+    /// <param name="other">The other NavPoint.</param>
+    /// <returns>The Euclidean distance between the two points.</returns>
+    public float DistanceTo(NavPoint other) => Vector3.Distance(Position, other.Position);
+
+    /// <summary>
+    /// Calculates the squared distance to another NavPoint.
+    /// </summary>
+    /// <param name="other">The other NavPoint.</param>
+    /// <returns>The squared distance (avoids square root calculation).</returns>
+    public float DistanceSquaredTo(NavPoint other) => Vector3.DistanceSquared(Position, other.Position);
+}

--- a/src/KeenEyes.Navigation.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Navigation.Abstractions/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/AgentSettingsTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/AgentSettingsTests.cs
@@ -1,0 +1,176 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <see cref="AgentSettings"/>.
+/// </summary>
+public class AgentSettingsTests
+{
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var settings = new AgentSettings(0.6f, 1.8f, 40f, 0.3f);
+
+        Assert.Equal(0.6f, settings.Radius);
+        Assert.Equal(1.8f, settings.Height);
+        Assert.Equal(40f, settings.MaxSlopeAngle);
+        Assert.Equal(0.3f, settings.StepHeight);
+    }
+
+    [Fact]
+    public void Default_ReturnsReasonableValues()
+    {
+        var settings = AgentSettings.Default;
+
+        Assert.Equal(0.5f, settings.Radius);
+        Assert.Equal(2.0f, settings.Height);
+        Assert.Equal(45f, settings.MaxSlopeAngle);
+        Assert.Equal(0.4f, settings.StepHeight);
+    }
+
+    [Fact]
+    public void Small_ReturnsSmallerValues()
+    {
+        var settings = AgentSettings.Small;
+
+        Assert.Equal(0.3f, settings.Radius);
+        Assert.Equal(1.0f, settings.Height);
+        Assert.Equal(50f, settings.MaxSlopeAngle);
+        Assert.Equal(0.25f, settings.StepHeight);
+    }
+
+    [Fact]
+    public void Large_ReturnsLargerValues()
+    {
+        var settings = AgentSettings.Large;
+
+        Assert.Equal(1.5f, settings.Radius);
+        Assert.Equal(3.0f, settings.Height);
+        Assert.Equal(30f, settings.MaxSlopeAngle);
+        Assert.Equal(0.6f, settings.StepHeight);
+    }
+
+    [Fact]
+    public void WithRadius_CreatesSettingsWithSpecifiedRadius()
+    {
+        var settings = AgentSettings.WithRadius(1.0f);
+
+        Assert.Equal(1.0f, settings.Radius);
+        Assert.Equal(AgentSettings.Default.Height, settings.Height);
+        Assert.Equal(AgentSettings.Default.MaxSlopeAngle, settings.MaxSlopeAngle);
+        Assert.Equal(AgentSettings.Default.StepHeight, settings.StepHeight);
+    }
+
+    [Fact]
+    public void Diameter_ReturnsDoubleRadius()
+    {
+        var settings = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+
+        Assert.Equal(1.0f, settings.Diameter);
+    }
+
+    [Fact]
+    public void IsValid_WithValidSettings_ReturnsTrue()
+    {
+        var settings = AgentSettings.Default;
+
+        Assert.True(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithZeroRadius_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0f, 2.0f, 45f, 0.4f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithNegativeRadius_ReturnsFalse()
+    {
+        var settings = new AgentSettings(-0.5f, 2.0f, 45f, 0.4f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithZeroHeight_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0.5f, 0f, 45f, 0.4f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithZeroSlope_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0.5f, 2.0f, 0f, 0.4f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithSlopeAt90Degrees_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0.5f, 2.0f, 90f, 0.4f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithStepHeightEqualToHeight_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0.5f, 2.0f, 45f, 2.0f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithNegativeStepHeight_ReturnsFalse()
+    {
+        var settings = new AgentSettings(0.5f, 2.0f, 45f, -0.1f);
+
+        Assert.False(settings.IsValid());
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var settings1 = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+        var settings2 = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+
+        Assert.Equal(settings1, settings2);
+        Assert.True(settings1 == settings2);
+    }
+
+    [Fact]
+    public void Equality_DifferentRadius_AreNotEqual()
+    {
+        var settings1 = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+        var settings2 = new AgentSettings(0.6f, 2.0f, 45f, 0.4f);
+
+        Assert.NotEqual(settings1, settings2);
+        Assert.True(settings1 != settings2);
+    }
+
+    [Fact]
+    public void GetHashCode_SameForEqualSettings()
+    {
+        var settings1 = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+        var settings2 = new AgentSettings(0.5f, 2.0f, 45f, 0.4f);
+
+        Assert.Equal(settings1.GetHashCode(), settings2.GetHashCode());
+    }
+
+    [Fact]
+    public void WithExpression_ModifiesSingleProperty()
+    {
+        var original = AgentSettings.Default;
+        var modified = original with { Radius = 1.0f };
+
+        Assert.Equal(0.5f, original.Radius);
+        Assert.Equal(1.0f, modified.Radius);
+        Assert.Equal(original.Height, modified.Height);
+    }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/KeenEyes.Navigation.Abstractions.Tests.csproj
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/KeenEyes.Navigation.Abstractions.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Navigation.Abstractions\KeenEyes.Navigation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavMeshAgentTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavMeshAgentTests.cs
@@ -1,0 +1,101 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <see cref="NavMeshAgent"/>.
+/// </summary>
+public class NavMeshAgentTests
+{
+    [Fact]
+    public void Create_ReturnsDefaultAgent()
+    {
+        var agent = NavMeshAgent.Create();
+
+        Assert.Equal(AgentSettings.Default, agent.Settings);
+        Assert.Equal(NavAreaMask.All, agent.AreaMask);
+        Assert.Equal(3.5f, agent.Speed);
+        Assert.Equal(8f, agent.Acceleration);
+        Assert.Equal(120f, agent.AngularSpeed);
+        Assert.Equal(0.1f, agent.StoppingDistance);
+        Assert.True(agent.AutoBraking);
+        Assert.True(agent.IsStopped);
+    }
+
+    [Fact]
+    public void Create_WithSettings_UsesProvidedSettings()
+    {
+        var settings = AgentSettings.Large;
+        var agent = NavMeshAgent.Create(settings, 5.0f);
+
+        Assert.Equal(settings, agent.Settings);
+        Assert.Equal(5.0f, agent.Speed);
+    }
+
+    [Fact]
+    public void SetDestination_UpdatesDestinationAndState()
+    {
+        var agent = NavMeshAgent.Create();
+        var destination = new Vector3(10f, 0f, 10f);
+
+        agent.SetDestination(destination);
+
+        Assert.Equal(destination, agent.Destination);
+        Assert.True(agent.PathPending);
+        Assert.False(agent.IsStopped);
+    }
+
+    [Fact]
+    public void Stop_ClearsPathAndStopsAgent()
+    {
+        var agent = NavMeshAgent.Create();
+        agent.SetDestination(new Vector3(10f, 0f, 10f));
+        agent.HasPath = true;
+        agent.DesiredVelocity = new Vector3(1f, 0f, 0f);
+        agent.RemainingDistance = 5f;
+
+        agent.Stop();
+
+        Assert.False(agent.HasPath);
+        Assert.False(agent.PathPending);
+        Assert.True(agent.IsStopped);
+        Assert.Equal(Vector3.Zero, agent.DesiredVelocity);
+        Assert.Equal(0f, agent.RemainingDistance);
+    }
+
+    [Fact]
+    public void Resume_UnstopsAgentWithPath()
+    {
+        var agent = NavMeshAgent.Create();
+        agent.HasPath = true;
+        agent.IsStopped = true;
+
+        agent.Resume();
+
+        Assert.False(agent.IsStopped);
+    }
+
+    [Fact]
+    public void Resume_WithNoPath_StaysStoppedStopped()
+    {
+        var agent = NavMeshAgent.Create();
+        agent.HasPath = false;
+        agent.IsStopped = true;
+
+        agent.Resume();
+
+        Assert.True(agent.IsStopped);
+    }
+
+    [Fact]
+    public void InitialState_HasNoPath()
+    {
+        var agent = NavMeshAgent.Create();
+
+        Assert.False(agent.HasPath);
+        Assert.False(agent.PathPending);
+        Assert.False(agent.IsOnNavMesh);
+    }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavMeshObstacleTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavMeshObstacleTests.cs
@@ -1,0 +1,84 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <see cref="NavMeshObstacle"/>.
+/// </summary>
+public class NavMeshObstacleTests
+{
+    [Fact]
+    public void Box_CreatesBoxShapedObstacle()
+    {
+        var size = new Vector3(2f, 3f, 4f);
+        var obstacle = NavMeshObstacle.Box(size);
+
+        Assert.Equal(ObstacleShape.Box, obstacle.Shape);
+        Assert.Equal(size, obstacle.Size);
+        Assert.True(obstacle.Carving);
+    }
+
+    [Fact]
+    public void Box_WithoutCarving_DisablesCarving()
+    {
+        var obstacle = NavMeshObstacle.Box(new Vector3(1f, 1f, 1f), carving: false);
+
+        Assert.False(obstacle.Carving);
+    }
+
+    [Fact]
+    public void Box_SetsDefaultCarvingThresholds()
+    {
+        var obstacle = NavMeshObstacle.Box(new Vector3(1f, 1f, 1f));
+
+        Assert.Equal(0.1f, obstacle.CarvingMoveThreshold);
+        Assert.Equal(0.5f, obstacle.CarvingTimeToStationary);
+    }
+
+    [Fact]
+    public void Cylinder_CreatesCylindricalObstacle()
+    {
+        var obstacle = NavMeshObstacle.Cylinder(1.5f, 2.0f);
+
+        Assert.Equal(ObstacleShape.Cylinder, obstacle.Shape);
+        Assert.Equal(1.5f, obstacle.Radius);
+        Assert.Equal(2.0f, obstacle.Height);
+        Assert.True(obstacle.Carving);
+    }
+
+    [Fact]
+    public void Cylinder_WithoutCarving_DisablesCarving()
+    {
+        var obstacle = NavMeshObstacle.Cylinder(1f, 2f, carving: false);
+
+        Assert.False(obstacle.Carving);
+    }
+
+    [Fact]
+    public void Cylinder_SetsDefaultCarvingThresholds()
+    {
+        var obstacle = NavMeshObstacle.Cylinder(1f, 2f);
+
+        Assert.Equal(0.1f, obstacle.CarvingMoveThreshold);
+        Assert.Equal(0.5f, obstacle.CarvingTimeToStationary);
+    }
+
+    [Fact]
+    public void Center_DefaultsToZero()
+    {
+        var obstacle = NavMeshObstacle.Box(new Vector3(1f, 1f, 1f));
+
+        Assert.Equal(Vector3.Zero, obstacle.Center);
+    }
+
+    [Fact]
+    public void Center_CanBeModified()
+    {
+        var obstacle = NavMeshObstacle.Box(new Vector3(1f, 1f, 1f));
+        obstacle.Center = new Vector3(0f, 1f, 0f);
+
+        Assert.Equal(new Vector3(0f, 1f, 0f), obstacle.Center);
+    }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavPathTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavPathTests.cs
@@ -1,0 +1,257 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <see cref="NavPath"/>.
+/// </summary>
+public class NavPathTests
+{
+    [Fact]
+    public void Empty_HasNoWaypoints()
+    {
+        var path = NavPath.Empty;
+
+        Assert.False(path.IsValid);
+        Assert.Empty(path);
+        Assert.False(path.IsComplete);
+    }
+
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 15.5f);
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.Equal(15.5f, path.TotalCost);
+        Assert.Equal(2, path.Count);
+    }
+
+    [Fact]
+    public void IsValid_WithWaypoints_ReturnsTrue()
+    {
+        var waypoints = new[] { NavPoint.At(0f, 0f, 0f) };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.True(path.IsValid);
+    }
+
+    [Fact]
+    public void IsValid_WithEmptyWaypoints_ReturnsFalse()
+    {
+        var path = new NavPath([], false, 0f);
+
+        Assert.False(path.IsValid);
+    }
+
+    [Fact]
+    public void Start_ReturnsFirstWaypoint()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(1f, 2f, 3f),
+            NavPoint.At(4f, 5f, 6f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.Equal(new Vector3(1f, 2f, 3f), path.Start.Position);
+    }
+
+    [Fact]
+    public void Start_OnEmptyPath_Throws()
+    {
+        var path = NavPath.Empty;
+
+        Assert.Throws<InvalidOperationException>(() => path.Start);
+    }
+
+    [Fact]
+    public void End_ReturnsLastWaypoint()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(1f, 2f, 3f),
+            NavPoint.At(4f, 5f, 6f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.Equal(new Vector3(4f, 5f, 6f), path.End.Position);
+    }
+
+    [Fact]
+    public void End_OnEmptyPath_Throws()
+    {
+        var path = NavPath.Empty;
+
+        Assert.Throws<InvalidOperationException>(() => path.End);
+    }
+
+    [Fact]
+    public void Indexer_ReturnsCorrectWaypoint()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(5f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.Equal(new Vector3(5f, 0f, 0f), path[1].Position);
+    }
+
+    [Fact]
+    public void Length_CalculatesTotalDistance()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(3f, 4f, 0f), // 5 units from start
+            NavPoint.At(6f, 8f, 0f)  // 5 units from previous
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.Equal(10f, path.Length);
+    }
+
+    [Fact]
+    public void Length_WithSingleWaypoint_ReturnsZero()
+    {
+        var waypoints = new[] { NavPoint.At(5f, 5f, 5f) };
+        var path = new NavPath(waypoints, true, 0f);
+
+        Assert.Equal(0f, path.Length);
+    }
+
+    [Fact]
+    public void Length_WithEmptyPath_ReturnsZero()
+    {
+        Assert.Equal(0f, NavPath.Empty.Length);
+    }
+
+    [Fact]
+    public void SamplePosition_AtStart_ReturnsFirstPosition()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var position = path.SamplePosition(0f);
+
+        Assert.Equal(new Vector3(0f, 0f, 0f), position);
+    }
+
+    [Fact]
+    public void SamplePosition_AtMiddle_ReturnsInterpolatedPosition()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var position = path.SamplePosition(5f);
+
+        Assert.Equal(new Vector3(5f, 0f, 0f), position);
+    }
+
+    [Fact]
+    public void SamplePosition_BeyondEnd_ReturnsLastPosition()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var position = path.SamplePosition(100f);
+
+        Assert.Equal(new Vector3(10f, 0f, 0f), position);
+    }
+
+    [Fact]
+    public void SamplePosition_OnEmptyPath_ReturnsZero()
+    {
+        var position = NavPath.Empty.SamplePosition(5f);
+
+        Assert.Equal(Vector3.Zero, position);
+    }
+
+    [Fact]
+    public void SamplePosition_AcrossMultipleSegments_ReturnsCorrectPosition()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(5f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var position = path.SamplePosition(7.5f);
+
+        Assert.Equal(new Vector3(7.5f, 0f, 0f), position);
+    }
+
+    [Fact]
+    public void AsSpan_ReturnsAllWaypoints()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(5f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var span = path.AsSpan();
+
+        Assert.Equal(2, span.Length);
+        Assert.Equal(waypoints[0], span[0]);
+        Assert.Equal(waypoints[1], span[1]);
+    }
+
+    [Fact]
+    public void Enumeration_IteratesAllWaypoints()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(5f, 0f, 0f),
+            NavPoint.At(10f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, true, 0f);
+
+        var list = path.ToList();
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal(waypoints[0], list[0]);
+        Assert.Equal(waypoints[1], list[1]);
+        Assert.Equal(waypoints[2], list[2]);
+    }
+
+    [Fact]
+    public void IsComplete_False_IndicatesPartialPath()
+    {
+        var waypoints = new[]
+        {
+            NavPoint.At(0f, 0f, 0f),
+            NavPoint.At(5f, 0f, 0f)
+        };
+        var path = new NavPath(waypoints, isComplete: false, totalCost: 5f);
+
+        Assert.True(path.IsValid);
+        Assert.False(path.IsComplete);
+    }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavPointTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavPointTests.cs
@@ -1,0 +1,120 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <see cref="NavPoint"/>.
+/// </summary>
+public class NavPointTests
+{
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var position = new Vector3(1f, 2f, 3f);
+        var point = new NavPoint(position, NavAreaType.Road, 42);
+
+        Assert.Equal(position, point.Position);
+        Assert.Equal(NavAreaType.Road, point.AreaType);
+        Assert.Equal(42u, point.PolygonId);
+    }
+
+    [Fact]
+    public void Constructor_WithDefaults_UsesWalkableAreaType()
+    {
+        var position = new Vector3(5f, 0f, 10f);
+        var point = new NavPoint(position);
+
+        Assert.Equal(NavAreaType.Walkable, point.AreaType);
+        Assert.Equal(0u, point.PolygonId);
+    }
+
+    [Fact]
+    public void At_CreatesNavPointAtPosition()
+    {
+        var position = new Vector3(10f, 20f, 30f);
+        var point = NavPoint.At(position);
+
+        Assert.Equal(position, point.Position);
+        Assert.Equal(NavAreaType.Walkable, point.AreaType);
+    }
+
+    [Fact]
+    public void At_WithCoordinates_CreatesNavPointAtPosition()
+    {
+        var point = NavPoint.At(1f, 2f, 3f);
+
+        Assert.Equal(new Vector3(1f, 2f, 3f), point.Position);
+    }
+
+    [Fact]
+    public void DistanceTo_ReturnsCorrectDistance()
+    {
+        var point1 = NavPoint.At(0f, 0f, 0f);
+        var point2 = NavPoint.At(3f, 4f, 0f);
+
+        var distance = point1.DistanceTo(point2);
+
+        Assert.Equal(5f, distance);
+    }
+
+    [Fact]
+    public void DistanceSquaredTo_ReturnsCorrectSquaredDistance()
+    {
+        var point1 = NavPoint.At(0f, 0f, 0f);
+        var point2 = NavPoint.At(3f, 4f, 0f);
+
+        var distanceSquared = point1.DistanceSquaredTo(point2);
+
+        Assert.Equal(25f, distanceSquared);
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var point1 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Water, 5);
+        var point2 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Water, 5);
+
+        Assert.Equal(point1, point2);
+        Assert.True(point1 == point2);
+    }
+
+    [Fact]
+    public void Equality_DifferentPosition_AreNotEqual()
+    {
+        var point1 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Walkable, 0);
+        var point2 = new NavPoint(new Vector3(4f, 5f, 6f), NavAreaType.Walkable, 0);
+
+        Assert.NotEqual(point1, point2);
+        Assert.True(point1 != point2);
+    }
+
+    [Fact]
+    public void Equality_DifferentAreaType_AreNotEqual()
+    {
+        var point1 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Walkable, 0);
+        var point2 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Water, 0);
+
+        Assert.NotEqual(point1, point2);
+    }
+
+    [Fact]
+    public void GetHashCode_SameForEqualPoints()
+    {
+        var point1 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Road, 10);
+        var point2 = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Road, 10);
+
+        Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
+    }
+
+    [Fact]
+    public void WithExpression_ModifiesSingleProperty()
+    {
+        var original = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Walkable, 0);
+        var modified = original with { AreaType = NavAreaType.Water };
+
+        Assert.Equal(NavAreaType.Walkable, original.AreaType);
+        Assert.Equal(NavAreaType.Water, modified.AreaType);
+        Assert.Equal(original.Position, modified.Position);
+    }
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavigationEnumTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavigationEnumTests.cs
@@ -1,0 +1,146 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Abstractions.Tests;
+
+/// <summary>
+/// Tests for navigation-related enums.
+/// </summary>
+public class NavigationEnumTests
+{
+    #region NavigationStrategy Tests
+
+    [Theory]
+    [InlineData(NavigationStrategy.NavMesh)]
+    [InlineData(NavigationStrategy.Grid)]
+    [InlineData(NavigationStrategy.Hierarchical)]
+    [InlineData(NavigationStrategy.Custom)]
+    public void NavigationStrategy_HasAllExpectedValues(NavigationStrategy strategy)
+    {
+        Assert.True(Enum.IsDefined(strategy));
+    }
+
+    [Fact]
+    public void NavigationStrategy_HasExpectedCount()
+    {
+        var values = Enum.GetValues<NavigationStrategy>();
+        Assert.Equal(4, values.Length);
+    }
+
+    #endregion
+
+    #region PathRequestStatus Tests
+
+    [Theory]
+    [InlineData(PathRequestStatus.Pending)]
+    [InlineData(PathRequestStatus.Computing)]
+    [InlineData(PathRequestStatus.Completed)]
+    [InlineData(PathRequestStatus.Failed)]
+    [InlineData(PathRequestStatus.Cancelled)]
+    public void PathRequestStatus_HasAllExpectedValues(PathRequestStatus status)
+    {
+        Assert.True(Enum.IsDefined(status));
+    }
+
+    [Fact]
+    public void PathRequestStatus_HasExpectedCount()
+    {
+        var values = Enum.GetValues<PathRequestStatus>();
+        Assert.Equal(5, values.Length);
+    }
+
+    #endregion
+
+    #region ObstacleShape Tests
+
+    [Theory]
+    [InlineData(ObstacleShape.Box)]
+    [InlineData(ObstacleShape.Cylinder)]
+    public void ObstacleShape_HasAllExpectedValues(ObstacleShape shape)
+    {
+        Assert.True(Enum.IsDefined(shape));
+    }
+
+    [Fact]
+    public void ObstacleShape_HasExpectedCount()
+    {
+        var values = Enum.GetValues<ObstacleShape>();
+        Assert.Equal(2, values.Length);
+    }
+
+    #endregion
+
+    #region NavAreaType Tests
+
+    [Theory]
+    [InlineData(NavAreaType.Walkable, 0)]
+    [InlineData(NavAreaType.Water, 1)]
+    [InlineData(NavAreaType.Road, 2)]
+    [InlineData(NavAreaType.Grass, 3)]
+    [InlineData(NavAreaType.Door, 4)]
+    [InlineData(NavAreaType.NotWalkable, 31)]
+    public void NavAreaType_HasCorrectValues(NavAreaType areaType, int expectedValue)
+    {
+        Assert.Equal(expectedValue, (int)areaType);
+    }
+
+    #endregion
+
+    #region NavAreaMask Tests
+
+    [Fact]
+    public void NavAreaMask_None_IsZero()
+    {
+        Assert.Equal(0u, (uint)NavAreaMask.None);
+    }
+
+    [Fact]
+    public void NavAreaMask_Walkable_MatchesAreaType()
+    {
+        var expected = 1u << (int)NavAreaType.Walkable;
+        Assert.Equal((uint)NavAreaMask.Walkable, expected);
+    }
+
+    [Fact]
+    public void NavAreaMask_Water_MatchesAreaType()
+    {
+        var expected = 1u << (int)NavAreaType.Water;
+        Assert.Equal((uint)NavAreaMask.Water, expected);
+    }
+
+    [Fact]
+    public void NavAreaMask_Ground_CombinesExpectedTypes()
+    {
+        var expected = NavAreaMask.Walkable | NavAreaMask.Road | NavAreaMask.Grass | NavAreaMask.Sand;
+        Assert.Equal(NavAreaMask.Ground, expected);
+    }
+
+    [Fact]
+    public void NavAreaMask_CanCombineWithBitwiseOr()
+    {
+        var combined = NavAreaMask.Walkable | NavAreaMask.Water;
+
+        Assert.True((combined & NavAreaMask.Walkable) != 0);
+        Assert.True((combined & NavAreaMask.Water) != 0);
+        Assert.False((combined & NavAreaMask.Road) != 0);
+    }
+
+    [Fact]
+    public void NavAreaMask_All_ExcludesNotWalkable()
+    {
+        var notWalkableBit = 1u << (int)NavAreaType.NotWalkable;
+        var allValue = (uint)NavAreaMask.All;
+
+        Assert.Equal(0u, allValue & notWalkableBit);
+    }
+
+    [Fact]
+    public void NavAreaMask_All_IncludesWalkable()
+    {
+        var walkableBit = 1u << (int)NavAreaType.Walkable;
+        var allValue = (uint)NavAreaMask.All;
+
+        Assert.NotEqual(0u, allValue & walkableBit);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/packages.lock.json
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/packages.lock.json
@@ -1,0 +1,258 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "HCfw7V1yuKxnm89vVKrb8b6aug96PUgxN9Z0YthEFCR8JOfTJF4XcU1i6RX2eEB08p3zriuFIG7BGXns4PyE8Q=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.1.0, )",
+        "resolved": "18.1.0",
+        "contentHash": "FJUCocHSPSjbeoGE/OojOhVUXwDng3VdNlwqzif9hMS2eFcG0f8RdjLM537aBsjP7zLHvGnWXbnUnc61v/EFCA==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "6.0.2",
+          "Microsoft.Testing.Platform": "2.0.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "6Tz2wZTNH/3hiskarOM5X9JaHV0QpIdIvEiLv6BJeJvtPS6AY+S47rg4K+czGSjQTkIgu5kT9SgZOwbfdhDD9Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "43NCOTEENtdc9fmlzX9KHQR14AZEYek5r4jOJlWPhTyV1+aYAQYl4x773nYXU5TKxV6+rMuniJ7wcj9C9qrP1A=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.1, )",
+        "resolved": "3.2.1",
+        "contentHash": "QnT7C+eEUM7ut6w4/RNPpSxE1Q9epiCNWf8Krc/vqcc+sc3Ejtl8lbf4w5DzBYWLUlkEEUr1u9czG0Qj7QK6IQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.26.0",
+          "xunit.v3.assert": "[3.2.1]",
+          "xunit.v3.core.mtp-v2": "[3.2.1]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QcZrCETsBJqy/vQpFtJc+jSXQ0K5sucQ6NUFbTNVHD4vfZZOwjZ/3sBzczkC4DityhD3AVO/+K/+9ioLs1AgRA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "HS5YsudCGSVoCVdsYJ5FAO9vx0z04qSAXgVzpDJSQ1/w/X9q8hrQVGU2p+Yfui+2KcXLL+Zjc0SX3yJWtBmYiw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.26.0",
+        "contentHash": "YrWZOfuU1Scg4iGizAlMNALOxVS+HPSVilfscNDEJAyrTIVdF4c+8o+Aerw2RYnrJxafj/F56YkJOKCURUWQmA=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "7hGxs+sfgPCiHg7CbWL8Vsmg8WS4vBfipZ7rfE+FEyS7ksU4+0vcV08TQvLIXLPAfinT06zVoK83YjRcMXcXLw=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "NUh3pPTC3Py4XTnjoCCCIEzvdKTQ9apu0ikDNCrUETBtfHHXcoUmIl5bOfJLQQu7awhu8eaZHjJnG7rx9lUZpg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EX7lPHnlJQYGj092TE+I7bw/iT9eYA+JcqRg0+31tSPgQqBhmOSxTT7YIfU6zFHo4ak4F/TPz3GjmvweJT1zZw==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.inproc.console": "[3.2.1]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "soZuThF5CwB/ZZ2HY/ivdinyM/6MvmjsHTG0vNw3fRd1ZKcmLzfxVb3fB6R3G5yoaN4Bh+aWzFGjOvYO05OzkA==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "oF0jwl0xH45/RWjDcaCPOeeI6HCoyiEXIT8yvByd37rhJorjL/Ri8S9A/Vql8DBPjCfQWd6Url5JRmeiQ55isA==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EC/VLj1E9BPWfmzdEMQEqouxh0rWAdX6SXuiiDRf0yXXsQo3E2PNLKCyJ9V8hmkGH/nBvM7pHLFbuCf00vCynw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.common": "[3.2.1]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project"
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Create the `KeenEyes.Navigation.Abstractions` package with backend-agnostic navigation and pathfinding interfaces
- Add core interfaces: `INavigationProvider`, `INavigationMesh`, `IPathRequest` for BYOP (Bring Your Own Pathfinding)
- Add data structures: `NavPath`, `NavPoint`, `AgentSettings` for path representation and agent configuration
- Add ECS components: `NavMeshAgent`, `NavMeshObstacle` for entity navigation
- Add comprehensive unit tests (91 passing tests)

## Test plan

- [x] All unit tests pass (91 tests)
- [x] Code compiles with zero warnings
- [x] Code formatting verified
- [x] Native AOT compatible (no reflection)
- [x] XML documentation on all public APIs

Closes #637