### PR TITLE
fix: Resolve unit test failures in Localization and Replay

### DIFF
--- a/src/KeenEyes.Localization/LocalizedAssetResolver.cs
+++ b/src/KeenEyes.Localization/LocalizedAssetResolver.cs
@@ -127,11 +127,11 @@ public sealed class LocalizedAssetResolver(string rootPath, LocalizationConfig c
             if (fileName.StartsWith(baseName + ".", StringComparison.OrdinalIgnoreCase) ||
                 fileName.Equals(baseName, StringComparison.OrdinalIgnoreCase))
             {
-                // Return path relative to root
+                // Return path relative to root, normalized to forward slashes for cross-platform consistency
                 var relativePath = string.IsNullOrEmpty(rootPath)
                     ? file
                     : Path.GetRelativePath(rootPath, file);
-                yield return relativePath;
+                yield return relativePath.Replace('\\', '/');
             }
         }
     }

--- a/src/KeenEyes.Replay/Ghost/GhostJsonContext.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostJsonContext.cs
@@ -14,7 +14,8 @@ namespace KeenEyes.Replay.Ghost;
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = false,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    Converters = [typeof(Vector3JsonConverter), typeof(QuaternionJsonConverter)])]
 [JsonSerializable(typeof(GhostData))]
 [JsonSerializable(typeof(GhostFrame))]
 [JsonSerializable(typeof(GhostFileInfo))]

--- a/src/KeenEyes.Replay/Ghost/NumericsJsonConverters.cs
+++ b/src/KeenEyes.Replay/Ghost/NumericsJsonConverters.cs
@@ -1,0 +1,131 @@
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace KeenEyes.Replay.Ghost;
+
+/// <summary>
+/// AOT-compatible JSON converter for <see cref="Vector3"/>.
+/// </summary>
+/// <remarks>
+/// Serializes Vector3 as <c>{"x":1.0,"y":2.0,"z":3.0}</c>.
+/// </remarks>
+internal sealed class Vector3JsonConverter : JsonConverter<Vector3>
+{
+    /// <inheritdoc />
+    public override Vector3 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object");
+        }
+
+        float x = 0, y = 0, z = 0;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return new Vector3(x, y, z);
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name");
+            }
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case "x":
+                    x = reader.GetSingle();
+                    break;
+                case "y":
+                    y = reader.GetSingle();
+                    break;
+                case "z":
+                    z = reader.GetSingle();
+                    break;
+            }
+        }
+
+        throw new JsonException("Expected end of object");
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, Vector3 value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("x", value.X);
+        writer.WriteNumber("y", value.Y);
+        writer.WriteNumber("z", value.Z);
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>
+/// AOT-compatible JSON converter for <see cref="Quaternion"/>.
+/// </summary>
+/// <remarks>
+/// Serializes Quaternion as <c>{"x":0.0,"y":0.0,"z":0.0,"w":1.0}</c>.
+/// </remarks>
+internal sealed class QuaternionJsonConverter : JsonConverter<Quaternion>
+{
+    /// <inheritdoc />
+    public override Quaternion Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object");
+        }
+
+        float x = 0, y = 0, z = 0, w = 0;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return new Quaternion(x, y, z, w);
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name");
+            }
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case "x":
+                    x = reader.GetSingle();
+                    break;
+                case "y":
+                    y = reader.GetSingle();
+                    break;
+                case "z":
+                    z = reader.GetSingle();
+                    break;
+                case "w":
+                    w = reader.GetSingle();
+                    break;
+            }
+        }
+
+        throw new JsonException("Expected end of object");
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, Quaternion value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("x", value.X);
+        writer.WriteNumber("y", value.Y);
+        writer.WriteNumber("z", value.Z);
+        writer.WriteNumber("w", value.W);
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
- Fix path separator issue in LocalizedAssetResolver.GetAllPaths() to normalize paths with forward slashes for cross-platform consistency
- Add AOT-compatible Vector3JsonConverter and QuaternionJsonConverter for proper System.Numerics type serialization in ghost files
- Register converters in GhostJsonContext for JSON source generation

Fixes failing tests:
- LocalizedAssetResolverTests.GetAllPaths_ReturnsAllMatchingFiles
- GhostFileFormatTests.Read_PreservesPosition
- GhostFileFormatTests.Read_PreservesFrameData

🤖 Generated with [Claude Code](https://claude.com/claude-code)