### PR TITLE
feat: Add component version infrastructure for schema evolution

### DIFF
--- a/benchmarks/KeenEyes.Benchmarks/SerializationBenchmarks.cs
+++ b/benchmarks/KeenEyes.Benchmarks/SerializationBenchmarks.cs
@@ -563,4 +563,7 @@ internal sealed class BenchmarkComponentSerializer : IComponentSerializer, IBina
 
         return null;
     }
+
+    public int GetVersion(string typeName) => 1;
+    public int GetVersion(Type type) => 1;
 }

--- a/editor/KeenEyes.Editor/Serialization/EditorComponentSerializer.cs
+++ b/editor/KeenEyes.Editor/Serialization/EditorComponentSerializer.cs
@@ -102,4 +102,10 @@ public sealed class EditorComponentSerializer : IComponentSerializer
             return null;
         }
     }
+
+    /// <inheritdoc/>
+    public int GetVersion(string typeName) => 1;
+
+    /// <inheritdoc/>
+    public int GetVersion(Type type) => 1;
 }

--- a/editor/KeenEyes.Generators/ComponentMigrationMetadataGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentMigrationMetadataGenerator.cs
@@ -1,0 +1,289 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace KeenEyes.Generators;
+
+/// <summary>
+/// Generates AOT-compatible version metadata for components.
+/// Produces the ComponentMigrationMetadata class with GetVersion methods.
+/// </summary>
+[Generator]
+public sealed class ComponentMigrationMetadataGenerator : IIncrementalGenerator
+{
+    private const string ComponentAttribute = "KeenEyes.ComponentAttribute";
+    private const string TagComponentAttribute = "KeenEyes.TagComponentAttribute";
+
+    /// <inheritdoc />
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Find all structs with [Component] attribute
+        var componentProvider = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                ComponentAttribute,
+                predicate: static (node, _) => node is StructDeclarationSyntax,
+                transform: static (ctx, _) => GetVersionedComponentInfo(ctx))
+            .Where(static info => info is not null);
+
+        // Find all structs with [TagComponent] attribute (always version 1)
+        var tagComponentProvider = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                TagComponentAttribute,
+                predicate: static (node, _) => node is StructDeclarationSyntax,
+                transform: static (ctx, _) => GetTagComponentInfo(ctx))
+            .Where(static info => info is not null);
+
+        // Combine both providers
+        var allComponents = componentProvider.Collect()
+            .Combine(tagComponentProvider.Collect());
+
+        // Generate the code
+        context.RegisterSourceOutput(allComponents, static (ctx, source) =>
+        {
+            var (components, tagComponents) = source;
+
+            var allInfos = components
+                .Concat(tagComponents)
+                .Where(static info => info is not null)
+                .Select(static info => info!)
+                .ToImmutableArray();
+
+            if (allInfos.Length == 0)
+            {
+                return;
+            }
+
+            var metadataSource = GenerateMigrationMetadata(allInfos);
+            ctx.AddSource("ComponentMigrationMetadata.g.cs", SourceText.From(metadataSource, Encoding.UTF8));
+        });
+    }
+
+    private static VersionedComponentInfo? GetVersionedComponentInfo(GeneratorAttributeSyntaxContext context)
+    {
+        if (context.TargetSymbol is not INamedTypeSymbol typeSymbol)
+        {
+            return null;
+        }
+
+        // Skip non-public components to avoid accessibility issues in generated code
+        if (!IsTypeAccessible(typeSymbol))
+        {
+            return null;
+        }
+
+        // Get the [Component] attribute
+        var attr = context.Attributes.First();
+
+        // Extract Version property (defaults to 1)
+        var version = 1;
+        var versionArg = attr.NamedArguments
+            .FirstOrDefault(a => a.Key == "Version");
+
+        if (versionArg.Value.Value is int v)
+        {
+            version = v;
+        }
+
+        // Skip components with invalid versions (will be reported by analyzer)
+        if (version < 1)
+        {
+            return null;
+        }
+
+        return new VersionedComponentInfo(
+            typeSymbol.Name,
+            typeSymbol.ToDisplayString(),
+            version,
+            IsTag: false);
+    }
+
+    private static VersionedComponentInfo? GetTagComponentInfo(GeneratorAttributeSyntaxContext context)
+    {
+        if (context.TargetSymbol is not INamedTypeSymbol typeSymbol)
+        {
+            return null;
+        }
+
+        // Skip non-public components to avoid accessibility issues in generated code
+        if (!IsTypeAccessible(typeSymbol))
+        {
+            return null;
+        }
+
+        // Tag components always have version 1 (they have no data to migrate)
+        return new VersionedComponentInfo(
+            typeSymbol.Name,
+            typeSymbol.ToDisplayString(),
+            Version: 1,
+            IsTag: true);
+    }
+
+    private static bool IsTypeAccessible(INamedTypeSymbol typeSymbol)
+    {
+        // Check if the type itself is public or internal
+        if (typeSymbol.DeclaredAccessibility != Accessibility.Public &&
+            typeSymbol.DeclaredAccessibility != Accessibility.Internal)
+        {
+            return false;
+        }
+
+        // Check containing types for accessibility
+        var containingType = typeSymbol.ContainingType;
+        while (containingType is not null)
+        {
+            if (containingType.DeclaredAccessibility != Accessibility.Public &&
+                containingType.DeclaredAccessibility != Accessibility.Internal)
+            {
+                return false;
+            }
+            containingType = containingType.ContainingType;
+        }
+
+        return true;
+    }
+
+    private static string GenerateMigrationMetadata(ImmutableArray<VersionedComponentInfo> components)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("// <auto-generated />");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("using KeenEyes;");
+        sb.AppendLine();
+        sb.AppendLine("namespace KeenEyes.Generated;");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Generated metadata for component schema versioning.");
+        sb.AppendLine("/// Provides AOT-compatible version lookup for migration support.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("public static partial class ComponentMigrationMetadata");
+        sb.AppendLine("{");
+
+        // Generate version lookup dictionary
+        sb.AppendLine("    private static readonly Dictionary<Type, int> VersionsByType = new()");
+        sb.AppendLine("    {");
+
+        foreach (var component in components)
+        {
+            sb.AppendLine($"        [typeof({component.FullName})] = {component.Version},");
+        }
+
+        sb.AppendLine("    };");
+        sb.AppendLine();
+
+        // Generate type name lookup dictionary
+        sb.AppendLine("    private static readonly Dictionary<string, int> VersionsByTypeName = new()");
+        sb.AppendLine("    {");
+
+        foreach (var component in components)
+        {
+            // Store both the full name and assembly-qualified name for lookup flexibility
+            sb.AppendLine($"        [\"{component.FullName}\"] = {component.Version},");
+            sb.AppendLine($"        [typeof({component.FullName}).AssemblyQualifiedName!] = {component.Version},");
+        }
+
+        sb.AppendLine("    };");
+        sb.AppendLine();
+
+        // Generate generic GetVersion<T>() method using type checks for AOT compatibility
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Gets the schema version of the specified component type.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <typeparam name=\"T\">The component type.</typeparam>");
+        sb.AppendLine("    /// <returns>The schema version of the component, or 1 if not found.</returns>");
+        sb.AppendLine("    public static int GetVersion<T>() where T : struct, IComponent");
+        sb.AppendLine("    {");
+
+        // Use type checks for compile-time optimization
+        var first = true;
+        foreach (var component in components)
+        {
+            var keyword = first ? "if" : "else if";
+            first = false;
+            sb.AppendLine($"        {keyword} (typeof(T) == typeof({component.FullName}))");
+            sb.AppendLine($"        {{");
+            sb.AppendLine($"            return {component.Version};");
+            sb.AppendLine($"        }}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("        return 1; // Default version for unknown components");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Generate GetVersion(Type) method for runtime lookup
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Gets the schema version of the specified component type.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"componentType\">The component type.</param>");
+        sb.AppendLine("    /// <returns>The schema version of the component, or 1 if not found.</returns>");
+        sb.AppendLine("    public static int GetVersion(Type componentType)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return VersionsByType.TryGetValue(componentType, out var version) ? version : 1;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Generate GetVersion(string) method for deserialization by type name
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Gets the schema version of the specified component type by name.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"typeName\">The fully-qualified type name or assembly-qualified type name.</param>");
+        sb.AppendLine("    /// <returns>The schema version of the component, or 1 if not found.</returns>");
+        sb.AppendLine("    public static int GetVersion(string typeName)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return VersionsByTypeName.TryGetValue(typeName, out var version) ? version : 1;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Generate GetAllVersions() method
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Gets all known component types and their versions.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <returns>A dictionary mapping component types to their schema versions.</returns>");
+        sb.AppendLine("    public static IReadOnlyDictionary<Type, int> GetAllVersions()");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return VersionsByType;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Generate HasVersion method for checking if a type is registered
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Checks if a component type has version metadata registered.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"componentType\">The component type to check.</param>");
+        sb.AppendLine("    /// <returns><c>true</c> if the type has version metadata; otherwise, <c>false</c>.</returns>");
+        sb.AppendLine("    public static bool HasVersion(Type componentType)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return VersionsByType.ContainsKey(componentType);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Generate HasVersion(string) method
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Checks if a component type name has version metadata registered.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"typeName\">The fully-qualified type name to check.</param>");
+        sb.AppendLine("    /// <returns><c>true</c> if the type has version metadata; otherwise, <c>false</c>.</returns>");
+        sb.AppendLine("    public static bool HasVersion(string typeName)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        return VersionsByTypeName.ContainsKey(typeName);");
+        sb.AppendLine("    }");
+
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private sealed record VersionedComponentInfo(
+        string Name,
+        string FullName,
+        int Version,
+        bool IsTag);
+}

