### PR TITLE
feat(abstractions): Add scene components for unified scene model

### DIFF
--- a/src/KeenEyes.Abstractions/Scenes/PersistentTag.cs
+++ b/src/KeenEyes.Abstractions/Scenes/PersistentTag.cs
@@ -1,0 +1,12 @@
+namespace KeenEyes.Scenes;
+
+/// <summary>
+/// Marks an entity as persistent across scene unloads.
+/// </summary>
+/// <remarks>
+/// Entities with this tag are never despawned by scene unload operations,
+/// regardless of their <see cref="SceneMembership"/>. Use for player entities,
+/// managers, or other objects that should survive scene transitions.
+/// </remarks>
+[TagComponent]
+public partial struct PersistentTag : ITagComponent;

--- a/src/KeenEyes.Abstractions/Scenes/SceneMembership.cs
+++ b/src/KeenEyes.Abstractions/Scenes/SceneMembership.cs
@@ -1,0 +1,28 @@
+namespace KeenEyes.Scenes;
+
+/// <summary>
+/// Tracks which scene an entity belongs to and its reference count.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Entities can belong to multiple scenes through reference counting.
+/// When an entity transitions between scenes, its reference count is adjusted.
+/// </para>
+/// <para>
+/// When a scene unloads, entities with <see cref="ReferenceCount"/> reaching zero
+/// are despawned (unless they have <see cref="PersistentTag"/>).
+/// </para>
+/// </remarks>
+[Component(Serializable = true)]
+public partial struct SceneMembership : IComponent
+{
+    /// <summary>
+    /// The scene root entity this entity originated from.
+    /// </summary>
+    public Entity OriginScene;
+
+    /// <summary>
+    /// Number of scenes currently referencing this entity.
+    /// </summary>
+    public int ReferenceCount;
+}

--- a/src/KeenEyes.Abstractions/Scenes/SceneMetadata.cs
+++ b/src/KeenEyes.Abstractions/Scenes/SceneMetadata.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.Scenes;
+
+/// <summary>
+/// Metadata for a scene root entity.
+/// </summary>
+/// <remarks>
+/// This component is automatically added to scene root entities when spawned.
+/// It provides identification and state tracking for the scene.
+/// </remarks>
+[Component(Serializable = true)]
+public partial struct SceneMetadata : IComponent
+{
+    /// <summary>
+    /// The name of the scene (matches the .kescene file name).
+    /// </summary>
+    public required string Name;
+
+    /// <summary>
+    /// Unique identifier for this scene instance.
+    /// </summary>
+    public Guid SceneId;
+
+    /// <summary>
+    /// Current state of the scene.
+    /// </summary>
+    public SceneState State;
+}

--- a/src/KeenEyes.Abstractions/Scenes/SceneRootTag.cs
+++ b/src/KeenEyes.Abstractions/Scenes/SceneRootTag.cs
@@ -1,0 +1,11 @@
+namespace KeenEyes.Scenes;
+
+/// <summary>
+/// Marks an entity as the root of a spawned scene.
+/// </summary>
+/// <remarks>
+/// Scene roots are created when a scene is spawned via <c>world.Scenes.Spawn()</c>.
+/// Each spawned scene has exactly one root entity with this tag.
+/// </remarks>
+[TagComponent]
+public partial struct SceneRootTag : ITagComponent;

--- a/src/KeenEyes.Abstractions/Scenes/SceneState.cs
+++ b/src/KeenEyes.Abstractions/Scenes/SceneState.cs
@@ -1,0 +1,17 @@
+namespace KeenEyes.Scenes;
+
+/// <summary>
+/// Represents the current state of a loaded scene.
+/// </summary>
+public enum SceneState
+{
+    /// <summary>
+    /// The scene is fully loaded and active.
+    /// </summary>
+    Loaded,
+
+    /// <summary>
+    /// The scene is in the process of being unloaded.
+    /// </summary>
+    Unloading
+}

