### PR TITLE
fix: Rename NPC struct to Npc for Pascal case compliance

### DIFF
--- a/samples/KeenEyes.Sample.SaveLoad/Components.cs
+++ b/samples/KeenEyes.Sample.SaveLoad/Components.cs
@@ -88,4 +88,4 @@ public partial struct Enemy;
 /// Tag for NPC entities.
 /// </summary>
 [TagComponent]
-public partial struct NPC;
+public partial struct Npc;

--- a/samples/KeenEyes.Sample.SaveLoad/Program.cs
+++ b/samples/KeenEyes.Sample.SaveLoad/Program.cs
@@ -53,12 +53,12 @@ for (int i = 0; i < 3; i++)
 // Create NPCs
 var merchant = world.Spawn("Merchant")
     .WithPosition(x: 50, y: 200)
-    .WithNPC()
+    .WithNpc()
     .Build();
 
 var questGiver = world.Spawn("QuestGiver")
     .WithPosition(x: 150, y: 200)
-    .WithNPC()
+    .WithNpc()
     .Build();
 
 Console.WriteLine($"Created NPCs: Merchant={merchant}, QuestGiver={questGiver}");
@@ -328,7 +328,7 @@ static void PrintWorldState(World world, string label)
 
     var playerCount = world.Query<Position>().With<Player>().Count();
     var enemyCount = world.Query<Position>().With<Enemy>().Count();
-    var npcCount = world.Query<Position>().With<NPC>().Count();
+    var npcCount = world.Query<Position>().With<Npc>().Count();
 
     Console.WriteLine($"Entities: {playerCount} players, {enemyCount} enemies, {npcCount} NPCs");
 


### PR DESCRIPTION
## Summary
- Renamed the `NPC` tag component struct to `Npc` to comply with SonarAnalyzer S101 Pascal case naming rules
- Updated all usages in the SaveLoad sample: builder methods `.WithNPC()` → `.WithNpc()` and query `With<NPC>()` → `With<Npc>()`

## Test plan
- [x] `dotnet format --verify-no-changes` passes
- [x] Pre-commit hook validation succeeded