--- a/src/KeenEyes.Abstractions/Attributes/ComponentAttribute.cs
+++ b/src/KeenEyes.Abstractions/Attributes/ComponentAttribute.cs
@@ -17,6 +17,12 @@ public sealed class ComponentAttribute : Attribute
     /// If true, generates binary serialization methods for this component.
     /// </summary>
     public bool Serializable { get; set; }
+
+    /// <summary>
+    /// The schema version of this component. Used for migration during deserialization.
+    /// Default is 1. Increment when the component's schema changes.
+    /// </summary>
+    public int Version { get; set; } = 1;
 }
 
 /// <summary>

--- a/src/KeenEyes.Core/Components/ComponentInfo.cs
+++ b/src/KeenEyes.Core/Components/ComponentInfo.cs
@@ -19,6 +19,12 @@ public sealed class ComponentInfo
     /// <summary>Whether this is a tag component (zero-size marker).</summary>
     public bool IsTag { get; }
 
+    /// <summary>
+    /// The schema version of this component for migration support.
+    /// Default is 1 for components that don't specify a version.
+    /// </summary>
+    public int Version { get; internal set; } = 1;
+
     /// <summary>The name of the component type.</summary>
     public string Name => Type.Name;
 
@@ -68,7 +74,7 @@ public sealed class ComponentInfo
     }
 
     /// <inheritdoc />
