### PR TITLE
feat: Deprecate PrefabManager in favor of source-generated spawn methods

### DIFF
--- a/editor/KeenEyes.Generators/SceneGenerator.cs
+++ b/editor/KeenEyes.Generators/SceneGenerator.cs
@@ -347,8 +347,15 @@ public sealed class SceneGenerator : IIncrementalGenerator
                 rootVarName = varName;
             }
 
-            // Generate entity spawn code
-            sb.AppendLine($"        var {varName} = world.Spawn(\"{EscapeString(entity.Name)}\")");
+            // Generate entity spawn code (only pass name if specified)
+            if (string.IsNullOrEmpty(entity.Name))
+            {
+                sb.AppendLine($"        var {varName} = world.Spawn()");
+            }
+            else
+            {
+                sb.AppendLine($"        var {varName} = world.Spawn(\"{EscapeString(entity.Name)}\")");
+            }
 
             foreach (var kvp in entity.Components)
             {

--- a/samples/KeenEyes.Sample.Prefabs/KeenEyes.Sample.Prefabs.csproj
+++ b/samples/KeenEyes.Sample.Prefabs/KeenEyes.Sample.Prefabs.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="Prefabs\*.keprefab" />
+  </ItemGroup>
+
 </Project>

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/BasicEnemy.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/BasicEnemy.keprefab
@@ -1,0 +1,14 @@
+{
+  "name": "BasicEnemy",
+  "version": 1,
+  "root": {
+    "id": "enemy",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Velocity": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Health": { "Current": 50, "Max": 50 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "enemy_basic.png", "Layer": 1 },
+      "KeenEyes.Sample.Prefabs.Enemy": {}
+    }
+  }
+}

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/BossEnemy.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/BossEnemy.keprefab
@@ -1,0 +1,16 @@
+{
+  "name": "BossEnemy",
+  "version": 1,
+  "root": {
+    "id": "boss-enemy",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Velocity": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Health": { "Current": 500, "Max": 500 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "boss.png", "Layer": 5 },
+      "KeenEyes.Sample.Prefabs.Damage": { "Amount": 25, "Range": 3 },
+      "KeenEyes.Sample.Prefabs.Enemy": {},
+      "KeenEyes.Sample.Prefabs.Boss": {}
+    }
+  }
+}

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/Coin.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/Coin.keprefab
@@ -1,0 +1,12 @@
+{
+  "name": "Coin",
+  "version": 1,
+  "root": {
+    "id": "coin",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "coin.png", "Layer": 0 },
+      "KeenEyes.Sample.Prefabs.Collectible": {}
+    }
+  }
+}

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/FlyingBoss.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/FlyingBoss.keprefab
@@ -1,0 +1,18 @@
+{
+  "name": "FlyingBoss",
+  "version": 1,
+  "root": {
+    "id": "flying-boss",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Velocity": { "X": 0, "Y": -2 },
+      "KeenEyes.Sample.Prefabs.Health": { "Current": 750, "Max": 750 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "enemy_basic.png", "Layer": 1 },
+      "KeenEyes.Sample.Prefabs.AIBehavior": { "DetectionRange": 150, "AttackCooldown": 0 },
+      "KeenEyes.Sample.Prefabs.Damage": { "Amount": 40, "Range": 5 },
+      "KeenEyes.Sample.Prefabs.Enemy": {},
+      "KeenEyes.Sample.Prefabs.Flying": {},
+      "KeenEyes.Sample.Prefabs.Boss": {}
+    }
+  }
+}

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/FlyingEnemy.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/FlyingEnemy.keprefab
@@ -1,0 +1,16 @@
+{
+  "name": "FlyingEnemy",
+  "version": 1,
+  "root": {
+    "id": "flying-enemy",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Velocity": { "X": 0, "Y": -2 },
+      "KeenEyes.Sample.Prefabs.Health": { "Current": 50, "Max": 50 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "enemy_basic.png", "Layer": 1 },
+      "KeenEyes.Sample.Prefabs.AIBehavior": { "DetectionRange": 150, "AttackCooldown": 0 },
+      "KeenEyes.Sample.Prefabs.Enemy": {},
+      "KeenEyes.Sample.Prefabs.Flying": {}
+    }
+  }
+}

--- a/samples/KeenEyes.Sample.Prefabs/Prefabs/Player.keprefab
+++ b/samples/KeenEyes.Sample.Prefabs/Prefabs/Player.keprefab
@@ -1,0 +1,14 @@
+{
+  "name": "Player",
+  "version": 1,
+  "root": {
+    "id": "player",
+    "components": {
+      "KeenEyes.Sample.Prefabs.Position": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Velocity": { "X": 0, "Y": 0 },
+      "KeenEyes.Sample.Prefabs.Health": { "Current": 100, "Max": 100 },
+      "KeenEyes.Sample.Prefabs.Sprite": { "TextureId": "player.png", "Layer": 10 },
+      "KeenEyes.Sample.Prefabs.Player": {}
+    }
+  }
+}

--- a/src/KeenEyes.Abstractions/Capabilities/IPrefabCapability.cs
+++ b/src/KeenEyes.Abstractions/Capabilities/IPrefabCapability.cs
@@ -34,6 +34,7 @@ namespace KeenEyes.Capabilities;
 /// }
 /// </code>
 /// </example>
