### PR TITLE
feat(replay): Add ReplayPlayer core engine and API

### DIFF
--- a/src/KeenEyes.Replay/Exceptions/ReplayException.cs
+++ b/src/KeenEyes.Replay/Exceptions/ReplayException.cs
@@ -1,0 +1,64 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Base exception for all replay-related errors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception serves as the base class for all replay system exceptions,
+/// enabling catch blocks to handle all replay errors uniformly when specific
+/// handling is not required.
+/// </para>
+/// <para>
+/// Derived exceptions include:
+/// <list type="bullet">
+/// <item><description><see cref="ReplayFormatException"/> - Invalid replay file format.</description></item>
+/// <item><description><see cref="ReplayVersionException"/> - Replay format version mismatch.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// try
+/// {
+///     player.LoadReplay("recording.kreplay");
+/// }
+/// catch (ReplayException ex)
+/// {
+///     Console.WriteLine($"Failed to load replay: {ex.Message}");
+/// }
+/// </code>
+/// </example>
+public class ReplayException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayException"/> class.
+    /// </summary>
+    public ReplayException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayException"/> class
+    /// with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ReplayException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayException"/> class
+    /// with a specified error message and a reference to the inner exception
+    /// that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception, or null if no inner exception is specified.
+    /// </param>
+    public ReplayException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/KeenEyes.Replay/Exceptions/ReplayFormatException.cs
+++ b/src/KeenEyes.Replay/Exceptions/ReplayFormatException.cs
@@ -1,0 +1,163 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Exception thrown when a replay file has an invalid or unrecognized format.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception is thrown in the following scenarios:
+/// <list type="bullet">
+/// <item><description>The file does not have valid .kreplay magic bytes.</description></item>
+/// <item><description>The file structure is corrupted or truncated.</description></item>
+/// <item><description>Required data sections are missing or malformed.</description></item>
+/// <item><description>The checksum validation fails (data corruption).</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// For version-related errors where the format is valid but unsupported,
+/// see <see cref="ReplayVersionException"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// try
+/// {
+///     player.LoadReplay("recording.kreplay");
+/// }
+/// catch (ReplayFormatException ex)
+/// {
+///     Console.WriteLine($"Invalid replay file: {ex.Message}");
+///     if (ex.FilePath is not null)
+///     {
+///         Console.WriteLine($"File: {ex.FilePath}");
+///     }
+/// }
+/// </code>
+/// </example>
+public class ReplayFormatException : ReplayException
+{
+    /// <summary>
+    /// Gets the path of the replay file that had the format error, if available.
+    /// </summary>
+    /// <remarks>
+    /// This property is null when the replay was loaded from a stream or byte array
+    /// without an associated file path.
+    /// </remarks>
+    public string? FilePath { get; }
+
+    /// <summary>
+    /// Gets the specific format issue that was detected, if available.
+    /// </summary>
+    public string? FormatIssue { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayFormatException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ReplayFormatException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayFormatException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="filePath">The path of the replay file that had the format error.</param>
+    public ReplayFormatException(string message, string? filePath)
+        : base(message)
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayFormatException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="filePath">The path of the replay file that had the format error.</param>
+    /// <param name="formatIssue">The specific format issue that was detected.</param>
+    public ReplayFormatException(string message, string? filePath, string? formatIssue)
+        : base(message)
+    {
+        FilePath = filePath;
+        FormatIssue = formatIssue;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayFormatException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that caused this exception.</param>
+    public ReplayFormatException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayFormatException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="filePath">The path of the replay file that had the format error.</param>
+    /// <param name="innerException">The exception that caused this exception.</param>
+    public ReplayFormatException(string message, string? filePath, Exception innerException)
+        : base(message, innerException)
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Creates a format exception for invalid magic bytes.
+    /// </summary>
+    /// <param name="filePath">The path of the file, if available.</param>
+    /// <returns>A new exception instance.</returns>
+    public static ReplayFormatException InvalidMagicBytes(string? filePath = null)
+        => new(
+            "Invalid replay file: missing or incorrect magic bytes. The file is not a valid .kreplay file.",
+            filePath,
+            "InvalidMagicBytes");
+
+    /// <summary>
+    /// Creates a format exception for a corrupted file.
+    /// </summary>
+    /// <param name="filePath">The path of the file, if available.</param>
+    /// <param name="details">Additional details about the corruption.</param>
+    /// <returns>A new exception instance.</returns>
+    public static ReplayFormatException Corrupted(string? filePath = null, string? details = null)
+    {
+        var message = "Replay file is corrupted or truncated.";
+        if (details is not null)
+        {
+            message += $" {details}";
+        }
+
+        return new ReplayFormatException(message, filePath, "Corrupted");
+    }
+
+    /// <summary>
+    /// Creates a format exception for checksum validation failure.
+    /// </summary>
+    /// <param name="expectedChecksum">The expected checksum value.</param>
+    /// <param name="actualChecksum">The actual checksum value.</param>
+    /// <param name="filePath">The path of the file, if available.</param>
+    /// <returns>A new exception instance.</returns>
+    public static ReplayFormatException ChecksumMismatch(
+        string expectedChecksum,
+        string actualChecksum,
+        string? filePath = null)
+        => new(
+            $"Replay file checksum validation failed. Expected: {expectedChecksum}, Actual: {actualChecksum}. The file may be corrupted.",
+            filePath,
+            "ChecksumMismatch");
+
+    /// <summary>
+    /// Creates a format exception for deserialization failure.
+    /// </summary>
+    /// <param name="innerException">The exception from the deserializer.</param>
+    /// <param name="filePath">The path of the file, if available.</param>
+    /// <returns>A new exception instance.</returns>
+    public static ReplayFormatException DeserializationFailed(Exception innerException, string? filePath = null)
+        => new(
+            $"Failed to deserialize replay data: {innerException.Message}",
+            filePath,
+            innerException);
+}

--- a/src/KeenEyes.Replay/Exceptions/ReplayVersionException.cs
+++ b/src/KeenEyes.Replay/Exceptions/ReplayVersionException.cs
@@ -1,0 +1,184 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Exception thrown when a replay file version is not supported.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception is thrown when:
+/// <list type="bullet">
+/// <item><description>
+/// The replay file was created with a newer version of the format than the current player supports.
+/// This typically means the application needs to be updated.
+/// </description></item>
+/// <item><description>
+/// The replay file was created with an older version that is no longer supported and cannot be migrated.
+/// </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The exception includes version information to help diagnose compatibility issues
+/// and provide guidance to users.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// try
+/// {
+///     player.LoadReplay("recording.kreplay");
+/// }
+/// catch (ReplayVersionException ex)
+/// {
+///     Console.WriteLine($"Version mismatch: file is v{ex.FileVersion}, but player supports v{ex.CurrentVersion}");
+///     if (ex.FileVersion > ex.CurrentVersion)
+///     {
+///         Console.WriteLine("Please update the application to play this replay.");
+///     }
+/// }
+/// </code>
+/// </example>
+public class ReplayVersionException : ReplayException
+{
+    /// <summary>
+    /// Gets the version of the replay file that was being loaded.
+    /// </summary>
+    public int FileVersion { get; }
+
+    /// <summary>
+    /// Gets the current version supported by the player.
+    /// </summary>
+    public int CurrentVersion { get; }
+
+    /// <summary>
+    /// Gets the minimum version supported by the player, if applicable.
+    /// </summary>
+    /// <remarks>
+    /// This is null if there is no minimum version constraint.
+    /// </remarks>
+    public int? MinimumSupportedVersion { get; }
+
+    /// <summary>
+    /// Gets the path of the replay file that had the version error, if available.
+    /// </summary>
+    public string? FilePath { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayVersionException"/> class.
+    /// </summary>
+    /// <param name="fileVersion">The version of the replay file.</param>
+    /// <param name="currentVersion">The current version supported by the player.</param>
+    public ReplayVersionException(int fileVersion, int currentVersion)
+        : base(CreateMessage(fileVersion, currentVersion, null))
+    {
+        FileVersion = fileVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayVersionException"/> class.
+    /// </summary>
+    /// <param name="fileVersion">The version of the replay file.</param>
+    /// <param name="currentVersion">The current version supported by the player.</param>
+    /// <param name="filePath">The path of the replay file.</param>
+    public ReplayVersionException(int fileVersion, int currentVersion, string? filePath)
+        : base(CreateMessage(fileVersion, currentVersion, filePath))
+    {
+        FileVersion = fileVersion;
+        CurrentVersion = currentVersion;
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayVersionException"/> class.
+    /// </summary>
+    /// <param name="fileVersion">The version of the replay file.</param>
+    /// <param name="currentVersion">The current version supported by the player.</param>
+    /// <param name="minimumSupportedVersion">The minimum version supported by the player.</param>
+    /// <param name="filePath">The path of the replay file.</param>
+    public ReplayVersionException(
+        int fileVersion,
+        int currentVersion,
+        int? minimumSupportedVersion,
+        string? filePath)
+        : base(CreateMessage(fileVersion, currentVersion, filePath, minimumSupportedVersion))
+    {
+        FileVersion = fileVersion;
+        CurrentVersion = currentVersion;
+        MinimumSupportedVersion = minimumSupportedVersion;
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the file version is newer than the current player supports.
+    /// </summary>
+    /// <remarks>
+    /// When true, the user should update their application to play this replay.
+    /// </remarks>
+    public bool IsNewerThanSupported => FileVersion > CurrentVersion;
+
+    /// <summary>
+    /// Gets a value indicating whether the file version is older than the minimum supported version.
+    /// </summary>
+    /// <remarks>
+    /// When true, the replay file is too old to be played by this version of the player.
+    /// </remarks>
+    public bool IsOlderThanSupported =>
+        MinimumSupportedVersion.HasValue && FileVersion < MinimumSupportedVersion.Value;
+
+    /// <summary>
+    /// Creates a version exception for an unknown or unparseable version error.
+    /// </summary>
+    /// <param name="details">Additional details about the version error.</param>
+    /// <param name="filePath">The path of the file, if available.</param>
+    /// <returns>A new exception instance.</returns>
+    public static ReplayVersionException UnknownVersion(string details, string? filePath = null)
+    {
+        var fileInfo = filePath is not null ? $"'{filePath}' " : "";
+        var message = $"Cannot load replay {fileInfo}due to a version error: {details}";
+
+        return new ReplayVersionException(message, 0, ReplayData.CurrentVersion, filePath);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayVersionException"/> class
+    /// with a custom message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="fileVersion">The version of the replay file.</param>
+    /// <param name="currentVersion">The current version supported by the player.</param>
+    /// <param name="filePath">The path of the replay file.</param>
+    private ReplayVersionException(string message, int fileVersion, int currentVersion, string? filePath)
+        : base(message)
+    {
+        FileVersion = fileVersion;
+        CurrentVersion = currentVersion;
+        FilePath = filePath;
+    }
+
+    private static string CreateMessage(
+        int fileVersion,
+        int currentVersion,
+        string? filePath,
+        int? minimumSupportedVersion = null)
+    {
+        var fileInfo = filePath is not null ? $"'{filePath}' " : "";
+
+        if (fileVersion > currentVersion)
+        {
+            return $"Cannot load replay {fileInfo}(version {fileVersion}). " +
+                   $"The current player supports version {currentVersion}. " +
+                   "Please update the application to play this replay.";
+        }
+
+        if (minimumSupportedVersion.HasValue && fileVersion < minimumSupportedVersion.Value)
+        {
+            return $"Cannot load replay {fileInfo}(version {fileVersion}). " +
+                   $"The minimum supported version is {minimumSupportedVersion.Value}. " +
+                   "This replay was created with an outdated version that is no longer supported.";
+        }
+
+        return $"Cannot load replay {fileInfo}(version {fileVersion}). " +
+               $"Current player version is {currentVersion}. " +
+               "Version compatibility check failed.";
+    }
+}

--- a/src/KeenEyes.Replay/PlaybackState.cs
+++ b/src/KeenEyes.Replay/PlaybackState.cs
@@ -1,0 +1,45 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Represents the current state of replay playback.
+/// </summary>
+/// <remarks>
+/// The playback state controls how the <see cref="ReplayPlayer"/> behaves during
+/// <see cref="ReplayPlayer.Update"/> calls:
+/// <list type="bullet">
+/// <item><description><see cref="Stopped"/> - Player is idle, no replay loaded or playback reset to beginning.</description></item>
+/// <item><description><see cref="Playing"/> - Playback is active, frames advance during Update calls.</description></item>
+/// <item><description><see cref="Paused"/> - Playback is suspended, Update calls do not advance frames.</description></item>
+/// </list>
+/// </remarks>
+public enum PlaybackState
+{
+    /// <summary>
+    /// Playback is stopped. No replay is loaded or playback has been reset.
+    /// </summary>
+    /// <remarks>
+    /// In this state, <see cref="ReplayPlayer.CurrentFrame"/> is 0 and
+    /// <see cref="ReplayPlayer.CurrentTime"/> is <see cref="TimeSpan.Zero"/>.
+    /// Call <see cref="ReplayPlayer.Play"/> to begin playback.
+    /// </remarks>
+    Stopped = 0,
+
+    /// <summary>
+    /// Playback is actively progressing through the replay.
+    /// </summary>
+    /// <remarks>
+    /// In this state, each call to <see cref="ReplayPlayer.Update"/> advances
+    /// the playback position based on the provided delta time.
+    /// </remarks>
+    Playing = 1,
+
+    /// <summary>
+    /// Playback is paused at the current position.
+    /// </summary>
+    /// <remarks>
+    /// In this state, <see cref="ReplayPlayer.Update"/> calls do not advance
+    /// the playback position. Call <see cref="ReplayPlayer.Play"/> to resume
+    /// or <see cref="ReplayPlayer.Stop"/> to reset to the beginning.
+    /// </remarks>
+    Paused = 2
+}

--- a/src/KeenEyes.Replay/ReplayPlayer.cs
+++ b/src/KeenEyes.Replay/ReplayPlayer.cs
@@ -1,0 +1,666 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Provides replay playback functionality for recorded game sessions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ReplayPlayer loads recorded replay data and provides controls for playback,
+/// including play, pause, stop, and frame-by-frame advancement. It supports loading
+/// replays from files, streams, or byte arrays.
+/// </para>
+/// <para>
+/// Basic usage:
+/// <list type="number">
+/// <item><description>Create a ReplayPlayer instance.</description></item>
+/// <item><description>Load a replay using <see cref="LoadReplay(string, bool)"/> or an overload.</description></item>
+/// <item><description>Call <see cref="Play"/> to start playback.</description></item>
+/// <item><description>Call <see cref="Update"/> each frame with the delta time.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The player maintains playback state and position, which can be queried through
+/// <see cref="State"/>, <see cref="CurrentFrame"/>, and <see cref="CurrentTime"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var player = new ReplayPlayer();
+///
+/// // Load a replay file
+/// player.LoadReplay("recording.kreplay");
+///
+/// // Start playback
+/// player.Play();
+///
+/// // In your game loop
+/// while (player.State == PlaybackState.Playing)
+/// {
+///     player.Update(deltaTime);
+///
+///     // Process the current frame
+///     var frame = player.GetCurrentFrame();
+///     // ... handle frame events ...
+/// }
+/// </code>
+/// </example>
+public sealed class ReplayPlayer : IDisposable
+{
+    private readonly Lock syncRoot = new();
+
+    private ReplayData? replayData;
+    private ReplayFileInfo? fileInfo;
+    private PlaybackState state;
+    private int currentFrameIndex;
+    private TimeSpan currentTime;
+    private TimeSpan accumulatedTime;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayPlayer"/> class.
+    /// </summary>
+    public ReplayPlayer()
+    {
+    }
+
+    /// <summary>
+    /// Gets the current playback state.
+    /// </summary>
+    /// <remarks>
+    /// The state indicates whether playback is stopped, playing, or paused.
+    /// </remarks>
+    public PlaybackState State
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return state;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current frame index (0-based).
+    /// </summary>
+    /// <remarks>
+    /// Returns -1 if no replay is loaded.
+    /// </remarks>
+    public int CurrentFrame
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return replayData is not null ? currentFrameIndex : -1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the total number of frames in the loaded replay.
+    /// </summary>
+    /// <remarks>
+    /// Returns 0 if no replay is loaded.
+    /// </remarks>
+    public int TotalFrames
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return replayData?.FrameCount ?? 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current playback time.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="TimeSpan.Zero"/> if no replay is loaded.
+    /// </remarks>
+    public TimeSpan CurrentTime
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return currentTime;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the total duration of the loaded replay.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="TimeSpan.Zero"/> if no replay is loaded.
+    /// </remarks>
+    public TimeSpan TotalDuration
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return replayData?.Duration ?? TimeSpan.Zero;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a replay is currently loaded.
+    /// </summary>
+    public bool IsLoaded
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return replayData is not null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the loaded replay data, if any.
+    /// </summary>
+    /// <remarks>
+    /// Returns null if no replay is loaded.
+    /// </remarks>
+    public ReplayData? LoadedReplay
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return replayData;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the file info for the loaded replay, if loaded from a file.
+    /// </summary>
+    /// <remarks>
+    /// Returns null if no replay is loaded or if the replay was loaded from raw data.
+    /// </remarks>
+    public ReplayFileInfo? FileInfo
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return fileInfo;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads a replay from a file path.
+    /// </summary>
+    /// <param name="path">The path to the .kreplay file.</param>
+    /// <param name="validateChecksum">Whether to validate the file checksum.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> is empty or whitespace.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
+    /// <exception cref="ReplayFormatException">Thrown when the file format is invalid.</exception>
+    /// <exception cref="ReplayVersionException">Thrown when the replay version is not supported.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// This method loads the replay file and prepares it for playback.
+    /// Any previously loaded replay is automatically unloaded.
+    /// </para>
+    /// <para>
+    /// After loading, the player is in <see cref="PlaybackState.Stopped"/> state
+    /// at frame 0. Call <see cref="Play"/> to begin playback.
+    /// </para>
+    /// </remarks>
+    public void LoadReplay(string path, bool validateChecksum = true)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        ThrowIfDisposed();
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Replay file not found: {path}", path);
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            LoadReplayCore(stream, validateChecksum, path);
+        }
+        catch (InvalidDataException ex)
+        {
+            throw ConvertToReplayException(ex, path);
+        }
+    }
+
+    /// <summary>
+    /// Loads a replay from a stream.
+    /// </summary>
+    /// <param name="stream">The stream containing replay data.</param>
+    /// <param name="validateChecksum">Whether to validate the file checksum.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/> is null.</exception>
+    /// <exception cref="ReplayFormatException">Thrown when the data format is invalid.</exception>
+    /// <exception cref="ReplayVersionException">Thrown when the replay version is not supported.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// The stream is read but not disposed. The caller retains ownership of the stream.
+    /// </para>
+    /// <para>
+    /// Any previously loaded replay is automatically unloaded.
+    /// </para>
+    /// </remarks>
+    public void LoadReplay(Stream stream, bool validateChecksum = true)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        ThrowIfDisposed();
+
+        try
+        {
+            LoadReplayCore(stream, validateChecksum, filePath: null);
+        }
+        catch (InvalidDataException ex)
+        {
+            throw ConvertToReplayException(ex, filePath: null);
+        }
+    }
+
+    /// <summary>
+    /// Loads a replay from a byte array.
+    /// </summary>
+    /// <param name="data">The byte array containing replay data.</param>
+    /// <param name="validateChecksum">Whether to validate the file checksum.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
+    /// <exception cref="ReplayFormatException">Thrown when the data format is invalid.</exception>
+    /// <exception cref="ReplayVersionException">Thrown when the replay version is not supported.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Any previously loaded replay is automatically unloaded.
+    /// </para>
+    /// </remarks>
+    public void LoadReplay(byte[] data, bool validateChecksum = true)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        ThrowIfDisposed();
+
+        try
+        {
+            using var stream = new MemoryStream(data);
+            LoadReplayCore(stream, validateChecksum, filePath: null);
+        }
+        catch (InvalidDataException ex)
+        {
+            throw ConvertToReplayException(ex, filePath: null);
+        }
+    }
+
+    /// <summary>
+    /// Loads replay data directly without file parsing.
+    /// </summary>
+    /// <param name="replay">The replay data to load.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="replay"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// This method allows loading replay data that was obtained programmatically,
+    /// such as directly from a <see cref="ReplayRecorder"/> or network transfer.
+    /// </para>
+    /// <para>
+    /// Any previously loaded replay is automatically unloaded.
+    /// </para>
+    /// </remarks>
+    public void LoadReplay(ReplayData replay)
+    {
+        ArgumentNullException.ThrowIfNull(replay);
+
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            UnloadReplayCore();
+            replayData = replay;
+            fileInfo = null;
+            ResetPlaybackPosition();
+        }
+    }
+
+    /// <summary>
+    /// Unloads the currently loaded replay.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After unloading, all playback properties return their default values
+    /// (e.g., <see cref="TotalFrames"/> returns 0, <see cref="CurrentFrame"/> returns -1).
+    /// </para>
+    /// <para>
+    /// This method does nothing if no replay is loaded.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    public void UnloadReplay()
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            UnloadReplayCore();
+        }
+    }
+
+    /// <summary>
+    /// Starts or resumes playback.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no replay is loaded.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// If playback was stopped, this starts from the beginning.
+    /// If playback was paused, this resumes from the current position.
+    /// If already playing, this method has no effect.
+    /// </para>
+    /// </remarks>
+    public void Play()
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            ThrowIfNoReplayLoaded();
+
+            state = PlaybackState.Playing;
+        }
+    }
+
+    /// <summary>
+    /// Pauses playback at the current position.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no replay is loaded.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Pausing preserves the current playback position. Call <see cref="Play"/>
+    /// to resume from the paused position.
+    /// </para>
+    /// <para>
+    /// If already paused or stopped, this method has no effect.
+    /// </para>
+    /// </remarks>
+    public void Pause()
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            ThrowIfNoReplayLoaded();
+
+            if (state == PlaybackState.Playing)
+            {
+                state = PlaybackState.Paused;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stops playback and resets to the beginning.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no replay is loaded.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// This resets <see cref="CurrentFrame"/> to 0 and <see cref="CurrentTime"/>
+    /// to <see cref="TimeSpan.Zero"/>.
+    /// </para>
+    /// <para>
+    /// If already stopped, this method has no effect.
+    /// </para>
+    /// </remarks>
+    public void Stop()
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            ThrowIfNoReplayLoaded();
+
+            ResetPlaybackPosition();
+        }
+    }
+
+    /// <summary>
+    /// Advances playback by the specified time delta.
+    /// </summary>
+    /// <param name="deltaTime">The time elapsed since the last update, in seconds.</param>
+    /// <returns>
+    /// True if the playback position changed (frame advanced or playback completed);
+    /// false if playback is not active or no change occurred.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// This method should be called each frame in your game loop while playback is active.
+    /// It accumulates time and advances frames based on the original recording timing.
+    /// </para>
+    /// <para>
+    /// When playback reaches the end of the replay, the state automatically
+    /// transitions to <see cref="PlaybackState.Stopped"/>.
+    /// </para>
+    /// <para>
+    /// If the state is not <see cref="PlaybackState.Playing"/>, this method
+    /// returns false without making any changes.
+    /// </para>
+    /// </remarks>
+    public bool Update(float deltaTime)
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            if (state != PlaybackState.Playing || replayData is null)
+            {
+                return false;
+            }
+
+            var frames = replayData.Frames;
+            if (frames.Count == 0 || currentFrameIndex >= frames.Count)
+            {
+                state = PlaybackState.Stopped;
+                return true;
+            }
+
+            // Accumulate time
+            accumulatedTime += TimeSpan.FromSeconds(deltaTime);
+            var changed = false;
+
+            // Advance frames based on accumulated time
+            while (currentFrameIndex < frames.Count)
+            {
+                var currentFrame = frames[currentFrameIndex];
+                var frameEndTime = currentFrame.ElapsedTime + currentFrame.DeltaTime;
+
+                if (accumulatedTime < currentFrame.DeltaTime)
+                {
+                    // Not enough time has passed to complete this frame
+                    break;
+                }
+
+                // Advance to the next frame
+                accumulatedTime -= currentFrame.DeltaTime;
+                currentTime = frameEndTime;
+                currentFrameIndex++;
+                changed = true;
+
+                // Check if we've reached the end
+                if (currentFrameIndex >= frames.Count)
+                {
+                    state = PlaybackState.Stopped;
+                    break;
+                }
+            }
+
+            return changed;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current frame data.
+    /// </summary>
+    /// <returns>The current frame, or null if no replay is loaded or playback is at the end.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    public ReplayFrame? GetCurrentFrame()
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            if (replayData is null || currentFrameIndex < 0 || currentFrameIndex >= replayData.Frames.Count)
+            {
+                return null;
+            }
+
+            return replayData.Frames[currentFrameIndex];
+        }
+    }
+
+    /// <summary>
+    /// Gets a frame at the specified index.
+    /// </summary>
+    /// <param name="frameIndex">The 0-based frame index.</param>
+    /// <returns>The frame at the specified index.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no replay is loaded.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the index is out of range.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    public ReplayFrame GetFrame(int frameIndex)
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            ThrowIfNoReplayLoaded();
+
+            if (frameIndex < 0 || frameIndex >= replayData!.Frames.Count)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(frameIndex),
+                    frameIndex,
+                    $"Frame index must be between 0 and {replayData!.Frames.Count - 1}.");
+            }
+
+            return replayData!.Frames[frameIndex];
+        }
+    }
+
+    /// <summary>
+    /// Releases all resources used by the <see cref="ReplayPlayer"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        lock (syncRoot)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            UnloadReplayCore();
+            disposed = true;
+        }
+    }
+
+    private void LoadReplayCore(Stream stream, bool validateChecksum, string? filePath)
+    {
+        // Validate format first
+        if (!ReplayFileFormat.IsValidFormat(stream))
+        {
+            throw ReplayFormatException.InvalidMagicBytes(filePath);
+        }
+
+        // Reset stream position after format check
+        stream.Position = 0;
+
+        // Read the replay file
+        var (info, data) = ReplayFileFormat.Read(stream, validateChecksum);
+
+        // Check version compatibility
+        if (data.Version > ReplayData.CurrentVersion)
+        {
+            throw new ReplayVersionException(data.Version, ReplayData.CurrentVersion, filePath);
+        }
+
+        lock (syncRoot)
+        {
+            UnloadReplayCore();
+            replayData = data;
+            fileInfo = info;
+            ResetPlaybackPosition();
+        }
+    }
+
+    private void UnloadReplayCore()
+    {
+        replayData = null;
+        fileInfo = null;
+        ResetPlaybackPosition();
+    }
+
+    private void ResetPlaybackPosition()
+    {
+        state = PlaybackState.Stopped;
+        currentFrameIndex = 0;
+        currentTime = TimeSpan.Zero;
+        accumulatedTime = TimeSpan.Zero;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+
+    private void ThrowIfNoReplayLoaded()
+    {
+        if (replayData is null)
+        {
+            throw new InvalidOperationException("No replay is loaded. Call LoadReplay first.");
+        }
+    }
+
+    private static ReplayException ConvertToReplayException(InvalidDataException ex, string? filePath)
+    {
+        var message = ex.Message;
+
+        // Check for known error patterns
+        if (message.Contains("magic bytes", StringComparison.OrdinalIgnoreCase))
+        {
+            return ReplayFormatException.InvalidMagicBytes(filePath);
+        }
+
+        if (message.Contains("checksum", StringComparison.OrdinalIgnoreCase))
+        {
+            // Extract checksum values if present in the message
+            return new ReplayFormatException(message, filePath, "ChecksumMismatch");
+        }
+
+        if (message.Contains("version", StringComparison.OrdinalIgnoreCase))
+        {
+            // Try to extract version info - default to unknown versions
+            return ReplayVersionException.UnknownVersion(message, filePath);
+        }
+
+        // Generic format error
+        return ReplayFormatException.Corrupted(filePath, message);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PlaybackState` enum (Stopped, Playing, Paused) to represent replay playback states
- Implement `ReplayPlayer` class with full lifecycle management and playback controls
- Add exception hierarchy: `ReplayException`, `ReplayFormatException`, `ReplayVersionException`

## Deliverables (from #405)
- [x] `ReplayPlayer` class implementing `IDisposable`
- [x] `PlaybackState` enum (Stopped, Playing, Paused)
- [x] Loading: `LoadReplay(path/stream/data)`, `UnloadReplay()`
- [x] Controls: `Play()`, `Pause()`, `Stop()`, `Update()`
- [x] Properties: `State`, `CurrentFrame`, `TotalFrames`, `CurrentTime`, `TotalDuration`
- [x] Exceptions: `ReplayException`, `ReplayFormatException`, `ReplayVersionException`

## Test plan
- [x] Build passes with zero warnings
- [x] All existing tests pass (10,873 tests)
- [x] Code formatting verified

## Related Issues
Closes #405