### PR TITLE
feat(navigation): Add grid-based A* pathfinding for 2D games

### DIFF
--- a/src/KeenEyes.Navigation.Grid/AStarPathfinder.cs
+++ b/src/KeenEyes.Navigation.Grid/AStarPathfinder.cs
@@ -1,0 +1,410 @@
+using System.Buffers;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// A* pathfinding algorithm for grid-based navigation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implements the A* algorithm with support for both 4-directional (cardinal)
+/// and 8-directional (including diagonal) movement. Uses a binary heap for
+/// efficient priority queue operations.
+/// </para>
+/// <para>
+/// For zero-allocation pathfinding, use <see cref="FindPath(GridCoordinate, GridCoordinate, Span{GridCoordinate})"/>
+/// with a pre-allocated buffer.
+/// </para>
+/// </remarks>
+public sealed class AStarPathfinder
+{
+    private readonly NavigationGrid grid;
+    private readonly GridConfig config;
+    private readonly float[] areaCosts;
+
+    // Node pool to reduce allocations
+    private readonly PathNode[] nodePool;
+    private readonly Dictionary<int, int> nodeIndices;
+    private readonly PriorityQueue<int, float> openSet;
+    private int nodeCount;
+
+    // Reusable neighbor buffer
+    private readonly GridCoordinate[] neighborBuffer = new GridCoordinate[8];
+
+    private const float DiagonalCost = 1.41421356f; // sqrt(2)
+    private const float CardinalCost = 1f;
+
+    /// <summary>
+    /// Creates a new A* pathfinder for the specified grid.
+    /// </summary>
+    /// <param name="grid">The navigation grid to pathfind on.</param>
+    /// <param name="config">Configuration options.</param>
+    public AStarPathfinder(NavigationGrid grid, GridConfig config)
+    {
+        this.grid = grid ?? throw new ArgumentNullException(nameof(grid));
+        this.config = config ?? throw new ArgumentNullException(nameof(config));
+
+        // Allocate node pool based on max iterations or grid size
+        int poolSize = config.MaxIterations > 0
+            ? Math.Min(config.MaxIterations, grid.CellCount)
+            : grid.CellCount;
+
+        nodePool = new PathNode[poolSize];
+        nodeIndices = new Dictionary<int, int>(poolSize);
+        openSet = new PriorityQueue<int, float>(poolSize);
+
+        // Initialize area costs to 1.0
+        areaCosts = new float[32];
+        for (int i = 0; i < areaCosts.Length; i++)
+        {
+            areaCosts[i] = 1f;
+        }
+    }
+
+    /// <summary>
+    /// Gets the navigation grid used by this pathfinder.
+    /// </summary>
+    public NavigationGrid Grid => grid;
+
+    /// <summary>
+    /// Gets the configuration used by this pathfinder.
+    /// </summary>
+    public GridConfig Config => config;
+
+    /// <summary>
+    /// Gets or sets the cost multiplier for an area type.
+    /// </summary>
+    /// <param name="areaType">The area type.</param>
+    /// <returns>The cost multiplier.</returns>
+    public float GetAreaCost(NavAreaType areaType) => areaCosts[(int)areaType];
+
+    /// <summary>
+    /// Sets the cost multiplier for an area type.
+    /// </summary>
+    /// <param name="areaType">The area type.</param>
+    /// <param name="cost">The cost multiplier (must be positive or zero for unwalkable).</param>
+    public void SetAreaCost(NavAreaType areaType, float cost)
+    {
+        areaCosts[(int)areaType] = cost;
+    }
+
+    /// <summary>
+    /// Finds a path from start to end and returns the result.
+    /// </summary>
+    /// <param name="start">The starting coordinate.</param>
+    /// <param name="end">The destination coordinate.</param>
+    /// <param name="areaMask">Optional area mask to filter traversable cells.</param>
+    /// <returns>A NavPath containing the computed path.</returns>
+    public NavPath FindPath(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        // Use a reasonable default buffer size
+        var buffer = ArrayPool<GridCoordinate>.Shared.Rent(grid.CellCount);
+        try
+        {
+            int pathLength = FindPath(start, end, areaMask, buffer.AsSpan());
+            if (pathLength <= 0)
+            {
+                return NavPath.Empty;
+            }
+
+            // Convert to NavPath
+            var waypoints = new NavPoint[pathLength];
+            float totalCost = 0f;
+
+            for (int i = 0; i < pathLength; i++)
+            {
+                var coord = buffer[i];
+                var areaType = grid.GetAreaType(coord);
+                var position = grid.ToWorldPosition(coord);
+                waypoints[i] = new NavPoint(position, areaType);
+
+                if (i > 0)
+                {
+                    // Calculate cost between waypoints
+                    bool isDiagonal = buffer[i - 1].X != coord.X && buffer[i - 1].Y != coord.Y;
+                    float moveCost = isDiagonal ? DiagonalCost : CardinalCost;
+                    totalCost += moveCost * grid.GetCost(coord) * areaCosts[(int)areaType];
+                }
+            }
+
+            bool isComplete = pathLength > 0 && buffer[pathLength - 1] == end;
+            return new NavPath(waypoints, isComplete, totalCost);
+        }
+        finally
+        {
+            ArrayPool<GridCoordinate>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Finds a path from start to end using a pre-allocated buffer (zero allocation).
+    /// </summary>
+    /// <param name="start">The starting coordinate.</param>
+    /// <param name="end">The destination coordinate.</param>
+    /// <param name="result">Buffer to store the path coordinates.</param>
+    /// <returns>The number of coordinates in the path, or -1 if no path exists.</returns>
+    public int FindPath(GridCoordinate start, GridCoordinate end, Span<GridCoordinate> result)
+    {
+        return FindPath(start, end, NavAreaMask.All, result);
+    }
+
+    /// <summary>
+    /// Finds a path from start to end using a pre-allocated buffer with area filtering.
+    /// </summary>
+    /// <param name="start">The starting coordinate.</param>
+    /// <param name="end">The destination coordinate.</param>
+    /// <param name="areaMask">Area mask to filter traversable cells.</param>
+    /// <param name="result">Buffer to store the path coordinates.</param>
+    /// <returns>
+    /// The number of coordinates in the path, or -1 if no path exists.
+    /// Returns 0 if start equals end.
+    /// </returns>
+    public int FindPath(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask, Span<GridCoordinate> result)
+    {
+        // Quick validation
+        if (!grid.IsWalkable(start, areaMask) || !grid.IsWalkable(end, areaMask))
+        {
+            return -1;
+        }
+
+        if (start == end)
+        {
+            if (result.Length > 0)
+            {
+                result[0] = start;
+                return 1;
+            }
+
+            return 0;
+        }
+
+        // Reset state
+        Reset();
+
+        // Add start node
+        int startIndex = GetOrCreateNode(start);
+        nodePool[startIndex].GCost = 0;
+        nodePool[startIndex].HCost = CalculateHeuristic(start, end);
+        nodePool[startIndex].State = NodeState.Open;
+        openSet.Enqueue(startIndex, nodePool[startIndex].FCost);
+
+        int iterations = 0;
+        int maxIterations = config.MaxIterations > 0 ? config.MaxIterations : int.MaxValue;
+
+        while (openSet.Count > 0 && iterations < maxIterations)
+        {
+            iterations++;
+
+            int currentIndex = openSet.Dequeue();
+            ref var currentNode = ref nodePool[currentIndex];
+
+            // Skip if already closed (we may have duplicate entries in priority queue)
+            if (currentNode.State == NodeState.Closed)
+            {
+                continue;
+            }
+
+            currentNode.State = NodeState.Closed;
+
+            // Found the goal?
+            if (currentNode.Coordinate == end)
+            {
+                return ReconstructPath(currentIndex, result);
+            }
+
+            // Explore neighbors
+            int neighborCount = grid.GetWalkableNeighbors(
+                currentNode.Coordinate,
+                config.AllowDiagonal,
+                areaMask,
+                neighborBuffer);
+
+            for (int i = 0; i < neighborCount; i++)
+            {
+                var neighbor = neighborBuffer[i];
+
+                // Check if we've exceeded node pool capacity
+                if (nodeCount >= nodePool.Length && !nodeIndices.ContainsKey(neighbor.Y * grid.Width + neighbor.X))
+                {
+                    // Can't expand further - path too complex for current limits
+                    return -1;
+                }
+
+                int neighborIndex = GetOrCreateNode(neighbor);
+                ref var neighborNode = ref nodePool[neighborIndex];
+
+                if (neighborNode.State == NodeState.Closed)
+                {
+                    continue;
+                }
+
+                // Calculate tentative G cost
+                bool isDiagonal = currentNode.Coordinate.X != neighbor.X &&
+                                  currentNode.Coordinate.Y != neighbor.Y;
+                float moveCost = isDiagonal ? DiagonalCost : CardinalCost;
+
+                var areaType = grid.GetAreaType(neighbor);
+                float areaCost = areaCosts[(int)areaType];
+                if (areaCost <= 0f)
+                {
+                    continue; // Unwalkable due to area cost
+                }
+
+                float cellCost = grid.GetCost(neighbor);
+                float tentativeG = currentNode.GCost + moveCost * cellCost * areaCost;
+
+                if (tentativeG < neighborNode.GCost)
+                {
+                    neighborNode.ParentIndex = currentIndex;
+                    neighborNode.GCost = tentativeG;
+                    neighborNode.HCost = CalculateHeuristic(neighbor, end);
+                    neighborNode.State = NodeState.Open;
+                    openSet.Enqueue(neighborIndex, neighborNode.FCost);
+                }
+            }
+        }
+
+        // No path found (either no path exists or iteration/node limit reached)
+        return -1;
+    }
+
+    /// <summary>
+    /// Finds a path between two world positions.
+    /// </summary>
+    /// <param name="startWorld">The starting world position.</param>
+    /// <param name="endWorld">The destination world position.</param>
+    /// <param name="areaMask">Optional area mask.</param>
+    /// <returns>A NavPath containing the computed path.</returns>
+    public NavPath FindPath(Vector3 startWorld, Vector3 endWorld, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        var start = grid.FromWorldPosition(startWorld);
+        var end = grid.FromWorldPosition(endWorld);
+        return FindPath(start, end, areaMask);
+    }
+
+    /// <summary>
+    /// Checks if a path exists between two coordinates without computing the full path.
+    /// </summary>
+    /// <param name="start">The starting coordinate.</param>
+    /// <param name="end">The destination coordinate.</param>
+    /// <param name="areaMask">Optional area mask.</param>
+    /// <returns>True if a path exists.</returns>
+    public bool HasPath(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        // Quick validation
+        if (!grid.IsWalkable(start, areaMask) || !grid.IsWalkable(end, areaMask))
+        {
+            return false;
+        }
+
+        if (start == end)
+        {
+            return true;
+        }
+
+        // Use a reasonable buffer size for HasPath queries
+        Span<GridCoordinate> buffer = stackalloc GridCoordinate[256];
+        int result = FindPath(start, end, areaMask, buffer);
+        // Result will be -1 if no path found
+        // If buffer is too small, result is negative (negative path length)
+        // Any value != -1 means path exists
+        return result != -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private float CalculateHeuristic(GridCoordinate from, GridCoordinate to)
+    {
+        return config.Heuristic switch
+        {
+            GridHeuristic.Manhattan => from.ManhattanDistance(to),
+            GridHeuristic.Chebyshev => from.ChebyshevDistance(to),
+            GridHeuristic.Euclidean => from.EuclideanDistance(to),
+            GridHeuristic.Octile or _ => from.OctileDistance(to)
+        };
+    }
+
+    private void Reset()
+    {
+        nodeCount = 0;
+        nodeIndices.Clear();
+        openSet.Clear();
+    }
+
+    private int GetOrCreateNode(GridCoordinate coord)
+    {
+        int key = coord.Y * grid.Width + coord.X;
+        if (nodeIndices.TryGetValue(key, out int existingIndex))
+        {
+            return existingIndex;
+        }
+
+        if (nodeCount >= nodePool.Length)
+        {
+            throw new InvalidOperationException(
+                $"Path search exceeded maximum node count of {nodePool.Length}. " +
+                "Consider increasing MaxIterations or the path may be too long.");
+        }
+
+        int index = nodeCount++;
+        nodePool[index] = new PathNode
+        {
+            Coordinate = coord,
+            GCost = float.MaxValue,
+            HCost = 0f,
+            ParentIndex = -1,
+            State = NodeState.Unvisited
+        };
+
+        nodeIndices[key] = index;
+        return index;
+    }
+
+    private int ReconstructPath(int endIndex, Span<GridCoordinate> result)
+    {
+        // First, count path length by walking backwards
+        int length = 0;
+        int current = endIndex;
+        while (current >= 0)
+        {
+            length++;
+            current = nodePool[current].ParentIndex;
+        }
+
+        if (length > result.Length)
+        {
+            // Buffer too small - return the required length as negative
+            return -length;
+        }
+
+        // Walk backwards and fill result in reverse
+        current = endIndex;
+        for (int i = length - 1; i >= 0; i--)
+        {
+            result[i] = nodePool[current].Coordinate;
+            current = nodePool[current].ParentIndex;
+        }
+
+        return length;
+    }
+
+    private struct PathNode
+    {
+        public GridCoordinate Coordinate;
+        public float GCost;     // Cost from start to this node
+        public float HCost;     // Heuristic cost from this node to goal
+        public int ParentIndex; // Index of parent node in pool
+        public NodeState State;
+
+        public readonly float FCost => GCost + HCost;
+    }
+
+    private enum NodeState : byte
+    {
+        Unvisited,
+        Open,
+        Closed
+    }
+}

--- a/src/KeenEyes.Navigation.Grid/GridCell.cs
+++ b/src/KeenEyes.Navigation.Grid/GridCell.cs
@@ -1,0 +1,82 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Represents a single cell in a navigation grid.
+/// </summary>
+/// <remarks>
+/// Each cell stores walkability information and an area type for cost calculations.
+/// </remarks>
+public struct GridCell
+{
+    /// <summary>
+    /// Gets or sets whether this cell is walkable.
+    /// </summary>
+    public bool IsWalkable;
+
+    /// <summary>
+    /// Gets or sets the area type of this cell.
+    /// </summary>
+    public NavAreaType AreaType;
+
+    /// <summary>
+    /// Gets or sets the base movement cost for this cell (before area cost multiplier).
+    /// </summary>
+    /// <remarks>
+    /// Default value is 1.0. Higher values make the cell less preferable.
+    /// A value of 0 or negative means the cell is unwalkable regardless of <see cref="IsWalkable"/>.
+    /// </remarks>
+    public float Cost;
+
+    /// <summary>
+    /// Gets or sets custom user data for this cell.
+    /// </summary>
+    /// <remarks>
+    /// Can be used to store game-specific information such as terrain type,
+    /// elevation, or other metadata.
+    /// </remarks>
+    public int UserData;
+
+    /// <summary>
+    /// Creates a walkable cell with default settings.
+    /// </summary>
+    public static GridCell Walkable => new()
+    {
+        IsWalkable = true,
+        AreaType = NavAreaType.Walkable,
+        Cost = 1f,
+        UserData = 0
+    };
+
+    /// <summary>
+    /// Creates a blocked (unwalkable) cell.
+    /// </summary>
+    public static GridCell Blocked => new()
+    {
+        IsWalkable = false,
+        AreaType = NavAreaType.NotWalkable,
+        Cost = 0f,
+        UserData = 0
+    };
+
+    /// <summary>
+    /// Creates a walkable cell with a specific area type.
+    /// </summary>
+    /// <param name="areaType">The area type for the cell.</param>
+    /// <param name="cost">The base movement cost (default 1.0).</param>
+    /// <returns>A new walkable cell.</returns>
+    public static GridCell WithAreaType(NavAreaType areaType, float cost = 1f) => new()
+    {
+        IsWalkable = true,
+        AreaType = areaType,
+        Cost = cost,
+        UserData = 0
+    };
+
+    /// <summary>
+    /// Gets the effective walkability considering both <see cref="IsWalkable"/> and <see cref="Cost"/>.
+    /// </summary>
+    /// <returns>True if the cell can be traversed.</returns>
+    public readonly bool CanTraverse() => IsWalkable && Cost > 0f;
+}

--- a/src/KeenEyes.Navigation.Grid/GridConfig.cs
+++ b/src/KeenEyes.Navigation.Grid/GridConfig.cs
@@ -1,0 +1,164 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Configuration options for grid-based navigation.
+/// </summary>
+public sealed class GridConfig
+{
+    /// <summary>
+    /// Gets or sets the width of the grid in cells.
+    /// </summary>
+    /// <remarks>Must be positive.</remarks>
+    public int Width { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the height of the grid in cells.
+    /// </summary>
+    /// <remarks>Must be positive.</remarks>
+    public int Height { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the size of each cell in world units.
+    /// </summary>
+    /// <remarks>Must be positive.</remarks>
+    public float CellSize { get; set; } = 1f;
+
+    /// <summary>
+    /// Gets or sets the world-space origin of the grid.
+    /// </summary>
+    public Vector3 WorldOrigin { get; set; } = Vector3.Zero;
+
+    /// <summary>
+    /// Gets or sets whether diagonal movement is allowed.
+    /// </summary>
+    public bool AllowDiagonal { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the heuristic to use for A* pathfinding.
+    /// </summary>
+    public GridHeuristic Heuristic { get; set; } = GridHeuristic.Octile;
+
+    /// <summary>
+    /// Gets or sets the maximum number of nodes to expand before giving up.
+    /// </summary>
+    /// <remarks>
+    /// A value of 0 means no limit. This prevents pathfinding from running
+    /// too long on impossible or very long paths.
+    /// </remarks>
+    public int MaxIterations { get; set; } = 10000;
+
+    /// <summary>
+    /// Gets or sets the maximum number of pending path requests.
+    /// </summary>
+    public int MaxPendingRequests { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the number of path requests to process per update.
+    /// </summary>
+    public int RequestsPerUpdate { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets whether to cache frequently used paths.
+    /// </summary>
+    public bool EnablePathCaching { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of cached paths.
+    /// </summary>
+    public int MaxCachedPaths { get; set; } = 100;
+
+    /// <summary>
+    /// Creates a default configuration.
+    /// </summary>
+    public static GridConfig Default => new();
+
+    /// <summary>
+    /// Creates a configuration for a specific grid size.
+    /// </summary>
+    /// <param name="width">The width in cells.</param>
+    /// <param name="height">The height in cells.</param>
+    /// <param name="cellSize">The cell size in world units.</param>
+    /// <returns>A new configuration.</returns>
+    public static GridConfig WithSize(int width, int height, float cellSize = 1f) => new()
+    {
+        Width = width,
+        Height = height,
+        CellSize = cellSize
+    };
+
+    /// <summary>
+    /// Validates the configuration.
+    /// </summary>
+    /// <returns>Null if valid, otherwise an error message.</returns>
+    public string? Validate()
+    {
+        if (Width <= 0)
+        {
+            return $"Width must be positive, got {Width}.";
+        }
+
+        if (Height <= 0)
+        {
+            return $"Height must be positive, got {Height}.";
+        }
+
+        if (CellSize <= 0f)
+        {
+            return $"CellSize must be positive, got {CellSize}.";
+        }
+
+        if (MaxIterations < 0)
+        {
+            return $"MaxIterations must be non-negative, got {MaxIterations}.";
+        }
+
+        if (MaxPendingRequests <= 0)
+        {
+            return $"MaxPendingRequests must be positive, got {MaxPendingRequests}.";
+        }
+
+        if (RequestsPerUpdate <= 0)
+        {
+            return $"RequestsPerUpdate must be positive, got {RequestsPerUpdate}.";
+        }
+
+        if (EnablePathCaching && MaxCachedPaths <= 0)
+        {
+            return $"MaxCachedPaths must be positive when caching is enabled, got {MaxCachedPaths}.";
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Heuristic functions for A* pathfinding on a grid.
+/// </summary>
+public enum GridHeuristic
+{
+    /// <summary>
+    /// Manhattan distance (sum of absolute differences).
+    /// Best for 4-directional movement.
+    /// </summary>
+    Manhattan,
+
+    /// <summary>
+    /// Chebyshev distance (maximum of absolute differences).
+    /// Assumes diagonal and cardinal moves have equal cost.
+    /// </summary>
+    Chebyshev,
+
+    /// <summary>
+    /// Octile distance (accounts for sqrt(2) diagonal cost).
+    /// Best for 8-directional movement with realistic diagonal costs.
+    /// </summary>
+    Octile,
+
+    /// <summary>
+    /// Euclidean distance (straight-line).
+    /// Most accurate but slightly slower to compute.
+    /// </summary>
+    Euclidean
+}

--- a/src/KeenEyes.Navigation.Grid/GridCoordinate.cs
+++ b/src/KeenEyes.Navigation.Grid/GridCoordinate.cs
@@ -1,0 +1,187 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Represents a 2D coordinate on a navigation grid.
+/// </summary>
+/// <remarks>
+/// Grid coordinates use integer X and Y values to identify cells.
+/// The Y coordinate typically maps to the Z axis in 3D space for top-down games.
+/// </remarks>
+/// <param name="X">The X coordinate (column) on the grid.</param>
+/// <param name="Y">The Y coordinate (row) on the grid.</param>
+public readonly record struct GridCoordinate(int X, int Y)
+{
+    /// <summary>
+    /// Gets the origin coordinate (0, 0).
+    /// </summary>
+    public static GridCoordinate Origin => new(0, 0);
+
+    /// <summary>
+    /// Gets the coordinate offset for moving up (negative Y).
+    /// </summary>
+    public static GridCoordinate Up => new(0, -1);
+
+    /// <summary>
+    /// Gets the coordinate offset for moving down (positive Y).
+    /// </summary>
+    public static GridCoordinate Down => new(0, 1);
+
+    /// <summary>
+    /// Gets the coordinate offset for moving left (negative X).
+    /// </summary>
+    public static GridCoordinate Left => new(-1, 0);
+
+    /// <summary>
+    /// Gets the coordinate offset for moving right (positive X).
+    /// </summary>
+    public static GridCoordinate Right => new(1, 0);
+
+    private static readonly GridCoordinate[] cardinalDirections =
+    [
+        new(0, -1),  // Up
+        new(0, 1),   // Down
+        new(-1, 0),  // Left
+        new(1, 0)    // Right
+    ];
+
+    private static readonly GridCoordinate[] diagonalDirections =
+    [
+        new(-1, -1), // Up-Left
+        new(1, -1),  // Up-Right
+        new(-1, 1),  // Down-Left
+        new(1, 1)    // Down-Right
+    ];
+
+    private static readonly GridCoordinate[] allDirections =
+    [
+        new(0, -1),  // Up
+        new(0, 1),   // Down
+        new(-1, 0),  // Left
+        new(1, 0),   // Right
+        new(-1, -1), // Up-Left
+        new(1, -1),  // Up-Right
+        new(-1, 1),  // Down-Left
+        new(1, 1)    // Down-Right
+    ];
+
+    /// <summary>
+    /// Gets the four cardinal direction offsets (up, down, left, right).
+    /// </summary>
+    public static ReadOnlySpan<GridCoordinate> CardinalDirections => cardinalDirections;
+
+    /// <summary>
+    /// Gets the four diagonal direction offsets.
+    /// </summary>
+    public static ReadOnlySpan<GridCoordinate> DiagonalDirections => diagonalDirections;
+
+    /// <summary>
+    /// Gets all eight direction offsets (cardinal + diagonal).
+    /// </summary>
+    public static ReadOnlySpan<GridCoordinate> AllDirections => allDirections;
+
+    /// <summary>
+    /// Calculates the Manhattan distance to another coordinate.
+    /// </summary>
+    /// <param name="other">The target coordinate.</param>
+    /// <returns>The Manhattan distance (sum of absolute differences).</returns>
+    public int ManhattanDistance(GridCoordinate other)
+        => Math.Abs(X - other.X) + Math.Abs(Y - other.Y);
+
+    /// <summary>
+    /// Calculates the Chebyshev distance (chessboard distance) to another coordinate.
+    /// </summary>
+    /// <param name="other">The target coordinate.</param>
+    /// <returns>The maximum of the absolute differences.</returns>
+    public int ChebyshevDistance(GridCoordinate other)
+        => Math.Max(Math.Abs(X - other.X), Math.Abs(Y - other.Y));
+
+    /// <summary>
+    /// Calculates the octile distance to another coordinate.
+    /// </summary>
+    /// <remarks>
+    /// Octile distance is used for grids with 8-directional movement where
+    /// diagonal moves cost sqrt(2) times the cardinal move cost.
+    /// </remarks>
+    /// <param name="other">The target coordinate.</param>
+    /// <returns>The octile distance as a float.</returns>
+    public float OctileDistance(GridCoordinate other)
+    {
+        int dx = Math.Abs(X - other.X);
+        int dy = Math.Abs(Y - other.Y);
+        const float Sqrt2 = 1.41421356f;
+        return dx > dy
+            ? dx + (Sqrt2 - 1f) * dy
+            : dy + (Sqrt2 - 1f) * dx;
+    }
+
+    /// <summary>
+    /// Calculates the Euclidean distance to another coordinate.
+    /// </summary>
+    /// <param name="other">The target coordinate.</param>
+    /// <returns>The straight-line distance.</returns>
+    public float EuclideanDistance(GridCoordinate other)
+    {
+        int dx = X - other.X;
+        int dy = Y - other.Y;
+        return MathF.Sqrt(dx * dx + dy * dy);
+    }
+
+    /// <summary>
+    /// Checks if this coordinate is adjacent to another (including diagonals).
+    /// </summary>
+    /// <param name="other">The coordinate to check.</param>
+    /// <returns>True if the coordinates are adjacent.</returns>
+    public bool IsAdjacentTo(GridCoordinate other)
+        => ChebyshevDistance(other) == 1;
+
+    /// <summary>
+    /// Checks if this coordinate is cardinally adjacent to another (not diagonal).
+    /// </summary>
+    /// <param name="other">The coordinate to check.</param>
+    /// <returns>True if the coordinates are cardinally adjacent.</returns>
+    public bool IsCardinallyAdjacentTo(GridCoordinate other)
+        => ManhattanDistance(other) == 1;
+
+    /// <summary>
+    /// Converts to a 3D world position using the specified cell size and height.
+    /// </summary>
+    /// <param name="cellSize">The size of each grid cell in world units.</param>
+    /// <param name="height">The Y height in world space (default 0).</param>
+    /// <returns>The world position at the center of this cell.</returns>
+    public Vector3 ToWorldPosition(float cellSize, float height = 0f)
+        => new((X + 0.5f) * cellSize, height, (Y + 0.5f) * cellSize);
+
+    /// <summary>
+    /// Creates a coordinate from a world position.
+    /// </summary>
+    /// <param name="position">The world position (uses X and Z).</param>
+    /// <param name="cellSize">The size of each grid cell.</param>
+    /// <returns>The grid coordinate containing this position.</returns>
+    public static GridCoordinate FromWorldPosition(Vector3 position, float cellSize)
+        => new(
+            (int)MathF.Floor(position.X / cellSize),
+            (int)MathF.Floor(position.Z / cellSize));
+
+    /// <summary>
+    /// Adds two coordinates together.
+    /// </summary>
+    public static GridCoordinate operator +(GridCoordinate a, GridCoordinate b)
+        => new(a.X + b.X, a.Y + b.Y);
+
+    /// <summary>
+    /// Subtracts one coordinate from another.
+    /// </summary>
+    public static GridCoordinate operator -(GridCoordinate a, GridCoordinate b)
+        => new(a.X - b.X, a.Y - b.Y);
+
+    /// <summary>
+    /// Multiplies a coordinate by a scalar.
+    /// </summary>
+    public static GridCoordinate operator *(GridCoordinate coord, int scalar)
+        => new(coord.X * scalar, coord.Y * scalar);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"({X}, {Y})";
+}

--- a/src/KeenEyes.Navigation.Grid/GridNavigationPlugin.cs
+++ b/src/KeenEyes.Navigation.Grid/GridNavigationPlugin.cs
@@ -1,0 +1,133 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Plugin that adds grid-based A* pathfinding to the ECS world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin provides efficient grid-based navigation for 2D games or games
+/// with tile-based movement. It registers a <see cref="GridNavigationProvider"/>
+/// that implements <see cref="INavigationProvider"/>.
+/// </para>
+/// <para>
+/// The plugin exposes the navigation provider as an extension that can be accessed
+/// via <c>world.GetExtension&lt;GridNavigationProvider&gt;()</c> or
+/// <c>world.GetExtension&lt;INavigationProvider&gt;()</c>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var world = new World();
+///
+/// // Install the plugin with configuration
+/// world.InstallPlugin(new GridNavigationPlugin(new GridConfig
+/// {
+///     Width = 100,
+///     Height = 100,
+///     CellSize = 1f,
+///     AllowDiagonal = true
+/// }));
+///
+/// // Get the navigation provider
+/// var navigation = world.GetExtension&lt;GridNavigationProvider&gt;();
+///
+/// // Set up obstacles
+/// navigation.Grid[10, 10] = GridCell.Blocked;
+///
+/// // Find a path
+/// var path = navigation.FindPath(
+///     new Vector3(0, 0, 0),
+///     new Vector3(50, 0, 50),
+///     AgentSettings.Default);
+///
+/// if (path.IsValid)
+/// {
+///     foreach (var waypoint in path)
+///     {
+///         // Follow the path
+///     }
+/// }
+/// </code>
+/// </example>
+public sealed class GridNavigationPlugin : IWorldPlugin
+{
+    private readonly GridConfig config;
+    private readonly NavigationGrid? existingGrid;
+    private GridNavigationProvider? provider;
+
+    /// <summary>
+    /// Creates a new grid navigation plugin with default configuration.
+    /// </summary>
+    public GridNavigationPlugin()
+        : this(GridConfig.Default)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new grid navigation plugin with the specified configuration.
+    /// </summary>
+    /// <param name="config">The grid navigation configuration.</param>
+    /// <exception cref="ArgumentException">Thrown if configuration is invalid.</exception>
+    public GridNavigationPlugin(GridConfig config)
+    {
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException($"Invalid GridConfig: {error}", nameof(config));
+        }
+
+        this.config = config;
+        existingGrid = null;
+    }
+
+    /// <summary>
+    /// Creates a new grid navigation plugin with an existing grid.
+    /// </summary>
+    /// <param name="grid">The pre-configured navigation grid to use.</param>
+    /// <param name="config">The grid navigation configuration.</param>
+    /// <exception cref="ArgumentNullException">Thrown if grid is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if configuration is invalid.</exception>
+    public GridNavigationPlugin(NavigationGrid grid, GridConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(grid);
+
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException($"Invalid GridConfig: {error}", nameof(config));
+        }
+
+        existingGrid = grid;
+        this.config = config;
+    }
+
+    /// <inheritdoc/>
+    public string Name => "GridNavigation";
+
+    /// <inheritdoc/>
+    public void Install(IPluginContext context)
+    {
+        // Create the navigation provider
+        provider = existingGrid != null
+            ? new GridNavigationProvider(existingGrid, config)
+            : new GridNavigationProvider(config);
+
+        // Register the provider as both the concrete type and the interface
+        context.SetExtension(provider);
+        context.SetExtension<INavigationProvider>(provider);
+    }
+
+    /// <inheritdoc/>
+    public void Uninstall(IPluginContext context)
+    {
+        // Remove extensions
+        context.RemoveExtension<GridNavigationProvider>();
+        context.RemoveExtension<INavigationProvider>();
+
+        // Dispose the provider
+        provider?.Dispose();
+        provider = null;
+    }
+}

--- a/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
@@ -1,0 +1,472 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Grid-based navigation provider implementing A* pathfinding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Provides pathfinding services on a 2D grid using the A* algorithm.
+/// Supports both synchronous and asynchronous path computation, area
+/// filtering, and configurable movement costs.
+/// </para>
+/// <para>
+/// For 2D games or games with tile-based movement, this provider offers
+/// simple and efficient pathfinding without the complexity of navmesh generation.
+/// </para>
+/// </remarks>
+public sealed class GridNavigationProvider : INavigationProvider
+{
+    private readonly NavigationGrid grid;
+    private readonly GridConfig config;
+    private readonly AStarPathfinder pathfinder;
+    private readonly Queue<GridPathRequest> pendingRequests;
+    private readonly Lock requestLock = new();
+    private bool disposed;
+
+    /// <summary>
+    /// Creates a new grid navigation provider.
+    /// </summary>
+    /// <param name="config">Configuration options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when config is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when config validation fails.</exception>
+    public GridNavigationProvider(GridConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException(error, nameof(config));
+        }
+
+        this.config = config;
+        grid = new NavigationGrid(config.Width, config.Height, config.CellSize, config.WorldOrigin);
+        pathfinder = new AStarPathfinder(grid, config);
+        pendingRequests = new Queue<GridPathRequest>(config.MaxPendingRequests);
+    }
+
+    /// <summary>
+    /// Creates a new grid navigation provider with an existing grid.
+    /// </summary>
+    /// <param name="grid">The navigation grid to use.</param>
+    /// <param name="config">Configuration options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when grid or config is null.</exception>
+    public GridNavigationProvider(NavigationGrid grid, GridConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(grid);
+        ArgumentNullException.ThrowIfNull(config);
+
+        this.grid = grid;
+        this.config = config;
+        pathfinder = new AStarPathfinder(grid, config);
+        pendingRequests = new Queue<GridPathRequest>(config.MaxPendingRequests);
+    }
+
+    /// <inheritdoc/>
+    public NavigationStrategy Strategy => NavigationStrategy.Grid;
+
+    /// <inheritdoc/>
+    public bool IsReady => !disposed;
+
+    /// <inheritdoc/>
+    public INavigationMesh? ActiveMesh => null; // Grid-based navigation doesn't use meshes
+
+    /// <summary>
+    /// Gets the underlying navigation grid.
+    /// </summary>
+    public NavigationGrid Grid => grid;
+
+    /// <summary>
+    /// Gets the A* pathfinder instance.
+    /// </summary>
+    public AStarPathfinder Pathfinder => pathfinder;
+
+    /// <summary>
+    /// Gets the current number of pending path requests.
+    /// </summary>
+    public int PendingRequestCount
+    {
+        get
+        {
+            lock (requestLock)
+            {
+                return pendingRequests.Count;
+            }
+        }
+    }
+
+    #region Pathfinding
+
+    /// <inheritdoc/>
+    public NavPath FindPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+
+        // Grid navigation ignores agent settings for now (could be extended to consider radius)
+        return pathfinder.FindPath(start, end, areaMask);
+    }
+
+    /// <summary>
+    /// Finds a path using grid coordinates.
+    /// </summary>
+    /// <param name="start">The starting grid coordinate.</param>
+    /// <param name="end">The destination grid coordinate.</param>
+    /// <param name="areaMask">Optional area mask.</param>
+    /// <returns>The computed path.</returns>
+    public NavPath FindPath(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+        return pathfinder.FindPath(start, end, areaMask);
+    }
+
+    /// <summary>
+    /// Finds a path using grid coordinates and a pre-allocated buffer (zero allocation).
+    /// </summary>
+    /// <param name="start">The starting grid coordinate.</param>
+    /// <param name="end">The destination grid coordinate.</param>
+    /// <param name="result">Buffer to store the path coordinates.</param>
+    /// <returns>The number of coordinates in the path, or -1 if no path exists.</returns>
+    public int FindPath(GridCoordinate start, GridCoordinate end, Span<GridCoordinate> result)
+    {
+        ThrowIfDisposed();
+        return pathfinder.FindPath(start, end, result);
+    }
+
+    /// <summary>
+    /// Finds a path using grid coordinates and a pre-allocated buffer with area filtering.
+    /// </summary>
+    /// <param name="start">The starting grid coordinate.</param>
+    /// <param name="end">The destination grid coordinate.</param>
+    /// <param name="areaMask">Area mask to filter traversable cells.</param>
+    /// <param name="result">Buffer to store the path coordinates.</param>
+    /// <returns>The number of coordinates in the path, or -1 if no path exists.</returns>
+    public int FindPath(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask, Span<GridCoordinate> result)
+    {
+        ThrowIfDisposed();
+        return pathfinder.FindPath(start, end, areaMask, result);
+    }
+
+    /// <inheritdoc/>
+    public IPathRequest RequestPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+
+        var request = new GridPathRequest(start, end, agent, areaMask);
+
+        lock (requestLock)
+        {
+            if (pendingRequests.Count >= config.MaxPendingRequests)
+            {
+                request.Fail();
+                return request;
+            }
+
+            pendingRequests.Enqueue(request);
+        }
+
+        return request;
+    }
+
+    /// <inheritdoc/>
+    public void CancelAllRequests()
+    {
+        ThrowIfDisposed();
+
+        lock (requestLock)
+        {
+            while (pendingRequests.Count > 0)
+            {
+                var request = pendingRequests.Dequeue();
+                request.Cancel();
+            }
+        }
+    }
+
+    #endregion
+
+    #region Raycasting
+
+    /// <inheritdoc/>
+    public bool Raycast(Vector3 start, Vector3 end, out Vector3 hitPosition)
+    {
+        ThrowIfDisposed();
+
+        var startCoord = grid.FromWorldPosition(start);
+        var endCoord = grid.FromWorldPosition(end);
+
+        if (RaycastGrid(startCoord, endCoord, NavAreaMask.All, out var hitCoord))
+        {
+            hitPosition = grid.ToWorldPosition(hitCoord);
+            return true;
+        }
+
+        hitPosition = end;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public bool Raycast(Vector3 start, Vector3 end, NavAreaMask areaMask, out Vector3 hitPosition, out NavAreaType hitAreaType)
+    {
+        ThrowIfDisposed();
+
+        var startCoord = grid.FromWorldPosition(start);
+        var endCoord = grid.FromWorldPosition(end);
+
+        if (RaycastGrid(startCoord, endCoord, areaMask, out var hitCoord))
+        {
+            hitPosition = grid.ToWorldPosition(hitCoord);
+            hitAreaType = grid.GetAreaType(hitCoord);
+            return true;
+        }
+
+        hitPosition = end;
+        hitAreaType = grid.GetAreaType(endCoord);
+        return false;
+    }
+
+    /// <summary>
+    /// Performs a raycast on the grid using Bresenham's line algorithm.
+    /// </summary>
+    /// <param name="start">The starting grid coordinate.</param>
+    /// <param name="end">The ending grid coordinate.</param>
+    /// <param name="areaMask">Area mask to filter traversable cells.</param>
+    /// <param name="hitCoord">The coordinate where the ray hit an obstacle.</param>
+    /// <returns>True if the ray hit an obstacle, false if the path is clear.</returns>
+    public bool RaycastGrid(GridCoordinate start, GridCoordinate end, NavAreaMask areaMask, out GridCoordinate hitCoord)
+    {
+        int x0 = start.X;
+        int y0 = start.Y;
+        int x1 = end.X;
+        int y1 = end.Y;
+
+        int dx = Math.Abs(x1 - x0);
+        int dy = Math.Abs(y1 - y0);
+        int sx = x0 < x1 ? 1 : -1;
+        int sy = y0 < y1 ? 1 : -1;
+        int err = dx - dy;
+
+        while (true)
+        {
+            var current = new GridCoordinate(x0, y0);
+
+            // Skip the start position
+            if (current != start && !grid.IsWalkable(current, areaMask))
+            {
+                hitCoord = current;
+                return true;
+            }
+
+            if (x0 == x1 && y0 == y1)
+            {
+                break;
+            }
+
+            int e2 = 2 * err;
+            if (e2 > -dy)
+            {
+                err -= dy;
+                x0 += sx;
+            }
+
+            if (e2 < dx)
+            {
+                err += dx;
+                y0 += sy;
+            }
+        }
+
+        hitCoord = end;
+        return false;
+    }
+
+    #endregion
+
+    #region Point Queries
+
+    /// <inheritdoc/>
+    public NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f)
+    {
+        ThrowIfDisposed();
+
+        var centerCoord = grid.FromWorldPosition(position);
+        int radiusCells = (int)MathF.Ceiling(searchRadius / grid.CellSize);
+
+        // Check center first
+        if (grid.IsWalkable(centerCoord))
+        {
+            return new NavPoint(
+                grid.ToWorldPosition(centerCoord),
+                grid.GetAreaType(centerCoord));
+        }
+
+        // Spiral outward
+        float bestDistSq = float.MaxValue;
+        GridCoordinate? best = null;
+
+        for (int r = 1; r <= radiusCells; r++)
+        {
+            for (int dx = -r; dx <= r; dx++)
+            {
+                for (int dy = -r; dy <= r; dy++)
+                {
+                    if (Math.Abs(dx) != r && Math.Abs(dy) != r)
+                    {
+                        continue; // Only check the perimeter at this radius
+                    }
+
+                    var coord = new GridCoordinate(centerCoord.X + dx, centerCoord.Y + dy);
+                    if (!grid.IsWalkable(coord))
+                    {
+                        continue;
+                    }
+
+                    var worldPos = grid.ToWorldPosition(coord);
+                    float distSq = Vector3.DistanceSquared(position, worldPos);
+                    if (distSq < bestDistSq && distSq <= searchRadius * searchRadius)
+                    {
+                        bestDistSq = distSq;
+                        best = coord;
+                    }
+                }
+            }
+
+            // If we found something at this radius, we're done
+            if (best.HasValue)
+            {
+                break;
+            }
+        }
+
+        if (!best.HasValue)
+        {
+            return null;
+        }
+
+        return new NavPoint(
+            grid.ToWorldPosition(best.Value),
+            grid.GetAreaType(best.Value));
+    }
+
+    /// <inheritdoc/>
+    public bool IsNavigable(Vector3 position, AgentSettings agent)
+    {
+        ThrowIfDisposed();
+
+        var coord = grid.FromWorldPosition(position);
+        return grid.IsWalkable(coord);
+    }
+
+    /// <inheritdoc/>
+    public Vector3? ProjectToNavMesh(Vector3 position, float maxDistance = 5f)
+    {
+        ThrowIfDisposed();
+
+        var nearestPoint = FindNearestPoint(position, maxDistance);
+        return nearestPoint?.Position;
+    }
+
+    /// <summary>
+    /// Checks if a grid coordinate is navigable.
+    /// </summary>
+    /// <param name="coord">The coordinate to check.</param>
+    /// <param name="areaMask">Optional area mask.</param>
+    /// <returns>True if the coordinate is navigable.</returns>
+    public bool IsNavigable(GridCoordinate coord, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+        return grid.IsWalkable(coord, areaMask);
+    }
+
+    #endregion
+
+    #region Area Costs
+
+    /// <inheritdoc/>
+    public float GetAreaCost(NavAreaType areaType)
+    {
+        ThrowIfDisposed();
+        return pathfinder.GetAreaCost(areaType);
+    }
+
+    /// <inheritdoc/>
+    public void SetAreaCost(NavAreaType areaType, float cost)
+    {
+        ThrowIfDisposed();
+        pathfinder.SetAreaCost(areaType, cost);
+    }
+
+    #endregion
+
+    #region Updates
+
+    /// <inheritdoc/>
+    public void Update(float deltaTime)
+    {
+        ThrowIfDisposed();
+
+        int requestsToProcess = config.RequestsPerUpdate;
+
+        for (int i = 0; i < requestsToProcess; i++)
+        {
+            GridPathRequest? request;
+
+            lock (requestLock)
+            {
+                if (pendingRequests.Count == 0)
+                {
+                    break;
+                }
+
+                request = pendingRequests.Dequeue();
+            }
+
+            if (request.Status == PathRequestStatus.Cancelled)
+            {
+                continue;
+            }
+
+            request.MarkComputing();
+
+            try
+            {
+                var path = pathfinder.FindPath(request.Start, request.End, request.AreaMask);
+                request.Complete(path);
+            }
+            catch
+            {
+                request.Fail();
+            }
+        }
+    }
+
+    #endregion
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        // Cancel requests before marking as disposed
+        lock (requestLock)
+        {
+            while (pendingRequests.Count > 0)
+            {
+                var request = pendingRequests.Dequeue();
+                request.Cancel();
+            }
+        }
+
+        disposed = true;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}

--- a/src/KeenEyes.Navigation.Grid/GridPathRequest.cs
+++ b/src/KeenEyes.Navigation.Grid/GridPathRequest.cs
@@ -1,0 +1,106 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Represents an asynchronous path computation request for grid navigation.
+/// </summary>
+/// <param name="start">The starting position.</param>
+/// <param name="end">The destination position.</param>
+/// <param name="agent">The agent settings.</param>
+/// <param name="areaMask">The area mask for filtering.</param>
+internal sealed class GridPathRequest(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask) : IPathRequest
+{
+    private static int nextId;
+
+    private readonly TaskCompletionSource<NavPath> taskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private PathRequestStatus status = PathRequestStatus.Pending;
+    private NavPath result = NavPath.Empty;
+
+    /// <inheritdoc/>
+    public int Id { get; } = Interlocked.Increment(ref nextId);
+
+    /// <inheritdoc/>
+    public PathRequestStatus Status => status;
+
+    /// <inheritdoc/>
+    public Vector3 Start { get; } = start;
+
+    /// <inheritdoc/>
+    public Vector3 End { get; } = end;
+
+    /// <inheritdoc/>
+    public AgentSettings Agent { get; } = agent;
+
+    /// <summary>
+    /// Gets the area mask for this request.
+    /// </summary>
+    public NavAreaMask AreaMask { get; } = areaMask;
+
+    /// <inheritdoc/>
+    public NavPath Result => result;
+
+    /// <inheritdoc/>
+    public void Cancel()
+    {
+        if (status is PathRequestStatus.Pending or PathRequestStatus.Computing)
+        {
+            status = PathRequestStatus.Cancelled;
+            result = NavPath.Empty;
+            taskSource.TrySetResult(NavPath.Empty);
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool Wait(TimeSpan timeout)
+    {
+        return taskSource.Task.Wait(timeout);
+    }
+
+    /// <inheritdoc/>
+    public Task<NavPath> AsTask() => taskSource.Task;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Cancel();
+    }
+
+    /// <summary>
+    /// Marks the request as computing.
+    /// </summary>
+    internal void MarkComputing()
+    {
+        if (status == PathRequestStatus.Pending)
+        {
+            status = PathRequestStatus.Computing;
+        }
+    }
+
+    /// <summary>
+    /// Completes the request with a path result.
+    /// </summary>
+    internal void Complete(NavPath path)
+    {
+        if (status is PathRequestStatus.Pending or PathRequestStatus.Computing)
+        {
+            result = path;
+            status = path.IsValid ? PathRequestStatus.Completed : PathRequestStatus.Failed;
+            taskSource.TrySetResult(path);
+        }
+    }
+
+    /// <summary>
+    /// Marks the request as failed.
+    /// </summary>
+    internal void Fail()
+    {
+        if (status is PathRequestStatus.Pending or PathRequestStatus.Computing)
+        {
+            status = PathRequestStatus.Failed;
+            result = NavPath.Empty;
+            taskSource.TrySetResult(NavPath.Empty);
+        }
+    }
+}

--- a/src/KeenEyes.Navigation.Grid/KeenEyes.Navigation.Grid.csproj
+++ b/src/KeenEyes.Navigation.Grid/KeenEyes.Navigation.Grid.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>KeenEyes.Navigation.Grid</PackageId>
+    <Description>Grid-based A* pathfinding for 2D games in KeenEyes ECS</Description>
+    <PackageTags>ecs;navigation;pathfinding;astar;grid;2d</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Navigation.Grid.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Navigation.Abstractions\KeenEyes.Navigation.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Navigation.Grid/NavigationGrid.cs
+++ b/src/KeenEyes.Navigation.Grid/NavigationGrid.cs
@@ -1,0 +1,373 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Grid;
+
+/// <summary>
+/// Represents a 2D navigation grid for pathfinding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The navigation grid stores walkability and area type information for a rectangular
+/// region. It supports both cardinal (4-direction) and diagonal (8-direction) movement.
+/// </para>
+/// <para>
+/// Grid coordinates map to world space using the configured cell size. The grid Y axis
+/// corresponds to the world Z axis (top-down perspective).
+/// </para>
+/// </remarks>
+public sealed class NavigationGrid
+{
+    private readonly GridCell[] cells;
+
+    /// <summary>
+    /// Gets the width of the grid in cells.
+    /// </summary>
+    public int Width { get; }
+
+    /// <summary>
+    /// Gets the height of the grid in cells.
+    /// </summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Gets the size of each cell in world units.
+    /// </summary>
+    public float CellSize { get; }
+
+    /// <summary>
+    /// Gets the world-space origin of the grid (minimum corner).
+    /// </summary>
+    public Vector3 WorldOrigin { get; }
+
+    /// <summary>
+    /// Gets the total number of cells in the grid.
+    /// </summary>
+    public int CellCount => Width * Height;
+
+    /// <summary>
+    /// Creates a new navigation grid.
+    /// </summary>
+    /// <param name="width">Width in cells.</param>
+    /// <param name="height">Height in cells.</param>
+    /// <param name="cellSize">Size of each cell in world units.</param>
+    /// <param name="worldOrigin">World-space origin (default: Vector3.Zero).</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when width, height, or cellSize is not positive.
+    /// </exception>
+    public NavigationGrid(int width, int height, float cellSize, Vector3? worldOrigin = null)
+    {
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "Width must be positive.");
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), height, "Height must be positive.");
+        }
+
+        if (cellSize <= 0f)
+        {
+            throw new ArgumentOutOfRangeException(nameof(cellSize), cellSize, "Cell size must be positive.");
+        }
+
+        Width = width;
+        Height = height;
+        CellSize = cellSize;
+        WorldOrigin = worldOrigin ?? Vector3.Zero;
+        cells = new GridCell[width * height];
+
+        // Initialize all cells as walkable by default
+        for (int i = 0; i < cells.Length; i++)
+        {
+            cells[i] = GridCell.Walkable;
+        }
+    }
+
+    /// <summary>
+    /// Gets the cell data at the specified coordinate.
+    /// </summary>
+    /// <param name="coord">The grid coordinate.</param>
+    /// <returns>A reference to the cell data.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the coordinate is outside the grid bounds.
+    /// </exception>
+    public ref GridCell this[GridCoordinate coord]
+    {
+        get
+        {
+            if (!IsInBounds(coord))
+            {
+                throw new ArgumentOutOfRangeException(nameof(coord), coord, "Coordinate is outside grid bounds.");
+            }
+
+            return ref cells[GetIndex(coord)];
+        }
+    }
+
+    /// <summary>
+    /// Gets the cell data at the specified coordinate.
+    /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
+    /// <returns>A reference to the cell data.</returns>
+    public ref GridCell this[int x, int y] => ref this[new GridCoordinate(x, y)];
+
+    /// <summary>
+    /// Tries to get the cell data at the specified coordinate.
+    /// </summary>
+    /// <param name="coord">The grid coordinate.</param>
+    /// <param name="cell">The cell data if the coordinate is valid.</param>
+    /// <returns>True if the coordinate is within bounds.</returns>
+    public bool TryGetCell(GridCoordinate coord, out GridCell cell)
+    {
+        if (!IsInBounds(coord))
+        {
+            cell = default;
+            return false;
+        }
+
+        cell = cells[GetIndex(coord)];
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the cell data at the specified coordinate.
+    /// </summary>
+    /// <param name="coord">The grid coordinate.</param>
+    /// <param name="cell">The cell data to set.</param>
+    /// <returns>True if the coordinate was valid and the cell was set.</returns>
+    public bool TrySetCell(GridCoordinate coord, GridCell cell)
+    {
+        if (!IsInBounds(coord))
+        {
+            return false;
+        }
+
+        cells[GetIndex(coord)] = cell;
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if a coordinate is within the grid bounds.
+    /// </summary>
+    /// <param name="coord">The coordinate to check.</param>
+    /// <returns>True if the coordinate is valid.</returns>
+    public bool IsInBounds(GridCoordinate coord)
+        => coord.X >= 0 && coord.X < Width && coord.Y >= 0 && coord.Y < Height;
+
+    /// <summary>
+    /// Checks if a coordinate is walkable.
+    /// </summary>
+    /// <param name="coord">The coordinate to check.</param>
+    /// <returns>True if the coordinate is in bounds and walkable.</returns>
+    public bool IsWalkable(GridCoordinate coord)
+        => IsInBounds(coord) && cells[GetIndex(coord)].CanTraverse();
+
+    /// <summary>
+    /// Checks if a coordinate is walkable considering the area mask.
+    /// </summary>
+    /// <param name="coord">The coordinate to check.</param>
+    /// <param name="areaMask">The area mask to filter traversable cells.</param>
+    /// <returns>True if the coordinate is walkable and its area type is in the mask.</returns>
+    public bool IsWalkable(GridCoordinate coord, NavAreaMask areaMask)
+    {
+        if (!IsInBounds(coord))
+        {
+            return false;
+        }
+
+        ref readonly var cell = ref cells[GetIndex(coord)];
+        if (!cell.CanTraverse())
+        {
+            return false;
+        }
+
+        var cellMask = (NavAreaMask)(1u << (int)cell.AreaType);
+        return (areaMask & cellMask) != NavAreaMask.None;
+    }
+
+    /// <summary>
+    /// Gets the area type at the specified coordinate.
+    /// </summary>
+    /// <param name="coord">The coordinate to query.</param>
+    /// <returns>The area type, or <see cref="NavAreaType.NotWalkable"/> if out of bounds.</returns>
+    public NavAreaType GetAreaType(GridCoordinate coord)
+        => IsInBounds(coord) ? cells[GetIndex(coord)].AreaType : NavAreaType.NotWalkable;
+
+    /// <summary>
+    /// Gets the movement cost at the specified coordinate.
+    /// </summary>
+    /// <param name="coord">The coordinate to query.</param>
+    /// <returns>The movement cost, or float.MaxValue if out of bounds or not walkable.</returns>
+    public float GetCost(GridCoordinate coord)
+    {
+        if (!IsInBounds(coord))
+        {
+            return float.MaxValue;
+        }
+
+        ref readonly var cell = ref cells[GetIndex(coord)];
+        return cell.CanTraverse() ? cell.Cost : float.MaxValue;
+    }
+
+    /// <summary>
+    /// Converts a grid coordinate to a world position.
+    /// </summary>
+    /// <param name="coord">The grid coordinate.</param>
+    /// <param name="height">The Y height in world space (default 0).</param>
+    /// <returns>The world position at the center of the cell.</returns>
+    public Vector3 ToWorldPosition(GridCoordinate coord, float height = 0f)
+        => WorldOrigin + new Vector3(
+            (coord.X + 0.5f) * CellSize,
+            height,
+            (coord.Y + 0.5f) * CellSize);
+
+    /// <summary>
+    /// Converts a world position to a grid coordinate.
+    /// </summary>
+    /// <param name="position">The world position.</param>
+    /// <returns>The grid coordinate containing this position.</returns>
+    public GridCoordinate FromWorldPosition(Vector3 position)
+    {
+        var relative = position - WorldOrigin;
+        return new GridCoordinate(
+            (int)MathF.Floor(relative.X / CellSize),
+            (int)MathF.Floor(relative.Z / CellSize));
+    }
+
+    /// <summary>
+    /// Gets the world-space bounds of the grid.
+    /// </summary>
+    /// <returns>A tuple containing the minimum and maximum corners.</returns>
+    public (Vector3 Min, Vector3 Max) GetWorldBounds()
+    {
+        var max = WorldOrigin + new Vector3(Width * CellSize, 0f, Height * CellSize);
+        return (WorldOrigin, max);
+    }
+
+    /// <summary>
+    /// Fills a rectangular region with the specified cell data.
+    /// </summary>
+    /// <param name="start">The start corner of the region.</param>
+    /// <param name="end">The end corner of the region (inclusive).</param>
+    /// <param name="cell">The cell data to fill with.</param>
+    public void Fill(GridCoordinate start, GridCoordinate end, GridCell cell)
+    {
+        int minX = Math.Max(0, Math.Min(start.X, end.X));
+        int maxX = Math.Min(Width - 1, Math.Max(start.X, end.X));
+        int minY = Math.Max(0, Math.Min(start.Y, end.Y));
+        int maxY = Math.Min(Height - 1, Math.Max(start.Y, end.Y));
+
+        for (int y = minY; y <= maxY; y++)
+        {
+            for (int x = minX; x <= maxX; x++)
+            {
+                cells[y * Width + x] = cell;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets all cells to walkable.
+    /// </summary>
+    public void Clear()
+    {
+        for (int i = 0; i < cells.Length; i++)
+        {
+            cells[i] = GridCell.Walkable;
+        }
+    }
+
+    /// <summary>
+    /// Sets all cells to blocked (unwalkable).
+    /// </summary>
+    public void Block()
+    {
+        for (int i = 0; i < cells.Length; i++)
+        {
+            cells[i] = GridCell.Blocked;
+        }
+    }
+
+    /// <summary>
+    /// Gets the neighbors of a cell that are walkable.
+    /// </summary>
+    /// <param name="coord">The center coordinate.</param>
+    /// <param name="allowDiagonal">Whether to include diagonal neighbors.</param>
+    /// <param name="results">Buffer to store the walkable neighbor coordinates.</param>
+    /// <returns>The number of walkable neighbors found.</returns>
+    public int GetWalkableNeighbors(GridCoordinate coord, bool allowDiagonal, Span<GridCoordinate> results)
+    {
+        return GetWalkableNeighbors(coord, allowDiagonal, NavAreaMask.All, results);
+    }
+
+    /// <summary>
+    /// Gets the neighbors of a cell that are walkable with area filtering.
+    /// </summary>
+    /// <param name="coord">The center coordinate.</param>
+    /// <param name="allowDiagonal">Whether to include diagonal neighbors.</param>
+    /// <param name="areaMask">The area mask to filter traversable cells.</param>
+    /// <param name="results">Buffer to store the walkable neighbor coordinates.</param>
+    /// <returns>The number of walkable neighbors found.</returns>
+    public int GetWalkableNeighbors(GridCoordinate coord, bool allowDiagonal, NavAreaMask areaMask, Span<GridCoordinate> results)
+    {
+        int count = 0;
+        int maxCount = results.Length;
+
+        // Cardinal directions first
+        ReadOnlySpan<GridCoordinate> cardinals = GridCoordinate.CardinalDirections;
+        for (int i = 0; i < cardinals.Length && count < maxCount; i++)
+        {
+            var neighbor = coord + cardinals[i];
+            if (IsWalkable(neighbor, areaMask))
+            {
+                results[count++] = neighbor;
+            }
+        }
+
+        if (!allowDiagonal)
+        {
+            return count;
+        }
+
+        // Diagonal directions - check corner cutting
+        ReadOnlySpan<GridCoordinate> diagonals = GridCoordinate.DiagonalDirections;
+        for (int i = 0; i < diagonals.Length && count < maxCount; i++)
+        {
+            var diagonal = diagonals[i];
+            var neighbor = coord + diagonal;
+
+            if (!IsWalkable(neighbor, areaMask))
+            {
+                continue;
+            }
+
+            // Check corner cutting: both adjacent cardinal cells must be walkable
+            var horizontal = coord + new GridCoordinate(diagonal.X, 0);
+            var vertical = coord + new GridCoordinate(0, diagonal.Y);
+
+            if (IsWalkable(horizontal, areaMask) && IsWalkable(vertical, areaMask))
+            {
+                results[count++] = neighbor;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Gets the raw cell array for advanced operations.
+    /// </summary>
+    /// <returns>A span over the cell data.</returns>
+    public Span<GridCell> GetCellsSpan() => cells.AsSpan();
+
+    /// <summary>
+    /// Gets a read-only span over the cell data.
+    /// </summary>
+    /// <returns>A read-only span over the cell data.</returns>
+    public ReadOnlySpan<GridCell> GetCellsReadOnlySpan() => cells.AsSpan();
+
+    private int GetIndex(GridCoordinate coord) => coord.Y * Width + coord.X;
+}

--- a/src/KeenEyes.Navigation.Grid/packages.lock.json
+++ b/src/KeenEyes.Navigation.Grid/packages.lock.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/AStarPathfinderTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/AStarPathfinderTests.cs
@@ -1,0 +1,518 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Grid.Tests;
+
+/// <summary>
+/// Tests for <see cref="AStarPathfinder"/> class.
+/// </summary>
+public class AStarPathfinderTests
+{
+    #region Construction Tests
+
+    [Fact]
+    public void Constructor_ValidParameters_CreatesPathfinder()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = GridConfig.Default;
+
+        var pathfinder = new AStarPathfinder(grid, config);
+
+        Assert.NotNull(pathfinder);
+        Assert.Same(grid, pathfinder.Grid);
+        Assert.Same(config, pathfinder.Config);
+    }
+
+    [Fact]
+    public void Constructor_NullGrid_ThrowsArgumentNull()
+    {
+        var config = GridConfig.Default;
+
+        Assert.Throws<ArgumentNullException>(() => new AStarPathfinder(null!, config));
+    }
+
+    [Fact]
+    public void Constructor_NullConfig_ThrowsArgumentNull()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.Throws<ArgumentNullException>(() => new AStarPathfinder(grid, null!));
+    }
+
+    #endregion
+
+    #region Simple Path Tests
+
+    [Fact]
+    public void FindPath_SameStartAndEnd_ReturnsSinglePointPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = GridConfig.Default;
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(5, 5),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.Equal(1, length);
+        Assert.Equal(new GridCoordinate(5, 5), result[0]);
+    }
+
+    [Fact]
+    public void FindPath_AdjacentCells_ReturnsDirectPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(5, 5),
+            new GridCoordinate(5, 6),
+            result);
+
+        Assert.Equal(2, length);
+        Assert.Equal(new GridCoordinate(5, 5), result[0]);
+        Assert.Equal(new GridCoordinate(5, 6), result[1]);
+    }
+
+    [Fact]
+    public void FindPath_StraightLine_ReturnsShortestPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 5),
+            new GridCoordinate(4, 5),
+            result);
+
+        Assert.Equal(5, length);
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.Equal(i, result[i].X);
+            Assert.Equal(5, result[i].Y);
+        }
+    }
+
+    [Fact]
+    public void FindPath_DiagonalEnabled_UsesDiagonalMoves()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = true };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(3, 3),
+            result);
+
+        // With diagonal movement, path should be 4 (0,0 -> 1,1 -> 2,2 -> 3,3)
+        Assert.Equal(4, length);
+    }
+
+    [Fact]
+    public void FindPath_DiagonalDisabled_UsesCardinalMoves()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(3, 3),
+            result);
+
+        // Without diagonal, path should be 7 (3 horizontal + 3 vertical + 1 start)
+        Assert.Equal(7, length);
+    }
+
+    #endregion
+
+    #region Obstacle Tests
+
+    [Fact]
+    public void FindPath_WithObstacle_PathsAround()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[2, 0] = GridCell.Blocked;  // Block direct path
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(4, 0),
+            result);
+
+        Assert.True(length > 5);  // Path must go around
+        Assert.DoesNotContain(new GridCoordinate(2, 0), result[..length].ToArray());
+    }
+
+    [Fact]
+    public void FindPath_StartBlocked_ReturnsNoPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[0, 0] = GridCell.Blocked;
+        var config = GridConfig.Default;
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.Equal(-1, length);
+    }
+
+    [Fact]
+    public void FindPath_EndBlocked_ReturnsNoPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 5] = GridCell.Blocked;
+        var config = GridConfig.Default;
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[10];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.Equal(-1, length);
+    }
+
+    [Fact]
+    public void FindPath_CompletelyBlocked_ReturnsNoPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        // Create a wall separating start from end
+        for (int y = 0; y < 10; y++)
+        {
+            grid[5, y] = GridCell.Blocked;
+        }
+
+        var config = GridConfig.Default;
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[100];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 5),
+            new GridCoordinate(9, 5),
+            result);
+
+        Assert.Equal(-1, length);
+    }
+
+    #endregion
+
+    #region Area Cost Tests
+
+    [Fact]
+    public void GetAreaCost_Default_ReturnsOne()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var pathfinder = new AStarPathfinder(grid, GridConfig.Default);
+
+        Assert.Equal(1f, pathfinder.GetAreaCost(NavAreaType.Walkable));
+        Assert.Equal(1f, pathfinder.GetAreaCost(NavAreaType.Road));
+        Assert.Equal(1f, pathfinder.GetAreaCost(NavAreaType.Water));
+    }
+
+    [Fact]
+    public void SetAreaCost_UpdatesCost()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var pathfinder = new AStarPathfinder(grid, GridConfig.Default);
+
+        pathfinder.SetAreaCost(NavAreaType.Mud, 5f);
+
+        Assert.Equal(5f, pathfinder.GetAreaCost(NavAreaType.Mud));
+    }
+
+    [Fact]
+    public void FindPath_HigherCostArea_PrefersLowerCost()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        // Create a direct path through mud
+        for (int x = 1; x < 4; x++)
+        {
+            grid[x, 5] = GridCell.WithAreaType(NavAreaType.Mud);
+        }
+
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        pathfinder.SetAreaCost(NavAreaType.Mud, 10f);  // Very expensive
+        Span<GridCoordinate> result = stackalloc GridCoordinate[50];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 5),
+            new GridCoordinate(5, 5),
+            result);
+
+        // Path should avoid mud if a cheaper alternative exists
+        // In this case, going around would be cheaper
+        Assert.True(length > 0);
+    }
+
+    #endregion
+
+    #region Area Mask Tests
+
+    [Fact]
+    public void FindPath_AreaMaskExcludesWater_AvoidsWater()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        // Create water area
+        grid[5, 4] = GridCell.WithAreaType(NavAreaType.Water);
+        grid[5, 5] = GridCell.WithAreaType(NavAreaType.Water);
+        grid[5, 6] = GridCell.WithAreaType(NavAreaType.Water);
+
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[50];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(3, 5),
+            new GridCoordinate(7, 5),
+            NavAreaMask.Walkable,  // Only walkable, no water
+            result);
+
+        // Should path around the water
+        Assert.True(length > 0);
+        foreach (var coord in result[..length].ToArray())
+        {
+            Assert.NotEqual(NavAreaType.Water, grid.GetAreaType(coord));
+        }
+    }
+
+    [Fact]
+    public void FindPath_AreaMaskIncludesWater_GoesThrough()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        for (int x = 0; x < 10; x++)
+        {
+            grid[x, 5] = GridCell.WithAreaType(NavAreaType.Water);
+        }
+
+        var config = new GridConfig { AllowDiagonal = false };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[50];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 4),
+            new GridCoordinate(0, 6),
+            NavAreaMask.Walkable | NavAreaMask.Water,
+            result);
+
+        Assert.Equal(3, length);  // Direct path through water
+    }
+
+    #endregion
+
+    #region NavPath Return Tests
+
+    [Fact]
+    public void FindPath_NavPath_ReturnsValidPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = true };
+        var pathfinder = new AStarPathfinder(grid, config);
+
+        var path = pathfinder.FindPath(new GridCoordinate(0, 0), new GridCoordinate(5, 5));
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.True(path.Count > 0);
+    }
+
+    [Fact]
+    public void FindPath_NavPath_NoPath_ReturnsEmpty()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[0, 0] = GridCell.Blocked;
+        var config = GridConfig.Default;
+        var pathfinder = new AStarPathfinder(grid, config);
+
+        var path = pathfinder.FindPath(new GridCoordinate(0, 0), new GridCoordinate(5, 5));
+
+        Assert.False(path.IsValid);
+        Assert.Same(NavPath.Empty, path);
+    }
+
+    [Fact]
+    public void FindPath_WorldPositions_ReturnsPath()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig { AllowDiagonal = true };
+        var pathfinder = new AStarPathfinder(grid, config);
+
+        var path = pathfinder.FindPath(
+            new Vector3(0.5f, 0f, 0.5f),
+            new Vector3(5.5f, 0f, 5.5f));
+
+        Assert.True(path.IsValid);
+    }
+
+    #endregion
+
+    #region HasPath Tests
+
+    [Fact]
+    public void HasPath_PathExists_ReturnsTrue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var pathfinder = new AStarPathfinder(grid, GridConfig.Default);
+
+        bool hasPath = pathfinder.HasPath(new GridCoordinate(0, 0), new GridCoordinate(5, 5));
+
+        Assert.True(hasPath);
+    }
+
+    [Fact]
+    public void HasPath_NoPath_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        // Create impassable wall
+        for (int y = 0; y < 10; y++)
+        {
+            grid[5, y] = GridCell.Blocked;
+        }
+
+        var pathfinder = new AStarPathfinder(grid, GridConfig.Default);
+
+        bool hasPath = pathfinder.HasPath(new GridCoordinate(0, 5), new GridCoordinate(9, 5));
+
+        Assert.False(hasPath);
+    }
+
+    [Fact]
+    public void HasPath_SamePoint_ReturnsTrue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var pathfinder = new AStarPathfinder(grid, GridConfig.Default);
+
+        bool hasPath = pathfinder.HasPath(new GridCoordinate(5, 5), new GridCoordinate(5, 5));
+
+        Assert.True(hasPath);
+    }
+
+    #endregion
+
+    #region Heuristic Tests
+
+    [Fact]
+    public void FindPath_ManhattanHeuristic_Works()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig
+        {
+            AllowDiagonal = false,
+            Heuristic = GridHeuristic.Manhattan
+        };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.True(length > 0);
+    }
+
+    [Fact]
+    public void FindPath_EuclideanHeuristic_Works()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig
+        {
+            AllowDiagonal = true,
+            Heuristic = GridHeuristic.Euclidean
+        };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.True(length > 0);
+    }
+
+    [Fact]
+    public void FindPath_OctileHeuristic_Works()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig
+        {
+            AllowDiagonal = true,
+            Heuristic = GridHeuristic.Octile
+        };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.True(length > 0);
+    }
+
+    [Fact]
+    public void FindPath_ChebyshevHeuristic_Works()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var config = new GridConfig
+        {
+            AllowDiagonal = true,
+            Heuristic = GridHeuristic.Chebyshev
+        };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[20];
+
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.True(length > 0);
+    }
+
+    #endregion
+
+    #region Max Iterations Tests
+
+    [Fact]
+    public void FindPath_ExceedsMaxIterations_ReturnsNoPath()
+    {
+        var grid = new NavigationGrid(100, 100, 1f);
+        var config = new GridConfig
+        {
+            MaxIterations = 10,  // Very low
+            AllowDiagonal = false
+        };
+        var pathfinder = new AStarPathfinder(grid, config);
+        Span<GridCoordinate> result = stackalloc GridCoordinate[200];
+
+        // Long path that would require many iterations
+        int length = pathfinder.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(99, 99),
+            result);
+
+        Assert.Equal(-1, length);  // Should fail due to iteration limit
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridConfigTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridConfigTests.cs
@@ -1,0 +1,421 @@
+using System.Numerics;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Grid.Tests;
+
+/// <summary>
+/// Tests for <see cref="GridConfig"/> validation and configuration.
+/// </summary>
+public class GridConfigTests
+{
+    #region Default Values Tests
+
+    [Fact]
+    public void Default_HasValidDefaults()
+    {
+        var config = GridConfig.Default;
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Default_HasExpectedValues()
+    {
+        var config = GridConfig.Default;
+
+        Assert.Equal(100, config.Width);
+        Assert.Equal(100, config.Height);
+        Assert.Equal(1f, config.CellSize);
+        Assert.Equal(Vector3.Zero, config.WorldOrigin);
+        Assert.True(config.AllowDiagonal);
+        Assert.Equal(GridHeuristic.Octile, config.Heuristic);
+        Assert.Equal(10000, config.MaxIterations);
+    }
+
+    [Fact]
+    public void WithSize_CreatesConfigWithCorrectSize()
+    {
+        var config = GridConfig.WithSize(50, 75, 2f);
+
+        Assert.Equal(50, config.Width);
+        Assert.Equal(75, config.Height);
+        Assert.Equal(2f, config.CellSize);
+    }
+
+    #endregion
+
+    #region Width Validation Tests
+
+    [Fact]
+    public void Validate_ZeroWidth_ReturnsError()
+    {
+        var config = new GridConfig { Width = 0 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("Width", error);
+        Assert.Contains("positive", error);
+    }
+
+    [Fact]
+    public void Validate_NegativeWidth_ReturnsError()
+    {
+        var config = new GridConfig { Width = -10 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("Width", error);
+        Assert.Contains("-10", error);
+    }
+
+    [Fact]
+    public void Validate_PositiveWidth_ReturnsNull()
+    {
+        var config = new GridConfig { Width = 1 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region Height Validation Tests
+
+    [Fact]
+    public void Validate_ZeroHeight_ReturnsError()
+    {
+        var config = new GridConfig { Height = 0 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("Height", error);
+        Assert.Contains("positive", error);
+    }
+
+    [Fact]
+    public void Validate_NegativeHeight_ReturnsError()
+    {
+        var config = new GridConfig { Height = -5 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("Height", error);
+        Assert.Contains("-5", error);
+    }
+
+    [Fact]
+    public void Validate_PositiveHeight_ReturnsNull()
+    {
+        var config = new GridConfig { Height = 1 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region CellSize Validation Tests
+
+    [Fact]
+    public void Validate_ZeroCellSize_ReturnsError()
+    {
+        var config = new GridConfig { CellSize = 0f };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("CellSize", error);
+        Assert.Contains("positive", error);
+    }
+
+    [Fact]
+    public void Validate_NegativeCellSize_ReturnsError()
+    {
+        var config = new GridConfig { CellSize = -1f };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("CellSize", error);
+    }
+
+    [Fact]
+    public void Validate_VerySmallCellSize_ReturnsNull()
+    {
+        var config = new GridConfig { CellSize = 0.001f };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Validate_LargeCellSize_ReturnsNull()
+    {
+        var config = new GridConfig { CellSize = 1000f };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region MaxIterations Validation Tests
+
+    [Fact]
+    public void Validate_NegativeMaxIterations_ReturnsError()
+    {
+        var config = new GridConfig { MaxIterations = -1 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxIterations", error);
+    }
+
+    [Fact]
+    public void Validate_ZeroMaxIterations_ReturnsNull()
+    {
+        var config = new GridConfig { MaxIterations = 0 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);  // 0 means no limit
+    }
+
+    [Fact]
+    public void Validate_PositiveMaxIterations_ReturnsNull()
+    {
+        var config = new GridConfig { MaxIterations = 50000 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region MaxPendingRequests Validation Tests
+
+    [Fact]
+    public void Validate_ZeroMaxPendingRequests_ReturnsError()
+    {
+        var config = new GridConfig { MaxPendingRequests = 0 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxPendingRequests", error);
+        Assert.Contains("positive", error);
+    }
+
+    [Fact]
+    public void Validate_NegativeMaxPendingRequests_ReturnsError()
+    {
+        var config = new GridConfig { MaxPendingRequests = -10 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxPendingRequests", error);
+    }
+
+    [Fact]
+    public void Validate_PositiveMaxPendingRequests_ReturnsNull()
+    {
+        var config = new GridConfig { MaxPendingRequests = 1 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region RequestsPerUpdate Validation Tests
+
+    [Fact]
+    public void Validate_ZeroRequestsPerUpdate_ReturnsError()
+    {
+        var config = new GridConfig { RequestsPerUpdate = 0 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("RequestsPerUpdate", error);
+        Assert.Contains("positive", error);
+    }
+
+    [Fact]
+    public void Validate_NegativeRequestsPerUpdate_ReturnsError()
+    {
+        var config = new GridConfig { RequestsPerUpdate = -5 };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("RequestsPerUpdate", error);
+    }
+
+    [Fact]
+    public void Validate_PositiveRequestsPerUpdate_ReturnsNull()
+    {
+        var config = new GridConfig { RequestsPerUpdate = 1 };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region Path Caching Validation Tests
+
+    [Fact]
+    public void Validate_CachingEnabledWithZeroMaxCached_ReturnsError()
+    {
+        var config = new GridConfig
+        {
+            EnablePathCaching = true,
+            MaxCachedPaths = 0
+        };
+
+        var error = config.Validate();
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxCachedPaths", error);
+    }
+
+    [Fact]
+    public void Validate_CachingDisabledWithZeroMaxCached_ReturnsNull()
+    {
+        var config = new GridConfig
+        {
+            EnablePathCaching = false,
+            MaxCachedPaths = 0
+        };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Validate_CachingEnabledWithPositiveMaxCached_ReturnsNull()
+    {
+        var config = new GridConfig
+        {
+            EnablePathCaching = true,
+            MaxCachedPaths = 50
+        };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region Heuristic Tests
+
+    [Fact]
+    public void Heuristic_AllValues_AreValid()
+    {
+        foreach (GridHeuristic heuristic in Enum.GetValues<GridHeuristic>())
+        {
+            var config = new GridConfig { Heuristic = heuristic };
+
+            var error = config.Validate();
+
+            Assert.Null(error);
+        }
+    }
+
+    #endregion
+
+    #region AllowDiagonal Tests
+
+    [Fact]
+    public void AllowDiagonal_True_IsValid()
+    {
+        var config = new GridConfig { AllowDiagonal = true };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void AllowDiagonal_False_IsValid()
+    {
+        var config = new GridConfig { AllowDiagonal = false };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region WorldOrigin Tests
+
+    [Fact]
+    public void WorldOrigin_AnyValue_IsValid()
+    {
+        var config = new GridConfig
+        {
+            WorldOrigin = new Vector3(-1000, 500, 2000)
+        };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void Validate_VeryLargeGrid_ReturnsNull()
+    {
+        var config = new GridConfig
+        {
+            Width = 10000,
+            Height = 10000,
+            CellSize = 0.1f
+        };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Validate_MinimalValidConfig_ReturnsNull()
+    {
+        var config = new GridConfig
+        {
+            Width = 1,
+            Height = 1,
+            CellSize = 0.0001f,
+            MaxPendingRequests = 1,
+            RequestsPerUpdate = 1
+        };
+
+        var error = config.Validate();
+
+        Assert.Null(error);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridCoordinateTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridCoordinateTests.cs
@@ -1,0 +1,391 @@
+using System.Numerics;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Grid.Tests;
+
+/// <summary>
+/// Tests for <see cref="GridCoordinate"/> struct.
+/// </summary>
+public class GridCoordinateTests
+{
+    #region Construction Tests
+
+    [Fact]
+    public void Constructor_CreatesCoordinate()
+    {
+        var coord = new GridCoordinate(5, 10);
+
+        Assert.Equal(5, coord.X);
+        Assert.Equal(10, coord.Y);
+    }
+
+    [Fact]
+    public void Origin_ReturnsZeroCoordinate()
+    {
+        var origin = GridCoordinate.Origin;
+
+        Assert.Equal(0, origin.X);
+        Assert.Equal(0, origin.Y);
+    }
+
+    [Fact]
+    public void DirectionalConstants_HaveCorrectValues()
+    {
+        Assert.Equal(new GridCoordinate(0, -1), GridCoordinate.Up);
+        Assert.Equal(new GridCoordinate(0, 1), GridCoordinate.Down);
+        Assert.Equal(new GridCoordinate(-1, 0), GridCoordinate.Left);
+        Assert.Equal(new GridCoordinate(1, 0), GridCoordinate.Right);
+    }
+
+    #endregion
+
+    #region Direction Collections Tests
+
+    [Fact]
+    public void CardinalDirections_HasFourElements()
+    {
+        var cardinals = GridCoordinate.CardinalDirections;
+
+        Assert.Equal(4, cardinals.Length);
+    }
+
+    [Fact]
+    public void DiagonalDirections_HasFourElements()
+    {
+        var diagonals = GridCoordinate.DiagonalDirections;
+
+        Assert.Equal(4, diagonals.Length);
+    }
+
+    [Fact]
+    public void AllDirections_HasEightElements()
+    {
+        var all = GridCoordinate.AllDirections;
+
+        Assert.Equal(8, all.Length);
+    }
+
+    [Fact]
+    public void CardinalDirections_ContainsCorrectDirections()
+    {
+        var cardinals = GridCoordinate.CardinalDirections.ToArray();
+
+        Assert.Contains(new GridCoordinate(0, -1), cardinals); // Up
+        Assert.Contains(new GridCoordinate(0, 1), cardinals);  // Down
+        Assert.Contains(new GridCoordinate(-1, 0), cardinals); // Left
+        Assert.Contains(new GridCoordinate(1, 0), cardinals);  // Right
+    }
+
+    [Fact]
+    public void DiagonalDirections_ContainsCorrectDirections()
+    {
+        var diagonals = GridCoordinate.DiagonalDirections.ToArray();
+
+        Assert.Contains(new GridCoordinate(-1, -1), diagonals); // Up-Left
+        Assert.Contains(new GridCoordinate(1, -1), diagonals);  // Up-Right
+        Assert.Contains(new GridCoordinate(-1, 1), diagonals);  // Down-Left
+        Assert.Contains(new GridCoordinate(1, 1), diagonals);   // Down-Right
+    }
+
+    #endregion
+
+    #region Distance Calculation Tests
+
+    [Fact]
+    public void ManhattanDistance_SamePoint_ReturnsZero()
+    {
+        var a = new GridCoordinate(5, 5);
+        var b = new GridCoordinate(5, 5);
+
+        Assert.Equal(0, a.ManhattanDistance(b));
+    }
+
+    [Fact]
+    public void ManhattanDistance_HorizontalOnly_ReturnsCorrectDistance()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(5, 0);
+
+        Assert.Equal(5, a.ManhattanDistance(b));
+    }
+
+    [Fact]
+    public void ManhattanDistance_VerticalOnly_ReturnsCorrectDistance()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(0, 7);
+
+        Assert.Equal(7, a.ManhattanDistance(b));
+    }
+
+    [Fact]
+    public void ManhattanDistance_Diagonal_ReturnsSumOfDistances()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(3, 4);
+
+        Assert.Equal(7, a.ManhattanDistance(b));
+    }
+
+    [Fact]
+    public void ChebyshevDistance_SamePoint_ReturnsZero()
+    {
+        var a = new GridCoordinate(5, 5);
+        var b = new GridCoordinate(5, 5);
+
+        Assert.Equal(0, a.ChebyshevDistance(b));
+    }
+
+    [Fact]
+    public void ChebyshevDistance_Diagonal_ReturnsMaxDimension()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(3, 5);
+
+        Assert.Equal(5, a.ChebyshevDistance(b));
+    }
+
+    [Fact]
+    public void OctileDistance_CardinalMove_ReturnsOne()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(1, 0);
+
+        Assert.Equal(1f, a.OctileDistance(b), 0.0001f);
+    }
+
+    [Fact]
+    public void OctileDistance_DiagonalMove_ReturnsSqrt2()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(1, 1);
+
+        Assert.Equal(1.41421356f, a.OctileDistance(b), 0.0001f);
+    }
+
+    [Fact]
+    public void EuclideanDistance_SamePoint_ReturnsZero()
+    {
+        var a = new GridCoordinate(5, 5);
+        var b = new GridCoordinate(5, 5);
+
+        Assert.Equal(0f, a.EuclideanDistance(b), 0.0001f);
+    }
+
+    [Fact]
+    public void EuclideanDistance_3_4_5Triangle_Returns5()
+    {
+        var a = new GridCoordinate(0, 0);
+        var b = new GridCoordinate(3, 4);
+
+        Assert.Equal(5f, a.EuclideanDistance(b), 0.0001f);
+    }
+
+    #endregion
+
+    #region Adjacency Tests
+
+    [Fact]
+    public void IsAdjacentTo_CardinalNeighbor_ReturnsTrue()
+    {
+        var center = new GridCoordinate(5, 5);
+
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(5, 4)));  // Up
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(5, 6)));  // Down
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(4, 5)));  // Left
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(6, 5)));  // Right
+    }
+
+    [Fact]
+    public void IsAdjacentTo_DiagonalNeighbor_ReturnsTrue()
+    {
+        var center = new GridCoordinate(5, 5);
+
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(4, 4)));  // Up-Left
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(6, 4)));  // Up-Right
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(4, 6)));  // Down-Left
+        Assert.True(center.IsAdjacentTo(new GridCoordinate(6, 6)));  // Down-Right
+    }
+
+    [Fact]
+    public void IsAdjacentTo_SameCoordinate_ReturnsFalse()
+    {
+        var coord = new GridCoordinate(5, 5);
+
+        Assert.False(coord.IsAdjacentTo(coord));
+    }
+
+    [Fact]
+    public void IsAdjacentTo_TwoAway_ReturnsFalse()
+    {
+        var center = new GridCoordinate(5, 5);
+
+        Assert.False(center.IsAdjacentTo(new GridCoordinate(5, 3)));  // Two up
+        Assert.False(center.IsAdjacentTo(new GridCoordinate(7, 5)));  // Two right
+    }
+
+    [Fact]
+    public void IsCardinallyAdjacentTo_CardinalNeighbor_ReturnsTrue()
+    {
+        var center = new GridCoordinate(5, 5);
+
+        Assert.True(center.IsCardinallyAdjacentTo(new GridCoordinate(5, 4)));  // Up
+        Assert.True(center.IsCardinallyAdjacentTo(new GridCoordinate(5, 6)));  // Down
+        Assert.True(center.IsCardinallyAdjacentTo(new GridCoordinate(4, 5)));  // Left
+        Assert.True(center.IsCardinallyAdjacentTo(new GridCoordinate(6, 5)));  // Right
+    }
+
+    [Fact]
+    public void IsCardinallyAdjacentTo_DiagonalNeighbor_ReturnsFalse()
+    {
+        var center = new GridCoordinate(5, 5);
+
+        Assert.False(center.IsCardinallyAdjacentTo(new GridCoordinate(4, 4)));  // Up-Left
+        Assert.False(center.IsCardinallyAdjacentTo(new GridCoordinate(6, 6)));  // Down-Right
+    }
+
+    #endregion
+
+    #region World Position Conversion Tests
+
+    [Fact]
+    public void ToWorldPosition_OriginWithCellSizeOne_ReturnsHalfCellOffset()
+    {
+        var coord = new GridCoordinate(0, 0);
+
+        var world = coord.ToWorldPosition(1f);
+
+        Assert.Equal(0.5f, world.X, 0.0001f);
+        Assert.Equal(0f, world.Y, 0.0001f);
+        Assert.Equal(0.5f, world.Z, 0.0001f);
+    }
+
+    [Fact]
+    public void ToWorldPosition_WithHeight_SetsYComponent()
+    {
+        var coord = new GridCoordinate(0, 0);
+
+        var world = coord.ToWorldPosition(1f, 5f);
+
+        Assert.Equal(5f, world.Y, 0.0001f);
+    }
+
+    [Fact]
+    public void ToWorldPosition_LargerCellSize_ScalesCorrectly()
+    {
+        var coord = new GridCoordinate(2, 3);
+
+        var world = coord.ToWorldPosition(2f);
+
+        Assert.Equal(5f, world.X, 0.0001f);  // (2 + 0.5) * 2 = 5
+        Assert.Equal(7f, world.Z, 0.0001f);  // (3 + 0.5) * 2 = 7
+    }
+
+    [Fact]
+    public void FromWorldPosition_ReturnsCorrectCell()
+    {
+        var world = new Vector3(2.5f, 0f, 3.5f);
+
+        var coord = GridCoordinate.FromWorldPosition(world, 1f);
+
+        Assert.Equal(2, coord.X);
+        Assert.Equal(3, coord.Y);
+    }
+
+    [Fact]
+    public void FromWorldPosition_NegativeCoordinates_WorksCorrectly()
+    {
+        var world = new Vector3(-0.5f, 0f, -0.5f);
+
+        var coord = GridCoordinate.FromWorldPosition(world, 1f);
+
+        Assert.Equal(-1, coord.X);
+        Assert.Equal(-1, coord.Y);
+    }
+
+    [Fact]
+    public void FromWorldPosition_LargerCellSize_ScalesCorrectly()
+    {
+        var world = new Vector3(5f, 0f, 7f);
+
+        var coord = GridCoordinate.FromWorldPosition(world, 2f);
+
+        Assert.Equal(2, coord.X);  // floor(5/2) = 2
+        Assert.Equal(3, coord.Y);  // floor(7/2) = 3
+    }
+
+    #endregion
+
+    #region Operator Tests
+
+    [Fact]
+    public void Addition_CombinesCoordinates()
+    {
+        var a = new GridCoordinate(3, 5);
+        var b = new GridCoordinate(2, 4);
+
+        var result = a + b;
+
+        Assert.Equal(5, result.X);
+        Assert.Equal(9, result.Y);
+    }
+
+    [Fact]
+    public void Subtraction_SubtractsCoordinates()
+    {
+        var a = new GridCoordinate(5, 8);
+        var b = new GridCoordinate(2, 3);
+
+        var result = a - b;
+
+        Assert.Equal(3, result.X);
+        Assert.Equal(5, result.Y);
+    }
+
+    [Fact]
+    public void Multiplication_ScalesCoordinate()
+    {
+        var coord = new GridCoordinate(3, 5);
+
+        var result = coord * 2;
+
+        Assert.Equal(6, result.X);
+        Assert.Equal(10, result.Y);
+    }
+
+    #endregion
+
+    #region Equality Tests
+
+    [Fact]
+    public void Equality_SameValues_ReturnsTrue()
+    {
+        var a = new GridCoordinate(5, 10);
+        var b = new GridCoordinate(5, 10);
+
+        Assert.Equal(a, b);
+        Assert.True(a == b);
+    }
+
+    [Fact]
+    public void Equality_DifferentValues_ReturnsFalse()
+    {
+        var a = new GridCoordinate(5, 10);
+        var b = new GridCoordinate(10, 5);
+
+        Assert.NotEqual(a, b);
+        Assert.True(a != b);
+    }
+
+    [Fact]
+    public void ToString_ReturnsFormattedString()
+    {
+        var coord = new GridCoordinate(5, 10);
+
+        var str = coord.ToString();
+
+        Assert.Equal("(5, 10)", str);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
@@ -1,0 +1,429 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Grid.Tests;
+
+/// <summary>
+/// Tests for <see cref="GridNavigationProvider"/> class.
+/// </summary>
+public class GridNavigationProviderTests : IDisposable
+{
+    private readonly GridNavigationProvider provider;
+    private readonly GridConfig config;
+
+    public GridNavigationProviderTests()
+    {
+        config = new GridConfig
+        {
+            Width = 20,
+            Height = 20,
+            CellSize = 1f,
+            AllowDiagonal = true
+        };
+        provider = new GridNavigationProvider(config);
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+    }
+
+    #region Construction Tests
+
+    [Fact]
+    public void Constructor_ValidConfig_CreatesProvider()
+    {
+        Assert.NotNull(provider);
+        Assert.Equal(NavigationStrategy.Grid, provider.Strategy);
+        Assert.True(provider.IsReady);
+        Assert.Null(provider.ActiveMesh);  // Grid doesn't use navmesh
+    }
+
+    [Fact]
+    public void Constructor_NullConfig_ThrowsArgumentNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GridNavigationProvider(null!));
+    }
+
+    [Fact]
+    public void Constructor_InvalidConfig_ThrowsArgument()
+    {
+        var invalidConfig = new GridConfig { Width = 0 };
+
+        Assert.Throws<ArgumentException>(() => new GridNavigationProvider(invalidConfig));
+    }
+
+    [Fact]
+    public void Constructor_WithExistingGrid_UsesGrid()
+    {
+        var grid = new NavigationGrid(10, 10, 2f);
+        grid[5, 5] = GridCell.Blocked;
+
+        using var providerWithGrid = new GridNavigationProvider(grid, GridConfig.Default);
+
+        Assert.Same(grid, providerWithGrid.Grid);
+        Assert.False(providerWithGrid.Grid[5, 5].IsWalkable);
+    }
+
+    #endregion
+
+    #region FindPath Tests
+
+    [Fact]
+    public void FindPath_ValidPath_ReturnsPath()
+    {
+        var path = provider.FindPath(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            AgentSettings.Default);
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.True(path.Count >= 2);
+    }
+
+    [Fact]
+    public void FindPath_GridCoordinates_ReturnsPath()
+    {
+        var path = provider.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5));
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+    }
+
+    [Fact]
+    public void FindPath_SpanOverload_ReturnsPathLength()
+    {
+        Span<GridCoordinate> result = stackalloc GridCoordinate[50];
+
+        int length = provider.FindPath(
+            new GridCoordinate(0, 0),
+            new GridCoordinate(5, 5),
+            result);
+
+        Assert.True(length > 0);
+    }
+
+    [Fact]
+    public void FindPath_WithAreaMask_FiltersCorrectly()
+    {
+        // Create a water barrier
+        for (int y = 0; y < 10; y++)
+        {
+            provider.Grid[10, y] = GridCell.WithAreaType(NavAreaType.Water);
+        }
+
+        // Path that needs to cross water
+        var pathWithWater = provider.FindPath(
+            new Vector3(5.5f, 0, 5.5f),
+            new Vector3(15.5f, 0, 5.5f),
+            AgentSettings.Default,
+            NavAreaMask.Walkable | NavAreaMask.Water);
+
+        var pathWithoutWater = provider.FindPath(
+            new Vector3(5.5f, 0, 5.5f),
+            new Vector3(15.5f, 0, 5.5f),
+            AgentSettings.Default,
+            NavAreaMask.Walkable);
+
+        Assert.True(pathWithWater.IsValid);
+        Assert.True(pathWithoutWater.IsValid);
+        // Path without water should be longer as it goes around
+        Assert.True(pathWithoutWater.Count > pathWithWater.Count);
+    }
+
+    #endregion
+
+    #region Async Path Request Tests
+
+    [Fact]
+    public void RequestPath_ReturnsPathRequest()
+    {
+        using var request = provider.RequestPath(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            AgentSettings.Default);
+
+        Assert.NotNull(request);
+        Assert.True(request.Id > 0);
+        Assert.Equal(PathRequestStatus.Pending, request.Status);
+    }
+
+    [Fact]
+    public void RequestPath_AfterUpdate_CompletesPath()
+    {
+        using var request = provider.RequestPath(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            AgentSettings.Default);
+
+        provider.Update(0.016f);  // Simulate frame update
+
+        Assert.Equal(PathRequestStatus.Completed, request.Status);
+        Assert.True(request.Result.IsValid);
+    }
+
+    [Fact]
+    public void RequestPath_Cancel_CancelsRequest()
+    {
+        using var request = provider.RequestPath(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            AgentSettings.Default);
+
+        request.Cancel();
+
+        Assert.Equal(PathRequestStatus.Cancelled, request.Status);
+    }
+
+    [Fact]
+    public async Task RequestPath_AsTask_Completes()
+    {
+        using var request = provider.RequestPath(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            AgentSettings.Default);
+
+        // Process the request synchronously, then await the completed task
+        provider.Update(0.016f);
+        var path = await request.AsTask();
+
+        Assert.True(path.IsValid);
+    }
+
+    [Fact]
+    public void CancelAllRequests_CancelsAllPending()
+    {
+        var request1 = provider.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+        var request2 = provider.RequestPath(Vector3.Zero, new Vector3(10, 0, 10), AgentSettings.Default);
+
+        provider.CancelAllRequests();
+
+        Assert.Equal(PathRequestStatus.Cancelled, request1.Status);
+        Assert.Equal(PathRequestStatus.Cancelled, request2.Status);
+    }
+
+    [Fact]
+    public void PendingRequestCount_ReflectsQueueSize()
+    {
+        Assert.Equal(0, provider.PendingRequestCount);
+
+        using var request1 = provider.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+        using var request2 = provider.RequestPath(Vector3.Zero, new Vector3(10, 0, 10), AgentSettings.Default);
+
+        Assert.Equal(2, provider.PendingRequestCount);
+
+        provider.Update(0.016f);  // Process requests
+
+        Assert.Equal(0, provider.PendingRequestCount);
+    }
+
+    #endregion
+
+    #region Raycast Tests
+
+    [Fact]
+    public void Raycast_ClearPath_ReturnsFalse()
+    {
+        bool hit = provider.Raycast(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 5.5f),
+            out var hitPosition);
+
+        Assert.False(hit);
+        Assert.Equal(new Vector3(5.5f, 0, 5.5f), hitPosition);
+    }
+
+    [Fact]
+    public void Raycast_HitsObstacle_ReturnsTrue()
+    {
+        provider.Grid[3, 0] = GridCell.Blocked;  // Block middle of ray
+
+        bool hit = provider.Raycast(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 0.5f),
+            out _);
+
+        Assert.True(hit);
+    }
+
+    [Fact]
+    public void Raycast_WithAreaMask_RespectsFilter()
+    {
+        provider.Grid[3, 0] = GridCell.WithAreaType(NavAreaType.Water);
+
+        bool hitWithoutWater = provider.Raycast(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 0.5f),
+            NavAreaMask.Walkable,
+            out _,
+            out _);
+
+        bool hitWithWater = provider.Raycast(
+            new Vector3(0.5f, 0, 0.5f),
+            new Vector3(5.5f, 0, 0.5f),
+            NavAreaMask.Walkable | NavAreaMask.Water,
+            out _,
+            out _);
+
+        Assert.True(hitWithoutWater);   // Water blocks when not in mask
+        Assert.False(hitWithWater);     // Water is traversable when in mask
+    }
+
+    [Fact]
+    public void RaycastGrid_ReturnsCorrectHitCoordinate()
+    {
+        provider.Grid[5, 5] = GridCell.Blocked;
+
+        bool hit = provider.RaycastGrid(
+            new GridCoordinate(0, 5),
+            new GridCoordinate(10, 5),
+            NavAreaMask.All,
+            out var hitCoord);
+
+        Assert.True(hit);
+        Assert.Equal(new GridCoordinate(5, 5), hitCoord);
+    }
+
+    #endregion
+
+    #region Point Query Tests
+
+    [Fact]
+    public void FindNearestPoint_WalkablePosition_ReturnsPoint()
+    {
+        var point = provider.FindNearestPoint(new Vector3(5.5f, 0, 5.5f));
+
+        Assert.NotNull(point);
+        Assert.Equal(NavAreaType.Walkable, point.Value.AreaType);
+    }
+
+    [Fact]
+    public void FindNearestPoint_BlockedPosition_FindsNearest()
+    {
+        provider.Grid[5, 5] = GridCell.Blocked;
+
+        var point = provider.FindNearestPoint(new Vector3(5.5f, 0, 5.5f), searchRadius: 5f);
+
+        Assert.NotNull(point);
+        // Should find a nearby walkable cell
+        Assert.True(point.Value.DistanceTo(new NavPoint(new Vector3(5.5f, 0, 5.5f))) > 0);
+    }
+
+    [Fact]
+    public void FindNearestPoint_NoWalkableInRadius_ReturnsNull()
+    {
+        // Block a large area
+        provider.Grid.Fill(new GridCoordinate(0, 0), new GridCoordinate(19, 19), GridCell.Blocked);
+
+        var point = provider.FindNearestPoint(new Vector3(10.5f, 0, 10.5f), searchRadius: 3f);
+
+        Assert.Null(point);
+    }
+
+    [Fact]
+    public void IsNavigable_WalkablePosition_ReturnsTrue()
+    {
+        bool navigable = provider.IsNavigable(new Vector3(5.5f, 0, 5.5f), AgentSettings.Default);
+
+        Assert.True(navigable);
+    }
+
+    [Fact]
+    public void IsNavigable_BlockedPosition_ReturnsFalse()
+    {
+        provider.Grid[5, 5] = GridCell.Blocked;
+
+        bool navigable = provider.IsNavigable(new Vector3(5.5f, 0, 5.5f), AgentSettings.Default);
+
+        Assert.False(navigable);
+    }
+
+    [Fact]
+    public void IsNavigable_GridCoordinate_Works()
+    {
+        Assert.True(provider.IsNavigable(new GridCoordinate(5, 5)));
+
+        provider.Grid[5, 5] = GridCell.Blocked;
+
+        Assert.False(provider.IsNavigable(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void ProjectToNavMesh_ReturnsNearestWalkable()
+    {
+        var projected = provider.ProjectToNavMesh(new Vector3(5.5f, 10f, 5.5f));
+
+        Assert.NotNull(projected);
+        Assert.Equal(0f, projected.Value.Y, 0.0001f);  // Grid is at Y=0
+    }
+
+    [Fact]
+    public void ProjectToNavMesh_NoNearby_ReturnsNull()
+    {
+        provider.Grid.Fill(new GridCoordinate(0, 0), new GridCoordinate(19, 19), GridCell.Blocked);
+
+        var projected = provider.ProjectToNavMesh(new Vector3(10.5f, 0, 10.5f), maxDistance: 3f);
+
+        Assert.Null(projected);
+    }
+
+    #endregion
+
+    #region Area Cost Tests
+
+    [Fact]
+    public void GetAreaCost_Default_ReturnsOne()
+    {
+        Assert.Equal(1f, provider.GetAreaCost(NavAreaType.Walkable));
+    }
+
+    [Fact]
+    public void SetAreaCost_UpdatesCost()
+    {
+        provider.SetAreaCost(NavAreaType.Mud, 5f);
+
+        Assert.Equal(5f, provider.GetAreaCost(NavAreaType.Mud));
+    }
+
+    #endregion
+
+    #region Disposal Tests
+
+    [Fact]
+    public void Dispose_MarksNotReady()
+    {
+        var tempProvider = new GridNavigationProvider(GridConfig.Default);
+        Assert.True(tempProvider.IsReady);
+
+        tempProvider.Dispose();
+
+        Assert.False(tempProvider.IsReady);
+    }
+
+    [Fact]
+    public void Dispose_SubsequentCalls_ThrowObjectDisposed()
+    {
+        var tempProvider = new GridNavigationProvider(GridConfig.Default);
+        tempProvider.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+            tempProvider.FindPath(Vector3.Zero, Vector3.One, AgentSettings.Default));
+    }
+
+    [Fact]
+    public void Dispose_CancelsPendingRequests()
+    {
+        var tempProvider = new GridNavigationProvider(GridConfig.Default);
+        var request = tempProvider.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+
+        tempProvider.Dispose();
+
+        Assert.Equal(PathRequestStatus.Cancelled, request.Status);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/KeenEyes.Navigation.Grid.Tests.csproj
+++ b/tests/KeenEyes.Navigation.Grid.Tests/KeenEyes.Navigation.Grid.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Navigation.Grid\KeenEyes.Navigation.Grid.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Navigation.Grid.Tests/NavigationGridTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/NavigationGridTests.cs
@@ -1,0 +1,475 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Grid.Tests;
+
+/// <summary>
+/// Tests for <see cref="NavigationGrid"/> class.
+/// </summary>
+public class NavigationGridTests
+{
+    #region Construction Tests
+
+    [Fact]
+    public void Constructor_ValidParameters_CreatesGrid()
+    {
+        var grid = new NavigationGrid(10, 20, 1f);
+
+        Assert.Equal(10, grid.Width);
+        Assert.Equal(20, grid.Height);
+        Assert.Equal(1f, grid.CellSize);
+        Assert.Equal(Vector3.Zero, grid.WorldOrigin);
+    }
+
+    [Fact]
+    public void Constructor_WithWorldOrigin_SetsOrigin()
+    {
+        var origin = new Vector3(100, 0, 50);
+
+        var grid = new NavigationGrid(10, 10, 1f, origin);
+
+        Assert.Equal(origin, grid.WorldOrigin);
+    }
+
+    [Fact]
+    public void Constructor_ZeroWidth_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NavigationGrid(0, 10, 1f));
+    }
+
+    [Fact]
+    public void Constructor_NegativeWidth_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NavigationGrid(-1, 10, 1f));
+    }
+
+    [Fact]
+    public void Constructor_ZeroHeight_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NavigationGrid(10, 0, 1f));
+    }
+
+    [Fact]
+    public void Constructor_ZeroCellSize_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NavigationGrid(10, 10, 0f));
+    }
+
+    [Fact]
+    public void CellCount_ReturnsWidthTimesHeight()
+    {
+        var grid = new NavigationGrid(10, 20, 1f);
+
+        Assert.Equal(200, grid.CellCount);
+    }
+
+    #endregion
+
+    #region Cell Access Tests
+
+    [Fact]
+    public void Indexer_ValidCoordinate_ReturnsWalkableCell()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        ref var cell = ref grid[new GridCoordinate(5, 5)];
+
+        Assert.True(cell.IsWalkable);
+        Assert.Equal(NavAreaType.Walkable, cell.AreaType);
+    }
+
+    [Fact]
+    public void Indexer_OutOfBounds_ThrowsArgumentOutOfRange()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(10, 5)]; });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(5, 10)]; });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(-1, 5)]; });
+    }
+
+    [Fact]
+    public void Indexer_IntParameters_Works()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        ref var cell = ref grid[5, 5];
+
+        Assert.True(cell.IsWalkable);
+    }
+
+    [Fact]
+    public void TryGetCell_ValidCoordinate_ReturnsTrueWithCell()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        bool success = grid.TryGetCell(new GridCoordinate(5, 5), out var cell);
+
+        Assert.True(success);
+        Assert.True(cell.IsWalkable);
+    }
+
+    [Fact]
+    public void TryGetCell_OutOfBounds_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        bool success = grid.TryGetCell(new GridCoordinate(15, 5), out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public void TrySetCell_ValidCoordinate_SetsCell()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var blockedCell = GridCell.Blocked;
+
+        bool success = grid.TrySetCell(new GridCoordinate(5, 5), blockedCell);
+
+        Assert.True(success);
+        Assert.False(grid[5, 5].IsWalkable);
+    }
+
+    [Fact]
+    public void TrySetCell_OutOfBounds_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        bool success = grid.TrySetCell(new GridCoordinate(15, 5), GridCell.Blocked);
+
+        Assert.False(success);
+    }
+
+    #endregion
+
+    #region Bounds Tests
+
+    [Fact]
+    public void IsInBounds_ValidCoordinate_ReturnsTrue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.True(grid.IsInBounds(new GridCoordinate(0, 0)));
+        Assert.True(grid.IsInBounds(new GridCoordinate(5, 5)));
+        Assert.True(grid.IsInBounds(new GridCoordinate(9, 9)));
+    }
+
+    [Fact]
+    public void IsInBounds_OutOfBounds_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.False(grid.IsInBounds(new GridCoordinate(-1, 0)));
+        Assert.False(grid.IsInBounds(new GridCoordinate(0, -1)));
+        Assert.False(grid.IsInBounds(new GridCoordinate(10, 0)));
+        Assert.False(grid.IsInBounds(new GridCoordinate(0, 10)));
+    }
+
+    [Fact]
+    public void GetWorldBounds_ReturnsCorrectBounds()
+    {
+        var grid = new NavigationGrid(10, 20, 2f, new Vector3(5, 0, 10));
+
+        var (min, max) = grid.GetWorldBounds();
+
+        Assert.Equal(new Vector3(5, 0, 10), min);
+        Assert.Equal(new Vector3(25, 0, 50), max);  // 5 + 10*2, 0, 10 + 20*2
+    }
+
+    #endregion
+
+    #region Walkability Tests
+
+    [Fact]
+    public void IsWalkable_WalkableCell_ReturnsTrue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.True(grid.IsWalkable(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void IsWalkable_BlockedCell_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 5] = GridCell.Blocked;
+
+        Assert.False(grid.IsWalkable(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void IsWalkable_OutOfBounds_ReturnsFalse()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.False(grid.IsWalkable(new GridCoordinate(15, 5)));
+    }
+
+    [Fact]
+    public void IsWalkable_WithAreaMask_FiltersCorrectly()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 5] = GridCell.WithAreaType(NavAreaType.Water);
+
+        Assert.True(grid.IsWalkable(new GridCoordinate(5, 5), NavAreaMask.Water));
+        Assert.False(grid.IsWalkable(new GridCoordinate(5, 5), NavAreaMask.Walkable));
+        Assert.True(grid.IsWalkable(new GridCoordinate(5, 5), NavAreaMask.All));
+    }
+
+    [Fact]
+    public void GetAreaType_ReturnsCorrectType()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 5] = GridCell.WithAreaType(NavAreaType.Road);
+
+        Assert.Equal(NavAreaType.Road, grid.GetAreaType(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void GetAreaType_OutOfBounds_ReturnsNotWalkable()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.Equal(NavAreaType.NotWalkable, grid.GetAreaType(new GridCoordinate(15, 5)));
+    }
+
+    [Fact]
+    public void GetCost_WalkableCell_ReturnsCost()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.Equal(1f, grid.GetCost(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void GetCost_BlockedCell_ReturnsMaxValue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 5] = GridCell.Blocked;
+
+        Assert.Equal(float.MaxValue, grid.GetCost(new GridCoordinate(5, 5)));
+    }
+
+    [Fact]
+    public void GetCost_OutOfBounds_ReturnsMaxValue()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        Assert.Equal(float.MaxValue, grid.GetCost(new GridCoordinate(15, 5)));
+    }
+
+    #endregion
+
+    #region World Position Conversion Tests
+
+    [Fact]
+    public void ToWorldPosition_ReturnsCorrectPosition()
+    {
+        var grid = new NavigationGrid(10, 10, 2f, new Vector3(10, 0, 20));
+
+        var world = grid.ToWorldPosition(new GridCoordinate(5, 3));
+
+        Assert.Equal(21f, world.X, 0.0001f);  // 10 + (5 + 0.5) * 2
+        Assert.Equal(0f, world.Y, 0.0001f);
+        Assert.Equal(27f, world.Z, 0.0001f);  // 20 + (3 + 0.5) * 2
+    }
+
+    [Fact]
+    public void FromWorldPosition_ReturnsCorrectCoordinate()
+    {
+        var grid = new NavigationGrid(10, 10, 2f, new Vector3(10, 0, 20));
+
+        var coord = grid.FromWorldPosition(new Vector3(21, 5, 27));
+
+        Assert.Equal(5, coord.X);  // (21 - 10) / 2 = 5.5 -> floor = 5
+        Assert.Equal(3, coord.Y);  // (27 - 20) / 2 = 3.5 -> floor = 3
+    }
+
+    #endregion
+
+    #region Fill and Clear Tests
+
+    [Fact]
+    public void Fill_SetsAllCellsInRegion()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        grid.Fill(new GridCoordinate(2, 2), new GridCoordinate(4, 4), GridCell.Blocked);
+
+        for (int x = 2; x <= 4; x++)
+        {
+            for (int y = 2; y <= 4; y++)
+            {
+                Assert.False(grid[x, y].IsWalkable);
+            }
+        }
+    }
+
+    [Fact]
+    public void Fill_ReversedCoordinates_StillWorks()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        grid.Fill(new GridCoordinate(4, 4), new GridCoordinate(2, 2), GridCell.Blocked);
+
+        for (int x = 2; x <= 4; x++)
+        {
+            for (int y = 2; y <= 4; y++)
+            {
+                Assert.False(grid[x, y].IsWalkable);
+            }
+        }
+    }
+
+    [Fact]
+    public void Clear_SetsAllCellsToWalkable()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid.Fill(new GridCoordinate(0, 0), new GridCoordinate(9, 9), GridCell.Blocked);
+
+        grid.Clear();
+
+        for (int x = 0; x < 10; x++)
+        {
+            for (int y = 0; y < 10; y++)
+            {
+                Assert.True(grid[x, y].IsWalkable);
+            }
+        }
+    }
+
+    [Fact]
+    public void Block_SetsAllCellsToBlocked()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        grid.Block();
+
+        for (int x = 0; x < 10; x++)
+        {
+            for (int y = 0; y < 10; y++)
+            {
+                Assert.False(grid[x, y].IsWalkable);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Neighbor Tests
+
+    [Fact]
+    public void GetWalkableNeighbors_OpenGrid_ReturnsFourCardinal()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int count = grid.GetWalkableNeighbors(new GridCoordinate(5, 5), allowDiagonal: false, neighbors);
+
+        Assert.Equal(4, count);
+    }
+
+    [Fact]
+    public void GetWalkableNeighbors_OpenGrid_ReturnsEightWithDiagonal()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int count = grid.GetWalkableNeighbors(new GridCoordinate(5, 5), allowDiagonal: true, neighbors);
+
+        Assert.Equal(8, count);
+    }
+
+    [Fact]
+    public void GetWalkableNeighbors_Corner_ReturnsLimitedNeighbors()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int count = grid.GetWalkableNeighbors(new GridCoordinate(0, 0), allowDiagonal: false, neighbors);
+
+        Assert.Equal(2, count);  // Only right and down
+    }
+
+    [Fact]
+    public void GetWalkableNeighbors_BlockedNeighbor_ExcludesBlocked()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 4] = GridCell.Blocked;  // Block the cell above
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int count = grid.GetWalkableNeighbors(new GridCoordinate(5, 5), allowDiagonal: false, neighbors);
+
+        Assert.Equal(3, count);
+        Assert.DoesNotContain(new GridCoordinate(5, 4), neighbors[..count].ToArray());
+    }
+
+    [Fact]
+    public void GetWalkableNeighbors_DiagonalCornerCutting_Prevents()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[4, 5] = GridCell.Blocked;  // Block left
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int count = grid.GetWalkableNeighbors(new GridCoordinate(5, 5), allowDiagonal: true, neighbors);
+
+        // Should not include (4,4) or (4,6) because (4,5) is blocked
+        Assert.DoesNotContain(new GridCoordinate(4, 4), neighbors[..count].ToArray());
+        Assert.DoesNotContain(new GridCoordinate(4, 6), neighbors[..count].ToArray());
+    }
+
+    [Fact]
+    public void GetWalkableNeighbors_WithAreaMask_FiltersCorrectly()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        grid[5, 4] = GridCell.WithAreaType(NavAreaType.Water);  // Water above
+        Span<GridCoordinate> neighbors = stackalloc GridCoordinate[8];
+
+        int countWalkableOnly = grid.GetWalkableNeighbors(
+            new GridCoordinate(5, 5), false, NavAreaMask.Walkable, neighbors);
+        int countWithWater = grid.GetWalkableNeighbors(
+            new GridCoordinate(5, 5), false, NavAreaMask.Walkable | NavAreaMask.Water, neighbors);
+
+        Assert.Equal(3, countWalkableOnly);  // Excludes water
+        Assert.Equal(4, countWithWater);     // Includes water
+    }
+
+    #endregion
+
+    #region Span Access Tests
+
+    [Fact]
+    public void GetCellsSpan_ReturnsAllCells()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        var span = grid.GetCellsSpan();
+
+        Assert.Equal(100, span.Length);
+    }
+
+    [Fact]
+    public void GetCellsReadOnlySpan_ReturnsAllCells()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+
+        var span = grid.GetCellsReadOnlySpan();
+
+        Assert.Equal(100, span.Length);
+    }
+
+    [Fact]
+    public void GetCellsSpan_ModificationsAffectGrid()
+    {
+        var grid = new NavigationGrid(10, 10, 1f);
+        var span = grid.GetCellsSpan();
+
+        span[0].IsWalkable = false;
+
+        Assert.False(grid[0, 0].IsWalkable);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Grid.Tests/packages.lock.json
+++ b/tests/KeenEyes.Navigation.Grid.Tests/packages.lock.json
@@ -1,0 +1,265 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "HCfw7V1yuKxnm89vVKrb8b6aug96PUgxN9Z0YthEFCR8JOfTJF4XcU1i6RX2eEB08p3zriuFIG7BGXns4PyE8Q=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.1.0, )",
+        "resolved": "18.1.0",
+        "contentHash": "FJUCocHSPSjbeoGE/OojOhVUXwDng3VdNlwqzif9hMS2eFcG0f8RdjLM537aBsjP7zLHvGnWXbnUnc61v/EFCA==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "6.0.2",
+          "Microsoft.Testing.Platform": "2.0.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "6Tz2wZTNH/3hiskarOM5X9JaHV0QpIdIvEiLv6BJeJvtPS6AY+S47rg4K+czGSjQTkIgu5kT9SgZOwbfdhDD9Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "43NCOTEENtdc9fmlzX9KHQR14AZEYek5r4jOJlWPhTyV1+aYAQYl4x773nYXU5TKxV6+rMuniJ7wcj9C9qrP1A=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.1, )",
+        "resolved": "3.2.1",
+        "contentHash": "QnT7C+eEUM7ut6w4/RNPpSxE1Q9epiCNWf8Krc/vqcc+sc3Ejtl8lbf4w5DzBYWLUlkEEUr1u9czG0Qj7QK6IQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.26.0",
+          "xunit.v3.assert": "[3.2.1]",
+          "xunit.v3.core.mtp-v2": "[3.2.1]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QcZrCETsBJqy/vQpFtJc+jSXQ0K5sucQ6NUFbTNVHD4vfZZOwjZ/3sBzczkC4DityhD3AVO/+K/+9ioLs1AgRA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "HS5YsudCGSVoCVdsYJ5FAO9vx0z04qSAXgVzpDJSQ1/w/X9q8hrQVGU2p+Yfui+2KcXLL+Zjc0SX3yJWtBmYiw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.26.0",
+        "contentHash": "YrWZOfuU1Scg4iGizAlMNALOxVS+HPSVilfscNDEJAyrTIVdF4c+8o+Aerw2RYnrJxafj/F56YkJOKCURUWQmA=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "7hGxs+sfgPCiHg7CbWL8Vsmg8WS4vBfipZ7rfE+FEyS7ksU4+0vcV08TQvLIXLPAfinT06zVoK83YjRcMXcXLw=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "NUh3pPTC3Py4XTnjoCCCIEzvdKTQ9apu0ikDNCrUETBtfHHXcoUmIl5bOfJLQQu7awhu8eaZHjJnG7rx9lUZpg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EX7lPHnlJQYGj092TE+I7bw/iT9eYA+JcqRg0+31tSPgQqBhmOSxTT7YIfU6zFHo4ak4F/TPz3GjmvweJT1zZw==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.inproc.console": "[3.2.1]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "soZuThF5CwB/ZZ2HY/ivdinyM/6MvmjsHTG0vNw3fRd1ZKcmLzfxVb3fB6R3G5yoaN4Bh+aWzFGjOvYO05OzkA==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "oF0jwl0xH45/RWjDcaCPOeeI6HCoyiEXIT8yvByd37rhJorjL/Ri8S9A/Vql8DBPjCfQWd6Url5JRmeiQ55isA==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EC/VLj1E9BPWfmzdEMQEqouxh0rWAdX6SXuiiDRf0yXXsQo3E2PNLKCyJ9V8hmkGH/nBvM7pHLFbuCf00vCynw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.common": "[3.2.1]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project"
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.grid": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements Issue #638: Grid-based A* pathfinding for 2D games
- Adds `KeenEyes.Navigation.Grid` package with complete grid-based navigation system
- Validates the navigation abstractions from #637 with a simpler implementation than NavMesh

## Deliverables

All acceptance criteria met:

- ✅ **NavigationGrid** - 2D grid representation with cell-based walkability, area types, and cost multipliers
- ✅ **AStarPathfinder** - A* algorithm with diagonal support, multiple heuristics (Manhattan, Chebyshev, Octile, Euclidean), and configurable corner-cutting prevention
- ✅ **GridNavigationProvider** - Full `INavigationProvider` implementation with async path requests, raycasting, and point queries
- ✅ **Zero-allocation path queries** - Span-based `FindPath(GridCoordinate, GridCoordinate, Span<GridCoordinate>)` for performance-critical scenarios

## New Files

### Core Types
- `GridCoordinate.cs` - 2D coordinate with distance calculations and world position conversion
- `GridCell.cs` - Cell data with walkability, area type, cost, and user data
- `NavigationGrid.cs` - 2D grid with neighbor queries and corner-cutting prevention
- `GridConfig.cs` - Configuration for grid dimensions, movement options, and pathfinding limits

### Pathfinding
- `AStarPathfinder.cs` - A* implementation with node pooling and priority queue
- `GridPathRequest.cs` - Async path request with task completion support
- `GridNavigationProvider.cs` - Full INavigationProvider implementation

### Integration
- `GridNavigationPlugin.cs` - World plugin for easy grid navigation setup

## Test Plan
- [x] 167 comprehensive unit tests covering all functionality
- [x] Tests for all heuristic types
- [x] Tests for diagonal and cardinal-only movement
- [x] Tests for area mask filtering
- [x] Tests for raycasting and point queries
- [x] Tests for async path requests
- [x] Build passes with zero warnings

Closes #638