### PR TITLE
feat(replay): Add input system integration for replay playback

### DIFF
--- a/src/KeenEyes.Replay/IInputRecorder.cs
+++ b/src/KeenEyes.Replay/IInputRecorder.cs
@@ -1,0 +1,172 @@
+using System.Numerics;
+
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Interface for recording input events during gameplay for replay playback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations of this interface capture user input events and store them
+/// for later replay. The recorded inputs can be synchronized with ECS frame
+/// updates to enable deterministic playback.
+/// </para>
+/// <para>
+/// The interface provides both low-level event recording (via <see cref="RecordInput"/>)
+/// and convenience methods for common input types (keyboard, mouse, gamepad).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Get the recorder from the world extension
+/// var recorder = world.GetExtension&lt;ReplayRecorder&gt;();
+///
+/// // Record keyboard input
+/// recorder.RecordKeyDown("Space");
+///
+/// // Record mouse movement
+/// recorder.RecordMouseMove(new Vector2(100, 200));
+///
+/// // Record gamepad axis
+/// recorder.RecordGamepadAxis("LeftStickX", 0.75f);
+/// </code>
+/// </example>
+public interface IInputRecorder
+{
+    /// <summary>
+    /// Gets a value indicating whether input recording is currently active.
+    /// </summary>
+    bool IsRecordingInputs { get; }
+
+    /// <summary>
+    /// Gets the current frame number for input recording.
+    /// </summary>
+    /// <remarks>
+    /// Returns -1 if recording is not active.
+    /// </remarks>
+    int CurrentInputFrame { get; }
+
+    /// <summary>
+    /// Records a raw input event.
+    /// </summary>
+    /// <param name="inputEvent">The input event to record.</param>
+    /// <remarks>
+    /// <para>
+    /// This is the low-level recording method that stores the event directly.
+    /// The <see cref="InputEvent.Frame"/> property should be set to the current
+    /// frame number, or it will be automatically set by the recorder.
+    /// </para>
+    /// <para>
+    /// This method does nothing if recording is not active.
+    /// </para>
+    /// </remarks>
+    void RecordInput(InputEvent inputEvent);
+
+    /// <summary>
+    /// Records a key press event.
+    /// </summary>
+    /// <param name="key">The key identifier (e.g., "A", "Space", "Escape").</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.KeyDown"/> event for the specified key.
+    /// </remarks>
+    void RecordKeyDown(string key);
+
+    /// <summary>
+    /// Records a key release event.
+    /// </summary>
+    /// <param name="key">The key identifier.</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.KeyUp"/> event for the specified key.
+    /// </remarks>
+    void RecordKeyUp(string key);
+
+    /// <summary>
+    /// Records a mouse movement event.
+    /// </summary>
+    /// <param name="position">The new cursor position.</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.MouseMove"/> event with the specified position.
+    /// </remarks>
+    void RecordMouseMove(Vector2 position);
+
+    /// <summary>
+    /// Records a mouse button press event.
+    /// </summary>
+    /// <param name="button">The button identifier (e.g., "Left", "Right", "Middle").</param>
+    /// <param name="position">The cursor position when the button was pressed.</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.MouseButtonDown"/> event.
+    /// </remarks>
+    void RecordMouseButtonDown(string button, Vector2 position);
+
+    /// <summary>
+    /// Records a mouse button release event.
+    /// </summary>
+    /// <param name="button">The button identifier.</param>
+    /// <param name="position">The cursor position when the button was released.</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.MouseButtonUp"/> event.
+    /// </remarks>
+    void RecordMouseButtonUp(string button, Vector2 position);
+
+    /// <summary>
+    /// Records a mouse wheel scroll event.
+    /// </summary>
+    /// <param name="delta">The scroll delta (positive=up, negative=down).</param>
+    /// <param name="position">The cursor position when scrolling.</param>
+    /// <remarks>
+    /// Records an <see cref="InputEventType.MouseWheel"/> event.
+    /// </remarks>
+    void RecordMouseWheel(float delta, Vector2 position);
+
+    /// <summary>
+    /// Records a gamepad button event.
+    /// </summary>
+    /// <param name="button">The button identifier (e.g., "A", "B", "Start").</param>
+    /// <param name="pressed">True if the button was pressed, false if released.</param>
+    /// <remarks>
+    /// Records a <see cref="InputEventType.GamepadButton"/> event with
+    /// <see cref="InputEvent.Value"/> set to 1.0 if pressed, 0.0 if released.
+    /// </remarks>
+    void RecordGamepadButton(string button, bool pressed);
+
+    /// <summary>
+    /// Records a gamepad axis value change.
+    /// </summary>
+    /// <param name="axis">The axis identifier (e.g., "LeftStickX", "RightTrigger").</param>
+    /// <param name="value">The axis value, typically in range [-1.0, 1.0] or [0.0, 1.0].</param>
+    /// <remarks>
+    /// Records a <see cref="InputEventType.GamepadAxis"/> event.
+    /// </remarks>
+    void RecordGamepadAxis(string axis, float value);
+
+    /// <summary>
+    /// Records a custom input event.
+    /// </summary>
+    /// <param name="customType">The custom event type name.</param>
+    /// <param name="customData">Optional event-specific data.</param>
+    /// <remarks>
+    /// <para>
+    /// Records an <see cref="InputEventType.Custom"/> event for application-specific
+    /// input types not covered by the built-in types.
+    /// </para>
+    /// <para>
+    /// The <paramref name="customData"/> must be serializable by the replay system.
+    /// </para>
+    /// </remarks>
+    void RecordCustomInput(string customType, object? customData = null);
+
+    /// <summary>
+    /// Records a custom input event with typed data.
+    /// </summary>
+    /// <typeparam name="T">The type of the custom data.</typeparam>
+    /// <param name="customType">The custom event type name.</param>
+    /// <param name="customData">The event-specific data.</param>
+    /// <remarks>
+    /// <para>
+    /// This generic overload provides type safety for custom input data.
+    /// The type <typeparamref name="T"/> must be serializable by the replay system.
+    /// </para>
+    /// </remarks>
+    void RecordCustomInput<T>(string customType, T customData);
+}

