### PR TITLE
feat(localization): Add localized asset support for textures, audio, and fonts

### DIFF
--- a/src/KeenEyes.Localization/Components/LocalizedAsset.cs
+++ b/src/KeenEyes.Localization/Components/LocalizedAsset.cs
@@ -1,0 +1,98 @@
+namespace KeenEyes.Localization;
+
+/// <summary>
+/// Component that marks an entity as having a localized asset reference.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attach this component to entities that reference assets which should be
+/// automatically swapped when the locale changes (e.g., textures with localized text,
+/// audio files in different languages, region-specific content).
+/// </para>
+/// <para>
+/// The <see cref="LocalizedAssetSystem"/> watches for locale changes and updates
+/// the <see cref="ResolvedPath"/> based on the asset key and current locale.
+/// </para>
+/// <para>
+/// Asset resolution follows a fallback chain:
+/// </para>
+/// <list type="number">
+/// <item><description>Exact locale match: <c>textures/logo.en-US.png</c></description></item>
+/// <item><description>Language only: <c>textures/logo.en.png</c></description></item>
+/// <item><description>Default fallback: <c>textures/logo.png</c></description></item>
+/// </list>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Create a sprite with a localized texture
+/// var logo = world.Spawn()
+///     .With(SpriteRenderer.Create())
+///     .With(new LocalizedAsset { AssetKey = "textures/logo" })
+///     .Build();
+///
+/// // When locale is "en-US", ResolvedPath becomes "textures/logo.en-US.png"
+/// // or falls back to "textures/logo.en.png" or "textures/logo.png"
+/// </code>
+/// </example>
+[Component]
+public partial struct LocalizedAsset : IComponent
+{
+    /// <summary>
+    /// The base asset key without locale suffix or extension.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This key is used to find locale-specific variants of the asset.
+    /// The system will search for files with locale suffixes appended.
+    /// </para>
+    /// <para>
+    /// Example: For <c>AssetKey = "textures/logo"</c>, the system searches for:
+    /// <list type="bullet">
+    /// <item><c>textures/logo.en-US.png</c></item>
+    /// <item><c>textures/logo.en.png</c></item>
+    /// <item><c>textures/logo.png</c></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public string AssetKey;
+
+    /// <summary>
+    /// The resolved asset path for the current locale.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is automatically set by the <see cref="LocalizedAssetSystem"/> based on
+    /// the <see cref="AssetKey"/> and available locale-specific files.
+    /// </para>
+    /// <para>
+    /// Use this path to load the actual asset from the asset manager.
+    /// </para>
+    /// </remarks>
+    public string? ResolvedPath;
+
+    /// <summary>
+    /// Gets whether this asset has been resolved to a path.
+    /// </summary>
+    public readonly bool IsResolved => !string.IsNullOrEmpty(ResolvedPath);
+
+    /// <summary>
+    /// Creates a LocalizedAsset component with the specified asset key.
+    /// </summary>
+    /// <param name="assetKey">The base asset key.</param>
+    public static LocalizedAsset Create(string assetKey) => new()
+    {
+        AssetKey = assetKey,
+        ResolvedPath = null
+    };
+
+    /// <summary>
+    /// Clears the resolved path, forcing re-resolution on next update.
+    /// </summary>
+    /// <remarks>
+    /// Call this after changing the <see cref="AssetKey"/> to trigger reloading.
+    /// </remarks>
+    public void Invalidate()
+    {
+        ResolvedPath = null;
+    }
+}

--- a/src/KeenEyes.Localization/ILocalization.cs
+++ b/src/KeenEyes.Localization/ILocalization.cs
@@ -178,4 +178,63 @@ public interface ILocalization
     /// <param name="key">The translation key.</param>
     /// <returns><c>true</c> if the key exists; otherwise, <c>false</c>.</returns>
     bool HasKey(string key);
+
+    /// <summary>
+    /// Gets the font configuration for a specific locale.
+    /// </summary>
+    /// <param name="locale">The locale to get font configuration for.</param>
+    /// <returns>
+    /// The font configuration for the locale, or null if no specific configuration exists.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// If no font configuration exists for the exact locale, the system will try:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>The exact locale</description></item>
+    /// <item><description>The language-only locale (e.g., "en-US" → "en")</description></item>
+    /// <item><description>The default locale's configuration</description></item>
+    /// </list>
+    /// </remarks>
+    LocalizedFontConfig? GetFontConfig(Locale locale);
+
+    /// <summary>
+    /// Gets the font configuration for the current locale.
+    /// </summary>
+    /// <returns>
+    /// The font configuration for the current locale, or null if no specific configuration exists.
+    /// </returns>
+    LocalizedFontConfig? GetCurrentFontConfig();
+
+    /// <summary>
+    /// Preloads all assets for a specific locale for seamless switching.
+    /// </summary>
+    /// <param name="locale">The locale to preload assets for.</param>
+    /// <param name="assetKeys">The asset keys to preload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when all assets are preloaded.</returns>
+    /// <remarks>
+    /// <para>
+    /// Call this method before switching to a locale to ensure all localized assets
+    /// are loaded and ready, preventing loading stutters during locale changes.
+    /// </para>
+    /// <para>
+    /// This method requires the world to have the Assets plugin installed.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Preload Japanese assets before switching
+    /// await localization.PreloadLocaleAssetsAsync(
+    ///     Locale.JapaneseJP,
+    ///     ["textures/logo", "textures/menu_background", "audio/intro_voice"]);
+    ///
+    /// // Now switch locale - assets are ready
+    /// localization.SetLocale(Locale.JapaneseJP);
+    /// </code>
+    /// </example>
+    Task PreloadLocaleAssetsAsync(
+        Locale locale,
+        IEnumerable<string> assetKeys,
+        CancellationToken cancellationToken = default);
 }

