### PR TITLE
feat: Add graph editor foundation (Phase 1)

### DIFF
--- a/src/KeenEyes.Graph.Abstractions/Components/GraphCanvas.cs
+++ b/src/KeenEyes.Graph.Abstractions/Components/GraphCanvas.cs
@@ -1,0 +1,68 @@
+using System.Numerics;
+
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Container component for a graph editing canvas.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A graph canvas is the root entity for a graph node editor. It stores the pan/zoom
+/// state and interaction mode. All graph nodes and connections are children of a canvas.
+/// </para>
+/// <para>
+/// The coordinate system uses canvas coordinates where (0,0) is the initial center.
+/// Pan and zoom transform between canvas and screen coordinates.
+/// </para>
+/// </remarks>
+public struct GraphCanvas : IComponent
+{
+    /// <summary>
+    /// The pan offset in canvas coordinates.
+    /// </summary>
+    public Vector2 Pan;
+
+    /// <summary>
+    /// The zoom level (1.0 = 100%).
+    /// </summary>
+    public float Zoom;
+
+    /// <summary>
+    /// The minimum allowed zoom level.
+    /// </summary>
+    public float MinZoom;
+
+    /// <summary>
+    /// The maximum allowed zoom level.
+    /// </summary>
+    public float MaxZoom;
+
+    /// <summary>
+    /// The grid spacing in canvas units.
+    /// </summary>
+    public float GridSize;
+
+    /// <summary>
+    /// Whether to snap nodes to the grid when dragging.
+    /// </summary>
+    public bool SnapToGrid;
+
+    /// <summary>
+    /// The current interaction mode.
+    /// </summary>
+    public GraphInteractionMode Mode;
+
+    /// <summary>
+    /// Creates a canvas with default settings.
+    /// </summary>
+    public static GraphCanvas Default => new()
+    {
+        Pan = Vector2.Zero,
+        Zoom = 1.0f,
+        MinZoom = 0.25f,
+        MaxZoom = 4.0f,
+        GridSize = 20f,
+        SnapToGrid = false,
+        Mode = GraphInteractionMode.None
+    };
+}

--- a/src/KeenEyes.Graph.Abstractions/Components/GraphConnection.cs
+++ b/src/KeenEyes.Graph.Abstractions/Components/GraphConnection.cs
@@ -1,0 +1,69 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Component for a connection between two graph nodes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Connections link an output port on one node to an input port on another.
+/// The connection entity is a child of the canvas and rendered as a line
+/// (or bezier curve in later phases).
+/// </para>
+/// <para>
+/// Port indices reference the port definitions in the port registry for each
+/// node's type.
+/// </para>
+/// </remarks>
+public struct GraphConnection : IComponent
+{
+    /// <summary>
+    /// The source node entity (has the output port).
+    /// </summary>
+    public Entity SourceNode;
+
+    /// <summary>
+    /// Index of the output port on the source node.
+    /// </summary>
+    public int SourcePortIndex;
+
+    /// <summary>
+    /// The target node entity (has the input port).
+    /// </summary>
+    public Entity TargetNode;
+
+    /// <summary>
+    /// Index of the input port on the target node.
+    /// </summary>
+    public int TargetPortIndex;
+
+    /// <summary>
+    /// Reference to the parent canvas entity.
+    /// </summary>
+    public Entity Canvas;
+
+    /// <summary>
+    /// Creates a connection between two nodes.
+    /// </summary>
+    /// <param name="sourceNode">The source node entity.</param>
+    /// <param name="sourcePort">The output port index on the source.</param>
+    /// <param name="targetNode">The target node entity.</param>
+    /// <param name="targetPort">The input port index on the target.</param>
+    /// <param name="canvas">The parent canvas entity.</param>
+    /// <returns>A new connection component.</returns>
+    public static GraphConnection Create(
+        Entity sourceNode,
+        int sourcePort,
+        Entity targetNode,
+        int targetPort,
+        Entity canvas)
+    {
+        return new()
+        {
+            SourceNode = sourceNode,
+            SourcePortIndex = sourcePort,
+            TargetNode = targetNode,
+            TargetPortIndex = targetPort,
+            Canvas = canvas
+        };
+    }
+}

--- a/src/KeenEyes.Graph.Abstractions/Components/GraphNode.cs
+++ b/src/KeenEyes.Graph.Abstractions/Components/GraphNode.cs
@@ -1,0 +1,73 @@
+using System.Numerics;
+
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Component for a graph node entity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Graph nodes are positioned in canvas coordinates and rendered as rounded rectangles
+/// with a title bar and ports. The node type determines available ports via the
+/// port registry.
+/// </para>
+/// <para>
+/// Node height is calculated dynamically based on the number of ports. Width is
+/// fixed but can be customized per node type.
+/// </para>
+/// </remarks>
+public struct GraphNode : IComponent
+{
+    /// <summary>
+    /// Position in canvas coordinates (top-left corner).
+    /// </summary>
+    public Vector2 Position;
+
+    /// <summary>
+    /// Width of the node in canvas units.
+    /// </summary>
+    public float Width;
+
+    /// <summary>
+    /// Height of the node in canvas units (calculated by layout system).
+    /// </summary>
+    public float Height;
+
+    /// <summary>
+    /// The node type ID for port registry lookup.
+    /// </summary>
+    public int NodeTypeId;
+
+    /// <summary>
+    /// Reference to the parent canvas entity.
+    /// </summary>
+    public Entity Canvas;
+
+    /// <summary>
+    /// Display name for this node instance.
+    /// </summary>
+    /// <remarks>
+    /// If null, the node type name from the registry is used.
+    /// </remarks>
+    public string? DisplayName;
+
+    /// <summary>
+    /// Creates a node with default settings at the specified position.
+    /// </summary>
+    /// <param name="position">The canvas position.</param>
+    /// <param name="nodeTypeId">The node type ID.</param>
+    /// <param name="canvas">The parent canvas entity.</param>
+    /// <returns>A new graph node component.</returns>
+    public static GraphNode Create(Vector2 position, int nodeTypeId, Entity canvas)
+    {
+        return new()
+        {
+            Position = position,
+            Width = 200f,
+            Height = 0f, // Calculated by layout
+            NodeTypeId = nodeTypeId,
+            Canvas = canvas,
+            DisplayName = null
+        };
+    }
+}

--- a/src/KeenEyes.Graph.Abstractions/KeenEyes.Graph.Abstractions.csproj
+++ b/src/KeenEyes.Graph.Abstractions/KeenEyes.Graph.Abstractions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>KeenEyes.Graph.Abstractions</PackageId>
+    <Description>Graph node editor abstractions for KeenEyes</Description>
+    <PackageTags>ecs;graph;nodes;editor;abstractions</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/KeenEyes.Graph.Abstractions/Tags/GraphTags.cs
+++ b/src/KeenEyes.Graph.Abstractions/Tags/GraphTags.cs
@@ -1,0 +1,21 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Marks an entity as a graph canvas root.
+/// </summary>
+public struct GraphCanvasTag : ITagComponent;
+
+/// <summary>
+/// Marks a graph node as currently selected.
+/// </summary>
+public struct GraphNodeSelectedTag : ITagComponent;
+
+/// <summary>
+/// Marks a graph connection as currently selected.
+/// </summary>
+public struct GraphConnectionSelectedTag : ITagComponent;
+
+/// <summary>
+/// Marks a graph node as being actively dragged.
+/// </summary>
+public struct GraphNodeDraggingTag : ITagComponent;

--- a/src/KeenEyes.Graph.Abstractions/Types/GraphInteractionMode.cs
+++ b/src/KeenEyes.Graph.Abstractions/Types/GraphInteractionMode.cs
@@ -1,0 +1,22 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Current interaction mode for a graph canvas.
+/// </summary>
+public enum GraphInteractionMode
+{
+    /// <summary>No active interaction.</summary>
+    None,
+
+    /// <summary>User is panning the canvas.</summary>
+    Panning,
+
+    /// <summary>User is drawing a selection box.</summary>
+    Selecting,
+
+    /// <summary>User is dragging one or more nodes.</summary>
+    DraggingNode,
+
+    /// <summary>User is creating a connection by dragging from a port.</summary>
+    ConnectingPort
+}

--- a/src/KeenEyes.Graph.Abstractions/Types/PortDefinition.cs
+++ b/src/KeenEyes.Graph.Abstractions/Types/PortDefinition.cs
@@ -1,0 +1,53 @@
+using System.Numerics;
+
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Defines a port on a graph node type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ports are not entities - they are defined in a registry and referenced by index.
+/// Each node type has a fixed set of port definitions that describe the available
+/// inputs and outputs.
+/// </para>
+/// <para>
+/// The <see cref="LocalOffset"/> is relative to the node's bounds. Input ports
+/// are typically positioned on the left edge, output ports on the right.
+/// </para>
+/// </remarks>
+/// <param name="Name">The display name of the port.</param>
+/// <param name="Direction">Whether this port receives or sends data.</param>
+/// <param name="TypeId">The data type of the port.</param>
+/// <param name="LocalOffset">Position offset relative to the node origin.</param>
+/// <param name="AllowMultiple">Whether multiple connections are allowed (inputs only).</param>
+public readonly record struct PortDefinition(
+    string Name,
+    PortDirection Direction,
+    PortTypeId TypeId,
+    Vector2 LocalOffset,
+    bool AllowMultiple = false
+)
+{
+    /// <summary>
+    /// Creates an input port definition.
+    /// </summary>
+    /// <param name="name">The display name.</param>
+    /// <param name="typeId">The data type.</param>
+    /// <param name="yOffset">The vertical offset from node top.</param>
+    /// <param name="allowMultiple">Whether multiple connections are allowed.</param>
+    /// <returns>A new port definition.</returns>
+    public static PortDefinition Input(string name, PortTypeId typeId, float yOffset, bool allowMultiple = false)
+        => new(name, PortDirection.Input, typeId, new Vector2(0, yOffset), allowMultiple);
+
+    /// <summary>
+    /// Creates an output port definition.
+    /// </summary>
+    /// <param name="name">The display name.</param>
+    /// <param name="typeId">The data type.</param>
+    /// <param name="yOffset">The vertical offset from node top.</param>
+    /// <param name="nodeWidth">The node width (for right-edge positioning).</param>
+    /// <returns>A new port definition.</returns>
+    public static PortDefinition Output(string name, PortTypeId typeId, float yOffset, float nodeWidth = 200f)
+        => new(name, PortDirection.Output, typeId, new Vector2(nodeWidth, yOffset), false);
+}

--- a/src/KeenEyes.Graph.Abstractions/Types/PortDirection.cs
+++ b/src/KeenEyes.Graph.Abstractions/Types/PortDirection.cs
@@ -1,0 +1,13 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Specifies the direction of a graph port.
+/// </summary>
+public enum PortDirection
+{
+    /// <summary>Port receives data from connections.</summary>
+    Input,
+
+    /// <summary>Port sends data to connections.</summary>
+    Output
+}

