### PR TITLE
feat(navigation): Add NavigationPlugin with ECS systems

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -68,6 +68,8 @@
     <Project Path="src/KeenEyes.Spatial/KeenEyes.Spatial.csproj" />
     <Project Path="src/KeenEyes.Testing/KeenEyes.Testing.csproj" />
     <Project Path="src/KeenEyes.Navigation.Abstractions/KeenEyes.Navigation.Abstractions.csproj" />
+    <Project Path="src/KeenEyes.Navigation.Grid/KeenEyes.Navigation.Grid.csproj" />
+    <Project Path="src/KeenEyes.Navigation/KeenEyes.Navigation.csproj" />
     <Project Path="src/KeenEyes.UI.Abstractions/KeenEyes.UI.Abstractions.csproj" />
     <Project Path="src/KeenEyes.UI/KeenEyes.UI.csproj" />
   </Folder>
@@ -90,6 +92,7 @@
     <Project Path="tests/KeenEyes.Input.Abstractions.Tests/KeenEyes.Input.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Logging.Tests/KeenEyes.Logging.Tests.csproj" />
     <Project Path="tests/KeenEyes.Navigation.Abstractions.Tests/KeenEyes.Navigation.Abstractions.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Navigation.Tests/KeenEyes.Navigation.Tests.csproj" />
     <Project Path="tests/KeenEyes.Network.Abstractions.Tests/KeenEyes.Network.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Network.Tests/KeenEyes.Network.Tests.csproj" />
     <Project Path="tests/KeenEyes.Parallelism.Tests/KeenEyes.Parallelism.Tests.csproj" />