--- a/src/KeenEyes.Localization/ILocalizedAssetResolver.cs
+++ b/src/KeenEyes.Localization/ILocalizedAssetResolver.cs
@@ -1,0 +1,51 @@
+namespace KeenEyes.Localization;
+
+/// <summary>
+/// Resolves asset paths based on the current locale.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations of this interface determine how asset keys are mapped to
+/// actual file paths based on the current locale, including fallback behavior.
+/// </para>
+/// </remarks>
+public interface ILocalizedAssetResolver
+{
+    /// <summary>
+    /// Resolves an asset key to a locale-specific path.
+    /// </summary>
+    /// <param name="assetKey">The base asset key (e.g., "textures/logo").</param>
+    /// <param name="locale">The locale to resolve for.</param>
+    /// <returns>
+    /// The resolved path if a matching asset exists, or null if no asset could be found.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The resolver should check for locale-specific variants in this order:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>Exact locale: <c>{key}.{locale}.{ext}</c></description></item>
+    /// <item><description>Language only: <c>{key}.{language}.{ext}</c></description></item>
+    /// <item><description>Default: <c>{key}.{ext}</c></description></item>
+    /// </list>
+    /// </remarks>
+    string? Resolve(string assetKey, Locale locale);
+
+    /// <summary>
+    /// Gets all available paths for an asset key across all locales.
+    /// </summary>
+    /// <param name="assetKey">The base asset key.</param>
+    /// <returns>An enumerable of all paths that match the asset key.</returns>
+    /// <remarks>
+    /// This is useful for preloading all locale variants of an asset.
+    /// </remarks>
+    IEnumerable<string> GetAllPaths(string assetKey);
+
+    /// <summary>
+    /// Checks if a locale-specific variant exists for the given asset key.
+    /// </summary>
+    /// <param name="assetKey">The base asset key.</param>
+    /// <param name="locale">The locale to check.</param>
+    /// <returns>True if a locale-specific variant exists, false otherwise.</returns>
+    bool HasLocaleVariant(string assetKey, Locale locale);
+}

--- a/src/KeenEyes.Localization/KeenEyes.Localization.csproj
+++ b/src/KeenEyes.Localization/KeenEyes.Localization.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+		<ProjectReference Include="..\KeenEyes.Assets\KeenEyes.Assets.csproj" />
 		<ProjectReference Include="..\KeenEyes.Core\KeenEyes.Core.csproj" />
 		<ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
 		<ProjectReference Include="..\KeenEyes.UI.Abstractions\KeenEyes.UI.Abstractions.csproj" />

--- a/src/KeenEyes.Localization/LocalizationConfig.cs
+++ b/src/KeenEyes.Localization/LocalizationConfig.cs
@@ -92,6 +92,64 @@ public sealed class LocalizationConfig
     public bool EnableFallback { get; init; } = true;
 
     /// <summary>
+    /// Gets or sets the root path for localized assets.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This path is used by the <see cref="LocalizedAssetResolver"/> to find
+    /// locale-specific asset variants.
+    /// </para>
+    /// <para>
+    /// If not set, the resolver will use relative paths from the current directory.
+    /// Typically this should match your asset manager's root path.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var config = new LocalizationConfig
+    /// {
+    ///     AssetRootPath = "Assets"
+    /// };
+    /// // Assets will be resolved from Assets/textures/logo.en-US.png, etc.
+    /// </code>
+    /// </example>
+    public string? AssetRootPath { get; init; }
+
+    /// <summary>
+    /// Gets the locale-specific font configurations.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Different languages may require different fonts to display correctly.
+    /// Use this dictionary to specify which fonts should be used for each locale.
+    /// </para>
+    /// <para>
+    /// If a locale is not in this dictionary, the system will fall back to the
+    /// default locale's font configuration, or use no specific font settings.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var config = new LocalizationConfig
+    /// {
+    ///     FontConfigs =
+    ///     {
+    ///         [Locale.EnglishUS] = new LocalizedFontConfig
+    ///         {
+    ///             PrimaryFont = "fonts/Roboto-Regular.ttf"
+    ///         },
+    ///         [Locale.JapaneseJP] = new LocalizedFontConfig
+    ///         {
+    ///             PrimaryFont = "fonts/NotoSansJP-Regular.ttf",
+    ///             FallbackFonts = ["fonts/Roboto-Regular.ttf"]
+    ///         }
+    ///     }
+    /// };
+    /// </code>
+    /// </example>
+    public Dictionary<Locale, LocalizedFontConfig> FontConfigs { get; init; } = [];
+
+    /// <summary>
     /// Gets the default configuration with sensible defaults for development.
     /// </summary>
     public static LocalizationConfig Default => new();