--- a/src/KeenEyes.Graph.Abstractions/Types/PortTypeCompatibility.cs
+++ b/src/KeenEyes.Graph.Abstractions/Types/PortTypeCompatibility.cs
@@ -1,0 +1,74 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Provides port type compatibility checking.
+/// </summary>
+public static class PortTypeCompatibility
+{
+    /// <summary>
+    /// Checks if a source port type can connect to a target port type.
+    /// </summary>
+    /// <param name="source">The source (output) port type.</param>
+    /// <param name="target">The target (input) port type.</param>
+    /// <returns>True if the connection is valid.</returns>
+    /// <remarks>
+    /// Supports implicit widening conversions:
+    /// <list type="bullet">
+    /// <item><description>float to float2, float3, float4</description></item>
+    /// <item><description>float2 to float3, float4</description></item>
+    /// <item><description>float3 to float4</description></item>
+    /// <item><description>int to float</description></item>
+    /// </list>
+    /// Narrowing conversions are not allowed.
+    /// </remarks>
+    public static bool CanConnect(PortTypeId source, PortTypeId target)
+    {
+        // Same type always connects
+        if (source == target)
+        {
+            return true;
+        }
+
+        // Any accepts anything
+        if (target == PortTypeId.Any)
+        {
+            return true;
+        }
+
+        // Flow can only connect to flow
+        if (source == PortTypeId.Flow || target == PortTypeId.Flow)
+        {
+            return false;
+        }
+
+        // Implicit widening conversions
+        return (source, target) switch
+        {
+            // Float widening
+            (PortTypeId.Float, PortTypeId.Float2 or PortTypeId.Float3 or PortTypeId.Float4) => true,
+            (PortTypeId.Float2, PortTypeId.Float3 or PortTypeId.Float4) => true,
+            (PortTypeId.Float3, PortTypeId.Float4) => true,
+
+            // Int to float conversion
+            (PortTypeId.Int, PortTypeId.Float) => true,
+
+            // Int widening
+            (PortTypeId.Int, PortTypeId.Int2 or PortTypeId.Int3 or PortTypeId.Int4) => true,
+            (PortTypeId.Int2, PortTypeId.Int3 or PortTypeId.Int4) => true,
+            (PortTypeId.Int3, PortTypeId.Int4) => true,
+
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Checks if a connection would require an implicit conversion.
+    /// </summary>
+    /// <param name="source">The source port type.</param>
+    /// <param name="target">The target port type.</param>
+    /// <returns>True if types differ but connection is valid.</returns>
+    public static bool RequiresConversion(PortTypeId source, PortTypeId target)
+    {
+        return source != target && target != PortTypeId.Any && CanConnect(source, target);
+    }
+}

--- a/src/KeenEyes.Graph.Abstractions/Types/PortTypeId.cs
+++ b/src/KeenEyes.Graph.Abstractions/Types/PortTypeId.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.Graph.Abstractions;
+
+/// <summary>
+/// Identifies the data type of a graph port.
+/// </summary>
+/// <remarks>
+/// Port types determine connection compatibility. Implicit widening conversions
+/// are allowed (e.g., float to float2) but narrowing conversions are not.
+/// </remarks>
+public enum PortTypeId
+{
+    /// <summary>Accepts any port type.</summary>
+    Any = 0,
+
+    /// <summary>Single-precision floating point.</summary>
+    Float = 1,
+
+    /// <summary>Two-component float vector.</summary>
+    Float2 = 2,
+
+    /// <summary>Three-component float vector.</summary>
+    Float3 = 3,
+
+    /// <summary>Four-component float vector.</summary>
+    Float4 = 4,
+
+    /// <summary>32-bit signed integer.</summary>
+    Int = 10,
+
+    /// <summary>Two-component integer vector.</summary>
+    Int2 = 11,
+
+    /// <summary>Three-component integer vector.</summary>
+    Int3 = 12,
+
+    /// <summary>Four-component integer vector.</summary>
+    Int4 = 13,
+
+    /// <summary>Boolean value.</summary>
+    Bool = 20,
+
+    /// <summary>Entity reference.</summary>
+    Entity = 30,
+
+    /// <summary>Execution flow (for control flow nodes).</summary>
+    Flow = 100
+}

--- a/src/KeenEyes.Graph.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Graph.Abstractions/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Graph/GraphContext.cs
+++ b/src/KeenEyes.Graph/GraphContext.cs
@@ -1,0 +1,303 @@
+using System.Numerics;
+using KeenEyes.Graph.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// Provides graph node editor state and manipulation methods.
+/// </summary>
+/// <remarks>
+/// <para>
+/// GraphContext is registered as a world extension by the GraphPlugin. It provides
+/// methods for creating and manipulating graph canvases, nodes, and connections.
+/// </para>
+/// <para>
+/// Access the context via <c>world.GetExtension&lt;GraphContext&gt;()</c> after installing
+/// the Graph plugin.
+/// </para>
+/// </remarks>
+[PluginExtension("Graph")]
+public sealed class GraphContext
+{
+    private readonly IWorld world;
+    private readonly PortRegistry portRegistry;
+
+    internal GraphContext(IWorld world, PortRegistry portRegistry)
+    {
+        this.world = world;
+        this.portRegistry = portRegistry;
+    }
+
+    /// <summary>
+    /// Gets the port registry for node type definitions.
+    /// </summary>
+    public PortRegistry PortRegistry => portRegistry;
+
+    /// <summary>
+    /// Creates a new graph canvas.
+    /// </summary>
+    /// <param name="name">Optional name for the canvas entity.</param>
+    /// <returns>The canvas entity.</returns>
+    public Entity CreateCanvas(string? name = null)
+    {
+        var builder = name is not null ? world.Spawn(name) : world.Spawn();
+
+        return builder
+            .With(GraphCanvas.Default)
+            .With(new GraphCanvasTag())
+            .Build();
+    }
+
+    /// <summary>
+    /// Creates a new node on the specified canvas.
+    /// </summary>
+    /// <param name="canvas">The parent canvas entity.</param>
+    /// <param name="nodeTypeId">The node type ID from the port registry.</param>
+    /// <param name="position">The initial position in canvas coordinates.</param>
+    /// <param name="displayName">Optional display name override.</param>
+    /// <returns>The node entity.</returns>
+    /// <exception cref="ArgumentException">Thrown if canvas is invalid or nodeTypeId is not registered.</exception>
+    public Entity CreateNode(Entity canvas, int nodeTypeId, Vector2 position, string? displayName = null)
+    {
+        if (!world.IsAlive(canvas))
+        {
+            throw new ArgumentException("Canvas entity is not valid.", nameof(canvas));
+        }
+
+        if (!world.Has<GraphCanvas>(canvas))
+        {
+            throw new ArgumentException("Entity is not a graph canvas.", nameof(canvas));
+        }
+
+        if (!portRegistry.IsRegistered(nodeTypeId))
+        {
+            throw new ArgumentException($"Node type {nodeTypeId} is not registered.", nameof(nodeTypeId));
+        }
+
+        var node = world.Spawn()
+            .With(new GraphNode
+            {
+                Position = position,
+                Width = 200f,
+                Height = 0f, // Calculated by layout
+                NodeTypeId = nodeTypeId,
+                Canvas = canvas,
+                DisplayName = displayName
+            })
+            .Build();
+
+        world.SetParent(node, canvas);
+        return node;
+    }
+
+    /// <summary>
+    /// Creates a connection between two nodes.
+    /// </summary>
+    /// <param name="sourceNode">The source node entity.</param>
+    /// <param name="sourcePortIndex">The output port index on the source.</param>
+    /// <param name="targetNode">The target node entity.</param>
+    /// <param name="targetPortIndex">The input port index on the target.</param>
+    /// <returns>The connection entity, or Entity.Null if connection is invalid.</returns>
+    public Entity Connect(Entity sourceNode, int sourcePortIndex, Entity targetNode, int targetPortIndex)
+    {
+        // Validate entities
+        if (!world.IsAlive(sourceNode) || !world.Has<GraphNode>(sourceNode))
+        {
+            return Entity.Null;
+        }
+
+        if (!world.IsAlive(targetNode) || !world.Has<GraphNode>(targetNode))
+        {
+            return Entity.Null;
+        }
+
+        ref readonly var source = ref world.Get<GraphNode>(sourceNode);
+        ref readonly var target = ref world.Get<GraphNode>(targetNode);
+
+        // Ensure same canvas
+        if (source.Canvas != target.Canvas)
+        {
+            return Entity.Null;
+        }
+
+        // Validate ports exist
+        if (!portRegistry.TryGetNodeType(source.NodeTypeId, out var sourceType) ||
+            !portRegistry.TryGetNodeType(target.NodeTypeId, out var targetType))
+        {
+            return Entity.Null;
+        }
+
+        if (sourcePortIndex < 0 || sourcePortIndex >= sourceType.OutputPorts.Length)
+        {
+            return Entity.Null;
+        }
+
+        if (targetPortIndex < 0 || targetPortIndex >= targetType.InputPorts.Length)
+        {
+            return Entity.Null;
+        }
+
+        // Check type compatibility
+        var sourcePort = sourceType.OutputPorts[sourcePortIndex];
+        var targetPort = targetType.InputPorts[targetPortIndex];
+
+        if (!PortTypeCompatibility.CanConnect(sourcePort.TypeId, targetPort.TypeId))
+        {
+            return Entity.Null;
+        }
+
+        // Create connection
+        var connection = world.Spawn()
+            .With(GraphConnection.Create(sourceNode, sourcePortIndex, targetNode, targetPortIndex, source.Canvas))
+            .Build();
+
+        world.SetParent(connection, source.Canvas);
+        return connection;
+    }
+
+    /// <summary>
+    /// Deletes a node and all its connections.
+    /// </summary>
+    /// <param name="node">The node entity to delete.</param>
+    public void DeleteNode(Entity node)
+    {
+        if (!world.IsAlive(node) || !world.Has<GraphNode>(node))
+        {
+            return;
+        }
+
+        // Find and delete all connections involving this node
+        foreach (var connectionEntity in world.Query<GraphConnection>())
+        {
+            ref readonly var conn = ref world.Get<GraphConnection>(connectionEntity);
+            if (conn.SourceNode == node || conn.TargetNode == node)
+            {
+                world.Despawn(connectionEntity);
+            }
+        }
+
+        // Delete the node
+        world.Despawn(node);
+    }
+
+    /// <summary>
+    /// Deletes a connection.
+    /// </summary>
+    /// <param name="connection">The connection entity to delete.</param>
+    public void DeleteConnection(Entity connection)
+    {
+        if (!world.IsAlive(connection) || !world.Has<GraphConnection>(connection))
+        {
+            return;
+        }
+
+        world.Despawn(connection);
+    }
+
+    /// <summary>
+    /// Selects a node.
+    /// </summary>
+    /// <param name="node">The node to select.</param>
+    /// <param name="addToSelection">If true, adds to selection; if false, replaces selection.</param>
+    public void SelectNode(Entity node, bool addToSelection = false)
+    {
+        if (!world.IsAlive(node) || !world.Has<GraphNode>(node))
+        {
+            return;
+        }
+
+        if (!addToSelection)
+        {
+            ClearSelection();
+        }
+
+        if (!world.Has<GraphNodeSelectedTag>(node))
+        {
+            world.Add(node, new GraphNodeSelectedTag());
+        }
+    }
+
+    /// <summary>
+    /// Deselects a node.
+    /// </summary>
+    /// <param name="node">The node to deselect.</param>
+    public void DeselectNode(Entity node)
+    {
+        if (!world.IsAlive(node))
+        {
+            return;
+        }
+
+        if (world.Has<GraphNodeSelectedTag>(node))
+        {
+            world.Remove<GraphNodeSelectedTag>(node);
+        }
+    }
+
+    /// <summary>
+    /// Clears all selections on all canvases.
+    /// </summary>
+    public void ClearSelection()
+    {
+        // Collect entities first to avoid modifying during iteration
+        var selectedNodes = world.Query<GraphNodeSelectedTag>().ToList();
+        foreach (var entity in selectedNodes)
+        {
+            world.Remove<GraphNodeSelectedTag>(entity);
+        }
+
+        var selectedConnections = world.Query<GraphConnectionSelectedTag>().ToList();
+        foreach (var entity in selectedConnections)
+        {
+            world.Remove<GraphConnectionSelectedTag>(entity);
+        }
+    }
+
+    /// <summary>
+    /// Gets all selected nodes.
+    /// </summary>
+    /// <returns>An enumerable of selected node entities.</returns>
+    public IEnumerable<Entity> GetSelectedNodes()
+    {
+        foreach (var entity in world.Query<GraphNode, GraphNodeSelectedTag>())
+        {
+            yield return entity;
+        }
+    }
+
+    /// <summary>
+    /// Converts screen coordinates to canvas coordinates.
+    /// </summary>
+    /// <param name="canvas">The canvas entity.</param>
+    /// <param name="screenPos">The screen position.</param>
+    /// <param name="canvasOrigin">The screen position of the canvas origin.</param>
+    /// <returns>The canvas position.</returns>
+    public Vector2 ScreenToCanvas(Entity canvas, Vector2 screenPos, Vector2 canvasOrigin)
+    {
+        if (!world.IsAlive(canvas) || !world.Has<GraphCanvas>(canvas))
+        {
+            return screenPos;
+        }
+
+        ref readonly var canvasData = ref world.Get<GraphCanvas>(canvas);
+        return GraphTransform.ScreenToCanvas(screenPos, canvasData.Pan, canvasData.Zoom, canvasOrigin);
+    }
+
+    /// <summary>
+    /// Converts canvas coordinates to screen coordinates.
+    /// </summary>
+    /// <param name="canvas">The canvas entity.</param>
+    /// <param name="canvasPos">The canvas position.</param>
+    /// <param name="canvasOrigin">The screen position of the canvas origin.</param>
+    /// <returns>The screen position.</returns>
+    public Vector2 CanvasToScreen(Entity canvas, Vector2 canvasPos, Vector2 canvasOrigin)
+    {
+        if (!world.IsAlive(canvas) || !world.Has<GraphCanvas>(canvas))
+        {
+            return canvasPos;
+        }
+
+        ref readonly var canvasData = ref world.Get<GraphCanvas>(canvas);
+        return GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, canvasOrigin);
+    }
+}

--- a/src/KeenEyes.Graph/GraphPlugin.cs
+++ b/src/KeenEyes.Graph/GraphPlugin.cs
@@ -1,0 +1,102 @@
+using KeenEyes.Graph.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// Plugin that adds graph node editor capabilities to the world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin provides a visual graph editor system for creating and manipulating
+/// node-based graphs. It registers systems for input handling, layout calculation,
+/// and rendering.
+/// </para>
+/// <para>
+/// The plugin exposes a <see cref="GraphContext"/> extension that can be accessed via
+/// <c>world.GetExtension&lt;GraphContext&gt;()</c> for graph manipulation.
+/// </para>
+/// <para>
+/// <b>System Execution Order:</b>
+/// </para>
+/// <list type="table">
+/// <listheader>
+/// <term>Phase</term>
+/// <term>Order</term>
+/// <term>System</term>
+/// <term>Responsibility</term>
+/// </listheader>
+/// <item>
+/// <term>EarlyUpdate</term>
+/// <term>0</term>
+/// <term><see cref="GraphInputSystem"/></term>
+/// <term>Pan, zoom, select, drag nodes</term>
+/// </item>
+/// <item>
+/// <term>LateUpdate</term>
+/// <term>-5</term>
+/// <term><see cref="GraphLayoutSystem"/></term>
+/// <term>Calculate node bounds, port positions</term>
+/// </item>
+/// <item>
+/// <term>Render</term>
+/// <term>90</term>
+/// <term><see cref="GraphRenderSystem"/></term>
+/// <term>Draw grid, nodes, connections</term>
+/// </item>
+/// </list>
+/// </remarks>
+public sealed class GraphPlugin : IWorldPlugin
+{
+    private GraphContext? graphContext;
+    private PortRegistry? portRegistry;
+
+    /// <inheritdoc/>
+    public string Name => "Graph";
+
+    /// <inheritdoc/>
+    public void Install(IPluginContext context)
+    {
+        // Register component types
+        RegisterComponents(context);
+
+        // Create registries and context
+        portRegistry = new PortRegistry();
+        graphContext = new GraphContext(context.World, portRegistry);
+
+        // Expose extensions
+        context.SetExtension(graphContext);
+        context.SetExtension(portRegistry);
+
+        // Register systems
+        context.AddSystem<GraphInputSystem>(SystemPhase.EarlyUpdate, order: 0);
+        context.AddSystem<GraphLayoutSystem>(SystemPhase.LateUpdate, order: -5);
+        context.AddSystem<GraphRenderSystem>(SystemPhase.Render, order: 90);
+    }
+
+    /// <inheritdoc/>
+    public void Uninstall(IPluginContext context)
+    {
+        // Remove extensions
+        context.RemoveExtension<GraphContext>();
+        context.RemoveExtension<PortRegistry>();
+
+        graphContext = null;
+        portRegistry = null;
+
+        // Systems are automatically cleaned up by PluginManager
+    }
+
+    private static void RegisterComponents(IPluginContext context)
+    {
+        // Core components
+        context.RegisterComponent<GraphCanvas>();
+        context.RegisterComponent<GraphNode>();
+        context.RegisterComponent<GraphConnection>();
+
+        // Tag components
+        context.RegisterComponent<GraphCanvasTag>(isTag: true);
+        context.RegisterComponent<GraphNodeSelectedTag>(isTag: true);
+        context.RegisterComponent<GraphConnectionSelectedTag>(isTag: true);
+        context.RegisterComponent<GraphNodeDraggingTag>(isTag: true);
+    }
+}

--- a/src/KeenEyes.Graph/GraphTransform.cs
+++ b/src/KeenEyes.Graph/GraphTransform.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// Provides coordinate transformation utilities for graph canvases.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The graph uses a canvas coordinate system where (0,0) is the initial center.
+/// Pan and zoom transform between canvas and screen coordinates.
+/// </para>
+/// <para>
+/// Coordinate formulas:
+/// <list type="bullet">
+/// <item>Screen = (Canvas - Pan) * Zoom + Origin</item>
+/// <item>Canvas = (Screen - Origin) / Zoom + Pan</item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class GraphTransform
+{
+    /// <summary>
+    /// Converts screen coordinates to canvas coordinates.
+    /// </summary>
+    /// <param name="screenPos">The position in screen coordinates.</param>
+    /// <param name="pan">The current pan offset.</param>
+    /// <param name="zoom">The current zoom level (1.0 = 100%).</param>
+    /// <param name="origin">The screen position of the canvas origin.</param>
+    /// <returns>The position in canvas coordinates.</returns>
+    public static Vector2 ScreenToCanvas(Vector2 screenPos, Vector2 pan, float zoom, Vector2 origin)
+    {
+        return (screenPos - origin) / zoom + pan;
+    }
+
+    /// <summary>
+    /// Converts canvas coordinates to screen coordinates.
+    /// </summary>
+    /// <param name="canvasPos">The position in canvas coordinates.</param>
+    /// <param name="pan">The current pan offset.</param>
+    /// <param name="zoom">The current zoom level (1.0 = 100%).</param>
+    /// <param name="origin">The screen position of the canvas origin.</param>
+    /// <returns>The position in screen coordinates.</returns>
+    public static Vector2 CanvasToScreen(Vector2 canvasPos, Vector2 pan, float zoom, Vector2 origin)
+    {
+        return (canvasPos - pan) * zoom + origin;
+    }
+
+    /// <summary>
+    /// Converts a canvas rectangle to screen coordinates.
+    /// </summary>
+    /// <param name="canvasRect">The rectangle in canvas coordinates.</param>
+    /// <param name="pan">The current pan offset.</param>
+    /// <param name="zoom">The current zoom level.</param>
+    /// <param name="origin">The screen position of the canvas origin.</param>
+    /// <returns>The rectangle in screen coordinates.</returns>
+    public static Rectangle CanvasToScreen(in Rectangle canvasRect, Vector2 pan, float zoom, Vector2 origin)
+    {
+        var screenTopLeft = CanvasToScreen(new Vector2(canvasRect.X, canvasRect.Y), pan, zoom, origin);
+        return new Rectangle(
+            screenTopLeft.X,
+            screenTopLeft.Y,
+            canvasRect.Width * zoom,
+            canvasRect.Height * zoom
+        );
+    }
+
+    /// <summary>
+    /// Gets the visible canvas area given the screen bounds and transform.
+    /// </summary>
+    /// <param name="screenBounds">The screen rectangle of the canvas area.</param>
+    /// <param name="pan">The current pan offset.</param>
+    /// <param name="zoom">The current zoom level.</param>
+    /// <returns>The visible area in canvas coordinates.</returns>
+    public static Rectangle GetVisibleArea(in Rectangle screenBounds, Vector2 pan, float zoom)
+    {
+        var origin = new Vector2(screenBounds.X, screenBounds.Y);
+        var topLeft = ScreenToCanvas(origin, pan, zoom, origin);
+        var bottomRight = ScreenToCanvas(origin + new Vector2(screenBounds.Width, screenBounds.Height), pan, zoom, origin);
+
+        return new Rectangle(
+            topLeft.X,
+            topLeft.Y,
+            bottomRight.X - topLeft.X,
+            bottomRight.Y - topLeft.Y
+        );
+    }
+
+    /// <summary>
+    /// Calculates the zoom centered on a screen point.
+    /// </summary>
+    /// <param name="currentPan">The current pan offset.</param>
+    /// <param name="currentZoom">The current zoom level.</param>
+    /// <param name="newZoom">The new zoom level.</param>
+    /// <param name="screenFocus">The screen point to zoom towards.</param>
+    /// <param name="origin">The screen position of the canvas origin.</param>
+    /// <returns>The new pan offset to keep the focus point stationary.</returns>
+    public static Vector2 ZoomToPoint(Vector2 currentPan, float currentZoom, float newZoom, Vector2 screenFocus, Vector2 origin)
+    {
+        // Get the canvas position under the mouse before zoom
+        var canvasPos = ScreenToCanvas(screenFocus, currentPan, currentZoom, origin);
+
+        // After zoom, this canvas position should still be at screenFocus
+        // screenFocus = (canvasPos - newPan) * newZoom + origin
+        // newPan = canvasPos - (screenFocus - origin) / newZoom
+        return canvasPos - (screenFocus - origin) / newZoom;
+    }
+
+    /// <summary>
+    /// Snaps a position to the nearest grid point.
+    /// </summary>
+    /// <param name="position">The position to snap.</param>
+    /// <param name="gridSize">The grid spacing.</param>
+    /// <returns>The snapped position.</returns>
+    public static Vector2 SnapToGrid(Vector2 position, float gridSize)
+    {
+        return new Vector2(
+            MathF.Round(position.X / gridSize) * gridSize,
+            MathF.Round(position.Y / gridSize) * gridSize
+        );
+    }
+
+    /// <summary>
+    /// Checks if a screen point is inside a canvas rectangle.
+    /// </summary>
+    /// <param name="screenPoint">The screen position to test.</param>
+    /// <param name="canvasRect">The rectangle in canvas coordinates.</param>
+    /// <param name="pan">The current pan offset.</param>
+    /// <param name="zoom">The current zoom level.</param>
+    /// <param name="origin">The screen position of the canvas origin.</param>
+    /// <returns>True if the point is inside the rectangle.</returns>
+    public static bool HitTest(Vector2 screenPoint, in Rectangle canvasRect, Vector2 pan, float zoom, Vector2 origin)
+    {
+        var screenRect = CanvasToScreen(canvasRect, pan, zoom, origin);
+        return screenRect.Contains(screenPoint);
+    }
+
+    /// <summary>
+    /// Creates a selection box from two screen points.
+    /// </summary>
+    /// <param name="start">The starting screen point.</param>
+    /// <param name="end">The ending screen point.</param>
+    /// <returns>A normalized rectangle (positive width/height) in screen coordinates.</returns>
+    public static Rectangle CreateSelectionBox(Vector2 start, Vector2 end)
+    {
+        var minX = MathF.Min(start.X, end.X);
+        var minY = MathF.Min(start.Y, end.Y);
+        var maxX = MathF.Max(start.X, end.X);
+        var maxY = MathF.Max(start.Y, end.Y);
+
+        return new Rectangle(minX, minY, maxX - minX, maxY - minY);
+    }
+}

--- a/src/KeenEyes.Graph/KeenEyes.Graph.csproj
+++ b/src/KeenEyes.Graph/KeenEyes.Graph.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>KeenEyes.Graph</PackageId>
+    <Description>Graph node editor systems for KeenEyes</Description>
+    <PackageTags>ecs;graph;nodes;editor;visual</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Graph.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
+    <ProjectReference Include="..\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Input.Abstractions\KeenEyes.Input.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Graph.Abstractions\KeenEyes.Graph.Abstractions.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/KeenEyes.Graph/PortRegistry.cs
+++ b/src/KeenEyes.Graph/PortRegistry.cs
@@ -1,0 +1,183 @@
+using KeenEyes.Graph.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// Registry for node type port definitions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The port registry stores port definitions for each node type. Node types are
+/// identified by integer IDs. Each node type has a name and arrays of input/output
+/// port definitions.
+/// </para>
+/// <para>
+/// In Phase 1, node types are registered manually. In Phase 4, the
+/// <c>INodeTypeDefinition</c> interface will provide this metadata.
+/// </para>
+/// </remarks>
+public sealed class PortRegistry
+{
+    private readonly Dictionary<int, NodeTypeInfo> nodeTypes = [];
+    private int nextTypeId = 1;
+
+    /// <summary>
+    /// Information about a registered node type.
+    /// </summary>
+    /// <param name="TypeId">The unique type identifier.</param>
+    /// <param name="Name">The display name for this node type.</param>
+    /// <param name="Category">The category for node palette organization.</param>
+    /// <param name="InputPorts">The input port definitions.</param>
+    /// <param name="OutputPorts">The output port definitions.</param>
+    public readonly record struct NodeTypeInfo(
+        int TypeId,
+        string Name,
+        string Category,
+        PortDefinition[] InputPorts,
+        PortDefinition[] OutputPorts
+    );
+
+    /// <summary>
+    /// Registers a new node type with the specified ports.
+    /// </summary>
+    /// <param name="name">The display name.</param>
+    /// <param name="category">The category for organization.</param>
+    /// <param name="inputPorts">The input port definitions.</param>
+    /// <param name="outputPorts">The output port definitions.</param>
+    /// <returns>The assigned type ID.</returns>
+    public int RegisterNodeType(
+        string name,
+        string category,
+        PortDefinition[] inputPorts,
+        PortDefinition[] outputPorts)
+    {
+        int typeId = nextTypeId++;
+        nodeTypes[typeId] = new NodeTypeInfo(typeId, name, category, inputPorts, outputPorts);
+        return typeId;
+    }
+
+    /// <summary>
+    /// Registers a new node type with a specific ID.
+    /// </summary>
+    /// <param name="typeId">The type ID to use.</param>
+    /// <param name="name">The display name.</param>
+    /// <param name="category">The category for organization.</param>
+    /// <param name="inputPorts">The input port definitions.</param>
+    /// <param name="outputPorts">The output port definitions.</param>
+    /// <exception cref="ArgumentException">Thrown if typeId is already registered.</exception>
+    public void RegisterNodeType(
+        int typeId,
+        string name,
+        string category,
+        PortDefinition[] inputPorts,
+        PortDefinition[] outputPorts)
+    {
+        if (nodeTypes.ContainsKey(typeId))
+        {
+            throw new ArgumentException($"Node type ID {typeId} is already registered.", nameof(typeId));
+        }
+
+        nodeTypes[typeId] = new NodeTypeInfo(typeId, name, category, inputPorts, outputPorts);
+
+        if (typeId >= nextTypeId)
+        {
+            nextTypeId = typeId + 1;
+        }
+    }
+
+    /// <summary>
+    /// Gets the node type information for the specified type ID.
+    /// </summary>
+    /// <param name="typeId">The type ID to look up.</param>
+    /// <returns>The node type information.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if the type ID is not registered.</exception>
+    public NodeTypeInfo GetNodeType(int typeId)
+    {
+        if (!nodeTypes.TryGetValue(typeId, out var info))
+        {
+            throw new KeyNotFoundException($"Node type ID {typeId} is not registered.");
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    /// Tries to get the node type information for the specified type ID.
+    /// </summary>
+    /// <param name="typeId">The type ID to look up.</param>
+    /// <param name="info">The node type information if found.</param>
+    /// <returns>True if the type was found.</returns>
+    public bool TryGetNodeType(int typeId, out NodeTypeInfo info)
+    {
+        return nodeTypes.TryGetValue(typeId, out info);
+    }
+
+    /// <summary>
+    /// Gets all registered node types.
+    /// </summary>
+    /// <returns>An enumerable of all node type information.</returns>
+    public IEnumerable<NodeTypeInfo> GetAllNodeTypes() => nodeTypes.Values;
+
+    /// <summary>
+    /// Gets all node types in a specific category.
+    /// </summary>
+    /// <param name="category">The category to filter by.</param>
+    /// <returns>An enumerable of matching node type information.</returns>
+    public IEnumerable<NodeTypeInfo> GetNodeTypesByCategory(string category)
+        => nodeTypes.Values.Where(t => t.Category == category);
+
+    /// <summary>
+    /// Gets all unique categories.
+    /// </summary>
+    /// <returns>An enumerable of category names.</returns>
+    public IEnumerable<string> GetCategories()
+        => nodeTypes.Values.Select(t => t.Category).Distinct().OrderBy(c => c);
+
+    /// <summary>
+    /// Checks if a node type is registered.
+    /// </summary>
+    /// <param name="typeId">The type ID to check.</param>
+    /// <returns>True if the type is registered.</returns>
+    public bool IsRegistered(int typeId) => nodeTypes.ContainsKey(typeId);
+
+    /// <summary>
+    /// Gets the total number of registered node types.
+    /// </summary>
+    public int Count => nodeTypes.Count;
+
+    /// <summary>
+    /// Gets the input port definitions for a node type.
+    /// </summary>
+    /// <param name="typeId">The type ID.</param>
+    /// <returns>The input port definitions.</returns>
+    public PortDefinition[] GetInputPorts(int typeId) => GetNodeType(typeId).InputPorts;
+
+    /// <summary>
+    /// Gets the output port definitions for a node type.
+    /// </summary>
+    /// <param name="typeId">The type ID.</param>
+    /// <returns>The output port definitions.</returns>
+    public PortDefinition[] GetOutputPorts(int typeId) => GetNodeType(typeId).OutputPorts;
+
+    /// <summary>
+    /// Registers a default "Generic" node type with configurable ports.
+    /// </summary>
+    /// <remarks>
+    /// This is a placeholder node type for Phase 1 testing before
+    /// <c>INodeTypeDefinition</c> is implemented.
+    /// </remarks>
+    /// <returns>The type ID for the generic node.</returns>
+    public int RegisterGenericNode()
+    {
+        return RegisterNodeType(
+            "Node",
+            "General",
+            [
+                PortDefinition.Input("Input 1", PortTypeId.Any, 60f),
+                PortDefinition.Input("Input 2", PortTypeId.Any, 90f)
+            ],
+            [
+                PortDefinition.Output("Output", PortTypeId.Any, 60f)
+            ]);
+    }
+}

--- a/src/KeenEyes.Graph/Systems/GraphInputSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphInputSystem.cs
@@ -1,0 +1,376 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graph.Abstractions;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// System that processes input events for graph editing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Handles pan, zoom, node selection, and node dragging for all graph canvases.
+/// </para>
+/// <para>
+/// Controls:
+/// <list type="bullet">
+/// <item><description>Mouse wheel: Zoom (centered on cursor)</description></item>
+/// <item><description>Middle mouse drag: Pan</description></item>
+/// <item><description>Left click: Select node (Ctrl to add to selection)</description></item>
+/// <item><description>Left drag on empty: Box selection</description></item>
+/// <item><description>Left drag on node: Move selected nodes</description></item>
+/// <item><description>Delete key: Delete selected nodes/connections</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class GraphInputSystem : SystemBase
+{
+    private IInputContext? inputContext;
+    private GraphContext? graphContext;
+    private PortRegistry? portRegistry;
+
+    // Interaction state
+    private Vector2 dragStartScreen;
+    private Vector2 dragStartPan;
+    private Vector2 lastMousePos;
+    private Vector2 selectionBoxStart;
+    private bool isDraggingNodes;
+    private bool isSelecting;
+    private bool isPanning;
+
+    // Canvas bounds cache (updated by layout system)
+    private Rectangle canvasBounds = new(0, 0, 1280, 720);
+
+    private const float ZoomSpeed = 0.1f;
+    private const float DragThreshold = 5f;
+
+    /// <summary>
+    /// Sets the canvas screen bounds for hit testing.
+    /// </summary>
+    /// <param name="bounds">The screen rectangle of the canvas area.</param>
+    public void SetCanvasBounds(Rectangle bounds)
+    {
+        canvasBounds = bounds;
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Lazy initialization
+        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        {
+            return;
+        }
+
+        if (graphContext is null && !World.TryGetExtension(out graphContext))
+        {
+            return;
+        }
+
+        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        {
+            return;
+        }
+
+        var mouse = inputContext!.Mouse;
+        var keyboard = inputContext.Keyboard;
+        var mousePos = mouse.Position;
+
+        // Process each canvas
+        foreach (var canvas in World.Query<GraphCanvas, GraphCanvasTag>())
+        {
+            ProcessCanvas(canvas, mouse, keyboard, mousePos);
+        }
+
+        lastMousePos = mousePos;
+    }
+
+    private void ProcessCanvas(Entity canvas, IMouse mouse, IKeyboard keyboard, Vector2 mousePos)
+    {
+        ref var canvasData = ref World.Get<GraphCanvas>(canvas);
+        var origin = new Vector2(canvasBounds.X, canvasBounds.Y);
+
+        // Handle zoom
+        var scrollDelta = mouse.GetState().ScrollDelta.Y;
+        if (!scrollDelta.IsApproximatelyZero())
+        {
+            ProcessZoom(ref canvasData, scrollDelta, mousePos, origin);
+        }
+
+        // Handle middle mouse panning
+        if (mouse.IsButtonDown(MouseButton.Middle))
+        {
+            if (!isPanning)
+            {
+                StartPan(ref canvasData, mousePos);
+            }
+            else
+            {
+                UpdatePan(ref canvasData, mousePos, origin);
+            }
+        }
+        else if (isPanning)
+        {
+            EndPan(ref canvasData);
+        }
+
+        // Handle left mouse for selection and dragging
+        if (mouse.IsButtonDown(MouseButton.Left))
+        {
+            if (!isDraggingNodes && !isSelecting && canvasData.Mode == GraphInteractionMode.None)
+            {
+                StartLeftMouseAction(canvas, ref canvasData, mousePos, origin, keyboard);
+            }
+            else if (isDraggingNodes)
+            {
+                UpdateNodeDrag(canvas, ref canvasData, mousePos, origin);
+            }
+            else if (isSelecting)
+            {
+                UpdateSelection(canvas, ref canvasData, mousePos, origin);
+            }
+        }
+        else
+        {
+            if (isDraggingNodes)
+            {
+                EndNodeDrag(ref canvasData);
+            }
+
+            if (isSelecting)
+            {
+                EndSelection(canvas, ref canvasData, origin);
+            }
+        }
+
+        // Handle delete key
+        if (keyboard.IsKeyDown(Key.Delete) || keyboard.IsKeyDown(Key.Backspace))
+        {
+            DeleteSelected();
+        }
+    }
+
+    private void ProcessZoom(ref GraphCanvas canvasData, float scrollDelta, Vector2 mousePos, Vector2 origin)
+    {
+        var zoomFactor = 1f + (scrollDelta > 0 ? ZoomSpeed : -ZoomSpeed);
+        var newZoom = Math.Clamp(canvasData.Zoom * zoomFactor, canvasData.MinZoom, canvasData.MaxZoom);
+
+        if (Math.Abs(newZoom - canvasData.Zoom) > 0.001f)
+        {
+            canvasData.Pan = GraphTransform.ZoomToPoint(canvasData.Pan, canvasData.Zoom, newZoom, mousePos, origin);
+            canvasData.Zoom = newZoom;
+        }
+    }
+
+    private void StartPan(ref GraphCanvas canvasData, Vector2 mousePos)
+    {
+        isPanning = true;
+        dragStartScreen = mousePos;
+        dragStartPan = canvasData.Pan;
+        canvasData.Mode = GraphInteractionMode.Panning;
+    }
+
+    private void UpdatePan(ref GraphCanvas canvasData, Vector2 mousePos, Vector2 origin)
+    {
+        var screenDelta = mousePos - dragStartScreen;
+        var canvasDelta = screenDelta / canvasData.Zoom;
+        canvasData.Pan = dragStartPan - canvasDelta;
+    }
+
+    private void EndPan(ref GraphCanvas canvasData)
+    {
+        isPanning = false;
+        canvasData.Mode = GraphInteractionMode.None;
+    }
+
+    private void StartLeftMouseAction(Entity canvas, ref GraphCanvas canvasData, Vector2 mousePos, Vector2 origin, IKeyboard keyboard)
+    {
+        dragStartScreen = mousePos;
+
+        // Hit test nodes
+        var hitNode = HitTestNodes(canvas, mousePos, canvasData.Pan, canvasData.Zoom, origin);
+
+        if (hitNode.IsValid)
+        {
+            // Clicked on a node
+            var addToSelection = (keyboard.Modifiers & KeyModifiers.Control) != 0;
+
+            if (!World.Has<GraphNodeSelectedTag>(hitNode))
+            {
+                graphContext!.SelectNode(hitNode, addToSelection);
+            }
+            else if (addToSelection)
+            {
+                // Toggle selection if Ctrl-clicking already selected node
+                graphContext!.DeselectNode(hitNode);
+            }
+
+            // Prepare for potential drag
+            isDraggingNodes = false; // Wait for movement threshold
+        }
+        else
+        {
+            // Clicked on empty space - start box selection
+            selectionBoxStart = mousePos;
+            isSelecting = false; // Wait for movement threshold
+            canvasData.Mode = GraphInteractionMode.Selecting;
+
+            if ((keyboard.Modifiers & KeyModifiers.Control) == 0)
+            {
+                graphContext!.ClearSelection();
+            }
+        }
+    }
+
+    private void UpdateNodeDrag(Entity canvas, ref GraphCanvas canvasData, Vector2 mousePos, Vector2 origin)
+    {
+        if (!isDraggingNodes)
+        {
+            // Check drag threshold
+            var distance = Vector2.Distance(mousePos, dragStartScreen);
+            if (distance >= DragThreshold)
+            {
+                isDraggingNodes = true;
+                canvasData.Mode = GraphInteractionMode.DraggingNode;
+
+                // Add dragging tag to selected nodes
+                foreach (var node in graphContext!.GetSelectedNodes())
+                {
+                    if (!World.Has<GraphNodeDraggingTag>(node))
+                    {
+                        World.Add(node, new GraphNodeDraggingTag());
+                    }
+                }
+            }
+        }
+
+        if (isDraggingNodes)
+        {
+            // Move all selected nodes
+            var screenDelta = mousePos - lastMousePos;
+            var canvasDelta = screenDelta / canvasData.Zoom;
+
+            foreach (var node in graphContext!.GetSelectedNodes())
+            {
+                ref var nodeData = ref World.Get<GraphNode>(node);
+                nodeData.Position += canvasDelta;
+
+                if (canvasData.SnapToGrid)
+                {
+                    nodeData.Position = GraphTransform.SnapToGrid(nodeData.Position, canvasData.GridSize);
+                }
+            }
+        }
+    }
+
+    private void EndNodeDrag(ref GraphCanvas canvasData)
+    {
+        isDraggingNodes = false;
+        canvasData.Mode = GraphInteractionMode.None;
+
+        // Remove dragging tags
+        foreach (var entity in World.Query<GraphNodeDraggingTag>())
+        {
+            World.Remove<GraphNodeDraggingTag>(entity);
+        }
+    }
+
+    private void UpdateSelection(Entity canvas, ref GraphCanvas canvasData, Vector2 mousePos, Vector2 origin)
+    {
+        if (!isSelecting)
+        {
+            var distance = Vector2.Distance(mousePos, selectionBoxStart);
+            if (distance >= DragThreshold)
+            {
+                isSelecting = true;
+            }
+        }
+    }
+
+    private void EndSelection(Entity canvas, ref GraphCanvas canvasData, Vector2 origin)
+    {
+        if (isSelecting)
+        {
+            // Select all nodes within the selection box
+            var selectionBox = GraphTransform.CreateSelectionBox(selectionBoxStart, lastMousePos);
+
+            foreach (var node in World.Query<GraphNode>())
+            {
+                ref readonly var nodeData = ref World.Get<GraphNode>(node);
+                if (nodeData.Canvas != canvas)
+                {
+                    continue;
+                }
+
+                var nodeRect = new Rectangle(nodeData.Position.X, nodeData.Position.Y, nodeData.Width, nodeData.Height);
+                var screenRect = GraphTransform.CanvasToScreen(nodeRect, canvasData.Pan, canvasData.Zoom, origin);
+
+                if (selectionBox.Intersects(screenRect))
+                {
+                    if (!World.Has<GraphNodeSelectedTag>(node))
+                    {
+                        World.Add(node, new GraphNodeSelectedTag());
+                    }
+                }
+            }
+        }
+
+        isSelecting = false;
+        canvasData.Mode = GraphInteractionMode.None;
+    }
+
+    private Entity HitTestNodes(Entity canvas, Vector2 screenPos, Vector2 pan, float zoom, Vector2 origin)
+    {
+        // Test in reverse order (top-most first, assuming last added is on top)
+        Entity hitNode = Entity.Null;
+
+        foreach (var node in World.Query<GraphNode>())
+        {
+            ref readonly var nodeData = ref World.Get<GraphNode>(node);
+            if (nodeData.Canvas != canvas)
+            {
+                continue;
+            }
+
+            var nodeRect = new Rectangle(nodeData.Position.X, nodeData.Position.Y, nodeData.Width, nodeData.Height);
+            if (GraphTransform.HitTest(screenPos, nodeRect, pan, zoom, origin))
+            {
+                hitNode = node;
+                // Don't break - continue to find the "top-most" (last) node
+            }
+        }
+
+        return hitNode;
+    }
+
+    private void DeleteSelected()
+    {
+        // Collect entities to delete (can't modify during iteration)
+        var nodesToDelete = new List<Entity>();
+        var connectionsToDelete = new List<Entity>();
+
+        foreach (var node in World.Query<GraphNode, GraphNodeSelectedTag>())
+        {
+            nodesToDelete.Add(node);
+        }
+
+        foreach (var connection in World.Query<GraphConnection, GraphConnectionSelectedTag>())
+        {
+            connectionsToDelete.Add(connection);
+        }
+
+        // Delete connections first
+        foreach (var connection in connectionsToDelete)
+        {
+            graphContext!.DeleteConnection(connection);
+        }
+
+        // Delete nodes (this also deletes their connections)
+        foreach (var node in nodesToDelete)
+        {
+            graphContext!.DeleteNode(node);
+        }
+    }
+}

--- a/src/KeenEyes.Graph/Systems/GraphLayoutSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphLayoutSystem.cs
@@ -1,0 +1,180 @@
+using System.Numerics;
+using KeenEyes.Graph.Abstractions;
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// System that calculates node dimensions and port positions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system updates the <see cref="GraphNode.Height"/> based on the number of
+/// ports, and calculates world positions for each port for use in rendering and
+/// hit testing.
+/// </para>
+/// <para>
+/// Port positions are cached in the <see cref="PortPositionCache"/> for efficient
+/// lookup during rendering and connection creation.
+/// </para>
+/// </remarks>
+public sealed class GraphLayoutSystem : SystemBase
+{
+    private PortRegistry? portRegistry;
+
+    /// <summary>
+    /// Height of the node header/title bar in pixels.
+    /// </summary>
+    public const float HeaderHeight = 30f;
+
+    /// <summary>
+    /// Height per port row in pixels.
+    /// </summary>
+    public const float PortRowHeight = 25f;
+
+    /// <summary>
+    /// Padding below the last port in pixels.
+    /// </summary>
+    public const float BottomPadding = 10f;
+
+    /// <summary>
+    /// Radius of port circles in pixels.
+    /// </summary>
+    public const float PortRadius = 6f;
+
+    /// <summary>
+    /// Minimum node height in pixels.
+    /// </summary>
+    public const float MinNodeHeight = 60f;
+
+    /// <summary>
+    /// Gets the port position cache, updated each frame.
+    /// </summary>
+    public PortPositionCache PortCache { get; } = new();
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Lazy initialization
+        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        {
+            return;
+        }
+
+        // Clear cache from previous frame
+        PortCache.Clear();
+
+        // Process each node
+        foreach (var node in World.Query<GraphNode>())
+        {
+            CalculateNodeLayout(node);
+        }
+    }
+
+    private void CalculateNodeLayout(Entity node)
+    {
+        ref var nodeData = ref World.Get<GraphNode>(node);
+
+        if (!portRegistry!.TryGetNodeType(nodeData.NodeTypeId, out var nodeType))
+        {
+            // Unknown node type - use minimum size
+            nodeData.Height = MinNodeHeight;
+            return;
+        }
+
+        // Calculate height based on port count
+        var inputCount = nodeType.InputPorts.Length;
+        var outputCount = nodeType.OutputPorts.Length;
+        var maxPortCount = Math.Max(inputCount, outputCount);
+
+        nodeData.Height = HeaderHeight + (maxPortCount * PortRowHeight) + BottomPadding;
+        nodeData.Height = Math.Max(nodeData.Height, MinNodeHeight);
+
+        // Calculate port positions
+        CalculatePortPositions(node, ref nodeData, nodeType);
+    }
+
+    private void CalculatePortPositions(Entity node, ref GraphNode nodeData, PortRegistry.NodeTypeInfo nodeType)
+    {
+        var nodeOrigin = nodeData.Position;
+
+        // Input ports (left edge)
+        for (int i = 0; i < nodeType.InputPorts.Length; i++)
+        {
+            var yOffset = HeaderHeight + (i * PortRowHeight) + (PortRowHeight / 2);
+            var position = nodeOrigin + new Vector2(0, yOffset);
+            PortCache.SetPortPosition(node, PortDirection.Input, i, position);
+        }
+
+        // Output ports (right edge)
+        for (int i = 0; i < nodeType.OutputPorts.Length; i++)
+        {
+            var yOffset = HeaderHeight + (i * PortRowHeight) + (PortRowHeight / 2);
+            var position = nodeOrigin + new Vector2(nodeData.Width, yOffset);
+            PortCache.SetPortPosition(node, PortDirection.Output, i, position);
+        }
+    }
+}
+
+/// <summary>
+/// Caches calculated port world positions for efficient lookup.
+/// </summary>
+public sealed class PortPositionCache
+{
+    private readonly Dictionary<PortKey, Vector2> positions = [];
+
+    /// <summary>
+    /// Key for identifying a specific port.
+    /// </summary>
+    public readonly record struct PortKey(Entity Node, PortDirection Direction, int PortIndex);
+
+    /// <summary>
+    /// Sets the world position for a port.
+    /// </summary>
+    /// <param name="node">The node entity.</param>
+    /// <param name="direction">The port direction.</param>
+    /// <param name="portIndex">The port index.</param>
+    /// <param name="position">The world position.</param>
+    public void SetPortPosition(Entity node, PortDirection direction, int portIndex, Vector2 position)
+    {
+        positions[new PortKey(node, direction, portIndex)] = position;
+    }
+
+    /// <summary>
+    /// Gets the world position for a port.
+    /// </summary>
+    /// <param name="node">The node entity.</param>
+    /// <param name="direction">The port direction.</param>
+    /// <param name="portIndex">The port index.</param>
+    /// <returns>The world position, or Vector2.Zero if not found.</returns>
+    public Vector2 GetPortPosition(Entity node, PortDirection direction, int portIndex)
+    {
+        return positions.TryGetValue(new PortKey(node, direction, portIndex), out var pos) ? pos : Vector2.Zero;
+    }
+
+    /// <summary>
+    /// Tries to get the world position for a port.
+    /// </summary>
+    /// <param name="node">The node entity.</param>
+    /// <param name="direction">The port direction.</param>
+    /// <param name="portIndex">The port index.</param>
+    /// <param name="position">The world position if found.</param>
+    /// <returns>True if the position was found.</returns>
+    public bool TryGetPortPosition(Entity node, PortDirection direction, int portIndex, out Vector2 position)
+    {
+        return positions.TryGetValue(new PortKey(node, direction, portIndex), out position);
+    }
+
+    /// <summary>
+    /// Clears all cached positions.
+    /// </summary>
+    public void Clear()
+    {
+        positions.Clear();
+    }
+
+    /// <summary>
+    /// Gets the number of cached port positions.
+    /// </summary>
+    public int Count => positions.Count;
+}

--- a/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
@@ -1,0 +1,290 @@
+using System.Numerics;
+using KeenEyes.Graph.Abstractions;
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graph;
+
+/// <summary>
+/// System that renders graph canvases, nodes, and connections.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Renders the following elements:
+/// <list type="bullet">
+/// <item><description>Grid lines in the visible canvas area</description></item>
+/// <item><description>Connections as straight lines between ports</description></item>
+/// <item><description>Nodes as rounded rectangles with headers and ports</description></item>
+/// <item><description>Selection highlight on selected nodes</description></item>
+/// <item><description>Selection box during box-select interaction</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class GraphRenderSystem : SystemBase
+{
+    private I2DRenderer? renderer;
+    private ITextRenderer? textRenderer;
+    private PortRegistry? portRegistry;
+
+    // Canvas screen bounds
+    private Rectangle canvasBounds = new(0, 0, 1280, 720);
+
+    // Colors
+    private static readonly Vector4 GridColorMajor = new(0.3f, 0.3f, 0.3f, 1f);
+    private static readonly Vector4 GridColorMinor = new(0.2f, 0.2f, 0.2f, 1f);
+    private static readonly Vector4 NodeBodyColor = new(0.15f, 0.15f, 0.15f, 1f);
+    private static readonly Vector4 NodeHeaderColor = new(0.25f, 0.35f, 0.5f, 1f);
+    private static readonly Vector4 NodeBorderColor = new(0.4f, 0.4f, 0.4f, 1f);
+    private static readonly Vector4 NodeSelectedBorderColor = new(0.3f, 0.6f, 1f, 1f);
+    private static readonly Vector4 PortColor = new(0.8f, 0.8f, 0.8f, 1f);
+    private static readonly Vector4 ConnectionColor = new(0.6f, 0.6f, 0.6f, 1f);
+    // Note: SelectionBoxColor, SelectionBoxBorderColor, and TextColor will be used
+    // when selection box drawing and text rendering are implemented in later phases
+
+    private const float NodeBorderRadius = 6f;
+    private const float BorderThickness = 2f;
+    private const float ConnectionThickness = 2f;
+
+    /// <summary>
+    /// Sets the canvas screen bounds.
+    /// </summary>
+    /// <param name="bounds">The screen rectangle of the canvas area.</param>
+    public void SetCanvasBounds(Rectangle bounds)
+    {
+        canvasBounds = bounds;
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Get renderer
+        if (renderer is null && !World.TryGetExtension(out renderer))
+        {
+            return;
+        }
+
+        // Text renderer is optional
+        if (textRenderer is null)
+        {
+            World.TryGetExtension(out textRenderer);
+        }
+
+        // Get port registry
+        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        {
+            return;
+        }
+
+        // Render each canvas
+        foreach (var canvas in World.Query<GraphCanvas, GraphCanvasTag>())
+        {
+            RenderCanvas(canvas);
+        }
+    }
+
+    private void RenderCanvas(Entity canvas)
+    {
+        ref readonly var canvasData = ref World.Get<GraphCanvas>(canvas);
+        var origin = new Vector2(canvasBounds.X, canvasBounds.Y);
+
+        renderer!.Begin();
+
+        try
+        {
+            // Clip to canvas bounds
+            renderer.PushClip(canvasBounds);
+
+            // Draw grid
+            DrawGrid(canvasData, origin);
+
+            // Draw connections
+            DrawConnections(canvas, canvasData, origin);
+
+            // Draw nodes
+            DrawNodes(canvas, canvasData, origin);
+
+            // Draw selection box if selecting
+            if (canvasData.Mode == GraphInteractionMode.Selecting)
+            {
+                DrawSelectionBox(canvasData);
+            }
+
+            renderer.PopClip();
+        }
+        finally
+        {
+            renderer.End();
+        }
+    }
+
+    private void DrawGrid(in GraphCanvas canvasData, Vector2 origin)
+    {
+        var visibleArea = GraphTransform.GetVisibleArea(canvasBounds, canvasData.Pan, canvasData.Zoom);
+        var gridSize = canvasData.GridSize;
+
+        if (gridSize <= 0)
+        {
+            return;
+        }
+
+        // Calculate grid line range
+        var startX = MathF.Floor(visibleArea.X / gridSize) * gridSize;
+        var startY = MathF.Floor(visibleArea.Y / gridSize) * gridSize;
+        var endX = visibleArea.X + visibleArea.Width;
+        var endY = visibleArea.Y + visibleArea.Height;
+
+        // Draw minor grid lines (every grid unit)
+        for (var x = startX; x <= endX; x += gridSize)
+        {
+            var screenStart = GraphTransform.CanvasToScreen(new Vector2(x, visibleArea.Y), canvasData.Pan, canvasData.Zoom, origin);
+            var screenEnd = GraphTransform.CanvasToScreen(new Vector2(x, visibleArea.Y + visibleArea.Height), canvasData.Pan, canvasData.Zoom, origin);
+
+            // Major lines every 5 grid units
+            var isMajor = MathF.Abs(x % (gridSize * 5)) < 0.1f;
+            var color = isMajor ? GridColorMajor : GridColorMinor;
+
+            renderer!.DrawLine(screenStart, screenEnd, color, 1f);
+        }
+
+        for (var y = startY; y <= endY; y += gridSize)
+        {
+            var screenStart = GraphTransform.CanvasToScreen(new Vector2(visibleArea.X, y), canvasData.Pan, canvasData.Zoom, origin);
+            var screenEnd = GraphTransform.CanvasToScreen(new Vector2(visibleArea.X + visibleArea.Width, y), canvasData.Pan, canvasData.Zoom, origin);
+
+            var isMajor = MathF.Abs(y % (gridSize * 5)) < 0.1f;
+            var color = isMajor ? GridColorMajor : GridColorMinor;
+
+            renderer!.DrawLine(screenStart, screenEnd, color, 1f);
+        }
+    }
+
+    private void DrawConnections(Entity canvas, in GraphCanvas canvasData, Vector2 origin)
+    {
+        foreach (var connectionEntity in World.Query<GraphConnection>())
+        {
+            ref readonly var connection = ref World.Get<GraphConnection>(connectionEntity);
+            if (connection.Canvas != canvas)
+            {
+                continue;
+            }
+
+            // Get source and target node positions
+            if (!World.IsAlive(connection.SourceNode) || !World.IsAlive(connection.TargetNode))
+            {
+                continue;
+            }
+
+            ref readonly var sourceNode = ref World.Get<GraphNode>(connection.SourceNode);
+            ref readonly var targetNode = ref World.Get<GraphNode>(connection.TargetNode);
+
+            // Calculate port positions
+            var sourcePortY = GraphLayoutSystem.HeaderHeight + (connection.SourcePortIndex * GraphLayoutSystem.PortRowHeight) + (GraphLayoutSystem.PortRowHeight / 2);
+            var targetPortY = GraphLayoutSystem.HeaderHeight + (connection.TargetPortIndex * GraphLayoutSystem.PortRowHeight) + (GraphLayoutSystem.PortRowHeight / 2);
+
+            var sourcePos = sourceNode.Position + new Vector2(sourceNode.Width, sourcePortY);
+            var targetPos = targetNode.Position + new Vector2(0, targetPortY);
+
+            // Convert to screen coordinates
+            var screenStart = GraphTransform.CanvasToScreen(sourcePos, canvasData.Pan, canvasData.Zoom, origin);
+            var screenEnd = GraphTransform.CanvasToScreen(targetPos, canvasData.Pan, canvasData.Zoom, origin);
+
+            // Draw connection line
+            var isSelected = World.Has<GraphConnectionSelectedTag>(connectionEntity);
+            var color = isSelected ? NodeSelectedBorderColor : ConnectionColor;
+            renderer!.DrawLine(screenStart, screenEnd, color, ConnectionThickness);
+        }
+    }
+
+    private void DrawNodes(Entity canvas, in GraphCanvas canvasData, Vector2 origin)
+    {
+        foreach (var node in World.Query<GraphNode>())
+        {
+            ref readonly var nodeData = ref World.Get<GraphNode>(node);
+            if (nodeData.Canvas != canvas)
+            {
+                continue;
+            }
+
+            DrawNode(node, in nodeData, canvasData, origin);
+        }
+    }
+
+    private void DrawNode(Entity node, ref readonly GraphNode nodeData, in GraphCanvas canvasData, Vector2 origin)
+    {
+        var nodeRect = new Rectangle(nodeData.Position.X, nodeData.Position.Y, nodeData.Width, nodeData.Height);
+        var screenRect = GraphTransform.CanvasToScreen(nodeRect, canvasData.Pan, canvasData.Zoom, origin);
+
+        var isSelected = World.Has<GraphNodeSelectedTag>(node);
+        var borderColor = isSelected ? NodeSelectedBorderColor : NodeBorderColor;
+        var scaledRadius = NodeBorderRadius * canvasData.Zoom;
+
+        // Draw node body
+        renderer!.FillRoundedRect(screenRect.X, screenRect.Y, screenRect.Width, screenRect.Height, scaledRadius, NodeBodyColor);
+
+        // Draw header
+        var headerHeight = GraphLayoutSystem.HeaderHeight * canvasData.Zoom;
+        renderer.FillRoundedRect(screenRect.X, screenRect.Y, screenRect.Width, headerHeight, scaledRadius, NodeHeaderColor);
+
+        // Draw node border
+        renderer.DrawRoundedRect(screenRect.X, screenRect.Y, screenRect.Width, screenRect.Height, scaledRadius, borderColor, BorderThickness);
+
+        // Note: Text rendering for node name would go here if textRenderer is available
+        // For Phase 1, we skip text since it requires font setup
+
+        // Draw ports
+        DrawPorts(node, in nodeData, canvasData, origin);
+    }
+
+    private void DrawPorts(Entity node, ref readonly GraphNode nodeData, in GraphCanvas canvasData, Vector2 origin)
+    {
+        if (!portRegistry!.TryGetNodeType(nodeData.NodeTypeId, out var nodeType))
+        {
+            return;
+        }
+
+        var portRadius = GraphLayoutSystem.PortRadius * canvasData.Zoom;
+
+        // Draw input ports (left edge)
+        for (int i = 0; i < nodeType.InputPorts.Length; i++)
+        {
+            var yOffset = GraphLayoutSystem.HeaderHeight + (i * GraphLayoutSystem.PortRowHeight) + (GraphLayoutSystem.PortRowHeight / 2);
+            var canvasPos = nodeData.Position + new Vector2(0, yOffset);
+            var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
+
+            var port = nodeType.InputPorts[i];
+            var portColor = GetPortColor(port.TypeId);
+            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, portColor);
+        }
+
+        // Draw output ports (right edge)
+        for (int i = 0; i < nodeType.OutputPorts.Length; i++)
+        {
+            var yOffset = GraphLayoutSystem.HeaderHeight + (i * GraphLayoutSystem.PortRowHeight) + (GraphLayoutSystem.PortRowHeight / 2);
+            var canvasPos = nodeData.Position + new Vector2(nodeData.Width, yOffset);
+            var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
+
+            var port = nodeType.OutputPorts[i];
+            var portColor = GetPortColor(port.TypeId);
+            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, portColor);
+        }
+    }
+
+    private void DrawSelectionBox(in GraphCanvas canvasData)
+    {
+        // The selection box coordinates would be provided by the input system
+        // For now, this is a placeholder - the actual implementation needs
+        // state from GraphInputSystem
+    }
+
+    private static Vector4 GetPortColor(PortTypeId typeId)
+    {
+        return typeId switch
+        {
+            PortTypeId.Float or PortTypeId.Float2 or PortTypeId.Float3 or PortTypeId.Float4 => new Vector4(0.4f, 0.8f, 0.4f, 1f),
+            PortTypeId.Int or PortTypeId.Int2 or PortTypeId.Int3 or PortTypeId.Int4 => new Vector4(0.3f, 0.5f, 0.8f, 1f),
+            PortTypeId.Bool => new Vector4(0.8f, 0.3f, 0.3f, 1f),
+            PortTypeId.Entity => new Vector4(0.8f, 0.6f, 0.2f, 1f),
+            PortTypeId.Flow => new Vector4(1f, 1f, 1f, 1f),
+            _ => PortColor
+        };
+    }
+}