--- a/src/KeenEyes.Navigation/KeenEyes.Navigation.csproj
+++ b/src/KeenEyes.Navigation/KeenEyes.Navigation.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>KeenEyes.Navigation</PackageId>
+    <Description>Navigation plugin with ECS systems for pathfinding in KeenEyes</Description>
+    <PackageTags>ecs;navigation;pathfinding;navmesh;agents</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Navigation.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Navigation.Abstractions\KeenEyes.Navigation.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Navigation/NavigationConfig.cs
+++ b/src/KeenEyes.Navigation/NavigationConfig.cs
@@ -1,0 +1,165 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation;
+
+/// <summary>
+/// Configuration for the navigation plugin.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This configuration determines how the navigation plugin operates, including
+/// the pathfinding strategy, request throttling, and agent behavior settings.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var config = new NavigationConfig
+/// {
+///     Strategy = NavigationStrategy.Grid,
+///     MaxPathRequestsPerFrame = 10,
+///     AgentSteeringEnabled = true
+/// };
+///
+/// world.InstallPlugin(new NavigationPlugin(config));
+/// </code>
+/// </example>
+public sealed class NavigationConfig
+{
+    /// <summary>
+    /// Gets or sets the navigation strategy to use.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set to <see cref="NavigationStrategy.Custom"/>, a custom
+    /// <see cref="INavigationProvider"/> must be supplied via
+    /// <see cref="CustomProvider"/>.
+    /// </para>
+    /// </remarks>
+    public NavigationStrategy Strategy { get; set; } = NavigationStrategy.Grid;
+
+    /// <summary>
+    /// Gets or sets the custom navigation provider.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="Strategy"/> is <see cref="NavigationStrategy.Custom"/>.
+    /// </remarks>
+    public INavigationProvider? CustomProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of path requests to process per frame.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Higher values allow faster path computation but may cause frame rate issues.
+    /// Consider the complexity of your navmesh and typical path lengths.
+    /// </para>
+    /// </remarks>
+    public int MaxPathRequestsPerFrame { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the maximum number of pending path requests.
+    /// </summary>
+    /// <remarks>
+    /// When this limit is reached, new path requests will fail immediately.
+    /// </remarks>
+    public int MaxPendingRequests { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets whether agent steering is enabled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the <see cref="Systems.NavMeshAgentSystem"/> will automatically
+    /// compute and apply steering velocities to move agents along their paths.
+    /// </para>
+    /// <para>
+    /// When disabled, paths are computed but agents must be moved manually.
+    /// </para>
+    /// </remarks>
+    public bool AgentSteeringEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the distance at which path waypoints are considered reached.
+    /// </summary>
+    /// <remarks>
+    /// Agents will advance to the next waypoint when within this distance.
+    /// </remarks>
+    public float WaypointReachDistance { get; set; } = 0.5f;
+
+    /// <summary>
+    /// Gets or sets whether dynamic obstacle carving is enabled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the <see cref="Systems.ObstacleUpdateSystem"/> will update
+    /// the navigation data when <see cref="KeenEyes.Navigation.Abstractions.Components.NavMeshObstacle"/>
+    /// components are added, moved, or removed.
+    /// </para>
+    /// </remarks>
+    public bool DynamicObstaclesEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the minimum time between obstacle recalculations in seconds.
+    /// </summary>
+    /// <remarks>
+    /// Prevents excessive recalculation when obstacles move frequently.
+    /// </remarks>
+    public float ObstacleUpdateInterval { get; set; } = 0.1f;
+
+    /// <summary>
+    /// Gets or sets whether to automatically project agents onto the navmesh.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, agents that move off the navmesh will be projected back onto it.
+    /// </remarks>
+    public bool AutoProjectToNavMesh { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum distance to project agents back onto the navmesh.
+    /// </summary>
+    public float MaxProjectionDistance { get; set; } = 5f;
+
+    /// <summary>
+    /// Gets a default configuration.
+    /// </summary>
+    public static NavigationConfig Default => new();
+
+    /// <summary>
+    /// Validates the configuration.
+    /// </summary>
+    /// <returns>Null if valid, otherwise an error message.</returns>
+    public string? Validate()
+    {
+        if (Strategy == NavigationStrategy.Custom && CustomProvider == null)
+        {
+            return "Custom strategy requires a CustomProvider to be set.";
+        }
+
+        if (MaxPathRequestsPerFrame <= 0)
+        {
+            return $"MaxPathRequestsPerFrame must be positive, got {MaxPathRequestsPerFrame}.";
+        }
+
+        if (MaxPendingRequests <= 0)
+        {
+            return $"MaxPendingRequests must be positive, got {MaxPendingRequests}.";
+        }
+
+        if (WaypointReachDistance <= 0f)
+        {
+            return $"WaypointReachDistance must be positive, got {WaypointReachDistance}.";
+        }
+
+        if (ObstacleUpdateInterval < 0f)
+        {
+            return $"ObstacleUpdateInterval must be non-negative, got {ObstacleUpdateInterval}.";
+        }
+
+        if (MaxProjectionDistance <= 0f)
+        {
+            return $"MaxProjectionDistance must be positive, got {MaxProjectionDistance}.";
+        }
+
+        return null;
+    }
+}

--- a/src/KeenEyes.Navigation/NavigationContext.cs
+++ b/src/KeenEyes.Navigation/NavigationContext.cs
@@ -1,0 +1,516 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation;
+
+/// <summary>
+/// Extension API for navigation operations in a world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class provides the primary API for navigation operations. It manages
+/// path requests, agent destinations, and provides access to underlying
+/// navigation data.
+/// </para>
+/// <para>
+/// Access this API through the world extension system:
+/// <code>
+/// var nav = world.GetExtension&lt;NavigationContext&gt;();
+/// nav.SetDestination(entity, targetPosition);
+/// </code>
+/// </para>
+/// </remarks>
+[PluginExtension("Navigation")]
+public sealed class NavigationContext : IDisposable
+{
+    private readonly IWorld world;
+    private readonly NavigationConfig config;
+    private readonly Dictionary<Entity, AgentNavigationState> agentStates;
+    private readonly Dictionary<Entity, IPathRequest> pendingRequests;
+    private readonly Lock stateLock = new();
+    private INavigationProvider? provider;
+    private bool disposed;
+
+    /// <summary>
+    /// Gets the navigation configuration.
+    /// </summary>
+    public NavigationConfig Config => config;
+
+    /// <summary>
+    /// Gets the underlying navigation provider.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if no provider is configured.</exception>
+    public INavigationProvider Provider => provider
+        ?? throw new InvalidOperationException("Navigation provider is not initialized.");
+
+    /// <summary>
+    /// Gets a value indicating whether the navigation system is ready.
+    /// </summary>
+    public bool IsReady => provider?.IsReady ?? false;
+
+    /// <summary>
+    /// Gets the current navigation strategy.
+    /// </summary>
+    public NavigationStrategy Strategy => provider?.Strategy ?? config.Strategy;
+
+    /// <summary>
+    /// Gets the number of agents currently navigating.
+    /// </summary>
+    public int ActiveAgentCount
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return agentStates.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of pending path requests.
+    /// </summary>
+    public int PendingRequestCount
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return pendingRequests.Count;
+            }
+        }
+    }
+
+    internal NavigationContext(IWorld world, NavigationConfig config)
+    {
+        this.world = world;
+        this.config = config;
+        agentStates = [];
+        pendingRequests = [];
+    }
+
+    internal void SetProvider(INavigationProvider provider)
+    {
+        this.provider = provider;
+    }
+
+    #region Destination API
+
+    /// <summary>
+    /// Sets the destination for an agent entity.
+    /// </summary>
+    /// <param name="entity">The entity with a <see cref="NavMeshAgent"/> component.</param>
+    /// <param name="destination">The target position to navigate to.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the entity doesn't have a <see cref="NavMeshAgent"/> component.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method initiates pathfinding to the destination. The path will be
+    /// computed asynchronously and the agent's <see cref="NavMeshAgent.HasPath"/>
+    /// property will be set when complete.
+    /// </para>
+    /// </remarks>
+    public void SetDestination(Entity entity, Vector3 destination)
+    {
+        ThrowIfDisposed();
+
+        if (!world.Has<NavMeshAgent>(entity))
+        {
+            throw new InvalidOperationException($"Entity {entity} does not have a NavMeshAgent component.");
+        }
+
+        ref var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.SetDestination(destination);
+
+        // Request a new path
+        RequestPathForAgent(entity, destination);
+    }
+
+    /// <summary>
+    /// Stops an agent and clears its current path.
+    /// </summary>
+    /// <param name="entity">The entity to stop.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the entity doesn't have a <see cref="NavMeshAgent"/> component.
+    /// </exception>
+    public void Stop(Entity entity)
+    {
+        ThrowIfDisposed();
+
+        if (!world.Has<NavMeshAgent>(entity))
+        {
+            throw new InvalidOperationException($"Entity {entity} does not have a NavMeshAgent component.");
+        }
+
+        ref var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.Stop();
+
+        // Cancel any pending request
+        CancelRequestForAgent(entity);
+
+        // Clear navigation state
+        lock (stateLock)
+        {
+            agentStates.Remove(entity);
+        }
+    }
+
+    /// <summary>
+    /// Resumes navigation for a stopped agent.
+    /// </summary>
+    /// <param name="entity">The entity to resume.</param>
+    public void Resume(Entity entity)
+    {
+        ThrowIfDisposed();
+
+        if (!world.Has<NavMeshAgent>(entity))
+        {
+            return;
+        }
+
+        ref var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.Resume();
+    }
+
+    /// <summary>
+    /// Warps an agent to a position without pathfinding.
+    /// </summary>
+    /// <param name="entity">The entity to warp.</param>
+    /// <param name="position">The position to warp to.</param>
+    /// <param name="clearPath">Whether to clear the current path.</param>
+    /// <returns>True if the position is on the navmesh, false otherwise.</returns>
+    public bool Warp(Entity entity, Vector3 position, bool clearPath = true)
+    {
+        ThrowIfDisposed();
+
+        if (provider == null || !world.Has<NavMeshAgent>(entity))
+        {
+            return false;
+        }
+
+        ref var agent = ref world.Get<NavMeshAgent>(entity);
+
+        var projectedPos = provider.ProjectToNavMesh(position, config.MaxProjectionDistance);
+        if (!projectedPos.HasValue)
+        {
+            return false;
+        }
+
+        // Update agent's position (if the entity has Transform3D, it should be updated separately)
+        agent.IsOnNavMesh = true;
+
+        if (clearPath)
+        {
+            agent.Stop();
+            CancelRequestForAgent(entity);
+            lock (stateLock)
+            {
+                agentStates.Remove(entity);
+            }
+        }
+
+        return true;
+    }
+
+    #endregion
+
+    #region Query API
+
+    /// <summary>
+    /// Finds a path synchronously.
+    /// </summary>
+    /// <param name="start">The starting position.</param>
+    /// <param name="end">The destination position.</param>
+    /// <param name="agent">The agent settings for path computation.</param>
+    /// <param name="areaMask">Optional mask to filter traversable areas.</param>
+    /// <returns>The computed path.</returns>
+    public NavPath FindPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+
+        if (provider == null)
+        {
+            return NavPath.Empty;
+        }
+
+        return provider.FindPath(start, end, agent, areaMask);
+    }
+
+    /// <summary>
+    /// Requests a path asynchronously.
+    /// </summary>
+    /// <param name="start">The starting position.</param>
+    /// <param name="end">The destination position.</param>
+    /// <param name="agent">The agent settings for path computation.</param>
+    /// <param name="areaMask">Optional mask to filter traversable areas.</param>
+    /// <returns>A path request object to track computation progress.</returns>
+    public IPathRequest? RequestPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+    {
+        ThrowIfDisposed();
+
+        if (provider == null)
+        {
+            return null;
+        }
+
+        return provider.RequestPath(start, end, agent, areaMask);
+    }
+
+    /// <summary>
+    /// Performs a raycast on the navigation data.
+    /// </summary>
+    /// <param name="start">The start position.</param>
+    /// <param name="end">The end position.</param>
+    /// <param name="hitPosition">The hit position, or end if no hit.</param>
+    /// <returns>True if the ray hit an obstacle.</returns>
+    public bool Raycast(Vector3 start, Vector3 end, out Vector3 hitPosition)
+    {
+        ThrowIfDisposed();
+
+        if (provider == null)
+        {
+            hitPosition = end;
+            return false;
+        }
+
+        return provider.Raycast(start, end, out hitPosition);
+    }
+
+    /// <summary>
+    /// Finds the nearest navigable point to a position.
+    /// </summary>
+    /// <param name="position">The query position.</param>
+    /// <param name="searchRadius">Maximum distance to search.</param>
+    /// <returns>The nearest navigable point, or null if none found.</returns>
+    public NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f)
+    {
+        ThrowIfDisposed();
+        return provider?.FindNearestPoint(position, searchRadius);
+    }
+
+    /// <summary>
+    /// Checks if a position is navigable.
+    /// </summary>
+    /// <param name="position">The position to check.</param>
+    /// <param name="agent">The agent settings.</param>
+    /// <returns>True if the position is navigable.</returns>
+    public bool IsNavigable(Vector3 position, AgentSettings agent)
+    {
+        ThrowIfDisposed();
+        return provider?.IsNavigable(position, agent) ?? false;
+    }
+
+    #endregion
+
+    #region Agent State Management
+
+    /// <summary>
+    /// Gets the navigation state for an agent.
+    /// </summary>
+    /// <param name="entity">The agent entity.</param>
+    /// <param name="state">The navigation state if found.</param>
+    /// <returns>True if the agent has navigation state.</returns>
+    public bool TryGetAgentState(Entity entity, out AgentNavigationState state)
+    {
+        lock (stateLock)
+        {
+            return agentStates.TryGetValue(entity, out state);
+        }
+    }
+
+    internal void SetAgentState(Entity entity, AgentNavigationState state)
+    {
+        lock (stateLock)
+        {
+            agentStates[entity] = state;
+        }
+    }
+
+    internal void RemoveAgent(Entity entity)
+    {
+        CancelRequestForAgent(entity);
+        lock (stateLock)
+        {
+            agentStates.Remove(entity);
+        }
+    }
+
+    internal IReadOnlyDictionary<Entity, AgentNavigationState> GetAllAgentStates()
+    {
+        lock (stateLock)
+        {
+            return new Dictionary<Entity, AgentNavigationState>(agentStates);
+        }
+    }
+
+    #endregion
+
+    #region Path Request Management
+
+    private void RequestPathForAgent(Entity entity, Vector3 destination)
+    {
+        if (provider == null || !world.Has<NavMeshAgent>(entity))
+        {
+            return;
+        }
+
+        // Cancel any existing request
+        CancelRequestForAgent(entity);
+
+        // Get agent's current position from Transform3D
+        if (!world.Has<Common.Transform3D>(entity))
+        {
+            return;
+        }
+
+        ref readonly var transform = ref world.Get<Common.Transform3D>(entity);
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        var request = provider.RequestPath(transform.Position, destination, agent.Settings, agent.AreaMask);
+
+        lock (stateLock)
+        {
+            pendingRequests[entity] = request;
+        }
+    }
+
+    private void CancelRequestForAgent(Entity entity)
+    {
+        IPathRequest? request;
+        lock (stateLock)
+        {
+            if (!pendingRequests.TryGetValue(entity, out request))
+            {
+                return;
+            }
+
+            pendingRequests.Remove(entity);
+        }
+
+        request.Cancel();
+        request.Dispose();
+    }
+
+    internal void ProcessPendingRequests()
+    {
+        if (provider == null)
+        {
+            return;
+        }
+
+        List<Entity>? completedRequests = null;
+
+        lock (stateLock)
+        {
+            foreach (var (entity, request) in pendingRequests)
+            {
+                if (request.Status == PathRequestStatus.Completed ||
+                    request.Status == PathRequestStatus.Failed ||
+                    request.Status == PathRequestStatus.Cancelled)
+                {
+                    completedRequests ??= [];
+                    completedRequests.Add(entity);
+
+                    if (request.Status == PathRequestStatus.Completed && world.Has<NavMeshAgent>(entity))
+                    {
+                        ref var agent = ref world.Get<NavMeshAgent>(entity);
+                        var path = request.Result;
+
+                        if (path.IsValid)
+                        {
+                            agent.HasPath = true;
+                            agent.PathPending = false;
+                            agent.RemainingDistance = path.Length;
+
+                            // Initialize navigation state
+                            agentStates[entity] = new AgentNavigationState
+                            {
+                                Path = path,
+                                CurrentWaypointIndex = 0,
+                                DistanceTraveled = 0f
+                            };
+                        }
+                        else
+                        {
+                            agent.HasPath = false;
+                            agent.PathPending = false;
+                        }
+                    }
+                    else if (world.Has<NavMeshAgent>(entity))
+                    {
+                        ref var agent = ref world.Get<NavMeshAgent>(entity);
+                        agent.HasPath = false;
+                        agent.PathPending = false;
+                    }
+                }
+            }
+
+            if (completedRequests != null)
+            {
+                foreach (var entity in completedRequests)
+                {
+                    if (pendingRequests.TryGetValue(entity, out var request))
+                    {
+                        pendingRequests.Remove(entity);
+                        request.Dispose();
+                    }
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // Cancel all pending requests
+        lock (stateLock)
+        {
+            foreach (var request in pendingRequests.Values)
+            {
+                request.Cancel();
+                request.Dispose();
+            }
+
+            pendingRequests.Clear();
+            agentStates.Clear();
+        }
+
+        // Don't dispose provider - it's managed by the plugin
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}
+
+/// <summary>
+/// Tracks the navigation state for an agent following a path.
+/// </summary>
+public struct AgentNavigationState
+{
+    /// <summary>
+    /// The current path being followed.
+    /// </summary>
+    public NavPath Path;
+
+    /// <summary>
+    /// The index of the current waypoint being navigated to.
+    /// </summary>
+    public int CurrentWaypointIndex;
+
+    /// <summary>
+    /// The distance traveled along the path so far.
+    /// </summary>
+    public float DistanceTraveled;
+}

--- a/src/KeenEyes.Navigation/NavigationPlugin.cs
+++ b/src/KeenEyes.Navigation/NavigationPlugin.cs
@@ -1,0 +1,238 @@
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Systems;
+
+namespace KeenEyes.Navigation;
+
+/// <summary>
+/// Plugin that adds navigation and pathfinding capabilities to the ECS world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin provides comprehensive navigation support including:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Asynchronous pathfinding via <see cref="PathRequestSystem"/></description></item>
+/// <item><description>Agent movement along paths via <see cref="NavMeshAgentSystem"/></description></item>
+/// <item><description>Dynamic obstacle handling via <see cref="ObstacleUpdateSystem"/></description></item>
+/// </list>
+/// <para>
+/// The plugin exposes a <see cref="NavigationContext"/> extension that can be accessed
+/// via <c>world.GetExtension&lt;NavigationContext&gt;()</c> or <c>world.Navigation</c>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var world = new World();
+///
+/// // Install with default configuration
+/// world.InstallPlugin(new NavigationPlugin());
+///
+/// // Or with custom configuration
+/// world.InstallPlugin(new NavigationPlugin(new NavigationConfig
+/// {
+///     Strategy = NavigationStrategy.Grid,
+///     MaxPathRequestsPerFrame = 10
+/// }));
+///
+/// // Create a navigating entity
+/// var agent = world.Spawn()
+///     .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+///     .With(NavMeshAgent.Create())
+///     .Build();
+///
+/// // Set destination
+/// var nav = world.GetExtension&lt;NavigationContext&gt;();
+/// nav.SetDestination(agent, new Vector3(10, 0, 10));
+/// </code>
+/// </example>
+public sealed class NavigationPlugin : IWorldPlugin
+{
+    private readonly NavigationConfig config;
+    private NavigationContext? navigationContext;
+    private INavigationProvider? provider;
+    private EventSubscription? agentAddedSubscription;
+    private EventSubscription? agentRemovedSubscription;
+    private EventSubscription? obstacleAddedSubscription;
+    private EventSubscription? obstacleRemovedSubscription;
+    private EventSubscription? entityDestroyedSubscription;
+
+    /// <summary>
+    /// Creates a new navigation plugin with default configuration.
+    /// </summary>
+    public NavigationPlugin()
+        : this(NavigationConfig.Default)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new navigation plugin with the specified configuration.
+    /// </summary>
+    /// <param name="config">The navigation configuration.</param>
+    /// <exception cref="ArgumentException">Thrown if configuration is invalid.</exception>
+    public NavigationPlugin(NavigationConfig config)
+    {
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException($"Invalid NavigationConfig: {error}", nameof(config));
+        }
+
+        this.config = config;
+    }
+
+    /// <inheritdoc/>
+    public string Name => "Navigation";
+
+    /// <inheritdoc/>
+    public void Install(IPluginContext context)
+    {
+        // Register components
+        context.RegisterComponent<NavMeshAgent>();
+        context.RegisterComponent<NavMeshObstacle>();
+
+        // Get or create navigation provider
+        provider = GetNavigationProvider(context);
+
+        // Create and expose the navigation context API
+        navigationContext = new NavigationContext(context.World, config);
+        navigationContext.SetProvider(provider);
+        context.SetExtension(navigationContext);
+
+        // Also register the INavigationProvider for direct access
+        context.SetExtension(provider);
+
+        // Register systems
+        RegisterSystems(context);
+
+        // Subscribe to component lifecycle events
+        SubscribeToEvents(context);
+    }
+
+    /// <inheritdoc/>
+    public void Uninstall(IPluginContext context)
+    {
+        // Unsubscribe from events
+        agentAddedSubscription?.Dispose();
+        agentRemovedSubscription?.Dispose();
+        obstacleAddedSubscription?.Dispose();
+        obstacleRemovedSubscription?.Dispose();
+        entityDestroyedSubscription?.Dispose();
+
+        agentAddedSubscription = null;
+        agentRemovedSubscription = null;
+        obstacleAddedSubscription = null;
+        obstacleRemovedSubscription = null;
+        entityDestroyedSubscription = null;
+
+        // Remove extensions
+        context.RemoveExtension<NavigationContext>();
+        context.RemoveExtension<INavigationProvider>();
+
+        // Dispose the context
+        navigationContext?.Dispose();
+        navigationContext = null;
+
+        // Dispose provider only if we own it (not custom provided)
+        if (config.Strategy != NavigationStrategy.Custom)
+        {
+            provider?.Dispose();
+        }
+
+        provider = null;
+
+        // Systems are automatically cleaned up by PluginManager
+    }
+
+    private INavigationProvider GetNavigationProvider(IPluginContext context)
+    {
+        // If custom provider is specified, use it
+        if (config.Strategy == NavigationStrategy.Custom && config.CustomProvider != null)
+        {
+            return config.CustomProvider;
+        }
+
+        // Check if a provider is already registered (e.g., GridNavigationPlugin was installed first)
+        if (context.TryGetExtension<INavigationProvider>(out var existingProvider) && existingProvider != null)
+        {
+            return existingProvider;
+        }
+
+        // For now, throw if no provider is available
+        // In a full implementation, we could create a default provider based on strategy
+        throw new InvalidOperationException(
+            $"No navigation provider available for strategy {config.Strategy}. " +
+            "Install a navigation provider plugin (e.g., GridNavigationPlugin) first, " +
+            "or provide a custom provider via NavigationConfig.CustomProvider.");
+    }
+
+    private void RegisterSystems(IPluginContext context)
+    {
+        // PathRequestSystem - processes async path requests
+        // Runs early in Update phase to process completed requests before agent movement
+        context.AddSystem<PathRequestSystem>(
+            SystemPhase.Update,
+            order: -100);
+
+        // NavMeshAgentSystem - moves agents along their paths
+        // Runs in Update phase after path requests are processed
+        if (config.AgentSteeringEnabled)
+        {
+            context.AddSystem<NavMeshAgentSystem>(
+                SystemPhase.Update,
+                order: 0);
+        }
+
+        // ObstacleUpdateSystem - syncs dynamic obstacles
+        // Runs in LateUpdate phase after all movement is complete
+        if (config.DynamicObstaclesEnabled)
+        {
+            context.AddSystem<ObstacleUpdateSystem>(
+                SystemPhase.LateUpdate,
+                order: 0);
+        }
+    }
+
+    private void SubscribeToEvents(IPluginContext context)
+    {
+        // Subscribe to NavMeshAgent component added/removed
+        agentAddedSubscription = context.World.OnComponentAdded<NavMeshAgent>(OnAgentAdded);
+        agentRemovedSubscription = context.World.OnComponentRemoved<NavMeshAgent>(OnAgentRemoved);
+
+        // Subscribe to NavMeshObstacle component added/removed
+        obstacleAddedSubscription = context.World.OnComponentAdded<NavMeshObstacle>(OnObstacleAdded);
+        obstacleRemovedSubscription = context.World.OnComponentRemoved<NavMeshObstacle>(OnObstacleRemoved);
+
+        // Subscribe to entity destroyed for cleanup
+        entityDestroyedSubscription = context.World.OnEntityDestroyed(OnEntityDestroyed);
+    }
+
+    private void OnAgentAdded(Entity entity, NavMeshAgent agent)
+    {
+        // Agent added - nothing to do initially
+        // Path will be requested when SetDestination is called
+    }
+
+    private void OnAgentRemoved(Entity entity)
+    {
+        // Clean up navigation state
+        navigationContext?.RemoveAgent(entity);
+    }
+
+    private void OnObstacleAdded(Entity entity, NavMeshObstacle obstacle)
+    {
+        // Obstacle added - obstacle system will handle updates
+        // Could mark navigation data as dirty here
+    }
+
+    private void OnObstacleRemoved(Entity entity)
+    {
+        // Obstacle removed - obstacle system will handle updates
+    }
+
+    private void OnEntityDestroyed(Entity entity)
+    {
+        // Clean up any navigation state for destroyed entity
+        navigationContext?.RemoveAgent(entity);
+    }
+}

--- a/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
@@ -1,0 +1,203 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Systems;
+
+/// <summary>
+/// System that moves agents along their computed paths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system processes all entities with <see cref="NavMeshAgent"/> and
+/// <see cref="Transform3D"/> components, moving them toward their destinations
+/// along their computed paths.
+/// </para>
+/// <para>
+/// The system:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Computes steering velocities based on path waypoints</description></item>
+/// <item><description>Applies acceleration and speed limits</description></item>
+/// <item><description>Advances to the next waypoint when close enough</description></item>
+/// <item><description>Updates agent state (remaining distance, steering target, etc.)</description></item>
+/// </list>
+/// </remarks>
+internal sealed class NavMeshAgentSystem : SystemBase
+{
+    private NavigationContext? context;
+    private NavigationConfig? config;
+
+    /// <inheritdoc/>
+    protected override void OnInitialize()
+    {
+        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        {
+            throw new InvalidOperationException("NavMeshAgentSystem requires NavigationContext extension.");
+        }
+
+        context = ctx;
+        config = ctx.Config;
+    }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        if (context == null || config == null)
+        {
+            return;
+        }
+
+        // Process all agents with paths
+        foreach (var entity in World.Query<NavMeshAgent, Transform3D>())
+        {
+            ref var agent = ref World.Get<NavMeshAgent>(entity);
+            ref var transform = ref World.Get<Transform3D>(entity);
+
+            // Skip stopped agents or those without paths
+            if (agent.IsStopped || !agent.HasPath || agent.PathPending)
+            {
+                continue;
+            }
+
+            // Get navigation state
+            if (!context.TryGetAgentState(entity, out var state) || !state.Path.IsValid)
+            {
+                continue;
+            }
+
+            // Process movement
+            ProcessAgentMovement(entity, ref agent, ref transform, ref state, deltaTime);
+
+            // Update state
+            context.SetAgentState(entity, state);
+        }
+    }
+
+    private void ProcessAgentMovement(
+        Entity entity,
+        ref NavMeshAgent agent,
+        ref Transform3D transform,
+        ref AgentNavigationState state,
+        float deltaTime)
+    {
+        var path = state.Path;
+
+        // Check if we've reached the end of the path
+        if (state.CurrentWaypointIndex >= path.Count)
+        {
+            CompleteNavigation(ref agent);
+            return;
+        }
+
+        // Get current waypoint position
+        var targetWaypoint = path[state.CurrentWaypointIndex].Position;
+        agent.SteeringTarget = targetWaypoint;
+
+        // Calculate distance to waypoint
+        var toWaypoint = targetWaypoint - transform.Position;
+        float distanceToWaypoint = toWaypoint.Length();
+
+        // Check if we've reached the waypoint
+        float reachDistance = config!.WaypointReachDistance;
+        if (distanceToWaypoint <= reachDistance)
+        {
+            state.CurrentWaypointIndex++;
+
+            // Check if this was the last waypoint
+            if (state.CurrentWaypointIndex >= path.Count)
+            {
+                CompleteNavigation(ref agent);
+                return;
+            }
+
+            // Update target to next waypoint
+            targetWaypoint = path[state.CurrentWaypointIndex].Position;
+            agent.SteeringTarget = targetWaypoint;
+            toWaypoint = targetWaypoint - transform.Position;
+            distanceToWaypoint = toWaypoint.Length();
+        }
+
+        // Calculate desired velocity
+        Vector3 desiredVelocity;
+        if (distanceToWaypoint > 0.001f)
+        {
+            var direction = toWaypoint / distanceToWaypoint;
+
+            // Apply auto-braking near destination
+            float speed = agent.Speed;
+            if (agent.AutoBraking && state.CurrentWaypointIndex == path.Count - 1)
+            {
+                float brakingDistance = agent.StoppingDistance * 2f;
+                if (distanceToWaypoint < brakingDistance)
+                {
+                    speed *= distanceToWaypoint / brakingDistance;
+                }
+            }
+
+            desiredVelocity = direction * speed;
+        }
+        else
+        {
+            desiredVelocity = Vector3.Zero;
+        }
+
+        // Apply acceleration
+        var velocityDiff = desiredVelocity - agent.DesiredVelocity;
+        float maxChange = agent.Acceleration * deltaTime;
+        if (velocityDiff.LengthSquared() > maxChange * maxChange)
+        {
+            velocityDiff = Vector3.Normalize(velocityDiff) * maxChange;
+        }
+
+        agent.DesiredVelocity += velocityDiff;
+
+        // Move the agent
+        var movement = agent.DesiredVelocity * deltaTime;
+        transform.Position += movement;
+        state.DistanceTraveled += movement.Length();
+
+        // Update remaining distance
+        agent.RemainingDistance = CalculateRemainingDistance(
+            transform.Position,
+            path,
+            state.CurrentWaypointIndex);
+
+        // Check if we've arrived at the final destination
+        float distanceToFinal = Vector3.Distance(transform.Position, path.End.Position);
+        if (distanceToFinal <= agent.StoppingDistance)
+        {
+            CompleteNavigation(ref agent);
+        }
+    }
+
+    private static void CompleteNavigation(ref NavMeshAgent agent)
+    {
+        agent.HasPath = false;
+        agent.IsStopped = true;
+        agent.DesiredVelocity = Vector3.Zero;
+        agent.RemainingDistance = 0f;
+    }
+
+    private static float CalculateRemainingDistance(
+        Vector3 currentPosition,
+        Abstractions.NavPath path,
+        int currentWaypointIndex)
+    {
+        if (currentWaypointIndex >= path.Count)
+        {
+            return 0f;
+        }
+
+        // Distance to current waypoint
+        float distance = Vector3.Distance(currentPosition, path[currentWaypointIndex].Position);
+
+        // Add distances between remaining waypoints
+        for (int i = currentWaypointIndex + 1; i < path.Count; i++)
+        {
+            distance += path[i - 1].DistanceTo(path[i]);
+        }
+
+        return distance;
+    }
+}

--- a/src/KeenEyes.Navigation/Systems/ObstacleUpdateSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/ObstacleUpdateSystem.cs
@@ -1,0 +1,168 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Systems;
+
+/// <summary>
+/// System that synchronizes dynamic obstacles with navigation data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system tracks <see cref="NavMeshObstacle"/> components and updates
+/// navigation data when obstacles are added, moved, or removed. It runs
+/// in the LateUpdate phase after all movement is complete.
+/// </para>
+/// <para>
+/// The system uses a dirty tracking mechanism to avoid unnecessary updates:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Tracks obstacle positions from the previous frame</description></item>
+/// <item><description>Only triggers updates when obstacles move significantly</description></item>
+/// <item><description>Respects the configured update interval to prevent excessive recalculation</description></item>
+/// </list>
+/// </remarks>
+internal sealed class ObstacleUpdateSystem : SystemBase
+{
+    private NavigationContext? context;
+    private NavigationConfig? config;
+    private readonly Dictionary<Entity, ObstacleState> obstacleStates;
+    private float timeSinceLastUpdate;
+    private bool navigationDataDirty;
+
+    /// <summary>
+    /// Creates a new obstacle update system.
+    /// </summary>
+    public ObstacleUpdateSystem()
+    {
+        obstacleStates = [];
+    }
+
+    /// <inheritdoc/>
+    protected override void OnInitialize()
+    {
+        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        {
+            throw new InvalidOperationException("ObstacleUpdateSystem requires NavigationContext extension.");
+        }
+
+        context = ctx;
+        config = ctx.Config;
+    }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        if (context == null || config == null)
+        {
+            return;
+        }
+
+        timeSinceLastUpdate += deltaTime;
+
+        // Check for obstacle changes
+        CheckForObstacleChanges();
+
+        // Process updates if dirty and enough time has passed
+        if (navigationDataDirty && timeSinceLastUpdate >= config.ObstacleUpdateInterval)
+        {
+            ProcessObstacleUpdates();
+            timeSinceLastUpdate = 0f;
+            navigationDataDirty = false;
+        }
+    }
+
+    private void CheckForObstacleChanges()
+    {
+        // Track which obstacles are still active
+        var activeObstacles = new HashSet<Entity>();
+
+        foreach (var entity in World.Query<NavMeshObstacle, Transform3D>())
+        {
+            activeObstacles.Add(entity);
+
+            ref readonly var obstacle = ref World.Get<NavMeshObstacle>(entity);
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+
+            // Calculate obstacle world position
+            var worldPosition = transform.Position + obstacle.Center;
+
+            // Check if this is a new obstacle
+            if (!obstacleStates.TryGetValue(entity, out var state))
+            {
+                // New obstacle - add to tracking
+                obstacleStates[entity] = new ObstacleState
+                {
+                    LastPosition = worldPosition,
+                    LastRotation = transform.Rotation,
+                    IsCarving = obstacle.Carving
+                };
+
+                if (obstacle.Carving)
+                {
+                    navigationDataDirty = true;
+                }
+
+                continue;
+            }
+
+            // Check if the obstacle has moved significantly
+            if (obstacle.Carving)
+            {
+                float distanceMoved = Vector3.Distance(worldPosition, state.LastPosition);
+
+                if (distanceMoved >= obstacle.CarvingMoveThreshold)
+                {
+                    navigationDataDirty = true;
+                    state.LastPosition = worldPosition;
+                    state.LastRotation = transform.Rotation;
+                    obstacleStates[entity] = state;
+                }
+            }
+        }
+
+        // Check for removed obstacles
+        var removedObstacles = obstacleStates.Keys
+            .Where(e => !activeObstacles.Contains(e))
+            .ToList();
+
+        foreach (var entity in removedObstacles)
+        {
+            var state = obstacleStates[entity];
+            if (state.IsCarving)
+            {
+                navigationDataDirty = true;
+            }
+
+            obstacleStates.Remove(entity);
+        }
+    }
+
+    private void ProcessObstacleUpdates()
+    {
+        // In a full implementation, this would:
+        // 1. Collect all carving obstacles with their current transforms
+        // 2. Send them to the navigation provider for mesh updates
+        // 3. Invalidate affected paths
+
+        // For now, this is a stub that logs the update
+        // The actual navmesh carving would depend on the navigation provider implementation
+
+        // Note: Grid-based navigation doesn't need carving updates in the same way
+        // as navmesh navigation does. For grids, we could mark affected cells as blocked.
+    }
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        obstacleStates.Clear();
+        base.Dispose();
+    }
+
+    private struct ObstacleState
+    {
+        public Vector3 LastPosition;
+        public Quaternion LastRotation;
+        public bool IsCarving;
+    }
+}