--- a/tests/KeenEyes.Core.Tests/Scenes/SceneComponentTests.cs
+++ b/tests/KeenEyes.Core.Tests/Scenes/SceneComponentTests.cs
@@ -1,0 +1,148 @@
+using KeenEyes.Scenes;
+
+namespace KeenEyes.Tests.Scenes;
+
+/// <summary>
+/// Tests for scene-related components and types from KeenEyes.Abstractions.
+/// </summary>
+public class SceneComponentTests
+{
+    #region SceneRootTag Tests
+
+    [Fact]
+    public void SceneRootTag_IsTagComponent()
+    {
+        var tag = new SceneRootTag();
+
+        Assert.IsAssignableFrom<ITagComponent>(tag);
+    }
+
+    #endregion
+
+    #region PersistentTag Tests
+
+    [Fact]
+    public void PersistentTag_IsTagComponent()
+    {
+        var tag = new PersistentTag();
+
+        Assert.IsAssignableFrom<ITagComponent>(tag);
+    }
+
+    #endregion
+
+    #region SceneState Tests
+
+    [Fact]
+    public void SceneState_HasLoadedValue()
+    {
+        var state = SceneState.Loaded;
+
+        Assert.Equal(0, (int)state);
+    }
+
+    [Fact]
+    public void SceneState_HasUnloadingValue()
+    {
+        var state = SceneState.Unloading;
+
+        Assert.Equal(1, (int)state);
+    }
+
+    #endregion
+
+    #region SceneMetadata Tests
+
+    [Fact]
+    public void SceneMetadata_IsComponent()
+    {
+        var metadata = new SceneMetadata { Name = "TestScene" };
+
+        Assert.IsAssignableFrom<IComponent>(metadata);
+    }
+
+    [Fact]
+    public void SceneMetadata_StoresName()
+    {
+        var metadata = new SceneMetadata { Name = "ForestLevel" };
+
+        Assert.Equal("ForestLevel", metadata.Name);
+    }
+
+    [Fact]
+    public void SceneMetadata_StoresSceneId()
+    {
+        var id = Guid.NewGuid();
+        var metadata = new SceneMetadata { Name = "Test", SceneId = id };
+
+        Assert.Equal(id, metadata.SceneId);
+    }
+
+    [Fact]
+    public void SceneMetadata_StoresState()
+    {
+        var metadata = new SceneMetadata
+        {
+            Name = "Test",
+            State = SceneState.Unloading
+        };
+
+        Assert.Equal(SceneState.Unloading, metadata.State);
+    }
+
+    [Fact]
+    public void SceneMetadata_DefaultState_IsLoaded()
+    {
+        var metadata = new SceneMetadata { Name = "Test" };
+
+        Assert.Equal(SceneState.Loaded, metadata.State);
+    }
+
+    #endregion
+
+    #region SceneMembership Tests
+
+    [Fact]
+    public void SceneMembership_IsComponent()
+    {
+        var membership = new SceneMembership();
+
+        Assert.IsAssignableFrom<IComponent>(membership);
+    }
+
+    [Fact]
+    public void SceneMembership_StoresOriginScene()
+    {
+        var sceneRoot = new Entity(42, 1);
+        var membership = new SceneMembership { OriginScene = sceneRoot };
+
+        Assert.Equal(sceneRoot, membership.OriginScene);
+    }
+
+    [Fact]
+    public void SceneMembership_StoresReferenceCount()
+    {
+        var membership = new SceneMembership { ReferenceCount = 3 };
+
+        Assert.Equal(3, membership.ReferenceCount);
+    }
+
+    [Fact]
+    public void SceneMembership_DefaultReferenceCount_IsZero()
+    {
+        var membership = new SceneMembership();
+
+        Assert.Equal(0, membership.ReferenceCount);
+    }
+
+    [Fact]
+    public void SceneMembership_DefaultOriginScene_IsDefaultEntity()
+    {
+        var membership = new SceneMembership();
+
+        // Default struct initialization gives (0, 0)
+        Assert.Equal(default, membership.OriginScene);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Implements Issue #623: Add foundational scene components to KeenEyes.Abstractions as specified in ADR-011 (Unified Scene Model).

This is the first issue in **Epic #600 Phase 6: Unified Scene Model** and unblocks 4 downstream issues.

### Components Added

| Type | Name | Description |
|------|------|-------------|
| Tag Component | `SceneRootTag` | Marks entities as spawned scene roots |
| Tag Component | `PersistentTag` | Marks entities to survive scene unloads |
| Component | `SceneMetadata` | Stores scene root info (name, ID, state) |
| Component | `SceneMembership` | Tracks scene ownership and reference counts |
| Enum | `SceneState` | `Loaded`, `Unloading` states |

### Files Added

**Source (5 files):**
- `src/KeenEyes.Abstractions/Scenes/SceneRootTag.cs`
- `src/KeenEyes.Abstractions/Scenes/PersistentTag.cs`
- `src/KeenEyes.Abstractions/Scenes/SceneState.cs`
- `src/KeenEyes.Abstractions/Scenes/SceneMetadata.cs`
- `src/KeenEyes.Abstractions/Scenes/SceneMembership.cs`

**Tests (1 file):**
- `tests/KeenEyes.Core.Tests/Scenes/SceneComponentTests.cs` (14 tests)

## Test plan
- [x] All 14 new scene component tests pass
- [x] Full solution builds with 0 warnings
- [x] All components have XML documentation

## Unblocks
- #624: SceneManager implementation
- #625: Scene loading/unloading
- #626: Scene transitions
- #627: Scene persistence

## Related Issues
Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)