--- a/src/KeenEyes.Replay/InputEvent.cs
+++ b/src/KeenEyes.Replay/InputEvent.cs
@@ -1,0 +1,224 @@
+using System.Numerics;
+
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Represents a recorded input event for replay playback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Input events capture user interactions such as keyboard presses, mouse movements,
+/// and gamepad inputs. These events are stored per-frame in the replay data and
+/// can be replayed to reproduce the original gameplay.
+/// </para>
+/// <para>
+/// The struct is immutable with init-only properties to ensure thread safety and
+/// prevent accidental modification after creation.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Create a keyboard event
+/// var keyEvent = new InputEvent
+/// {
+///     Type = InputEventType.KeyDown,
+///     Frame = 42,
+///     Key = "Space"
+/// };
+///
+/// // Create a mouse move event
+/// var mouseEvent = new InputEvent
+/// {
+///     Type = InputEventType.MouseMove,
+///     Frame = 42,
+///     Position = new Vector2(100f, 200f)
+/// };
+///
+/// // Create a gamepad axis event
+/// var gamepadEvent = new InputEvent
+/// {
+///     Type = InputEventType.GamepadAxis,
+///     Frame = 42,
+///     Key = "LeftStickX",
+///     Value = 0.75f
+/// };
+/// </code>
+/// </example>
+public readonly struct InputEvent
+{
+    /// <summary>
+    /// Gets the type of this input event.
+    /// </summary>
+    /// <remarks>
+    /// Determines how other properties should be interpreted. For example,
+    /// <see cref="InputEventType.MouseMove"/> uses <see cref="Position"/>,
+    /// while <see cref="InputEventType.GamepadAxis"/> uses <see cref="Key"/>
+    /// and <see cref="Value"/>.
+    /// </remarks>
+    public InputEventType Type { get; init; }
+
+    /// <summary>
+    /// Gets the frame number when this input event occurred.
+    /// </summary>
+    /// <remarks>
+    /// Frame numbers correspond to <see cref="ReplayFrame.FrameNumber"/> and
+    /// enable synchronization between input events and world state during playback.
+    /// </remarks>
+    public int Frame { get; init; }
+
+    /// <summary>
+    /// Gets the key or button identifier for this event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The interpretation depends on <see cref="Type"/>:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <see cref="InputEventType.KeyDown"/>/<see cref="InputEventType.KeyUp"/>:
+    /// Keyboard key name (e.g., "A", "Space", "Escape", "F1").
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.MouseButtonDown"/>/<see cref="InputEventType.MouseButtonUp"/>:
+    /// Mouse button name (e.g., "Left", "Right", "Middle", "X1", "X2").
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.GamepadButton"/>:
+    /// Gamepad button name (e.g., "A", "B", "LeftBumper", "Start").
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.GamepadAxis"/>:
+    /// Axis name (e.g., "LeftStickX", "LeftStickY", "RightTrigger").
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// For other event types, this property may be null.
+    /// </para>
+    /// </remarks>
+    public string? Key { get; init; }
+
+    /// <summary>
+    /// Gets the numeric value associated with this event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The interpretation depends on <see cref="Type"/>:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <see cref="InputEventType.MouseWheel"/>: Scroll delta (positive=up, negative=down).
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.GamepadButton"/>: 1.0 for pressed, 0.0 for released.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.GamepadAxis"/>: Axis value, typically [-1.0, 1.0]
+    /// for sticks or [0.0, 1.0] for triggers.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    public float Value { get; init; }
+
+    /// <summary>
+    /// Gets the position associated with this event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Used for mouse events to record cursor position:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <see cref="InputEventType.MouseMove"/>: New cursor position.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.MouseButtonDown"/>/<see cref="InputEventType.MouseButtonUp"/>:
+    /// Position where the button was pressed/released.
+    /// </description></item>
+    /// <item><description>
+    /// <see cref="InputEventType.MouseWheel"/>: Cursor position when scrolling.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// For non-mouse events, this defaults to <see cref="Vector2.Zero"/>.
+    /// </para>
+    /// </remarks>
+    public Vector2 Position { get; init; }
+
+    /// <summary>
+    /// Gets the custom event type name for <see cref="InputEventType.Custom"/> events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property identifies application-specific input types not covered by
+    /// the built-in <see cref="InputEventType"/> values. Use this for custom
+    /// input sources like touch gestures, VR controllers, or voice commands.
+    /// </para>
+    /// <para>
+    /// Only relevant when <see cref="Type"/> is <see cref="InputEventType.Custom"/>.
+    /// </para>
+    /// </remarks>
+    public string? CustomType { get; init; }
+
+    /// <summary>
+    /// Gets custom data associated with this event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For <see cref="InputEventType.Custom"/> events, this can store any
+    /// serializable data specific to the custom input type. The data must be
+    /// serializable by the replay system.
+    /// </para>
+    /// <para>
+    /// Common uses include:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Touch gesture parameters (pinch scale, rotation angle)</description></item>
+    /// <item><description>VR controller tracking data</description></item>
+    /// <item><description>Voice command transcription</description></item>
+    /// <item><description>Multi-touch point arrays</description></item>
+    /// </list>
+    /// </remarks>
+    public object? CustomData { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp of this event within the frame.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Represents the offset from the start of the frame when this input occurred.
+    /// This enables accurate sub-frame input timing during playback when multiple
+    /// inputs occur within the same frame.
+    /// </para>
+    /// <para>
+    /// Default is <see cref="TimeSpan.Zero"/>, indicating the input occurred at
+    /// the start of the frame.
+    /// </para>
+    /// </remarks>
+    public TimeSpan Timestamp { get; init; }
+
+    /// <summary>
+    /// Returns a string representation of this input event.
+    /// </summary>
+    /// <returns>A string describing the event type, frame, and relevant data.</returns>
+    public override string ToString()
+    {
+        return Type switch
+        {
+            InputEventType.KeyDown or InputEventType.KeyUp =>
+                $"{Type}(Frame={Frame}, Key={Key})",
+            InputEventType.MouseMove =>
+                $"{Type}(Frame={Frame}, Position={Position})",
+            InputEventType.MouseButtonDown or InputEventType.MouseButtonUp =>
+                $"{Type}(Frame={Frame}, Button={Key}, Position={Position})",
+            InputEventType.MouseWheel =>
+                $"{Type}(Frame={Frame}, Delta={Value}, Position={Position})",
+            InputEventType.GamepadButton =>
+                $"{Type}(Frame={Frame}, Button={Key}, Pressed={Value > 0.5f})",
+            InputEventType.GamepadAxis =>
+                $"{Type}(Frame={Frame}, Axis={Key}, Value={Value})",
+            InputEventType.Custom =>
+                $"{Type}(Frame={Frame}, CustomType={CustomType})",
+            _ => $"{Type}(Frame={Frame})"
+        };
+    }
+}

--- a/src/KeenEyes.Replay/InputEventType.cs
+++ b/src/KeenEyes.Replay/InputEventType.cs
@@ -1,0 +1,128 @@
+namespace KeenEyes.Replay;
+
+/// <summary>
+/// Represents the type of an input event in the replay system.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Input event types categorize user input for recording and playback.
+/// This enables deterministic replay of gameplay by capturing all user
+/// interactions including keyboard, mouse, and gamepad inputs.
+/// </para>
+/// <para>
+/// For application-specific input types not covered by the built-in types,
+/// use <see cref="Custom"/> and specify the custom type name in
+/// <see cref="InputEvent.CustomType"/>.
+/// </para>
+/// </remarks>
+public enum InputEventType
+{
+    /// <summary>
+    /// A keyboard key was pressed down.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="InputEvent.Key"/> property contains the key identifier.
+    /// </remarks>
+    KeyDown = 0,
+
+    /// <summary>
+    /// A keyboard key was released.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="InputEvent.Key"/> property contains the key identifier.
+    /// </remarks>
+    KeyUp = 1,
+
+    /// <summary>
+    /// The mouse cursor moved.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="InputEvent.Position"/> property contains the new cursor position.
+    /// </remarks>
+    MouseMove = 2,
+
+    /// <summary>
+    /// A mouse button was pressed down.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="InputEvent.Key"/> property contains the button identifier
+    /// (e.g., "Left", "Right", "Middle").
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.Position"/> property contains the click position.
+    /// </para>
+    /// </remarks>
+    MouseButtonDown = 3,
+
+    /// <summary>
+    /// A mouse button was released.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="InputEvent.Key"/> property contains the button identifier.
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.Position"/> property contains the release position.
+    /// </para>
+    /// </remarks>
+    MouseButtonUp = 4,
+
+    /// <summary>
+    /// The mouse wheel was scrolled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="InputEvent.Value"/> property contains the scroll delta.
+    /// Positive values indicate scrolling up/forward, negative values indicate
+    /// scrolling down/backward.
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.Position"/> property contains the cursor position.
+    /// </para>
+    /// </remarks>
+    MouseWheel = 5,
+
+    /// <summary>
+    /// A gamepad button was pressed or released.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="InputEvent.Key"/> property contains the button identifier.
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.Value"/> property is 1.0 for pressed, 0.0 for released.
+    /// </para>
+    /// </remarks>
+    GamepadButton = 6,
+
+    /// <summary>
+    /// A gamepad analog axis changed value.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="InputEvent.Key"/> property contains the axis identifier
+    /// (e.g., "LeftStickX", "RightTrigger").
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.Value"/> property contains the axis value,
+    /// typically in the range [-1.0, 1.0] for sticks or [0.0, 1.0] for triggers.
+    /// </para>
+    /// </remarks>
+    GamepadAxis = 7,
+
+    /// <summary>
+    /// A custom input event type defined by the application.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this type for application-specific inputs not covered by the built-in types,
+    /// such as touch gestures, voice commands, or VR controller inputs.
+    /// </para>
+    /// <para>
+    /// The <see cref="InputEvent.CustomType"/> property should contain the custom type name,
+    /// and <see cref="InputEvent.CustomData"/> can store event-specific data.
+    /// </para>
+    /// </remarks>
+    Custom = 8,
+}

--- a/src/KeenEyes.Replay/ReplayFrame.cs
+++ b/src/KeenEyes.Replay/ReplayFrame.cs
@@ -97,4 +97,23 @@ public sealed record ReplayFrame
     /// <seealso cref="WorldChecksum"/>
     /// <seealso cref="ReplayDesyncException"/>
     public uint? Checksum { get; init; }
+
+    /// <summary>
+    /// Gets or sets the input events that occurred during this frame.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Input events capture user interactions such as keyboard presses, mouse
+    /// movements, and gamepad inputs. These are stored separately from replay
+    /// events to enable efficient input playback.
+    /// </para>
+    /// <para>
+    /// Input events are ordered by their <see cref="InputEvent.Timestamp"/>
+    /// values for accurate sub-frame timing during playback.
+    /// </para>
+    /// <para>
+    /// An empty list indicates no input events occurred during this frame.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<InputEvent> InputEvents { get; init; } = [];
 }