--- a/src/KeenEyes.Graph/packages.lock.json
+++ b/src/KeenEyes.Graph/packages.lock.json
@@ -1,0 +1,47 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graph.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Graph.Tests/GraphContextTests.cs
+++ b/tests/KeenEyes.Graph.Tests/GraphContextTests.cs
@@ -1,0 +1,319 @@
+using System.Numerics;
+using KeenEyes.Graph;
+using KeenEyes.Graph.Abstractions;
+
+namespace KeenEyes.Graph.Tests;
+
+public class GraphContextTests
+{
+    private World CreateWorldWithGraphPlugin()
+    {
+        var world = new World();
+        world.InstallPlugin(new GraphPlugin());
+        return world;
+    }
+
+    [Fact]
+    public void CreateCanvas_ReturnsValidEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+
+        var canvas = context.CreateCanvas();
+
+        Assert.True(canvas.IsValid);
+        Assert.True(world.Has<GraphCanvas>(canvas));
+        Assert.True(world.Has<GraphCanvasTag>(canvas));
+    }
+
+    [Fact]
+    public void CreateCanvas_WithName_SetsEntityName()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+
+        var canvas = context.CreateCanvas("TestCanvas");
+
+        Assert.True(canvas.IsValid);
+        Assert.Equal("TestCanvas", world.GetName(canvas));
+    }
+
+    [Fact]
+    public void CreateNode_ReturnsValidEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var position = new Vector2(100, 100);
+
+        var node = context.CreateNode(canvas, nodeTypeId, position);
+
+        Assert.True(node.IsValid);
+        Assert.True(world.Has<GraphNode>(node));
+        ref readonly var nodeData = ref world.Get<GraphNode>(node);
+        Assert.Equal(position, nodeData.Position);
+        Assert.Equal(canvas, nodeData.Canvas);
+    }
+
+    [Fact]
+    public void CreateNode_SetsParentToCanvas()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        Assert.Equal(canvas, world.GetParent(node));
+    }
+
+    [Fact]
+    public void CreateNode_WithInvalidCanvas_ThrowsArgumentException()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var nodeTypeId = registry.RegisterGenericNode();
+
+        Assert.Throws<ArgumentException>(() =>
+            context.CreateNode(Entity.Null, nodeTypeId, Vector2.Zero));
+    }
+
+    [Fact]
+    public void CreateNode_WithUnregisteredType_ThrowsArgumentException()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+
+        var canvas = context.CreateCanvas();
+
+        Assert.Throws<ArgumentException>(() =>
+            context.CreateNode(canvas, 999, Vector2.Zero));
+    }
+
+    [Fact]
+    public void Connect_WithValidNodes_ReturnsConnectionEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+
+        var connection = context.Connect(node1, 0, node2, 0);
+
+        Assert.True(connection.IsValid);
+        Assert.True(world.Has<GraphConnection>(connection));
+    }
+
+    [Fact]
+    public void Connect_WithInvalidSourceNode_ReturnsNullEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        var connection = context.Connect(Entity.Null, 0, node, 0);
+
+        Assert.False(connection.IsValid);
+    }
+
+    [Fact]
+    public void Connect_WithInvalidTargetNode_ReturnsNullEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        var connection = context.Connect(node, 0, Entity.Null, 0);
+
+        Assert.False(connection.IsValid);
+    }
+
+    [Fact]
+    public void DeleteNode_RemovesNodeEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        context.DeleteNode(node);
+
+        Assert.False(world.IsAlive(node));
+    }
+
+    [Fact]
+    public void DeleteNode_RemovesRelatedConnections()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+        var connection = context.Connect(node1, 0, node2, 0);
+
+        context.DeleteNode(node1);
+
+        Assert.False(world.IsAlive(connection));
+    }
+
+    [Fact]
+    public void DeleteConnection_RemovesConnectionEntity()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+        var connection = context.Connect(node1, 0, node2, 0);
+
+        context.DeleteConnection(connection);
+
+        Assert.False(world.IsAlive(connection));
+        Assert.True(world.IsAlive(node1)); // Nodes should remain
+        Assert.True(world.IsAlive(node2));
+    }
+
+    [Fact]
+    public void SelectNode_AddsSelectedTag()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        context.SelectNode(node);
+
+        Assert.True(world.Has<GraphNodeSelectedTag>(node));
+    }
+
+    [Fact]
+    public void SelectNode_WithoutAddToSelection_ClearsPreviousSelection()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+
+        context.SelectNode(node1);
+        context.SelectNode(node2, addToSelection: false);
+
+        Assert.False(world.Has<GraphNodeSelectedTag>(node1));
+        Assert.True(world.Has<GraphNodeSelectedTag>(node2));
+    }
+
+    [Fact]
+    public void SelectNode_WithAddToSelection_KeepsPreviousSelection()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+
+        context.SelectNode(node1);
+        context.SelectNode(node2, addToSelection: true);
+
+        Assert.True(world.Has<GraphNodeSelectedTag>(node1));
+        Assert.True(world.Has<GraphNodeSelectedTag>(node2));
+    }
+
+    [Fact]
+    public void DeselectNode_RemovesSelectedTag()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node = context.CreateNode(canvas, nodeTypeId, Vector2.Zero);
+
+        context.SelectNode(node);
+        context.DeselectNode(node);
+
+        Assert.False(world.Has<GraphNodeSelectedTag>(node));
+    }
+
+    [Fact]
+    public void ClearSelection_RemovesAllSelectedTags()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+
+        context.SelectNode(node1);
+        context.SelectNode(node2, addToSelection: true);
+        context.ClearSelection();
+
+        Assert.False(world.Has<GraphNodeSelectedTag>(node1));
+        Assert.False(world.Has<GraphNodeSelectedTag>(node2));
+    }
+
+    [Fact]
+    public void GetSelectedNodes_ReturnsAllSelectedNodes()
+    {
+        using var world = CreateWorldWithGraphPlugin();
+        var context = world.GetExtension<GraphContext>();
+        var registry = world.GetExtension<PortRegistry>();
+
+        var canvas = context.CreateCanvas();
+        var nodeTypeId = registry.RegisterGenericNode();
+        var node1 = context.CreateNode(canvas, nodeTypeId, new Vector2(0, 0));
+        var node2 = context.CreateNode(canvas, nodeTypeId, new Vector2(200, 0));
+        var node3 = context.CreateNode(canvas, nodeTypeId, new Vector2(400, 0));
+
+        context.SelectNode(node1);
+        context.SelectNode(node2, addToSelection: true);
+
+        var selected = context.GetSelectedNodes().ToList();
+
+        Assert.Equal(2, selected.Count);
+        Assert.Contains(node1, selected);
+        Assert.Contains(node2, selected);
+        Assert.DoesNotContain(node3, selected);
+    }
+}