-    public override string ToString() => $"ComponentInfo({Name}, Id={Id.Value}, Size={Size}, IsTag={IsTag})";
+    public override string ToString() => $"ComponentInfo({Name}, Id={Id.Value}, Size={Size}, IsTag={IsTag}, Version={Version})";
 }
 
 /// <summary>

--- a/src/KeenEyes.Core/Serialization/ComponentVersionException.cs
+++ b/src/KeenEyes.Core/Serialization/ComponentVersionException.cs
@@ -1,0 +1,97 @@
+namespace KeenEyes.Serialization;
+
+/// <summary>
+/// Exception thrown when a component version mismatch is detected during deserialization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception is thrown when:
+/// <list type="bullet">
+/// <item><description>
+/// The serialized data contains a newer version of a component than the current runtime version.
+/// This typically means the save file was created with a newer version of the application.
+/// </description></item>
+/// <item><description>
+/// A component migration is required but no migration path is available.
+/// </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// For cases where the serialized version is older than the current version, the migration
+/// pipeline will attempt to automatically migrate the data to the current version.
+/// </para>
+/// </remarks>
+public class ComponentVersionException : InvalidOperationException
+{
+    /// <summary>
+    /// Gets the name of the component that had a version mismatch.
+    /// </summary>
+    public string ComponentName { get; }
+
+    /// <summary>
+    /// Gets the version of the component that was serialized.
+    /// </summary>
+    public int SerializedVersion { get; }
+
+    /// <summary>
+    /// Gets the current version of the component in the runtime.
+    /// </summary>
+    public int CurrentVersion { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComponentVersionException"/> class.
+    /// </summary>
+    /// <param name="componentName">The name of the component that had a version mismatch.</param>
+    /// <param name="serializedVersion">The version of the component that was serialized.</param>
+    /// <param name="currentVersion">The current version of the component in the runtime.</param>
+    public ComponentVersionException(string componentName, int serializedVersion, int currentVersion)
+        : base(CreateMessage(componentName, serializedVersion, currentVersion))
+    {
+        ComponentName = componentName;
+        SerializedVersion = serializedVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComponentVersionException"/> class.
+    /// </summary>
+    /// <param name="componentName">The name of the component that had a version mismatch.</param>
+    /// <param name="serializedVersion">The version of the component that was serialized.</param>
+    /// <param name="currentVersion">The current version of the component in the runtime.</param>
+    /// <param name="message">A custom error message.</param>
+    public ComponentVersionException(string componentName, int serializedVersion, int currentVersion, string message)
+        : base(message)
+    {
+        ComponentName = componentName;
+        SerializedVersion = serializedVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComponentVersionException"/> class.
+    /// </summary>
+    /// <param name="componentName">The name of the component that had a version mismatch.</param>
+    /// <param name="serializedVersion">The version of the component that was serialized.</param>
+    /// <param name="currentVersion">The current version of the component in the runtime.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public ComponentVersionException(string componentName, int serializedVersion, int currentVersion, Exception innerException)
+        : base(CreateMessage(componentName, serializedVersion, currentVersion), innerException)
+    {
+        ComponentName = componentName;
+        SerializedVersion = serializedVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    private static string CreateMessage(string componentName, int serializedVersion, int currentVersion)
+    {
+        if (serializedVersion > currentVersion)
+        {
+            return $"Cannot load {componentName} v{serializedVersion} (current version is v{currentVersion}). " +
+                   "The save file was created with a newer version of the application. " +
+                   "Update the application to load this save file.";
+        }
+
+        return $"Cannot migrate {componentName} from v{serializedVersion} to v{currentVersion}. " +
+               "No migration path is available for this version.";
+    }
+}

--- a/src/KeenEyes.Core/Serialization/IComponentSerializer.cs
+++ b/src/KeenEyes.Core/Serialization/IComponentSerializer.cs
@@ -102,4 +102,38 @@ public interface IComponentSerializer
     /// This is primarily used for tag components during delta restoration.
     /// </remarks>
     object? CreateDefault(string typeName);
+
+    /// <summary>
+    /// Gets the schema version of a component type by name.
+    /// </summary>
+    /// <param name="typeName">The fully-qualified type name of the component.</param>
+    /// <returns>The schema version, or 1 if the type is not registered or has no version.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method enables version tracking for component migration support.
+    /// Components declare their version via <c>[Component(Version = n)]</c> attribute.
+    /// </para>
+    /// <para>
+    /// Returns 1 (the default version) for components that don't specify a version
+    /// or are not registered in this serializer.
+    /// </para>
+    /// </remarks>
+    int GetVersion(string typeName);
+
+    /// <summary>
+    /// Gets the schema version of a component type.
+    /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <returns>The schema version, or 1 if the type is not registered or has no version.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method enables version tracking for component migration support.
+    /// Components declare their version via <c>[Component(Version = n)]</c> attribute.
+    /// </para>
+    /// <para>
+    /// Returns 1 (the default version) for components that don't specify a version
+    /// or are not registered in this serializer.
+    /// </para>
+    /// </remarks>
+    int GetVersion(Type type);
 }

--- a/src/KeenEyes.Core/Serialization/SerializedComponent.cs
+++ b/src/KeenEyes.Core/Serialization/SerializedComponent.cs
@@ -46,4 +46,19 @@ public sealed record SerializedComponent
     /// When <see langword="true"/>, the <see cref="Data"/> property may be null or empty.
     /// </remarks>
     public bool IsTag { get; init; }
+
+    /// <summary>
+    /// Gets or sets the schema version of this component.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This value is used during deserialization to detect version mismatches
+    /// and trigger component migrations when necessary.
+    /// </para>
+    /// <para>
+    /// Default is 1 for backward compatibility with data serialized before
+    /// versioning was introduced.
+    /// </para>
+    /// </remarks>
+    public int Version { get; init; } = 1;
 }

--- a/tests/KeenEyes.Core.Tests/Serialization/TestJsonSerializer.cs
+++ b/tests/KeenEyes.Core.Tests/Serialization/TestJsonSerializer.cs
@@ -151,4 +151,10 @@ internal sealed class TestJsonSerializer : IComponentSerializer
         }
         return null;
     }