--- a/src/KeenEyes.Navigation/Systems/PathRequestSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/PathRequestSystem.cs
@@ -1,0 +1,52 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Systems;
+
+/// <summary>
+/// System that processes asynchronous path requests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs early in the Update phase to process completed path requests
+/// before agent movement systems run. It:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Updates the navigation provider to process pending requests</description></item>
+/// <item><description>Checks for completed path requests and updates agent components</description></item>
+/// <item><description>Initializes agent navigation state when paths are ready</description></item>
+/// </list>
+/// </remarks>
+internal sealed class PathRequestSystem : SystemBase
+{
+    private NavigationContext? context;
+    private INavigationProvider? provider;
+
+    /// <inheritdoc/>
+    protected override void OnInitialize()
+    {
+        if (!World.TryGetExtension<NavigationContext>(out context))
+        {
+            throw new InvalidOperationException("PathRequestSystem requires NavigationContext extension.");
+        }
+
+        if (!World.TryGetExtension<INavigationProvider>(out provider))
+        {
+            throw new InvalidOperationException("PathRequestSystem requires INavigationProvider extension.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        if (context == null || provider == null)
+        {
+            return;
+        }
+
+        // Update the navigation provider to process pending path requests
+        provider.Update(deltaTime);
+
+        // Process completed requests and update agent components
+        context.ProcessPendingRequests();
+    }
+}

--- a/src/KeenEyes.Navigation/packages.lock.json
+++ b/src/KeenEyes.Navigation/packages.lock.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Navigation.Tests/KeenEyes.Navigation.Tests.csproj
+++ b/tests/KeenEyes.Navigation.Tests/KeenEyes.Navigation.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Common\KeenEyes.Common.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Navigation\KeenEyes.Navigation.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Navigation.Grid\KeenEyes.Navigation.Grid.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Navigation.Tests/NavigationConfigTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationConfigTests.cs
@@ -1,0 +1,226 @@
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Tests;
+
+/// <summary>
+/// Tests for NavigationConfig validation.
+/// </summary>
+public class NavigationConfigTests
+{
+    #region Default Configuration
+
+    [Fact]
+    public void Default_ReturnsValidConfig()
+    {
+        var config = NavigationConfig.Default;
+
+        var error = config.Validate();
+
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Default_HasExpectedDefaults()
+    {
+        var config = NavigationConfig.Default;
+
+        config.Strategy.ShouldBe(NavigationStrategy.Grid);
+        config.MaxPathRequestsPerFrame.ShouldBe(10);
+        config.MaxPendingRequests.ShouldBe(100);
+        config.AgentSteeringEnabled.ShouldBeTrue();
+        config.DynamicObstaclesEnabled.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region Strategy Validation
+
+    [Fact]
+    public void Validate_CustomStrategyWithoutProvider_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = null
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("CustomProvider");
+    }
+
+    #endregion
+
+    #region MaxPathRequestsPerFrame Validation
+
+    [Fact]
+    public void Validate_ZeroMaxPathRequestsPerFrame_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPathRequestsPerFrame = 0
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxPathRequestsPerFrame");
+    }
+
+    [Fact]
+    public void Validate_NegativeMaxPathRequestsPerFrame_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPathRequestsPerFrame = -5
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxPathRequestsPerFrame");
+    }
+
+    [Fact]
+    public void Validate_PositiveMaxPathRequestsPerFrame_Succeeds()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPathRequestsPerFrame = 50
+        };
+
+        var error = config.Validate();
+
+        error.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region MaxPendingRequests Validation
+
+    [Fact]
+    public void Validate_ZeroMaxPendingRequests_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPendingRequests = 0
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxPendingRequests");
+    }
+
+    [Fact]
+    public void Validate_NegativeMaxPendingRequests_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPendingRequests = -10
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxPendingRequests");
+    }
+
+    #endregion
+
+    #region WaypointReachDistance Validation
+
+    [Fact]
+    public void Validate_ZeroWaypointReachDistance_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            WaypointReachDistance = 0f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("WaypointReachDistance");
+    }
+
+    [Fact]
+    public void Validate_NegativeWaypointReachDistance_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            WaypointReachDistance = -0.5f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("WaypointReachDistance");
+    }
+
+    #endregion
+
+    #region ObstacleUpdateInterval Validation
+
+    [Fact]
+    public void Validate_ZeroObstacleUpdateInterval_Succeeds()
+    {
+        var config = new NavigationConfig
+        {
+            ObstacleUpdateInterval = 0f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Validate_NegativeObstacleUpdateInterval_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            ObstacleUpdateInterval = -0.1f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("ObstacleUpdateInterval");
+    }
+
+    #endregion
+
+    #region MaxProjectionDistance Validation
+
+    [Fact]
+    public void Validate_ZeroMaxProjectionDistance_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxProjectionDistance = 0f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxProjectionDistance");
+    }
+
+    [Fact]
+    public void Validate_NegativeMaxProjectionDistance_ReturnsError()
+    {
+        var config = new NavigationConfig
+        {
+            MaxProjectionDistance = -5f
+        };
+
+        var error = config.Validate();
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("MaxProjectionDistance");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Tests/NavigationContextTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationContextTests.cs
@@ -1,0 +1,304 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Grid;
+
+namespace KeenEyes.Navigation.Tests;
+
+/// <summary>
+/// Tests for NavigationContext API.
+/// </summary>
+public class NavigationContextTests : IDisposable
+{
+    private readonly World world;
+    private readonly NavigationContext context;
+
+    public NavigationContextTests()
+    {
+        world = new World();
+
+        // Install grid navigation provider
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        world.InstallPlugin(new GridNavigationPlugin(gridConfig));
+
+        // Install navigation plugin
+        world.InstallPlugin(new NavigationPlugin());
+
+        context = world.GetExtension<NavigationContext>();
+    }
+
+    public void Dispose()
+    {
+        world.Dispose();
+    }
+
+    #region Properties
+
+    [Fact]
+    public void IsReady_WhenProviderReady_ReturnsTrue()
+    {
+        context.IsReady.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Strategy_ReturnsProviderStrategy()
+    {
+        context.Strategy.ShouldBe(NavigationStrategy.Grid);
+    }
+
+    [Fact]
+    public void Config_ReturnsPluginConfig()
+    {
+        context.Config.ShouldNotBeNull();
+    }
+
+    #endregion
+
+    #region SetDestination Tests
+
+    [Fact]
+    public void SetDestination_WithValidEntity_RequestsPath()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+
+        context.PendingRequestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void SetDestination_WithoutNavMeshAgent_ThrowsInvalidOperationException()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        Should.Throw<InvalidOperationException>(() =>
+            context.SetDestination(entity, new Vector3(10, 0, 10)));
+    }
+
+    [Fact]
+    public void SetDestination_UpdatesAgentComponent()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        var destination = new Vector3(10, 0, 10);
+        context.SetDestination(entity, destination);
+
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.Destination.ShouldBe(destination);
+        agent.PathPending.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetDestination_CalledTwice_CancelsPreviousRequest()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        context.SetDestination(entity, new Vector3(20, 0, 20));
+
+        // Should only have one pending request
+        context.PendingRequestCount.ShouldBe(1);
+    }
+
+    #endregion
+
+    #region Stop Tests
+
+    [Fact]
+    public void Stop_WithValidEntity_StopsAgent()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        context.Stop(entity);
+
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.IsStopped.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Stop_WithoutNavMeshAgent_ThrowsInvalidOperationException()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        Should.Throw<InvalidOperationException>(() => context.Stop(entity));
+    }
+
+    [Fact]
+    public void Stop_CancelsPendingPathRequest()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        context.PendingRequestCount.ShouldBe(1);
+
+        context.Stop(entity);
+        context.PendingRequestCount.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region Resume Tests
+
+    [Fact]
+    public void Resume_WithStoppedAgentWithPath_ResumesMovement()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        // Request a path and process it
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        world.Update(0.016f); // Process path request
+
+        // Now stop and resume
+        context.Stop(entity);
+
+        // Give the agent a path again for resume to work
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        world.Update(0.016f); // Process path request
+
+        context.Stop(entity);
+        ref var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.IsStopped.ShouldBeTrue();
+
+        // Resume only works if agent has a path
+        // First we need to ensure agent has a path set
+        agent.HasPath = true;
+        context.Resume(entity);
+
+        ref readonly var agentAfter = ref world.Get<NavMeshAgent>(entity);
+        agentAfter.IsStopped.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Resume_WithoutPath_DoesNotResume()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        // Stop without setting a destination (no path)
+        context.Stop(entity);
+        context.Resume(entity);
+
+        // Agent should still be stopped because Resume only resumes if HasPath is true
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.IsStopped.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Resume_WithoutNavMeshAgent_DoesNotThrow()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        // Should not throw - just returns early
+        context.Resume(entity);
+    }
+
+    #endregion
+
+    #region Query Tests
+
+    [Fact]
+    public void FindPath_ReturnsPath()
+    {
+        var path = context.FindPath(
+            Vector3.Zero,
+            new Vector3(10, 0, 10),
+            AgentSettings.Default);
+
+        path.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequestPath_ReturnsPathRequest()
+    {
+        var request = context.RequestPath(
+            Vector3.Zero,
+            new Vector3(10, 0, 10),
+            AgentSettings.Default);
+
+        request.ShouldNotBeNull();
+        request.Status.ShouldBe(PathRequestStatus.Pending);
+    }
+
+    [Fact]
+    public void IsNavigable_WithValidPosition_ReturnsTrue()
+    {
+        var isNavigable = context.IsNavigable(Vector3.Zero, AgentSettings.Default);
+
+        isNavigable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Raycast_WithClearPath_ReturnsFalse()
+    {
+        var hit = context.Raycast(Vector3.Zero, new Vector3(10, 0, 10), out var hitPosition);
+
+        hit.ShouldBeFalse();
+        hitPosition.ShouldBe(new Vector3(10, 0, 10));
+    }
+
+    #endregion
+
+    #region Agent State Tests
+
+    [Fact]
+    public void ActiveAgentCount_ReturnsCorrectCount()
+    {
+        context.ActiveAgentCount.ShouldBe(0);
+
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+
+        // Process the request
+        world.Update(0.016f);
+
+        // Agent should have state now (path completed)
+        context.ActiveAgentCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TryGetAgentState_WithNoPath_ReturnsFalse()
+    {
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        var result = context.TryGetAgentState(entity, out _);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
@@ -1,0 +1,302 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Grid;
+using KeenEyes.Testing.Plugins;
+
+namespace KeenEyes.Navigation.Tests;
+
+/// <summary>
+/// Tests for NavigationPlugin integration with the World.
+/// </summary>
+public class NavigationPluginTests : IDisposable
+{
+    private World? world;
+
+    public void Dispose()
+    {
+        world?.Dispose();
+    }
+
+    #region Installation Tests
+
+    [Fact]
+    public void Install_WithGridProvider_Succeeds()
+    {
+        world = new World();
+
+        // Install grid navigation provider first
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        world.InstallPlugin(new GridNavigationPlugin(gridConfig));
+
+        // Then install the navigation plugin
+        world.InstallPlugin(new NavigationPlugin());
+
+        // Should have both extensions
+        world.TryGetExtension<NavigationContext>(out _).ShouldBeTrue();
+        world.TryGetExtension<INavigationProvider>(out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithCustomProvider_Succeeds()
+    {
+        world = new World();
+
+        // Create a custom provider
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider
+        };
+
+        // Install with custom provider - should not throw
+        world.InstallPlugin(new NavigationPlugin(config));
+
+        world.TryGetExtension<NavigationContext>(out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithInvalidConfig_ThrowsArgumentException()
+    {
+        var config = new NavigationConfig
+        {
+            MaxPathRequestsPerFrame = 0 // Invalid
+        };
+
+        var ex = Should.Throw<ArgumentException>(() => new NavigationPlugin(config));
+        ex.Message.ShouldContain("Invalid NavigationConfig");
+    }
+
+    [Fact]
+    public void Install_WithoutProvider_ThrowsInvalidOperationException()
+    {
+        world = new World();
+
+        // No provider installed - should throw
+        Should.Throw<InvalidOperationException>(() =>
+            world.InstallPlugin(new NavigationPlugin()));
+    }
+
+    #endregion
+
+    #region Uninstallation Tests
+
+    [Fact]
+    public void Uninstall_RemovesExtensions()
+    {
+        world = new World();
+
+        // Setup
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        world.InstallPlugin(new GridNavigationPlugin(gridConfig));
+        world.InstallPlugin(new NavigationPlugin());
+
+        world.TryGetExtension<NavigationContext>(out _).ShouldBeTrue();
+
+        // Uninstall
+        world.UninstallPlugin<NavigationPlugin>();
+
+        world.TryGetExtension<NavigationContext>(out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Uninstall_DisposesContext()
+    {
+        world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        world.InstallPlugin(new GridNavigationPlugin(gridConfig));
+        world.InstallPlugin(new NavigationPlugin());
+
+        var context = world.GetExtension<NavigationContext>();
+
+        // Add an agent to trigger state creation
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+        context.PendingRequestCount.ShouldBeGreaterThan(0);
+
+        // Uninstall should dispose context and cancel pending requests
+        world.UninstallPlugin<NavigationPlugin>();
+
+        // Extension should be gone
+        world.TryGetExtension<NavigationContext>(out _).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Component Registration Tests
+
+    [Fact]
+    public void Install_RegistersNavMeshAgentComponent()
+    {
+        using var world = new World();
+
+        // Use custom provider to avoid dependency on GridNavigationPlugin
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasComponentRegistered<NavMeshAgent>().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_RegistersNavMeshObstacleComponent()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasComponentRegistered<NavMeshObstacle>().ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region System Registration Tests
+
+    [Fact]
+    public void Install_RegistersPathRequestSystem()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasSystemRegistered<Systems.PathRequestSystem>().ShouldBeTrue();
+        context.WasSystemRegisteredAtPhase<Systems.PathRequestSystem>(SystemPhase.Update).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithSteeringEnabled_RegistersNavMeshAgentSystem()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider,
+            AgentSteeringEnabled = true
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasSystemRegistered<Systems.NavMeshAgentSystem>().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithSteeringDisabled_DoesNotRegisterNavMeshAgentSystem()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider,
+            AgentSteeringEnabled = false
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasSystemRegistered<Systems.NavMeshAgentSystem>().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Install_WithDynamicObstaclesEnabled_RegistersObstacleUpdateSystem()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider,
+            DynamicObstaclesEnabled = true
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasSystemRegistered<Systems.ObstacleUpdateSystem>().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithDynamicObstaclesDisabled_DoesNotRegisterObstacleUpdateSystem()
+    {
+        using var world = new World();
+
+        var gridConfig = GridConfig.WithSize(100, 100, 1f);
+        var customProvider = new GridNavigationProvider(gridConfig);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider,
+            DynamicObstaclesEnabled = false
+        };
+
+        var plugin = new NavigationPlugin(config);
+        var context = new MockPluginContext(plugin, world);
+
+        plugin.Install(context);
+
+        context.WasSystemRegistered<Systems.ObstacleUpdateSystem>().ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.Tests/packages.lock.json
+++ b/tests/KeenEyes.Navigation.Tests/packages.lock.json
@@ -1,0 +1,272 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "HCfw7V1yuKxnm89vVKrb8b6aug96PUgxN9Z0YthEFCR8JOfTJF4XcU1i6RX2eEB08p3zriuFIG7BGXns4PyE8Q=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.1.0, )",
+        "resolved": "18.1.0",
+        "contentHash": "FJUCocHSPSjbeoGE/OojOhVUXwDng3VdNlwqzif9hMS2eFcG0f8RdjLM537aBsjP7zLHvGnWXbnUnc61v/EFCA==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "6.0.2",
+          "Microsoft.Testing.Platform": "2.0.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "6Tz2wZTNH/3hiskarOM5X9JaHV0QpIdIvEiLv6BJeJvtPS6AY+S47rg4K+czGSjQTkIgu5kT9SgZOwbfdhDD9Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "43NCOTEENtdc9fmlzX9KHQR14AZEYek5r4jOJlWPhTyV1+aYAQYl4x773nYXU5TKxV6+rMuniJ7wcj9C9qrP1A=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.1, )",
+        "resolved": "3.2.1",
+        "contentHash": "QnT7C+eEUM7ut6w4/RNPpSxE1Q9epiCNWf8Krc/vqcc+sc3Ejtl8lbf4w5DzBYWLUlkEEUr1u9czG0Qj7QK6IQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.26.0",
+          "xunit.v3.assert": "[3.2.1]",
+          "xunit.v3.core.mtp-v2": "[3.2.1]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QcZrCETsBJqy/vQpFtJc+jSXQ0K5sucQ6NUFbTNVHD4vfZZOwjZ/3sBzczkC4DityhD3AVO/+K/+9ioLs1AgRA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "HS5YsudCGSVoCVdsYJ5FAO9vx0z04qSAXgVzpDJSQ1/w/X9q8hrQVGU2p+Yfui+2KcXLL+Zjc0SX3yJWtBmYiw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.26.0",
+        "contentHash": "YrWZOfuU1Scg4iGizAlMNALOxVS+HPSVilfscNDEJAyrTIVdF4c+8o+Aerw2RYnrJxafj/F56YkJOKCURUWQmA=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "7hGxs+sfgPCiHg7CbWL8Vsmg8WS4vBfipZ7rfE+FEyS7ksU4+0vcV08TQvLIXLPAfinT06zVoK83YjRcMXcXLw=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "NUh3pPTC3Py4XTnjoCCCIEzvdKTQ9apu0ikDNCrUETBtfHHXcoUmIl5bOfJLQQu7awhu8eaZHjJnG7rx9lUZpg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EX7lPHnlJQYGj092TE+I7bw/iT9eYA+JcqRg0+31tSPgQqBhmOSxTT7YIfU6zFHo4ak4F/TPz3GjmvweJT1zZw==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.inproc.console": "[3.2.1]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "soZuThF5CwB/ZZ2HY/ivdinyM/6MvmjsHTG0vNw3fRd1ZKcmLzfxVb3fB6R3G5yoaN4Bh+aWzFGjOvYO05OzkA==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "oF0jwl0xH45/RWjDcaCPOeeI6HCoyiEXIT8yvByd37rhJorjL/Ri8S9A/Vql8DBPjCfQWd6Url5JRmeiQ55isA==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EC/VLj1E9BPWfmzdEMQEqouxh0rWAdX6SXuiiDRf0yXXsQo3E2PNLKCyJ9V8hmkGH/nBvM7pHLFbuCf00vCynw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.common": "[3.2.1]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project"
+      },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.grid": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add NavigationPlugin implementing IWorldPlugin for integrating pathfinding with ECS
- Implement NavigationConfig for strategy selection (Grid/NavMesh/Custom) and request throttling
- Create NavigationContext extension API with SetDestination/Stop/Resume methods
- Add PathRequestSystem, NavMeshAgentSystem, and ObstacleUpdateSystem for agent movement

## Test plan
- [x] Unit tests for NavigationConfig validation (46 tests passing)
- [x] Integration tests for plugin installation/uninstallation
- [x] Tests for NavigationContext API methods
- [x] Build passes with zero warnings

Closes #640