--- a/tests/KeenEyes.Graph.Tests/GraphTransformTests.cs
+++ b/tests/KeenEyes.Graph.Tests/GraphTransformTests.cs
@@ -1,0 +1,223 @@
+using System.Numerics;
+using KeenEyes.Graph;
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graph.Tests;
+
+public class GraphTransformTests
+{
+    [Fact]
+    public void ScreenToCanvas_WithNoPanOrZoom_ReturnsRelativeToOrigin()
+    {
+        var screenPos = new Vector2(100, 100);
+        var pan = Vector2.Zero;
+        var zoom = 1f;
+        var origin = new Vector2(50, 50);
+
+        var canvasPos = GraphTransform.ScreenToCanvas(screenPos, pan, zoom, origin);
+
+        Assert.Equal(50f, canvasPos.X);
+        Assert.Equal(50f, canvasPos.Y);
+    }
+
+    [Fact]
+    public void CanvasToScreen_WithNoPanOrZoom_ReturnsRelativeToOrigin()
+    {
+        var canvasPos = new Vector2(50, 50);
+        var pan = Vector2.Zero;
+        var zoom = 1f;
+        var origin = new Vector2(50, 50);
+
+        var screenPos = GraphTransform.CanvasToScreen(canvasPos, pan, zoom, origin);
+
+        Assert.Equal(100f, screenPos.X);
+        Assert.Equal(100f, screenPos.Y);
+    }
+
+    [Fact]
+    public void ScreenToCanvas_AndBack_ReturnsOriginalPosition()
+    {
+        var screenPos = new Vector2(200, 300);
+        var pan = new Vector2(10, 20);
+        var zoom = 1.5f;
+        var origin = new Vector2(100, 100);
+
+        var canvasPos = GraphTransform.ScreenToCanvas(screenPos, pan, zoom, origin);
+        var backToScreen = GraphTransform.CanvasToScreen(canvasPos, pan, zoom, origin);
+
+        Assert.Equal(screenPos.X, backToScreen.X, precision: 4);
+        Assert.Equal(screenPos.Y, backToScreen.Y, precision: 4);
+    }
+
+    [Fact]
+    public void CanvasToScreen_WithZoom_ScalesPosition()
+    {
+        var canvasPos = new Vector2(100, 100);
+        var pan = Vector2.Zero;
+        var zoom = 2f;
+        var origin = Vector2.Zero;
+
+        var screenPos = GraphTransform.CanvasToScreen(canvasPos, pan, zoom, origin);
+
+        Assert.Equal(200f, screenPos.X);
+        Assert.Equal(200f, screenPos.Y);
+    }
+
+    [Fact]
+    public void ScreenToCanvas_WithZoom_UnscalesPosition()
+    {
+        var screenPos = new Vector2(200, 200);
+        var pan = Vector2.Zero;
+        var zoom = 2f;
+        var origin = Vector2.Zero;
+
+        var canvasPos = GraphTransform.ScreenToCanvas(screenPos, pan, zoom, origin);
+
+        Assert.Equal(100f, canvasPos.X);
+        Assert.Equal(100f, canvasPos.Y);
+    }
+
+    [Fact]
+    public void CanvasToScreen_WithPan_OffsetsByPan()
+    {
+        var canvasPos = new Vector2(100, 100);
+        var pan = new Vector2(50, 50);
+        var zoom = 1f;
+        var origin = Vector2.Zero;
+
+        var screenPos = GraphTransform.CanvasToScreen(canvasPos, pan, zoom, origin);
+
+        Assert.Equal(50f, screenPos.X);
+        Assert.Equal(50f, screenPos.Y);
+    }
+
+    [Fact]
+    public void GetVisibleArea_ReturnsCorrectCanvasArea()
+    {
+        var screenBounds = new Rectangle(0, 0, 800, 600);
+        var pan = Vector2.Zero;
+        var zoom = 1f;
+
+        var visible = GraphTransform.GetVisibleArea(screenBounds, pan, zoom);
+
+        Assert.Equal(800f, visible.Width);
+        Assert.Equal(600f, visible.Height);
+    }
+
+    [Fact]
+    public void GetVisibleArea_WithZoom_ScalesArea()
+    {
+        var screenBounds = new Rectangle(0, 0, 800, 600);
+        var pan = Vector2.Zero;
+        var zoom = 2f;
+
+        var visible = GraphTransform.GetVisibleArea(screenBounds, pan, zoom);
+
+        Assert.Equal(400f, visible.Width);
+        Assert.Equal(300f, visible.Height);
+    }
+
+    [Fact]
+    public void ZoomToPoint_KeepsFocusPointStationary()
+    {
+        var currentPan = Vector2.Zero;
+        var currentZoom = 1f;
+        var newZoom = 2f;
+        var screenFocus = new Vector2(400, 300);
+        var origin = Vector2.Zero;
+
+        // Get the canvas position under focus before zoom
+        var canvasFocus = GraphTransform.ScreenToCanvas(screenFocus, currentPan, currentZoom, origin);
+
+        // Calculate new pan
+        var newPan = GraphTransform.ZoomToPoint(currentPan, currentZoom, newZoom, screenFocus, origin);
+
+        // Get the screen position of the same canvas point after zoom
+        var screenAfter = GraphTransform.CanvasToScreen(canvasFocus, newPan, newZoom, origin);
+
+        Assert.Equal(screenFocus.X, screenAfter.X, precision: 4);
+        Assert.Equal(screenFocus.Y, screenAfter.Y, precision: 4);
+    }
+
+    [Fact]
+    public void SnapToGrid_SnapsToNearestGridPoint()
+    {
+        var position = new Vector2(33, 47);
+        var gridSize = 20f;
+
+        var snapped = GraphTransform.SnapToGrid(position, gridSize);
+
+        Assert.Equal(40f, snapped.X);
+        Assert.Equal(40f, snapped.Y);
+    }
+
+    [Fact]
+    public void SnapToGrid_WithExactGridPoint_ReturnsUnchanged()
+    {
+        var position = new Vector2(40, 60);
+        var gridSize = 20f;
+
+        var snapped = GraphTransform.SnapToGrid(position, gridSize);
+
+        Assert.Equal(40f, snapped.X);
+        Assert.Equal(60f, snapped.Y);
+    }
+
+    [Fact]
+    public void HitTest_WithPointInsideRect_ReturnsTrue()
+    {
+        var screenPoint = new Vector2(150, 150);
+        var canvasRect = new Rectangle(100, 100, 100, 100);
+        var pan = Vector2.Zero;
+        var zoom = 1f;
+        var origin = Vector2.Zero;
+
+        var hit = GraphTransform.HitTest(screenPoint, canvasRect, pan, zoom, origin);
+
+        Assert.True(hit);
+    }
+
+    [Fact]
+    public void HitTest_WithPointOutsideRect_ReturnsFalse()
+    {
+        var screenPoint = new Vector2(50, 50);
+        var canvasRect = new Rectangle(100, 100, 100, 100);
+        var pan = Vector2.Zero;
+        var zoom = 1f;
+        var origin = Vector2.Zero;
+
+        var hit = GraphTransform.HitTest(screenPoint, canvasRect, pan, zoom, origin);
+
+        Assert.False(hit);
+    }
+
+    [Fact]
+    public void CreateSelectionBox_NormalizesNegativeSize()
+    {
+        var start = new Vector2(200, 200);
+        var end = new Vector2(100, 100);
+
+        var box = GraphTransform.CreateSelectionBox(start, end);
+
+        Assert.Equal(100f, box.X);
+        Assert.Equal(100f, box.Y);
+        Assert.Equal(100f, box.Width);
+        Assert.Equal(100f, box.Height);
+    }
+
+    [Fact]
+    public void CanvasToScreen_Rectangle_TransformsCorrectly()
+    {
+        var canvasRect = new Rectangle(100, 100, 50, 50);
+        var pan = Vector2.Zero;
+        var zoom = 2f;
+        var origin = Vector2.Zero;
+
+        var screenRect = GraphTransform.CanvasToScreen(canvasRect, pan, zoom, origin);
+
+        Assert.Equal(200f, screenRect.X);
+        Assert.Equal(200f, screenRect.Y);
+        Assert.Equal(100f, screenRect.Width);
+        Assert.Equal(100f, screenRect.Height);
+    }
+}