+
+    /// <inheritdoc />
+    public int GetVersion(string typeName) => 1;
+
+    /// <inheritdoc />
+    public int GetVersion(Type type) => 1;
 }

--- a/tests/KeenEyes.Core.Tests/TestHelpers.cs
+++ b/tests/KeenEyes.Core.Tests/TestHelpers.cs
@@ -126,4 +126,10 @@ internal sealed class TestComponentSerializer : IComponentSerializer, IBinaryCom
 
     /// <inheritdoc />
     public object? ReadFrom(string typeName, BinaryReader reader) => binarySerializer.ReadFrom(typeName, reader);
+
+    /// <inheritdoc />
+    public int GetVersion(string typeName) => 1;
+
+    /// <inheritdoc />
+    public int GetVersion(Type type) => 1;
 }

--- a/tests/KeenEyes.Editor.Tests/PlayMode/PlayModeManagerTests.cs
+++ b/tests/KeenEyes.Editor.Tests/PlayMode/PlayModeManagerTests.cs
@@ -402,6 +402,8 @@ public class PlayModeManagerTests : IDisposable
         public ComponentInfo? RegisterComponent(ISerializationCapability serialization, string typeName, bool isTag) => null;
         public bool SetSingleton(ISerializationCapability serialization, string typeName, object value) => false;
         public object? CreateDefault(string typeName) => null;