--- a/src/KeenEyes.Localization/LocalizedAssetResolver.cs
+++ b/src/KeenEyes.Localization/LocalizedAssetResolver.cs
@@ -1,0 +1,222 @@
+namespace KeenEyes.Localization;
+
+/// <summary>
+/// Default implementation of <see cref="ILocalizedAssetResolver"/> that resolves
+/// locale-specific assets using file system checks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This resolver searches for locale-specific asset variants in the following order:
+/// </para>
+/// <list type="number">
+/// <item><description>Exact locale match: <c>textures/logo.en-US.png</c></description></item>
+/// <item><description>Language only: <c>textures/logo.en.png</c></description></item>
+/// <item><description>Default fallback: <c>textures/logo.png</c></description></item>
+/// </list>
+/// <para>
+/// The resolver supports custom fallback chains via <see cref="LocalizationConfig.FallbackOverrides"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var resolver = new LocalizedAssetResolver("Assets", config);
+///
+/// // For locale "en-US", checks in order:
+/// // 1. Assets/textures/logo.en-US.png
+/// // 2. Assets/textures/logo.en.png
+/// // 3. Assets/textures/logo.png
+/// var path = resolver.Resolve("textures/logo", Locale.EnglishUS);
+/// </code>
+/// </example>
+/// <param name="rootPath">The root path for asset files.</param>
+/// <param name="config">The localization configuration for fallback behavior.</param>
+public sealed class LocalizedAssetResolver(string rootPath, LocalizationConfig config) : ILocalizedAssetResolver
+{
+    private readonly string rootPath = rootPath ?? string.Empty;
+    private readonly LocalizationConfig config = config ?? LocalizationConfig.Default;
+    private readonly string[] commonExtensions = [".png", ".jpg", ".jpeg", ".webp", ".wav", ".ogg", ".mp3", ".ttf", ".otf"];
+
+    /// <inheritdoc />
+    public string? Resolve(string assetKey, Locale locale)
+    {
+        if (string.IsNullOrEmpty(assetKey))
+        {
+            return null;
+        }
+
+        // Try exact locale match
+        var path = TryResolveForLocale(assetKey, locale);
+        if (path != null)
+        {
+            return path;
+        }
+
+        if (!config.EnableFallback)
+        {
+            return TryResolveDefault(assetKey);
+        }
+
+        // Try custom fallback override
+        if (config.FallbackOverrides.TryGetValue(locale, out var fallbackLocale))
+        {
+            path = TryResolveForLocale(assetKey, fallbackLocale);
+            if (path != null)
+            {
+                return path;
+            }
+        }
+
+        // Try language-only fallback (e.g., "en-US" -> "en")
+        if (locale.HasRegion)
+        {
+            path = TryResolveForLocale(assetKey, locale.LanguageOnly);
+            if (path != null)
+            {
+                return path;
+            }
+        }
+
+        // Try default locale as last resort
+        if (locale != config.DefaultLocale)
+        {
+            path = TryResolveForLocale(assetKey, config.DefaultLocale);
+            if (path != null)
+            {
+                return path;
+            }
+
+            // Try language-only of default locale
+            if (config.DefaultLocale.HasRegion)
+            {
+                path = TryResolveForLocale(assetKey, config.DefaultLocale.LanguageOnly);
+                if (path != null)
+                {
+                    return path;
+                }
+            }
+        }
+
+        // Fall back to unlocalized asset
+        return TryResolveDefault(assetKey);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetAllPaths(string assetKey)
+    {
+        if (string.IsNullOrEmpty(assetKey))
+        {
+            yield break;
+        }
+
+        var directory = Path.GetDirectoryName(assetKey);
+        var baseName = Path.GetFileNameWithoutExtension(assetKey);
+
+        var searchDir = string.IsNullOrEmpty(rootPath)
+            ? (string.IsNullOrEmpty(directory) ? "." : directory)
+            : (string.IsNullOrEmpty(directory) ? rootPath : Path.Combine(rootPath, directory));
+
+        if (!Directory.Exists(searchDir))
+        {
+            yield break;
+        }
+
+        // Find all files that match the base name pattern
+        foreach (var file in Directory.EnumerateFiles(searchDir))
+        {
+            var fileName = Path.GetFileName(file);
+            if (fileName.StartsWith(baseName + ".", StringComparison.OrdinalIgnoreCase) ||
+                fileName.Equals(baseName, StringComparison.OrdinalIgnoreCase))
+            {
+                // Return path relative to root
+                var relativePath = string.IsNullOrEmpty(rootPath)
+                    ? file
+                    : Path.GetRelativePath(rootPath, file);
+                yield return relativePath;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public bool HasLocaleVariant(string assetKey, Locale locale)
+    {
+        if (string.IsNullOrEmpty(assetKey))
+        {
+            return false;
+        }
+
+        return TryResolveForLocale(assetKey, locale) != null;
+    }
+
+    private string? TryResolveForLocale(string assetKey, Locale locale)
+    {
+        // Check if assetKey already has an extension
+        var existingExt = Path.GetExtension(assetKey);
+        if (!string.IsNullOrEmpty(existingExt))
+        {
+            // Asset key has extension, insert locale before it
+            var basePath = assetKey[..^existingExt.Length];
+            var localizedPath = $"{basePath}.{locale.Code}{existingExt}";
+            var fullPath = string.IsNullOrEmpty(rootPath)
+                ? localizedPath
+                : Path.Combine(rootPath, localizedPath);
+
+            if (File.Exists(fullPath))
+            {
+                return localizedPath;
+            }
+        }
+        else
+        {
+            // No extension, try common extensions
+            foreach (var ext in commonExtensions)
+            {
+                var localizedPath = $"{assetKey}.{locale.Code}{ext}";
+                var fullPath = string.IsNullOrEmpty(rootPath)
+                    ? localizedPath
+                    : Path.Combine(rootPath, localizedPath);
+
+                if (File.Exists(fullPath))
+                {
+                    return localizedPath;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private string? TryResolveDefault(string assetKey)
+    {
+        // Check if assetKey already has an extension
+        var existingExt = Path.GetExtension(assetKey);
+        if (!string.IsNullOrEmpty(existingExt))
+        {
+            var fullPath = string.IsNullOrEmpty(rootPath)
+                ? assetKey
+                : Path.Combine(rootPath, assetKey);
+
+            if (File.Exists(fullPath))
+            {
+                return assetKey;
+            }
+        }
+        else
+        {
+            // No extension, try common extensions
+            foreach (var ext in commonExtensions)
+            {
+                var defaultPath = $"{assetKey}{ext}";
+                var fullPath = string.IsNullOrEmpty(rootPath)
+                    ? defaultPath
+                    : Path.Combine(rootPath, defaultPath);
+
+                if (File.Exists(fullPath))
+                {
+                    return defaultPath;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/KeenEyes.Localization/LocalizedFontConfig.cs
+++ b/src/KeenEyes.Localization/LocalizedFontConfig.cs
@@ -1,0 +1,144 @@
+namespace KeenEyes.Localization;
+
+/// <summary>
+/// Configuration for locale-specific font settings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Different languages require different fonts to display correctly. For example,
+/// Japanese text requires fonts with CJK character support, while Latin scripts
+/// can use standard Western fonts.
+/// </para>
+/// <para>
+/// This configuration allows specifying primary and fallback fonts for each locale,
+/// ensuring text renders correctly regardless of the active language.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var fontConfig = new LocalizedFontConfig
+/// {
+///     PrimaryFont = "fonts/NotoSansJP-Regular.ttf",
+///     FallbackFonts = ["fonts/Roboto-Regular.ttf", "fonts/NotoEmoji-Regular.ttf"]
+/// };
+///
+/// var locConfig = new LocalizationConfig
+/// {
+///     FontConfigs =
+///     {
+///         [Locale.EnglishUS] = new() { PrimaryFont = "fonts/Roboto-Regular.ttf" },
+///         [Locale.JapaneseJP] = fontConfig
+///     }
+/// };
+/// </code>
+/// </example>
+public sealed class LocalizedFontConfig
+{
+    /// <summary>
+    /// The primary font asset path for this locale.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the main font used to render text in this locale. It should support
+    /// all characters commonly used in the language.
+    /// </para>
+    /// <para>
+    /// The path is relative to the asset root directory.
+    /// </para>
+    /// </remarks>
+    public string? PrimaryFont { get; init; }
+
+    /// <summary>
+    /// Fallback font asset paths, checked in order when the primary font
+    /// doesn't contain a required glyph.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Fallback fonts are used when the primary font doesn't contain a character.
+    /// This is useful for:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Emoji support (most fonts don't include emoji)</description></item>
+    /// <item><description>Mixed-script text (e.g., Japanese text with Western names)</description></item>
+    /// <item><description>Special symbols and punctuation</description></item>
+    /// </list>
+    /// <para>
+    /// Fonts are checked in array order until a glyph is found.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var config = new LocalizedFontConfig
+    /// {
+    ///     PrimaryFont = "fonts/NotoSansJP-Regular.ttf",
+    ///     FallbackFonts =
+    ///     [
+    ///         "fonts/Roboto-Regular.ttf",      // For Western characters
+    ///         "fonts/NotoEmoji-Regular.ttf"    // For emoji
+    ///     ]
+    /// };
+    /// </code>
+    /// </example>
+    public string[]? FallbackFonts { get; init; }
+
+    /// <summary>
+    /// Optional font size multiplier for this locale.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Some scripts require different sizing to maintain readability. For example,
+    /// CJK characters may need to be slightly larger than Latin characters at the
+    /// same nominal point size.
+    /// </para>
+    /// <para>
+    /// Default is 1.0 (no scaling). A value of 1.2 would make text 20% larger.
+    /// </para>
+    /// </remarks>
+    public float SizeMultiplier { get; init; } = 1.0f;
+
+    /// <summary>
+    /// Optional line height multiplier for this locale.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Some scripts require more vertical space between lines. CJK text often
+    /// benefits from increased line height compared to Latin scripts.
+    /// </para>
+    /// <para>
+    /// Default is 1.0 (use font's default line height). A value of 1.5 would
+    /// add 50% more space between lines.
+    /// </para>
+    /// </remarks>
+    public float LineHeightMultiplier { get; init; } = 1.0f;
+
+    /// <summary>
+    /// Gets all font paths including primary and fallbacks.
+    /// </summary>
+    /// <returns>An enumerable of all font paths configured for this locale.</returns>
+    /// <remarks>
+    /// This is useful for preloading all fonts needed for a locale.
+    /// </remarks>
+    public IEnumerable<string> GetAllFontPaths()
+    {
+        if (!string.IsNullOrEmpty(PrimaryFont))
+        {
+            yield return PrimaryFont;
+        }
+
+        if (FallbackFonts != null)
+        {
+            foreach (var font in FallbackFonts)
+            {
+                if (!string.IsNullOrEmpty(font))
+                {
+                    yield return font;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the default font configuration with no fonts specified.
+    /// </summary>
+    public static LocalizedFontConfig Default => new();
+}

--- a/src/KeenEyes.Localization/Systems/LocalizedAssetSystem.cs
+++ b/src/KeenEyes.Localization/Systems/LocalizedAssetSystem.cs
@@ -1,0 +1,147 @@
+namespace KeenEyes.Localization;
+
+/// <summary>
+/// System that resolves localized asset paths when the locale changes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system listens for <see cref="LocaleChangedEvent"/> and automatically
+/// updates the <see cref="LocalizedAsset.ResolvedPath"/> for all entities that
+/// have the <see cref="LocalizedAsset"/> component.
+/// </para>
+/// <para>
+/// The system runs in the <see cref="SystemPhase.EarlyUpdate"/> phase to ensure
+/// asset paths are resolved before rendering systems run.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Create an entity with a localized texture
+/// var logo = world.Spawn()
+///     .With(new LocalizedAsset { AssetKey = "textures/logo" })
+///     .Build();
+///
+/// // When locale changes, ResolvedPath is automatically updated
+/// localization.SetLocale(Locale.JapaneseJP);
+/// // logo's LocalizedAsset.ResolvedPath is now "textures/logo.ja-JP.png" (or fallback)
+/// </code>
+/// </example>
+public sealed class LocalizedAssetSystem : SystemBase
+{
+    private LocalizationManager? localization;
+    private ILocalizedAssetResolver? resolver;
+    private EventSubscription? localeChangedSubscription;
+    private bool needsFullUpdate;
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        World.TryGetExtension(out localization);
+        World.TryGetExtension(out resolver);
+
+        // Subscribe to locale changes
+        localeChangedSubscription = World.Subscribe<LocaleChangedEvent>(OnLocaleChanged);
+
+        // Do an initial update for any existing entities
+        needsFullUpdate = true;
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (localization == null && !World.TryGetExtension(out localization))
+        {
+            return;
+        }
+
+        if (resolver == null && !World.TryGetExtension(out resolver))
+        {
+            return;
+        }
+
+        if (needsFullUpdate)
+        {
+            UpdateAllLocalizedAssets();
+            needsFullUpdate = false;
+        }
+        else
+        {
+            // Check for newly added or invalidated assets
+            UpdateUnresolvedAssets();
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        localeChangedSubscription?.Dispose();
+        localeChangedSubscription = null;
+        base.Dispose();
+    }
+
+    private void OnLocaleChanged(LocaleChangedEvent evt)
+    {
+        // Mark for full update on next Update() call
+        needsFullUpdate = true;
+    }
+
+    private void UpdateAllLocalizedAssets()
+    {
+        if (localization == null || resolver == null)
+        {
+            return;
+        }
+
+        var currentLocale = localization.CurrentLocale;
+
+        foreach (var entity in World.Query<LocalizedAsset>())
+        {
+            ref var localizedAsset = ref World.Get<LocalizedAsset>(entity);
+            ResolveAsset(ref localizedAsset, currentLocale);
+        }
+    }
+
+    private void UpdateUnresolvedAssets()
+    {
+        if (localization == null || resolver == null)
+        {
+            return;
+        }
+
+        var currentLocale = localization.CurrentLocale;
+
+        foreach (var entity in World.Query<LocalizedAsset>())
+        {
+            ref var localizedAsset = ref World.Get<LocalizedAsset>(entity);
+
+            // Only resolve if not already resolved
+            if (!localizedAsset.IsResolved && !string.IsNullOrEmpty(localizedAsset.AssetKey))
+            {
+                ResolveAsset(ref localizedAsset, currentLocale);
+            }
+        }
+    }
+
+    private void ResolveAsset(ref LocalizedAsset asset, Locale locale)
+    {
+        if (string.IsNullOrEmpty(asset.AssetKey))
+        {
+            asset.ResolvedPath = null;
+            return;
+        }
+
+        asset.ResolvedPath = resolver!.Resolve(asset.AssetKey, locale);
+    }
+
+    /// <summary>
+    /// Forces a re-resolution of all localized assets.
+    /// </summary>
+    /// <remarks>
+    /// Call this if asset files have been added or removed and you want to
+    /// refresh the resolved paths without changing the locale.
+    /// </remarks>
+    public void RefreshAllAssets()
+    {
+        needsFullUpdate = true;
+    }
+}

--- a/src/KeenEyes.Localization/packages.lock.json
+++ b/src/KeenEyes.Localization/packages.lock.json
@@ -25,6 +25,25 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NVorbis": "[0.10.5, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -57,6 +76,24 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Input.Abstractions": "[1.0.0, )"
         }
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       }
     }
   }

--- a/tests/KeenEyes.Localization.Tests/LocalizationManagerTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizationManagerTests.cs
@@ -569,4 +569,100 @@ public class LocalizationManagerTests : IDisposable
     }
 
     #endregion
+
+    #region GetFontConfig
+
+    [Fact]
+    public void GetFontConfig_ExactLocaleMatch_ReturnsFontConfig()
+    {
+        var fontConfig = new LocalizedFontConfig { PrimaryFont = "fonts/Roboto.ttf" };
+        var config = new LocalizationConfig
+        {
+            FontConfigs =
+            {
+                [Locale.EnglishUS] = fontConfig
+            }
+        };
+        using var manager = CreateManager(config);
+
+        var result = manager.GetFontConfig(Locale.EnglishUS);
+
+        result.ShouldBe(fontConfig);
+    }
+
+    [Fact]
+    public void GetFontConfig_LanguageOnlyFallback_ReturnsFontConfig()
+    {
+        var fontConfig = new LocalizedFontConfig { PrimaryFont = "fonts/Roboto.ttf" };
+        var config = new LocalizationConfig
+        {
+            FontConfigs =
+            {
+                [new Locale("en")] = fontConfig
+            }
+        };
+        using var manager = CreateManager(config);
+
+        // Request en-US, should fall back to "en"
+        var result = manager.GetFontConfig(Locale.EnglishUS);
+
+        result.ShouldBe(fontConfig);
+    }
+
+    [Fact]
+    public void GetFontConfig_DefaultLocaleFallback_ReturnsFontConfig()
+    {
+        var fontConfig = new LocalizedFontConfig { PrimaryFont = "fonts/Roboto.ttf" };
+        var config = new LocalizationConfig
+        {
+            DefaultLocale = Locale.EnglishUS,
+            FontConfigs =
+            {
+                [Locale.EnglishUS] = fontConfig
+            }
+        };
+        using var manager = CreateManager(config);
+
+        // Request Japanese, should fall back to default (en-US)
+        var result = manager.GetFontConfig(Locale.JapaneseJP);
+
+        result.ShouldBe(fontConfig);
+    }
+
+    [Fact]
+    public void GetFontConfig_NoConfig_ReturnsNull()
+    {
+        var config = new LocalizationConfig();
+        using var manager = CreateManager(config);
+
+        var result = manager.GetFontConfig(Locale.EnglishUS);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetCurrentFontConfig_ReturnsConfigForCurrentLocale()
+    {
+        var enConfig = new LocalizedFontConfig { PrimaryFont = "fonts/Roboto.ttf" };
+        var jaConfig = new LocalizedFontConfig { PrimaryFont = "fonts/NotoSansJP.ttf" };
+        var config = new LocalizationConfig
+        {
+            DefaultLocale = Locale.EnglishUS,
+            FontConfigs =
+            {
+                [Locale.EnglishUS] = enConfig,
+                [Locale.JapaneseJP] = jaConfig
+            }
+        };
+        using var manager = CreateManager(config);
+
+        // Start with default (en-US)
+        manager.GetCurrentFontConfig().ShouldBe(enConfig);
+
+        // Switch to Japanese
+        manager.SetLocale(Locale.JapaneseJP);
+        manager.GetCurrentFontConfig().ShouldBe(jaConfig);
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Localization.Tests/LocalizationPluginTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizationPluginTests.cs
@@ -17,6 +17,31 @@ public class LocalizationPluginTests
     }
 
     [Fact]
+    public void Install_RegistersAssetResolverExtension()
+    {
+        using var world = new World();
+        var plugin = new LocalizationPlugin();
+
+        world.InstallPlugin(plugin);
+
+        world.TryGetExtension<ILocalizedAssetResolver>(out var resolver).ShouldBeTrue();
+        resolver.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Install_WithAssetRootPath_ConfiguresResolver()
+    {
+        using var world = new World();
+        var config = new LocalizationConfig { AssetRootPath = "Assets" };
+        var plugin = new LocalizationPlugin(config);
+
+        world.InstallPlugin(plugin);
+
+        world.TryGetExtension<ILocalizedAssetResolver>(out var resolver).ShouldBeTrue();
+        resolver.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void Install_DefaultConfig_UsesEnglishUS()
     {
         using var world = new World();
@@ -55,6 +80,18 @@ public class LocalizationPluginTests
         world.UninstallPlugin<LocalizationPlugin>();
 
         world.TryGetExtension<LocalizationManager>(out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Uninstall_RemovesAssetResolverExtension()
+    {
+        using var world = new World();
+        var plugin = new LocalizationPlugin();
+        world.InstallPlugin(plugin);
+
+        world.UninstallPlugin<LocalizationPlugin>();
+
+        world.TryGetExtension<ILocalizedAssetResolver>(out _).ShouldBeFalse();
     }
 
     #endregion

--- a/tests/KeenEyes.Localization.Tests/LocalizedAssetResolverTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizedAssetResolverTests.cs
@@ -1,0 +1,302 @@
+namespace KeenEyes.Localization.Tests;
+
+public class LocalizedAssetResolverTests : IDisposable
+{
+    private readonly string testDir;
+
+    public LocalizedAssetResolverTests()
+    {
+        // Create a unique temp directory for each test
+        testDir = Path.Combine(Path.GetTempPath(), $"LocalizedAssetTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(testDir);
+    }
+
+    public void Dispose()
+    {
+        // Clean up temp directory
+        if (Directory.Exists(testDir))
+        {
+            Directory.Delete(testDir, recursive: true);
+        }
+    }
+
+    #region Resolve Tests
+
+    [Fact]
+    public void Resolve_ExactLocaleMatch_ReturnsLocalizedPath()
+    {
+        // Arrange
+        CreateFile("textures/logo.en-US.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBe("textures/logo.en-US.png");
+    }
+
+    [Fact]
+    public void Resolve_LanguageOnlyFallback_ReturnsLanguagePath()
+    {
+        // Arrange
+        CreateFile("textures/logo.en.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBe("textures/logo.en.png");
+    }
+
+    [Fact]
+    public void Resolve_DefaultFallback_ReturnsUnlocalizedPath()
+    {
+        // Arrange
+        CreateFile("textures/logo.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", Locale.JapaneseJP);
+
+        // Assert
+        result.ShouldBe("textures/logo.png");
+    }
+
+    [Fact]
+    public void Resolve_NoMatchingFile_ReturnsNull()
+    {
+        // Arrange
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/nonexistent", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_EmptyAssetKey_ReturnsNull()
+    {
+        // Arrange
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_FallbackDisabled_OnlyChecksCurrentLocale()
+    {
+        // Arrange
+        CreateFile("textures/logo.png"); // Default (unlocalized)
+        var config = new LocalizationConfig
+        {
+            DefaultLocale = Locale.EnglishUS,
+            EnableFallback = false
+        };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", Locale.JapaneseJP);
+
+        // Assert - with fallback disabled, should still find default but not through full fallback chain
+        result.ShouldBe("textures/logo.png");
+    }
+
+    [Fact]
+    public void Resolve_CustomFallbackOverride_UsesFallbackLocale()
+    {
+        // Arrange
+        CreateFile("textures/logo.en-GB.png");
+        var config = new LocalizationConfig
+        {
+            DefaultLocale = Locale.EnglishUS,
+            FallbackOverrides =
+            {
+                [new Locale("en-AU")] = Locale.EnglishGB
+            }
+        };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", new Locale("en-AU"));
+
+        // Assert - Should use en-GB from FallbackOverrides
+        result.ShouldBe("textures/logo.en-GB.png");
+    }
+
+    [Fact]
+    public void Resolve_WithExtension_PreservesExtension()
+    {
+        // Arrange
+        CreateFile("audio/music.en-US.ogg");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("audio/music.ogg", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBe("audio/music.en-US.ogg");
+    }
+
+    [Fact]
+    public void Resolve_PrioritizesExactLocaleOverLanguageOnly()
+    {
+        // Arrange
+        CreateFile("textures/logo.en.png");
+        CreateFile("textures/logo.en-US.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.Resolve("textures/logo", Locale.EnglishUS);
+
+        // Assert - Should prefer exact match
+        result.ShouldBe("textures/logo.en-US.png");
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToDefaultLocale_WhenRequestedLocaleNotFound()
+    {
+        // Arrange
+        CreateFile("textures/logo.en-US.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act - Request Japanese, but only English exists
+        var result = resolver.Resolve("textures/logo", Locale.JapaneseJP);
+
+        // Assert - Should fall back to default locale's asset
+        result.ShouldBe("textures/logo.en-US.png");
+    }
+
+    #endregion
+
+    #region HasLocaleVariant Tests
+
+    [Fact]
+    public void HasLocaleVariant_FileExists_ReturnsTrue()
+    {
+        // Arrange
+        CreateFile("textures/logo.ja-JP.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.HasLocaleVariant("textures/logo", Locale.JapaneseJP);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasLocaleVariant_FileNotExists_ReturnsFalse()
+    {
+        // Arrange
+        CreateFile("textures/logo.en-US.png");
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.HasLocaleVariant("textures/logo", Locale.JapaneseJP);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasLocaleVariant_EmptyAssetKey_ReturnsFalse()
+    {
+        // Arrange
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var result = resolver.HasLocaleVariant("", Locale.EnglishUS);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region GetAllPaths Tests
+
+    [Fact]
+    public void GetAllPaths_ReturnsAllMatchingFiles()
+    {
+        // Arrange
+        CreateFile("textures/logo.png");
+        CreateFile("textures/logo.en-US.png");
+        CreateFile("textures/logo.ja-JP.png");
+        CreateFile("textures/other.png"); // Should not be included
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var results = resolver.GetAllPaths("textures/logo").ToList();
+
+        // Assert
+        results.Count.ShouldBe(3);
+        results.ShouldContain("textures/logo.png");
+        results.ShouldContain("textures/logo.en-US.png");
+        results.ShouldContain("textures/logo.ja-JP.png");
+    }
+
+    [Fact]
+    public void GetAllPaths_NoMatchingFiles_ReturnsEmpty()
+    {
+        // Arrange
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var results = resolver.GetAllPaths("textures/nonexistent").ToList();
+
+        // Assert
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllPaths_EmptyAssetKey_ReturnsEmpty()
+    {
+        // Arrange
+        var config = new LocalizationConfig { DefaultLocale = Locale.EnglishUS };
+        var resolver = new LocalizedAssetResolver(testDir, config);
+
+        // Act
+        var results = resolver.GetAllPaths("").ToList();
+
+        // Assert
+        results.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void CreateFile(string relativePath)
+    {
+        var fullPath = Path.Combine(testDir, relativePath);
+        var dir = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+        File.WriteAllBytes(fullPath, [0x00]);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Localization.Tests/LocalizedAssetTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizedAssetTests.cs
@@ -1,0 +1,119 @@
+namespace KeenEyes.Localization.Tests;
+
+public class LocalizedAssetTests
+{
+    #region Create Tests
+
+    [Fact]
+    public void Create_SetsAssetKey()
+    {
+        var asset = LocalizedAsset.Create("textures/logo");
+
+        asset.AssetKey.ShouldBe("textures/logo");
+    }
+
+    [Fact]
+    public void Create_ResolvedPathIsNull()
+    {
+        var asset = LocalizedAsset.Create("textures/logo");
+
+        asset.ResolvedPath.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_IsResolvedIsFalse()
+    {
+        var asset = LocalizedAsset.Create("textures/logo");
+
+        asset.IsResolved.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region IsResolved Tests
+
+    [Fact]
+    public void IsResolved_WithResolvedPath_ReturnsTrue()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = "textures/logo.en-US.png"
+        };
+
+        asset.IsResolved.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsResolved_WithEmptyResolvedPath_ReturnsFalse()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = ""
+        };
+
+        asset.IsResolved.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsResolved_WithNullResolvedPath_ReturnsFalse()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = null
+        };
+
+        asset.IsResolved.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Invalidate Tests
+
+    [Fact]
+    public void Invalidate_ClearsResolvedPath()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = "textures/logo.en-US.png"
+        };
+
+        asset.Invalidate();
+
+        asset.ResolvedPath.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Invalidate_PreservesAssetKey()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = "textures/logo.en-US.png"
+        };
+
+        asset.Invalidate();
+
+        asset.AssetKey.ShouldBe("textures/logo");
+    }
+
+    [Fact]
+    public void Invalidate_SetsIsResolvedToFalse()
+    {
+        var asset = new LocalizedAsset
+        {
+            AssetKey = "textures/logo",
+            ResolvedPath = "textures/logo.en-US.png"
+        };
+        asset.IsResolved.ShouldBeTrue();
+
+        asset.Invalidate();
+
+        asset.IsResolved.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Localization.Tests/LocalizedFontConfigTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizedFontConfigTests.cs
@@ -1,0 +1,142 @@
+namespace KeenEyes.Localization.Tests;
+
+public class LocalizedFontConfigTests
+{
+    #region Default Values
+
+    [Fact]
+    public void Default_HasNullPrimaryFont()
+    {
+        var config = LocalizedFontConfig.Default;
+
+        config.PrimaryFont.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Default_HasNullFallbackFonts()
+    {
+        var config = LocalizedFontConfig.Default;
+
+        config.FallbackFonts.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Default_SizeMultiplierIsOne()
+    {
+        var config = LocalizedFontConfig.Default;
+
+        config.SizeMultiplier.ShouldBe(1.0f);
+    }
+
+    [Fact]
+    public void Default_LineHeightMultiplierIsOne()
+    {
+        var config = LocalizedFontConfig.Default;
+
+        config.LineHeightMultiplier.ShouldBe(1.0f);
+    }
+
+    #endregion
+
+    #region GetAllFontPaths
+
+    [Fact]
+    public void GetAllFontPaths_WithPrimaryOnly_ReturnsPrimary()
+    {
+        var config = new LocalizedFontConfig
+        {
+            PrimaryFont = "fonts/Roboto.ttf"
+        };
+
+        var paths = config.GetAllFontPaths().ToList();
+
+        paths.Count.ShouldBe(1);
+        paths[0].ShouldBe("fonts/Roboto.ttf");
+    }
+
+    [Fact]
+    public void GetAllFontPaths_WithFallbacks_ReturnsAllFonts()
+    {
+        var config = new LocalizedFontConfig
+        {
+            PrimaryFont = "fonts/NotoSansJP.ttf",
+            FallbackFonts = ["fonts/Roboto.ttf", "fonts/NotoEmoji.ttf"]
+        };
+
+        var paths = config.GetAllFontPaths().ToList();
+
+        paths.Count.ShouldBe(3);
+        paths[0].ShouldBe("fonts/NotoSansJP.ttf");
+        paths[1].ShouldBe("fonts/Roboto.ttf");
+        paths[2].ShouldBe("fonts/NotoEmoji.ttf");
+    }
+
+    [Fact]
+    public void GetAllFontPaths_WithNoPrimary_ReturnsOnlyFallbacks()
+    {
+        var config = new LocalizedFontConfig
+        {
+            FallbackFonts = ["fonts/Roboto.ttf"]
+        };
+
+        var paths = config.GetAllFontPaths().ToList();
+
+        paths.Count.ShouldBe(1);
+        paths[0].ShouldBe("fonts/Roboto.ttf");
+    }
+
+    [Fact]
+    public void GetAllFontPaths_Empty_ReturnsEmpty()
+    {
+        var config = new LocalizedFontConfig();
+
+        var paths = config.GetAllFontPaths().ToList();
+
+        paths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllFontPaths_SkipsNullAndEmptyFallbacks()
+    {
+        var config = new LocalizedFontConfig
+        {
+            PrimaryFont = "fonts/Roboto.ttf",
+            FallbackFonts = ["fonts/Valid.ttf", null!, "", "fonts/Another.ttf"]
+        };
+
+        var paths = config.GetAllFontPaths().ToList();
+
+        paths.Count.ShouldBe(3);
+        paths[0].ShouldBe("fonts/Roboto.ttf");
+        paths[1].ShouldBe("fonts/Valid.ttf");
+        paths[2].ShouldBe("fonts/Another.ttf");
+    }
+
+    #endregion
+
+    #region Custom Values
+
+    [Fact]
+    public void CustomSizeMultiplier_IsPreserved()
+    {
+        var config = new LocalizedFontConfig
+        {
+            SizeMultiplier = 1.2f
+        };
+
+        config.SizeMultiplier.ShouldBe(1.2f);
+    }
+
+    [Fact]
+    public void CustomLineHeightMultiplier_IsPreserved()
+    {
+        var config = new LocalizedFontConfig
+        {
+            LineHeightMultiplier = 1.5f
+        };
+
+        config.LineHeightMultiplier.ShouldBe(1.5f);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Localization.Tests/packages.lock.json
+++ b/tests/KeenEyes.Localization.Tests/packages.lock.json
@@ -199,6 +199,25 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NVorbis": "[0.10.5, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -228,6 +247,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.UI.Abstractions": "[1.0.0, )",
@@ -278,6 +298,24 @@
         "dependencies": {
           "Microsoft.Extensions.ObjectPool": "8.0.10"
         }
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `LocalizedAsset` component for entities that reference locale-specific assets (textures, audio, fonts)
- Implement `ILocalizedAssetResolver` and `LocalizedAssetResolver` with fallback chain resolution
- Add `LocalizedAssetSystem` to automatically update resolved paths on locale changes
- Add `LocalizedFontConfig` for per-locale font configuration with primary/fallback fonts and scaling options
- Add `PreloadLocaleAssetsAsync()` for seamless locale switching

## Test plan
- [x] Unit tests for LocalizedAssetResolver (resolution fallback chain, all paths, has variant)
- [x] Unit tests for LocalizedAsset component (create, invalidate, is resolved)
- [x] Unit tests for LocalizedFontConfig (default values, get all font paths)
- [x] Unit tests for LocalizationManager font config methods
- [x] Unit tests for LocalizationPlugin extension registration
- [x] All 10,944 tests pass
- [x] Build succeeds with zero warnings

Closes #634