--- a/tests/KeenEyes.Graph.Tests/KeenEyes.Graph.Tests.csproj
+++ b/tests/KeenEyes.Graph.Tests/KeenEyes.Graph.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Graph\KeenEyes.Graph.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Graph.Tests/PortRegistryTests.cs
+++ b/tests/KeenEyes.Graph.Tests/PortRegistryTests.cs
@@ -1,0 +1,157 @@
+using System.Numerics;
+using KeenEyes.Graph;
+using KeenEyes.Graph.Abstractions;
+
+namespace KeenEyes.Graph.Tests;
+
+public class PortRegistryTests
+{
+    [Fact]
+    public void RegisterNodeType_ReturnsUniqueId()
+    {
+        var registry = new PortRegistry();
+
+        var id1 = registry.RegisterNodeType("Add", "Math", [], []);
+        var id2 = registry.RegisterNodeType("Subtract", "Math", [], []);
+
+        Assert.NotEqual(id1, id2);
+    }
+
+    [Fact]
+    public void RegisterNodeType_WithExplicitId_UsesProvidedId()
+    {
+        var registry = new PortRegistry();
+
+        registry.RegisterNodeType(100, "Custom", "Custom", [], []);
+
+        Assert.True(registry.IsRegistered(100));
+        Assert.False(registry.IsRegistered(1));
+    }
+
+    [Fact]
+    public void RegisterNodeType_WithDuplicateId_ThrowsArgumentException()
+    {
+        var registry = new PortRegistry();
+
+        registry.RegisterNodeType(1, "First", "General", [], []);
+
+        Assert.Throws<ArgumentException>(() =>
+            registry.RegisterNodeType(1, "Second", "General", [], []));
+    }
+
+    [Fact]
+    public void GetNodeType_WithValidId_ReturnsNodeTypeInfo()
+    {
+        var registry = new PortRegistry();
+        var inputs = new[] { PortDefinition.Input("A", PortTypeId.Float, 0) };
+        var outputs = new[] { PortDefinition.Output("Result", PortTypeId.Float, 0) };
+
+        var id = registry.RegisterNodeType("Add", "Math", inputs, outputs);
+        var info = registry.GetNodeType(id);
+
+        Assert.Equal("Add", info.Name);
+        Assert.Equal("Math", info.Category);
+        Assert.Single(info.InputPorts);
+        Assert.Single(info.OutputPorts);
+    }
+
+    [Fact]
+    public void GetNodeType_WithInvalidId_ThrowsKeyNotFoundException()
+    {
+        var registry = new PortRegistry();
+
+        Assert.Throws<KeyNotFoundException>(() => registry.GetNodeType(999));
+    }
+
+    [Fact]
+    public void TryGetNodeType_WithValidId_ReturnsTrueAndInfo()
+    {
+        var registry = new PortRegistry();
+        var id = registry.RegisterNodeType("Test", "General", [], []);
+
+        var result = registry.TryGetNodeType(id, out var info);
+
+        Assert.True(result);
+        Assert.Equal("Test", info.Name);
+    }
+
+    [Fact]
+    public void TryGetNodeType_WithInvalidId_ReturnsFalse()
+    {
+        var registry = new PortRegistry();
+
+        var result = registry.TryGetNodeType(999, out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetAllNodeTypes_ReturnsAllRegisteredTypes()
+    {
+        var registry = new PortRegistry();
+        registry.RegisterNodeType("A", "Cat1", [], []);
+        registry.RegisterNodeType("B", "Cat2", [], []);
+        registry.RegisterNodeType("C", "Cat1", [], []);
+
+        var all = registry.GetAllNodeTypes().ToList();
+
+        Assert.Equal(3, all.Count);
+    }
+
+    [Fact]
+    public void GetNodeTypesByCategory_ReturnsOnlyMatchingTypes()
+    {
+        var registry = new PortRegistry();
+        registry.RegisterNodeType("A", "Math", [], []);
+        registry.RegisterNodeType("B", "Logic", [], []);
+        registry.RegisterNodeType("C", "Math", [], []);
+
+        var mathTypes = registry.GetNodeTypesByCategory("Math").ToList();
+
+        Assert.Equal(2, mathTypes.Count);
+        Assert.All(mathTypes, t => Assert.Equal("Math", t.Category));
+    }
+
+    [Fact]
+    public void GetCategories_ReturnsUniqueCategories()
+    {
+        var registry = new PortRegistry();
+        registry.RegisterNodeType("A", "Math", [], []);
+        registry.RegisterNodeType("B", "Logic", [], []);
+        registry.RegisterNodeType("C", "Math", [], []);
+
+        var categories = registry.GetCategories().ToList();
+
+        Assert.Equal(2, categories.Count);
+        Assert.Contains("Math", categories);
+        Assert.Contains("Logic", categories);
+    }
+
+    [Fact]
+    public void RegisterGenericNode_CreatesPlaceholderNode()
+    {
+        var registry = new PortRegistry();
+
+        var id = registry.RegisterGenericNode();
+
+        Assert.True(registry.IsRegistered(id));
+        var info = registry.GetNodeType(id);
+        Assert.Equal("Node", info.Name);
+        Assert.Equal(2, info.InputPorts.Length);
+        Assert.Single(info.OutputPorts);
+    }
+
+    [Fact]
+    public void Count_ReflectsNumberOfRegisteredTypes()
+    {
+        var registry = new PortRegistry();
+
+        Assert.Equal(0, registry.Count);
+
+        registry.RegisterNodeType("A", "General", [], []);
+        Assert.Equal(1, registry.Count);
+
+        registry.RegisterNodeType("B", "General", [], []);
+        Assert.Equal(2, registry.Count);
+    }
+}

--- a/tests/KeenEyes.Graph.Tests/packages.lock.json
+++ b/tests/KeenEyes.Graph.Tests/packages.lock.json
@@ -1,0 +1,241 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "HCfw7V1yuKxnm89vVKrb8b6aug96PUgxN9Z0YthEFCR8JOfTJF4XcU1i6RX2eEB08p3zriuFIG7BGXns4PyE8Q=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.1.0, )",
+        "resolved": "18.1.0",
+        "contentHash": "FJUCocHSPSjbeoGE/OojOhVUXwDng3VdNlwqzif9hMS2eFcG0f8RdjLM537aBsjP7zLHvGnWXbnUnc61v/EFCA==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "6.0.2",
+          "Microsoft.Testing.Platform": "2.0.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "6Tz2wZTNH/3hiskarOM5X9JaHV0QpIdIvEiLv6BJeJvtPS6AY+S47rg4K+czGSjQTkIgu5kT9SgZOwbfdhDD9Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "43NCOTEENtdc9fmlzX9KHQR14AZEYek5r4jOJlWPhTyV1+aYAQYl4x773nYXU5TKxV6+rMuniJ7wcj9C9qrP1A=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.1, )",
+        "resolved": "3.2.1",
+        "contentHash": "QnT7C+eEUM7ut6w4/RNPpSxE1Q9epiCNWf8Krc/vqcc+sc3Ejtl8lbf4w5DzBYWLUlkEEUr1u9czG0Qj7QK6IQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.26.0",
+          "xunit.v3.assert": "[3.2.1]",
+          "xunit.v3.core.mtp-v2": "[3.2.1]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QcZrCETsBJqy/vQpFtJc+jSXQ0K5sucQ6NUFbTNVHD4vfZZOwjZ/3sBzczkC4DityhD3AVO/+K/+9ioLs1AgRA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "HS5YsudCGSVoCVdsYJ5FAO9vx0z04qSAXgVzpDJSQ1/w/X9q8hrQVGU2p+Yfui+2KcXLL+Zjc0SX3yJWtBmYiw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.26.0",
+        "contentHash": "YrWZOfuU1Scg4iGizAlMNALOxVS+HPSVilfscNDEJAyrTIVdF4c+8o+Aerw2RYnrJxafj/F56YkJOKCURUWQmA=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "7hGxs+sfgPCiHg7CbWL8Vsmg8WS4vBfipZ7rfE+FEyS7ksU4+0vcV08TQvLIXLPAfinT06zVoK83YjRcMXcXLw=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "NUh3pPTC3Py4XTnjoCCCIEzvdKTQ9apu0ikDNCrUETBtfHHXcoUmIl5bOfJLQQu7awhu8eaZHjJnG7rx9lUZpg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EX7lPHnlJQYGj092TE+I7bw/iT9eYA+JcqRg0+31tSPgQqBhmOSxTT7YIfU6zFHo4ak4F/TPz3GjmvweJT1zZw==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.inproc.console": "[3.2.1]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "soZuThF5CwB/ZZ2HY/ivdinyM/6MvmjsHTG0vNw3fRd1ZKcmLzfxVb3fB6R3G5yoaN4Bh+aWzFGjOvYO05OzkA==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "oF0jwl0xH45/RWjDcaCPOeeI6HCoyiEXIT8yvByd37rhJorjL/Ri8S9A/Vql8DBPjCfQWd6Url5JRmeiQ55isA==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.1]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.1",
+        "contentHash": "EC/VLj1E9BPWfmzdEMQEqouxh0rWAdX6SXuiiDRf0yXXsQo3E2PNLKCyJ9V8hmkGH/nBvM7pHLFbuCf00vCynw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.1]",
+          "xunit.v3.runner.common": "[3.2.1]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graph": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graph.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graph.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implement Graph Editor Phase 1 as specified in ADR-010 and Issue #570
- Add `KeenEyes.Graph.Abstractions` project with components (GraphCanvas, GraphNode, GraphConnection), types (PortDefinition, PortTypeId, PortDirection, GraphInteractionMode), and tag components
- Add `KeenEyes.Graph` project with GraphPlugin, GraphContext extension, PortRegistry, GraphTransform utility, and three systems (GraphInputSystem, GraphLayoutSystem, GraphRenderSystem)
- Add comprehensive unit tests for GraphContext, PortRegistry, and GraphTransform (45 tests)

## Features
- Create graph canvases with configurable pan/zoom/grid settings
- Add and position nodes on canvases with typed ports
- Connect nodes via typed ports with straight lines
- Pan (middle mouse), zoom (scroll wheel), select (left click), and drag nodes
- Box selection for multi-select (with Ctrl modifier support)
- Delete selected nodes/connections (Delete/Backspace key)

## Test plan
- [x] Unit tests added for GraphContext, PortRegistry, GraphTransform
- [x] All 45 tests passing
- [x] Full solution build with 0 warnings, 0 errors

## Related Issues
Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)