+        public int GetVersion(string typeName) => 1;
+        public int GetVersion(Type type) => 1;
     }
 
     #endregion

--- a/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
+++ b/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
@@ -843,6 +843,9 @@ internal sealed class TestPersistenceSerializer : IComponentSerializer, IBinaryC
         }
         return null;
     }
+
+    public int GetVersion(string typeName) => 1;
+    public int GetVersion(Type type) => 1;
 }
 
 #endregion

--- a/tests/KeenEyes.Replay.Tests/ReplayRecorderTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayRecorderTests.cs
@@ -1258,4 +1258,6 @@ internal sealed class MockComponentSerializer : IComponentSerializer
     public ComponentInfo? RegisterComponent(ISerializationCapability serialization, string typeName, bool isTag) => null;
     public bool SetSingleton(ISerializationCapability serialization, string typeName, object value) => false;
     public object? CreateDefault(string typeName) => null;
+    public int GetVersion(string typeName) => 1;
+    public int GetVersion(Type type) => 1;
 }


### PR DESCRIPTION
## Summary
- Add `Version` property to `[Component]` attribute for declaring component schema versions
- Create `ComponentMigrationMetadataGenerator` to generate AOT-compatible version lookup code
- Add `ComponentVersionException` for detecting and reporting version mismatches during deserialization
- Update binary serialization format (v2) to include component version field (int16)
- Add version mismatch detection in `SnapshotManager.RestoreSnapshot()`

## Test plan
- [x] Unit tests for `ComponentVersionException` properties and messages
- [x] Unit tests for `SerializedComponent.Version` property
- [x] Unit tests for version mismatch detection during restore
- [x] Unit tests for `ComponentInfo.Version` property
- [x] All 2175 core tests pass
- [x] Build succeeds with zero warnings

## Related Issues
Closes #697

Blocks: #698, #699, #700, #701, #702