--- a/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
@@ -1,0 +1,1019 @@
+using System.Numerics;
+using KeenEyes.Serialization;
+
+namespace KeenEyes.Replay.Tests;
+
+/// <summary>
+/// Unit tests for the input recording and playback functionality.
+/// </summary>
+public class ReplayInputTests
+{
+    #region InputEvent Tests
+
+    [Fact]
+    public void InputEvent_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var inputEvent = new InputEvent();
+
+        // Assert
+        Assert.Equal(InputEventType.KeyDown, inputEvent.Type);
+        Assert.Equal(0, inputEvent.Frame);
+        Assert.Null(inputEvent.Key);
+        Assert.Equal(0f, inputEvent.Value);
+        Assert.Equal(Vector2.Zero, inputEvent.Position);
+        Assert.Null(inputEvent.CustomType);
+        Assert.Null(inputEvent.CustomData);
+        Assert.Equal(TimeSpan.Zero, inputEvent.Timestamp);
+    }
+
+    [Fact]
+    public void InputEvent_WithProperties_SetsValuesCorrectly()
+    {
+        // Arrange & Act
+        var inputEvent = new InputEvent
+        {
+            Type = InputEventType.MouseMove,
+            Frame = 42,
+            Key = "Left",
+            Value = 1.5f,
+            Position = new Vector2(100, 200),
+            CustomType = "TestType",
+            CustomData = "TestData",
+            Timestamp = TimeSpan.FromMilliseconds(10)
+        };
+
+        // Assert
+        Assert.Equal(InputEventType.MouseMove, inputEvent.Type);
+        Assert.Equal(42, inputEvent.Frame);
+        Assert.Equal("Left", inputEvent.Key);
+        Assert.Equal(1.5f, inputEvent.Value);
+        Assert.Equal(new Vector2(100, 200), inputEvent.Position);
+        Assert.Equal("TestType", inputEvent.CustomType);
+        Assert.Equal("TestData", inputEvent.CustomData);
+        Assert.Equal(TimeSpan.FromMilliseconds(10), inputEvent.Timestamp);
+    }
+
+    [Fact]
+    public void InputEvent_ToString_ReturnsExpectedFormat()
+    {
+        // Arrange
+        var keyEvent = new InputEvent
+        {
+            Type = InputEventType.KeyDown,
+            Frame = 42,
+            Key = "Space"
+        };
+
+        var mouseEvent = new InputEvent
+        {
+            Type = InputEventType.MouseMove,
+            Frame = 42,
+            Position = new Vector2(100, 200)
+        };
+
+        // Act
+        var keyString = keyEvent.ToString();
+        var mouseString = mouseEvent.ToString();
+
+        // Assert
+        Assert.Contains("KeyDown", keyString);
+        Assert.Contains("Frame=42", keyString);
+        Assert.Contains("Key=Space", keyString);
+
+        Assert.Contains("MouseMove", mouseString);
+        Assert.Contains("Frame=42", mouseString);
+    }
+
+    #endregion
+
+    #region ReplayRecorder Input Recording Tests
+
+    [Fact]
+    public void RecordKeyDown_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordKeyDown("Space");
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.KeyDown, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("Space", result.Frames[0].InputEvents[0].Key);
+    }
+
+    [Fact]
+    public void RecordKeyUp_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordKeyUp("Enter");
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.KeyUp, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("Enter", result.Frames[0].InputEvents[0].Key);
+    }
+
+    [Fact]
+    public void RecordMouseMove_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordMouseMove(new Vector2(100, 200));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.MouseMove, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal(new Vector2(100, 200), result.Frames[0].InputEvents[0].Position);
+    }
+
+    [Fact]
+    public void RecordMouseButtonDown_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordMouseButtonDown("Left", new Vector2(50, 75));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.MouseButtonDown, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("Left", result.Frames[0].InputEvents[0].Key);
+        Assert.Equal(new Vector2(50, 75), result.Frames[0].InputEvents[0].Position);
+    }
+
+    [Fact]
+    public void RecordMouseButtonUp_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordMouseButtonUp("Right", new Vector2(150, 175));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.MouseButtonUp, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("Right", result.Frames[0].InputEvents[0].Key);
+        Assert.Equal(new Vector2(150, 175), result.Frames[0].InputEvents[0].Position);
+    }
+
+    [Fact]
+    public void RecordMouseWheel_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordMouseWheel(3.5f, new Vector2(200, 300));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.MouseWheel, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal(3.5f, result.Frames[0].InputEvents[0].Value);
+        Assert.Equal(new Vector2(200, 300), result.Frames[0].InputEvents[0].Position);
+    }
+
+    [Fact]
+    public void RecordGamepadButton_Pressed_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordGamepadButton("A", pressed: true);
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.GamepadButton, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("A", result.Frames[0].InputEvents[0].Key);
+        Assert.Equal(1.0f, result.Frames[0].InputEvents[0].Value);
+    }
+
+    [Fact]
+    public void RecordGamepadButton_Released_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordGamepadButton("B", pressed: false);
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.GamepadButton, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("B", result.Frames[0].InputEvents[0].Key);
+        Assert.Equal(0.0f, result.Frames[0].InputEvents[0].Value);
+    }
+
+    [Fact]
+    public void RecordGamepadAxis_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordGamepadAxis("LeftStickX", 0.75f);
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.GamepadAxis, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("LeftStickX", result.Frames[0].InputEvents[0].Key);
+        Assert.Equal(0.75f, result.Frames[0].InputEvents[0].Value);
+    }
+
+    [Fact]
+    public void RecordCustomInput_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordCustomInput("TouchGesture", "SwipeLeft");
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.Custom, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("TouchGesture", result.Frames[0].InputEvents[0].CustomType);
+        Assert.Equal("SwipeLeft", result.Frames[0].InputEvents[0].CustomData);
+    }
+
+    [Fact]
+    public void RecordCustomInput_Generic_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordCustomInput("GestureData", new TestGestureData("Pinch", 1.5f));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.Custom, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("GestureData", result.Frames[0].InputEvents[0].CustomType);
+        var gestureData = Assert.IsType<TestGestureData>(result.Frames[0].InputEvents[0].CustomData);
+        Assert.Equal("Pinch", gestureData.GestureType);
+        Assert.Equal(1.5f, gestureData.Scale);
+    }
+
+    [Fact]
+    public void RecordInput_RawEvent_WhenRecording_AddsInputEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        var inputEvent = new InputEvent
+        {
+            Type = InputEventType.KeyDown,
+            Frame = 0,
+            Key = "Escape",
+            Timestamp = TimeSpan.FromMilliseconds(5)
+        };
+
+        // Act
+        recorder.RecordInput(inputEvent);
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(InputEventType.KeyDown, result.Frames[0].InputEvents[0].Type);
+        Assert.Equal("Escape", result.Frames[0].InputEvents[0].Key);
+    }
+
+    [Fact]
+    public void RecordInput_WhenNotRecording_DoesNotAddEvent()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        // Act - Record before starting
+        recorder.RecordKeyDown("Space");
+
+        // Assert - Should not throw and no events recorded
+        Assert.False(recorder.IsRecording);
+    }
+
+    [Fact]
+    public void RecordMultipleInputs_SameFrame_AddsAllEvents()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+
+        // Act
+        recorder.RecordKeyDown("W");
+        recorder.RecordKeyDown("Shift");
+        recorder.RecordMouseMove(new Vector2(100, 100));
+        recorder.EndFrame(0.016f);
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Frames[0].InputEvents.Count);
+    }
+
+    [Fact]
+    public void RecordInputsAcrossFrames_StoresCorrectly()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+        recorder.StartRecording();
+
+        // Act - Record inputs across multiple frames
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("A");
+        recorder.EndFrame(0.016f);
+
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyUp("A");
+        recorder.RecordKeyDown("B");
+        recorder.EndFrame(0.016f);
+
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyUp("B");
+        recorder.EndFrame(0.016f);
+
+        var result = recorder.StopRecording();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.FrameCount);
+        Assert.Single(result.Frames[0].InputEvents);
+        Assert.Equal(2, result.Frames[1].InputEvents.Count);
+        Assert.Single(result.Frames[2].InputEvents);
+    }
+
+    [Fact]
+    public void IInputRecorder_IsRecordingInputs_ReturnsCorrectValue()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        IInputRecorder recorder = new ReplayRecorder(world, serializer);
+
+        // Act & Assert
+        Assert.False(recorder.IsRecordingInputs);
+
+        ((ReplayRecorder)recorder).StartRecording();
+        Assert.True(recorder.IsRecordingInputs);
+
+        ((ReplayRecorder)recorder).StopRecording();
+        Assert.False(recorder.IsRecordingInputs);
+    }
+
+    [Fact]
+    public void IInputRecorder_CurrentInputFrame_ReturnsCorrectValue()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        IInputRecorder recorder = new ReplayRecorder(world, serializer);
+
+        // Assert - Not recording
+        Assert.Equal(-1, recorder.CurrentInputFrame);
+
+        // Start recording
+        ((ReplayRecorder)recorder).StartRecording();
+        Assert.Equal(0, recorder.CurrentInputFrame);
+
+        // Record a frame
+        ((ReplayRecorder)recorder).BeginFrame(0.016f);
+        ((ReplayRecorder)recorder).EndFrame(0.016f);
+        Assert.Equal(1, recorder.CurrentInputFrame);
+
+        ((ReplayRecorder)recorder).StopRecording();
+        Assert.Equal(-1, recorder.CurrentInputFrame);
+    }
+
+    #endregion
+
+    #region ReplayPlayer Input Handler Tests
+
+    [Fact]
+    public void RegisterInputHandler_WithHandler_AddsHandler()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+        var handlerCalled = false;
+
+        // Act
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => handlerCalled = true);
+
+        // Assert - Handler registered (we can't directly verify, but no exception thrown)
+        Assert.False(handlerCalled); // Not called yet
+    }
+
+    [Fact]
+    public void RegisterInputHandler_WithNullHandler_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            player.RegisterInputHandler(InputEventType.KeyDown, null!));
+    }
+
+    [Fact]
+    public void RegisterInputHandler_Generic_WithHandler_AddsHandler()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+        var handlerCalled = false;
+
+        // Act
+        player.RegisterInputHandler<TestGestureData>("TouchGesture", _ => handlerCalled = true);
+
+        // Assert - Handler registered (no exception thrown)
+        Assert.False(handlerCalled);
+    }
+
+    [Fact]
+    public void RegisterInputHandler_Generic_WithNullCustomType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            player.RegisterInputHandler<TestGestureData>(null!, _ => { }));
+    }
+
+    [Fact]
+    public void RegisterInputHandler_Generic_WithEmptyCustomType_ThrowsArgumentException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+            player.RegisterInputHandler<TestGestureData>("", _ => { }));
+    }
+
+    [Fact]
+    public void RegisterInputHandler_Generic_WithNullHandler_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            player.RegisterInputHandler<TestGestureData>("TouchGesture", null!));
+    }
+
+    [Fact]
+    public void UnregisterInputHandlers_RemovesHandlers()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+        var callCount = 0;
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => callCount++);
+
+        // Act
+        player.UnregisterInputHandlers(InputEventType.KeyDown);
+
+        // Assert - No exception thrown (handlers removed)
+    }
+
+    [Fact]
+    public void UnregisterCustomInputHandlers_RemovesHandlers()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+        var callCount = 0;
+        player.RegisterInputHandler<TestGestureData>("TouchGesture", _ => callCount++);
+
+        // Act
+        player.UnregisterCustomInputHandlers("TouchGesture");
+
+        // Assert - No exception thrown (handlers removed)
+    }
+
+    [Fact]
+    public void ClearInputHandlers_RemovesAllHandlers()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => { });
+        player.RegisterInputHandler(InputEventType.MouseMove, _ => { });
+        player.RegisterInputHandler<TestGestureData>("TouchGesture", _ => { });
+
+        // Act
+        player.ClearInputHandlers();
+
+        // Assert - No exception thrown (all handlers removed)
+    }
+
+    #endregion
+
+    #region ApplyInputFrame Tests
+
+    [Fact]
+    public void ApplyInputFrame_WithNoReplayLoaded_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => player.ApplyInputFrame());
+    }
+
+    [Fact]
+    public void ApplyInputFrame_WithKeyDownEvent_InvokesHandler()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("Space");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        InputEvent? capturedEvent = null;
+        player.RegisterInputHandler(InputEventType.KeyDown, evt => capturedEvent = evt);
+
+        // Act
+        player.ApplyInputFrame();
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal(InputEventType.KeyDown, capturedEvent.Value.Type);
+        Assert.Equal("Space", capturedEvent.Value.Key);
+    }
+
+    [Fact]
+    public void ApplyInputFrame_WithMultipleEvents_InvokesAllHandlers()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("W");
+        recorder.RecordMouseMove(new Vector2(100, 200));
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        var keyEvents = new List<InputEvent>();
+        var mouseEvents = new List<InputEvent>();
+        player.RegisterInputHandler(InputEventType.KeyDown, evt => keyEvents.Add(evt));
+        player.RegisterInputHandler(InputEventType.MouseMove, evt => mouseEvents.Add(evt));
+
+        // Act
+        player.ApplyInputFrame();
+
+        // Assert
+        Assert.Single(keyEvents);
+        Assert.Single(mouseEvents);
+        Assert.Equal("W", keyEvents[0].Key);
+        Assert.Equal(new Vector2(100, 200), mouseEvents[0].Position);
+    }
+
+    [Fact]
+    public void ApplyInputFrame_WithNoHandlerRegistered_DoesNotThrow()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("Space");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Act & Assert - Should not throw
+        player.ApplyInputFrame();
+    }
+
+    [Fact]
+    public void ApplyInputFrame_WithCustomEvent_InvokesTypedHandler()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        var gestureData = new TestGestureData("Pinch", 1.5f);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordCustomInput("GestureData", gestureData);
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        TestGestureData? capturedData = null;
+        player.RegisterInputHandler<TestGestureData>("GestureData", data => capturedData = data);
+
+        // Act
+        player.ApplyInputFrame();
+
+        // Assert
+        Assert.NotNull(capturedData);
+        Assert.Equal("Pinch", capturedData.GestureType);
+        Assert.Equal(1.5f, capturedData.Scale);
+    }
+
+    [Fact]
+    public void ApplyInputFrame_ByIndex_AppliesCorrectFrame()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("A");
+        recorder.EndFrame(0.016f);
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("B");
+        recorder.EndFrame(0.016f);
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("C");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        var capturedKeys = new List<string>();
+        player.RegisterInputHandler(InputEventType.KeyDown, evt => capturedKeys.Add(evt.Key!));
+
+        // Act - Apply frame 1 (second frame with "B")
+        player.ApplyInputFrame(1);
+
+        // Assert
+        Assert.Single(capturedKeys);
+        Assert.Equal("B", capturedKeys[0]);
+    }
+
+    [Fact]
+    public void ApplyInputFrame_ByIndex_WithInvalidIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.ApplyInputFrame(10));
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.ApplyInputFrame(-1));
+    }
+
+    [Fact]
+    public void ApplyInputFrame_WithMultipleHandlersForSameType_InvokesAll()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("Space");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        var callCount = 0;
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => callCount++);
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => callCount++);
+        player.RegisterInputHandler(InputEventType.KeyDown, _ => callCount++);
+
+        // Act
+        player.ApplyInputFrame();
+
+        // Assert
+        Assert.Equal(3, callCount);
+    }
+
+    #endregion
+
+    #region GetInputEvents Tests
+
+    [Fact]
+    public void GetCurrentInputEvents_WithNoReplayLoaded_ReturnsEmptyList()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act
+        var events = player.GetCurrentInputEvents();
+
+        // Assert
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void GetCurrentInputEvents_WithReplayLoaded_ReturnsInputEvents()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("Space");
+        recorder.RecordKeyDown("Enter");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Act
+        var events = player.GetCurrentInputEvents();
+
+        // Assert
+        Assert.Equal(2, events.Count);
+    }
+
+    [Fact]
+    public void GetInputEvents_ByIndex_ReturnsInputEvents()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("A");
+        recorder.EndFrame(0.016f);
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("B");
+        recorder.RecordKeyDown("C");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Act
+        var frame0Events = player.GetInputEvents(0);
+        var frame1Events = player.GetInputEvents(1);
+
+        // Assert
+        Assert.Single(frame0Events);
+        Assert.Equal(2, frame1Events.Count);
+    }
+
+    [Fact]
+    public void GetInputEvents_WithInvalidIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.GetInputEvents(10));
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.GetInputEvents(-1));
+    }
+
+    [Fact]
+    public void GetInputEvents_WithNoReplayLoaded_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var player = new ReplayPlayer();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => player.GetInputEvents(0));
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void FullInputPlayback_RecordAndReplay_WorksCorrectly()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        // Record session
+        recorder.StartRecording("Input Test");
+        for (int frame = 0; frame < 10; frame++)
+        {
+            recorder.BeginFrame(0.016f);
+            recorder.RecordKeyDown($"Key{frame}");
+            recorder.RecordMouseMove(new Vector2(frame * 10, frame * 20));
+            recorder.EndFrame(0.016f);
+        }
+        var replayData = recorder.StopRecording();
+
+        // Playback
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        var keyEvents = new List<InputEvent>();
+        var mouseEvents = new List<InputEvent>();
+        player.RegisterInputHandler(InputEventType.KeyDown, evt => keyEvents.Add(evt));
+        player.RegisterInputHandler(InputEventType.MouseMove, evt => mouseEvents.Add(evt));
+
+        // Apply all frames
+        for (int frame = 0; frame < replayData!.FrameCount; frame++)
+        {
+            player.ApplyInputFrame(frame);
+        }
+
+        // Assert
+        Assert.Equal(10, keyEvents.Count);
+        Assert.Equal(10, mouseEvents.Count);
+
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.Equal($"Key{i}", keyEvents[i].Key);
+            Assert.Equal(new Vector2(i * 10, i * 20), mouseEvents[i].Position);
+        }
+    }
+
+    [Fact]
+    public void InputPlayback_WithPlaybackLoop_WorksCorrectly()
+    {
+        // Arrange
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyDown("Jump");
+        recorder.EndFrame(0.016f);
+        recorder.BeginFrame(0.016f);
+        recorder.RecordKeyUp("Jump");
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        var allEvents = new List<InputEvent>();
+        player.RegisterInputHandler(InputEventType.KeyDown, evt => allEvents.Add(evt));
+        player.RegisterInputHandler(InputEventType.KeyUp, evt => allEvents.Add(evt));
+
+        player.Play();
+
+        // Apply first frame before entering the loop
+        player.ApplyInputFrame();
+
+        // Act - Simulate playback loop
+        while (player.State == PlaybackState.Playing)
+        {
+            if (player.Update(0.016f))
+            {
+                player.ApplyInputFrame();
+            }
+        }
+
+        // Assert - Should have captured events from both frames
+        Assert.Equal(2, allEvents.Count);
+        Assert.Equal(InputEventType.KeyDown, allEvents[0].Type);
+        Assert.Equal(InputEventType.KeyUp, allEvents[1].Type);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Test data class for custom input events.
+/// </summary>
+public record TestGestureData(string GestureType, float Scale);


### PR DESCRIPTION
## Summary

- Implements issue #410 - Input recording and playback system for deterministic replay
- Adds `InputEventType` enum and `InputEvent` struct for capturing keyboard, mouse, gamepad, and custom inputs
- Adds `IInputRecorder` interface with convenience methods for all input types
- Extends `ReplayRecorder` to implement `IInputRecorder` and store inputs per-frame
- Extends `ReplayPlayer` with handler registration and `ApplyInputFrame()` for playback

## API

**Recording:**
```csharp
var recorder = world.GetExtension<ReplayRecorder>();
recorder.RecordKeyDown("Space");
recorder.RecordMouseMove(new Vector2(100, 200));
recorder.RecordGamepadAxis("LeftStickX", 0.75f);
recorder.RecordCustomInput<GestureData>("TouchGesture", gestureData);
```

**Playback:**
```csharp
player.RegisterInputHandler(InputEventType.KeyDown, evt => 
    inputSystem.SimulateKeyDown(evt.Key));
player.RegisterInputHandler<GestureData>("TouchGesture", gesture => 
    HandleGesture(gesture));

while (player.State == PlaybackState.Playing)
{
    if (player.Update(deltaTime))
        player.ApplyInputFrame();
}
```

## Test plan

- [x] Unit tests for InputEvent struct construction and ToString()
- [x] Unit tests for all IInputRecorder recording methods
- [x] Unit tests for input handler registration (standard and custom types)
- [x] Unit tests for ApplyInputFrame() with various input types
- [x] Integration tests for full record/replay cycle
- [x] All 349 replay tests pass
- [x] Build succeeds with zero warnings

Closes #410