+[Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
 public interface IPrefabCapability
 {
     /// <summary>

--- a/src/KeenEyes.Abstractions/Prefabs/EntityPrefab.cs
+++ b/src/KeenEyes.Abstractions/Prefabs/EntityPrefab.cs
@@ -24,6 +24,7 @@ namespace KeenEyes;
 /// </code>
 /// </example>
 /// </remarks>
+[Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
 public sealed class EntityPrefab
 {
     private readonly List<ComponentDefinition> components = [];
@@ -134,4 +135,5 @@ public sealed class EntityPrefab
 /// <param name="Type">The CLR type of the component.</param>
 /// <param name="Data">The component data (boxed struct).</param>
 /// <param name="IsTag">Whether this is a tag component.</param>
+[Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
 public readonly record struct ComponentDefinition(Type Type, object Data, bool IsTag);

--- a/src/KeenEyes.Core/Prefabs/PrefabManager.cs
+++ b/src/KeenEyes.Core/Prefabs/PrefabManager.cs
@@ -17,6 +17,7 @@ namespace KeenEyes;
 /// concurrently from multiple threads.
 /// </para>
 /// </remarks>
+[Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
 internal sealed class PrefabManager
 {
     private readonly Lock syncRoot = new();

--- a/src/KeenEyes.Core/World.Prefabs.cs
+++ b/src/KeenEyes.Core/World.Prefabs.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete - internal usage of deprecated PrefabManager
+
 namespace KeenEyes;
 
 public sealed partial class World
@@ -44,6 +46,7 @@ public sealed partial class World
     /// <seealso cref="SpawnFromPrefab(string)"/>
     /// <seealso cref="SpawnFromPrefab(string, string?)"/>
     /// <seealso cref="HasPrefab(string)"/>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public void RegisterPrefab(string name, EntityPrefab prefab)
         => prefabManager.Register(name, prefab);
 
@@ -84,6 +87,7 @@ public sealed partial class World
     /// </example>
     /// <seealso cref="RegisterPrefab(string, EntityPrefab)"/>
     /// <seealso cref="SpawnFromPrefab(string, string?)"/>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public IEntityBuilder SpawnFromPrefab(string name)
         => prefabManager.SpawnFromPrefab(name);
 
@@ -126,6 +130,7 @@ public sealed partial class World
     /// <seealso cref="RegisterPrefab(string, EntityPrefab)"/>
     /// <seealso cref="SpawnFromPrefab(string)"/>
     /// <seealso cref="GetEntityByName(string)"/>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public IEntityBuilder SpawnFromPrefab(string prefabName, string? entityName)
         => prefabManager.SpawnFromPrefab(prefabName, entityName);
 
@@ -143,6 +148,7 @@ public sealed partial class World
     /// }
     /// </code>
     /// </example>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public bool HasPrefab(string name)
         => prefabManager.HasPrefab(name);
 
@@ -156,6 +162,7 @@ public sealed partial class World
     /// Unregistering a prefab does not affect entities that were already spawned from it.
     /// Those entities continue to exist with their components intact.
     /// </remarks>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public bool UnregisterPrefab(string name)
         => prefabManager.Unregister(name);
 
@@ -166,6 +173,7 @@ public sealed partial class World
     /// <remarks>
     /// The returned names are in no particular order.
     /// </remarks>
+    [Obsolete("Runtime prefabs are deprecated. Use .keprefab files with source-generated spawn methods instead. See docs/prefabs.md for migration guidance.")]
     public IEnumerable<string> GetAllPrefabNames()
         => prefabManager.GetAllPrefabNames();
 

--- a/src/KeenEyes.Core/World.cs
+++ b/src/KeenEyes.Core/World.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete - World implements deprecated IPrefabCapability for backwards compatibility
+
 using KeenEyes.Capabilities;
 using KeenEyes.Events;
 

--- a/src/KeenEyes.Testing/Capabilities/MockPrefabCapability.cs
+++ b/src/KeenEyes.Testing/Capabilities/MockPrefabCapability.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete - mock for deprecated prefab API
+
 using KeenEyes.Capabilities;
 
 namespace KeenEyes.Testing.Capabilities;

--- a/tests/KeenEyes.Core.Tests/PrefabTests.cs
+++ b/tests/KeenEyes.Core.Tests/PrefabTests.cs
@@ -1,8 +1,15 @@
+#pragma warning disable CS0618 // Type or member is obsolete - testing deprecated prefab API
+
 namespace KeenEyes.Tests;
 
 /// <summary>
 /// Tests for the prefab system (reusable entity templates).
 /// </summary>
+/// <remarks>
+/// Note: The runtime prefab API is deprecated in favor of .keprefab files with
+/// source-generated spawn methods. These tests ensure the deprecated API remains
+/// functional for backwards compatibility.
+/// </remarks>
 public class PrefabTests
 {
     #region Test Components

--- a/tests/KeenEyes.Testing.Tests/Capabilities/MockPrefabCapabilityTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Capabilities/MockPrefabCapabilityTests.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618 // Type or member is obsolete - testing deprecated prefab API
+
 using KeenEyes.Testing.Capabilities;
 
 namespace KeenEyes.Testing.Tests.Capabilities;


### PR DESCRIPTION
## Summary
- Mark all runtime prefab APIs (`EntityPrefab`, `PrefabManager`, `IPrefabCapability`, `World.Prefabs.cs` methods) with `[Obsolete]` attribute
- Create `.keprefab` sample files demonstrating the recommended approach (BasicEnemy, Coin, FlyingEnemy, BossEnemy, FlyingBoss, Player)
- Fix SceneGenerator to use `world.Spawn()` when entity name is empty/null (prevents duplicate name conflicts when spawning multiple entities from same prefab)
- Update `docs/prefabs.md` with deprecation notice and migration guide

## Test plan
- [x] Build passes with zero warnings/errors
- [x] All Core tests pass (2237 tests)
- [x] All Generator tests pass (397 tests)
- [x] Sample runs successfully demonstrating both source-generated and deprecated approaches

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)