### PR TITLE
feat: Add screenshot capture to TestBridge (Phase 3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup Label="Assets">
     <PackageVersion Include="StbImageSharp" Version="2.30.15" />
+    <PackageVersion Include="StbImageWriteSharp" Version="1.16.7" />
     <PackageVersion Include="SharpGLTF.Core" Version="1.0.6" />
     <PackageVersion Include="NVorbis" Version="0.10.5" />
   </ItemGroup>

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
@@ -430,5 +430,26 @@ public interface IGraphicsDevice : IDisposable
     /// <param name="data">The buffer to receive the data.</param>
     void GetTexImage(TextureTarget target, int level, PixelFormat format, Span<byte> data);
 
+    /// <summary>
+    /// Reads pixel data from the current framebuffer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method reads pixels from the currently bound framebuffer (or the default framebuffer
+    /// if none is bound). The data is returned in the specified pixel format.
+    /// </para>
+    /// <para>
+    /// Note: OpenGL reads pixels from bottom-left origin, so the resulting image may need
+    /// to be flipped vertically for typical image file formats.
+    /// </para>
+    /// </remarks>
+    /// <param name="x">The X coordinate of the lower-left corner of the rectangle to read.</param>
+    /// <param name="y">The Y coordinate of the lower-left corner of the rectangle to read.</param>
+    /// <param name="width">The width of the rectangle to read.</param>
+    /// <param name="height">The height of the rectangle to read.</param>
+    /// <param name="format">The pixel format.</param>
+    /// <param name="data">The buffer to receive the pixel data. Must be large enough to hold width * height * bytes-per-pixel.</param>
+    void ReadFramebuffer(int x, int y, int width, int height, PixelFormat format, Span<byte> data);
+
     #endregion
 }

--- a/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
@@ -488,6 +488,18 @@ public sealed class OpenGLDevice(GL gl) : IGraphicsDevice
         }
     }
 
+    /// <inheritdoc />
+    public void ReadFramebuffer(int x, int y, int width, int height, Abstractions.PixelFormat format, Span<byte> data)
+    {
+        unsafe
+        {
+            fixed (byte* ptr = data)
+            {
+                gl.ReadPixels(x, y, (uint)width, (uint)height, ToGL(format), PixelType.UnsignedByte, ptr);
+            }
+        }
+    }
+
     #endregion
 
     /// <inheritdoc />

--- a/src/KeenEyes.Logging/packages.lock.json
+++ b/src/KeenEyes.Logging/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "10.0.1",
         "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
       "keeneyes.abstractions": {
         "type": "Project"
       }

--- a/src/KeenEyes.TestBridge.Client/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Client/packages.lock.json
@@ -43,7 +43,10 @@
         }
       },
       "keeneyes.logging": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.network.abstractions": {
         "type": "Project",
@@ -62,8 +65,10 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
-          "KeenEyes.Testing": "[1.0.0, )"
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
         }
       },
       "keeneyes.testbridge.abstractions": {
@@ -92,6 +97,12 @@
           "KeenEyes.Network.Abstractions": "[1.0.0, )",
           "KeenEyes.Persistence": "[1.0.0, )"
         }
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
       }
     }
   }

--- a/src/KeenEyes.TestBridge.Ipc/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Ipc/packages.lock.json
@@ -43,7 +43,10 @@
         }
       },
       "keeneyes.logging": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.network.abstractions": {
         "type": "Project",
@@ -62,8 +65,10 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
-          "KeenEyes.Testing": "[1.0.0, )"
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
         }
       },
       "keeneyes.testbridge.abstractions": {
@@ -84,6 +89,12 @@
           "KeenEyes.Network.Abstractions": "[1.0.0, )",
           "KeenEyes.Persistence": "[1.0.0, )"
         }
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
       }
     }
   }

--- a/src/KeenEyes.TestBridge/Capture/CaptureControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/Capture/CaptureControllerImpl.cs
@@ -1,4 +1,4 @@
-using KeenEyes.TestBridge.Capture;
+using KeenEyes.Graphics.Abstractions;
 
 namespace KeenEyes.TestBridge.Capture;
 
@@ -6,10 +6,14 @@ namespace KeenEyes.TestBridge.Capture;
 /// In-process implementation of <see cref="ICaptureController"/>.
 /// </summary>
 /// <remarks>
-/// This is a stub implementation for Phase 1. Full capture functionality
-/// will be implemented in Phase 3 with GPU framebuffer and platform fallbacks.
+/// <para>
+/// This implementation captures screenshots directly from the GPU framebuffer
+/// when a graphics context is available. Falls back gracefully when no graphics
+/// context is present (e.g., headless testing mode).
+/// </para>
 /// </remarks>
-internal sealed class CaptureControllerImpl : ICaptureController
+/// <param name="graphicsContext">Optional graphics context for GPU capture.</param>
+internal sealed class CaptureControllerImpl(IGraphicsContext? graphicsContext = null) : ICaptureController
 {
     private readonly List<FrameCapture> recordedFrames = [];
     private bool isRecording;
@@ -17,7 +21,7 @@ internal sealed class CaptureControllerImpl : ICaptureController
     private long currentFrameNumber;
 
     /// <inheritdoc />
-    public bool IsAvailable => false; // Will be true when capture providers are implemented
+    public bool IsAvailable => graphicsContext?.IsInitialized == true && graphicsContext.Device != null;
 
     /// <inheritdoc />
     public bool IsRecording => isRecording;
@@ -38,12 +42,21 @@ internal sealed class CaptureControllerImpl : ICaptureController
     {
         ThrowIfNotAvailable();
 
-        // Stub: Return empty frame
+        var width = graphicsContext!.Width;
+        var height = graphicsContext.Height;
+        var pixels = new byte[width * height * 4];
+
+        // Read pixels from GPU framebuffer
+        graphicsContext.Device!.ReadFramebuffer(0, 0, width, height, PixelFormat.RGBA, pixels);
+
+        // OpenGL reads pixels from bottom-left origin, flip vertically for standard top-left origin
+        FlipVertically(pixels, width, height);
+
         var capture = new FrameCapture
         {
-            Width = 0,
-            Height = 0,
-            Pixels = [],
+            Width = width,
+            Height = height,
+            Pixels = pixels,
             FrameNumber = currentFrameNumber,
             Timestamp = TimeSpan.FromSeconds(currentFrameNumber / 60.0)
         };
@@ -57,28 +70,38 @@ internal sealed class CaptureControllerImpl : ICaptureController
     }
 
     /// <inheritdoc />
-    public Task<string> SaveScreenshotAsync(string filePath, ImageFormat format = ImageFormat.Png)
+    public async Task<string> SaveScreenshotAsync(string filePath, ImageFormat format = ImageFormat.Png)
     {
-        ThrowIfNotAvailable();
+        var bytes = await GetScreenshotBytesAsync(format);
+        var fullPath = Path.GetFullPath(filePath);
 
-        // Stub: Would capture and save to file
-        return Task.FromResult(Path.GetFullPath(filePath));
+        // Ensure directory exists
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllBytesAsync(fullPath, bytes);
+        return fullPath;
     }
 
     /// <inheritdoc />
-    public Task<byte[]> GetScreenshotBytesAsync(ImageFormat format = ImageFormat.Png)
+    public async Task<byte[]> GetScreenshotBytesAsync(ImageFormat format = ImageFormat.Png)
     {
-        ThrowIfNotAvailable();
-
-        // Stub: Would capture and encode
-        return Task.FromResult(Array.Empty<byte>());
+        var capture = await CaptureFrameAsync();
+        return ImageEncoder.Encode(capture.Pixels, capture.Width, capture.Height, format);
     }
 
     /// <inheritdoc />
     public Task<(int Width, int Height)> GetFrameSizeAsync()
     {
-        // Stub: Return default size
-        return Task.FromResult((0, 0));
+        if (!IsAvailable)
+        {
+            return Task.FromResult((0, 0));
+        }
+
+        return Task.FromResult((graphicsContext!.Width, graphicsContext.Height));
     }
 
     /// <inheritdoc />
@@ -122,12 +145,35 @@ internal sealed class CaptureControllerImpl : ICaptureController
         }
     }
 
+    /// <summary>
+    /// Flips pixel data vertically (bottom-to-top becomes top-to-bottom).
+    /// </summary>
+    /// <param name="pixels">RGBA pixel data.</param>
+    /// <param name="width">Image width.</param>
+    /// <param name="height">Image height.</param>
+    private static void FlipVertically(byte[] pixels, int width, int height)
+    {
+        var rowSize = width * 4;
+        var tempRow = new byte[rowSize];
+
+        for (var y = 0; y < height / 2; y++)
+        {
+            var topRowStart = y * rowSize;
+            var bottomRowStart = (height - 1 - y) * rowSize;
+
+            // Swap rows
+            Array.Copy(pixels, topRowStart, tempRow, 0, rowSize);
+            Array.Copy(pixels, bottomRowStart, pixels, topRowStart, rowSize);
+            Array.Copy(tempRow, 0, pixels, bottomRowStart, rowSize);
+        }
+    }
+
     private void ThrowIfNotAvailable()
     {
         if (!IsAvailable)
         {
             throw new InvalidOperationException(
-                "Capture is not available. Ensure a graphics context is configured and capture providers are implemented.");
+                "Capture is not available. Ensure a graphics context is configured and initialized.");
         }
     }
 }

--- a/src/KeenEyes.TestBridge/Capture/ImageEncoder.cs
+++ b/src/KeenEyes.TestBridge/Capture/ImageEncoder.cs
@@ -1,0 +1,105 @@
+using StbImageWriteSharp;
+
+namespace KeenEyes.TestBridge.Capture;
+
+/// <summary>
+/// Encodes raw pixel data to various image formats.
+/// </summary>
+internal static class ImageEncoder
+{
+    /// <summary>
+    /// Default JPEG quality (0-100).
+    /// </summary>
+    private const int DefaultJpegQuality = 90;
+
+    /// <summary>
+    /// Encodes pixel data to the specified image format.
+    /// </summary>
+    /// <param name="pixels">Raw RGBA pixel data.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="format">The target image format.</param>
+    /// <returns>Encoded image bytes.</returns>
+    public static byte[] Encode(byte[] pixels, int width, int height, ImageFormat format)
+    {
+        return format switch
+        {
+            ImageFormat.Png => EncodePng(pixels, width, height),
+            ImageFormat.Jpeg => EncodeJpeg(pixels, width, height),
+            ImageFormat.Bmp => EncodeBmp(pixels, width, height),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown image format")
+        };
+    }
+
+    /// <summary>
+    /// Encodes pixel data to PNG format.
+    /// </summary>
+    /// <param name="pixels">Raw RGBA pixel data.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <returns>PNG encoded image bytes.</returns>
+    public static byte[] EncodePng(byte[] pixels, int width, int height)
+    {
+        using var stream = new MemoryStream();
+        var writer = new ImageWriter();
+        writer.WritePng(pixels, width, height, ColorComponents.RedGreenBlueAlpha, stream);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Encodes pixel data to JPEG format.
+    /// </summary>
+    /// <param name="pixels">Raw RGBA pixel data.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="quality">JPEG quality (0-100). Defaults to 90.</param>
+    /// <returns>JPEG encoded image bytes.</returns>
+    public static byte[] EncodeJpeg(byte[] pixels, int width, int height, int quality = DefaultJpegQuality)
+    {
+        // JPEG doesn't support alpha, convert RGBA to RGB
+        var rgbPixels = ConvertRgbaToRgb(pixels);
+
+        using var stream = new MemoryStream();
+        var writer = new ImageWriter();
+        writer.WriteJpg(rgbPixels, width, height, ColorComponents.RedGreenBlue, stream, quality);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Encodes pixel data to BMP format.
+    /// </summary>
+    /// <param name="pixels">Raw RGBA pixel data.</param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <returns>BMP encoded image bytes.</returns>
+    public static byte[] EncodeBmp(byte[] pixels, int width, int height)
+    {
+        using var stream = new MemoryStream();
+        var writer = new ImageWriter();
+        writer.WriteBmp(pixels, width, height, ColorComponents.RedGreenBlueAlpha, stream);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Converts RGBA pixel data to RGB by removing the alpha channel.
+    /// </summary>
+    /// <param name="rgbaPixels">RGBA pixel data (4 bytes per pixel).</param>
+    /// <returns>RGB pixel data (3 bytes per pixel).</returns>
+    private static byte[] ConvertRgbaToRgb(byte[] rgbaPixels)
+    {
+        var pixelCount = rgbaPixels.Length / 4;
+        var rgbPixels = new byte[pixelCount * 3];
+
+        for (var i = 0; i < pixelCount; i++)
+        {
+            var rgbaOffset = i * 4;
+            var rgbOffset = i * 3;
+            rgbPixels[rgbOffset] = rgbaPixels[rgbaOffset];         // R
+            rgbPixels[rgbOffset + 1] = rgbaPixels[rgbaOffset + 1]; // G
+            rgbPixels[rgbOffset + 2] = rgbaPixels[rgbaOffset + 2]; // B
+            // Skip alpha
+        }
+
+        return rgbPixels;
+    }
+}

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -1,3 +1,4 @@
+using KeenEyes.Graphics.Abstractions;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -34,7 +35,8 @@ public sealed class InProcessBridge : ITestBridge
     /// </summary>
     /// <param name="world">The world to bridge.</param>
     /// <param name="options">Configuration options.</param>
-    public InProcessBridge(World world, TestBridgeOptions? options = null)
+    /// <param name="graphicsContext">Optional graphics context for screenshot capture.</param>
+    public InProcessBridge(World world, TestBridgeOptions? options = null, IGraphicsContext? graphicsContext = null)
     {
         this.world = world;
         this.options = options ?? new TestBridgeOptions();
@@ -45,7 +47,7 @@ public sealed class InProcessBridge : ITestBridge
 
         inputController = new InputControllerImpl(inputContext);
         stateController = new StateControllerImpl(world);
-        captureController = new CaptureControllerImpl();
+        captureController = new CaptureControllerImpl(graphicsContext);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
+++ b/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
@@ -12,9 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StbImageWriteSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KeenEyes.TestBridge.Abstractions\KeenEyes.TestBridge.Abstractions.csproj" />
     <ProjectReference Include="..\KeenEyes.Core\KeenEyes.Core.csproj" />
     <ProjectReference Include="..\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+    <ProjectReference Include="..\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.TestBridge/TestBridgePlugin.cs
+++ b/src/KeenEyes.TestBridge/TestBridgePlugin.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using KeenEyes.Capabilities;
+using KeenEyes.Graphics.Abstractions;
 
 namespace KeenEyes.TestBridge;
 
@@ -36,8 +37,11 @@ public sealed class TestBridgePlugin(TestBridgeOptions? options = null) : IWorld
         var world = context.World as World
             ?? throw new InvalidOperationException("TestBridgePlugin requires a concrete World instance.");
 
+        // Try to get graphics context (optional - may not exist in headless mode)
+        context.TryGetExtension<IGraphicsContext>(out var graphicsContext);
+
         // Create the in-process bridge
-        bridge = new InProcessBridge(world, options);
+        bridge = new InProcessBridge(world, options, graphicsContext);
 
         // Expose the bridge as an extension
         context.SetExtension<ITestBridge>(bridge);

--- a/src/KeenEyes.TestBridge/packages.lock.json
+++ b/src/KeenEyes.TestBridge/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "10.17.0.131074",
         "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
       },
+      "StbImageWriteSharp": {
+        "type": "Direct",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
+      },
       "keeneyes.abstractions": {
         "type": "Project"
       },
@@ -43,7 +49,10 @@
         }
       },
       "keeneyes.logging": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.network.abstractions": {
         "type": "Project",

--- a/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
+++ b/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
@@ -417,6 +417,22 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
         }
     }
 
+    public void ReadFramebuffer(int x, int y, int width, int height, PixelFormat format, Span<byte> data)
+    {
+        Calls.Add($"ReadFramebuffer({x}, {y}, {width}, {height}, {format}, {data.Length} bytes)");
+        // Fill with test pattern in mock
+        for (int i = 0; i < data.Length; i += 4)
+        {
+            data[i] = 128;     // R
+            data[i + 1] = 64;  // G
+            data[i + 2] = 32;  // B
+            if (i + 3 < data.Length)
+            {
+                data[i + 3] = 255; // A
+            }
+        }
+    }
+
     #endregion
 
     /// <summary>

--- a/tests/KeenEyes.TestBridge.Tests/Capture/CaptureControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Capture/CaptureControllerImplTests.cs
@@ -1,0 +1,452 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.TestBridge.Capture;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.TestBridge.Tests.Capture;
+
+public class CaptureControllerImplTests
+{
+    #region IsAvailable
+
+    [Fact]
+    public void IsAvailable_WithNoGraphicsContext_ReturnsFalse()
+    {
+        var controller = new CaptureControllerImpl();
+
+        controller.IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_WithUninitializedContext_ReturnsFalse()
+    {
+        var context = new MockGraphicsContext { IsInitialized = false };
+        var controller = new CaptureControllerImpl(context);
+
+        controller.IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_WithNullDevice_ReturnsFalse()
+    {
+        var context = new MockGraphicsContext { Device = null };
+        var controller = new CaptureControllerImpl(context);
+
+        controller.IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_WithInitializedContextAndDevice_ReturnsTrue()
+    {
+        var device = new MockGraphicsDevice();
+        var context = new MockGraphicsContext
+        {
+            IsInitialized = true,
+            Device = device
+        };
+        var controller = new CaptureControllerImpl(context);
+
+        controller.IsAvailable.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region GetFrameSizeAsync
+
+    [Fact]
+    public async Task GetFrameSizeAsync_WhenNotAvailable_ReturnsZero()
+    {
+        var controller = new CaptureControllerImpl();
+
+        var (width, height) = await controller.GetFrameSizeAsync();
+
+        width.ShouldBe(0);
+        height.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetFrameSizeAsync_WhenAvailable_ReturnsContextDimensions()
+    {
+        var device = new MockGraphicsDevice();
+        var context = new MockGraphicsContext
+        {
+            IsInitialized = true,
+            Device = device,
+            Width = 1920,
+            Height = 1080
+        };
+        var controller = new CaptureControllerImpl(context);
+
+        var (width, height) = await controller.GetFrameSizeAsync();
+
+        width.ShouldBe(1920);
+        height.ShouldBe(1080);
+    }
+
+    #endregion
+
+    #region CaptureFrameAsync
+
+    [Fact]
+    public async Task CaptureFrameAsync_WhenNotAvailable_ThrowsInvalidOperation()
+    {
+        var controller = new CaptureControllerImpl();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await controller.CaptureFrameAsync());
+    }
+
+    [Fact]
+    public async Task CaptureFrameAsync_WhenAvailable_ReturnsFrameWithCorrectDimensions()
+    {
+        var (controller, _) = CreateInitializedController(100, 100);
+
+        var frame = await controller.CaptureFrameAsync();
+
+        frame.Width.ShouldBe(100);
+        frame.Height.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task CaptureFrameAsync_WhenAvailable_ReturnsPixelsOfCorrectSize()
+    {
+        var (controller, _) = CreateInitializedController(50, 50);
+
+        var frame = await controller.CaptureFrameAsync();
+
+        frame.Pixels.Length.ShouldBe(50 * 50 * 4);
+    }
+
+    [Fact]
+    public async Task CaptureFrameAsync_IncrementsFrameNumber_OnEachCapture()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+
+        var frame1 = await controller.CaptureFrameAsync();
+        controller.OnFrameComplete();
+        var frame2 = await controller.CaptureFrameAsync();
+
+        frame2.FrameNumber.ShouldBeGreaterThan(frame1.FrameNumber);
+    }
+
+    [Fact]
+    public async Task CaptureFrameAsync_FlipsPixelsVertically()
+    {
+        var device = new MockGraphicsDevice();
+
+        // Create a framebuffer with a known pattern:
+        // Row 0 (bottom in OpenGL): Red
+        // Row 1 (top in OpenGL): Blue
+        const int width = 2;
+        const int height = 2;
+        var framebufferData = new byte[width * height * 4];
+
+        // Row 0 - Red (will be flipped to bottom)
+        framebufferData[0] = 255;  // R
+        framebufferData[1] = 0;    // G
+        framebufferData[2] = 0;    // B
+        framebufferData[3] = 255;  // A
+        framebufferData[4] = 255;
+        framebufferData[5] = 0;
+        framebufferData[6] = 0;
+        framebufferData[7] = 255;
+
+        // Row 1 - Blue (will be flipped to top)
+        framebufferData[8] = 0;
+        framebufferData[9] = 0;
+        framebufferData[10] = 255;
+        framebufferData[11] = 255;
+        framebufferData[12] = 0;
+        framebufferData[13] = 0;
+        framebufferData[14] = 255;
+        framebufferData[15] = 255;
+
+        device.SimulatedFramebufferData = framebufferData;
+        device.SimulatedFramebufferWidth = width;
+        device.SimulatedFramebufferHeight = height;
+
+        var context = new MockGraphicsContext
+        {
+            IsInitialized = true,
+            Device = device,
+            Width = width,
+            Height = height
+        };
+        var controller = new CaptureControllerImpl(context);
+
+        var frame = await controller.CaptureFrameAsync();
+
+        // After flipping, row 0 in output should be blue (was row 1 in framebuffer)
+        // Top-left pixel should be blue
+        var (r, g, b, _) = frame.GetPixel(0, 0);
+        r.ShouldBe((byte)0);
+        g.ShouldBe((byte)0);
+        b.ShouldBe((byte)255);
+
+        // Bottom-left pixel should be red
+        var (r2, g2, b2, _) = frame.GetPixel(0, 1);
+        r2.ShouldBe((byte)255);
+        g2.ShouldBe((byte)0);
+        b2.ShouldBe((byte)0);
+    }
+
+    #endregion
+
+    #region GetScreenshotBytesAsync
+
+    [Fact]
+    public async Task GetScreenshotBytesAsync_WhenNotAvailable_ThrowsInvalidOperation()
+    {
+        var controller = new CaptureControllerImpl();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await controller.GetScreenshotBytesAsync());
+    }
+
+    [Fact]
+    public async Task GetScreenshotBytesAsync_DefaultFormat_ReturnsPng()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+
+        var bytes = await controller.GetScreenshotBytesAsync();
+
+        // PNG magic bytes
+        bytes[0].ShouldBe((byte)0x89);
+        bytes[1].ShouldBe((byte)'P');
+    }
+
+    [Fact]
+    public async Task GetScreenshotBytesAsync_JpegFormat_ReturnsJpeg()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+
+        var bytes = await controller.GetScreenshotBytesAsync(ImageFormat.Jpeg);
+
+        // JPEG magic bytes
+        bytes[0].ShouldBe((byte)0xFF);
+        bytes[1].ShouldBe((byte)0xD8);
+    }
+
+    [Fact]
+    public async Task GetScreenshotBytesAsync_BmpFormat_ReturnsBmp()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+
+        var bytes = await controller.GetScreenshotBytesAsync(ImageFormat.Bmp);
+
+        // BMP magic bytes
+        bytes[0].ShouldBe((byte)'B');
+        bytes[1].ShouldBe((byte)'M');
+    }
+
+    #endregion
+
+    #region SaveScreenshotAsync
+
+    [Fact]
+    public async Task SaveScreenshotAsync_WhenNotAvailable_ThrowsInvalidOperation()
+    {
+        var controller = new CaptureControllerImpl();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await controller.SaveScreenshotAsync("test.png"));
+    }
+
+    [Fact]
+    public async Task SaveScreenshotAsync_WritesFile_ToSpecifiedPath()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        var tempPath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.png");
+
+        try
+        {
+            var resultPath = await controller.SaveScreenshotAsync(tempPath);
+
+            File.Exists(resultPath).ShouldBeTrue();
+            resultPath.ShouldBe(Path.GetFullPath(tempPath));
+
+#pragma warning disable xUnit1051 // Test verifies file content, cancellation not needed
+            var bytes = await File.ReadAllBytesAsync(resultPath);
+#pragma warning restore xUnit1051
+            bytes[0].ShouldBe((byte)0x89); // PNG magic byte
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SaveScreenshotAsync_CreatesDirectory_IfNotExists()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        var tempDir = Path.Combine(Path.GetTempPath(), $"screenshot_test_{Guid.NewGuid()}");
+        var tempPath = Path.Combine(tempDir, "screenshot.png");
+
+        try
+        {
+            await controller.SaveScreenshotAsync(tempPath);
+
+            Directory.Exists(tempDir).ShouldBeTrue();
+            File.Exists(tempPath).ShouldBeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Recording
+
+    [Fact]
+    public void IsRecording_Initially_ReturnsFalse()
+    {
+        var controller = new CaptureControllerImpl();
+
+        controller.IsRecording.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StartRecordingAsync_SetsIsRecordingToTrue()
+    {
+        var controller = new CaptureControllerImpl();
+
+        await controller.StartRecordingAsync();
+
+        controller.IsRecording.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StartRecordingAsync_WhenAlreadyRecording_ThrowsInvalidOperation()
+    {
+        var controller = new CaptureControllerImpl();
+        await controller.StartRecordingAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await controller.StartRecordingAsync());
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_SetsIsRecordingToFalse()
+    {
+        var controller = new CaptureControllerImpl();
+        await controller.StartRecordingAsync();
+
+        await controller.StopRecordingAsync();
+
+        controller.IsRecording.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_WhenNotRecording_ThrowsInvalidOperation()
+    {
+        var controller = new CaptureControllerImpl();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await controller.StopRecordingAsync());
+    }
+
+    [Fact]
+    public void RecordedFrameCount_Initially_ReturnsZero()
+    {
+        var controller = new CaptureControllerImpl();
+
+        controller.RecordedFrameCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CaptureFrameAsync_WhileRecording_IncrementsRecordedFrameCount()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        await controller.StartRecordingAsync();
+
+        await controller.CaptureFrameAsync();
+        await controller.CaptureFrameAsync();
+
+        controller.RecordedFrameCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_ReturnsAllRecordedFrames()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        await controller.StartRecordingAsync();
+
+        await controller.CaptureFrameAsync();
+        controller.OnFrameComplete();
+        await controller.CaptureFrameAsync();
+        controller.OnFrameComplete();
+        await controller.CaptureFrameAsync();
+
+        var frames = await controller.StopRecordingAsync();
+
+        frames.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_ClearsRecordedFrames()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        await controller.StartRecordingAsync();
+        await controller.CaptureFrameAsync();
+        await controller.StopRecordingAsync();
+
+        controller.RecordedFrameCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task StartRecordingAsync_WithMaxFrames_TrimsOlderFrames()
+    {
+        var (controller, _) = CreateInitializedController(10, 10);
+        await controller.StartRecordingAsync(maxFrames: 2);
+
+        await controller.CaptureFrameAsync();
+        controller.OnFrameComplete();
+        await controller.CaptureFrameAsync();
+        controller.OnFrameComplete();
+        await controller.CaptureFrameAsync();
+
+        controller.RecordedFrameCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static (CaptureControllerImpl Controller, MockGraphicsDevice Device) CreateInitializedController(int width, int height)
+    {
+        var device = new MockGraphicsDevice();
+
+        // Create solid color framebuffer data
+        var framebufferData = new byte[width * height * 4];
+        for (var i = 0; i < framebufferData.Length; i += 4)
+        {
+            framebufferData[i] = 128;     // R
+            framebufferData[i + 1] = 64;  // G
+            framebufferData[i + 2] = 32;  // B
+            framebufferData[i + 3] = 255; // A
+        }
+        device.SimulatedFramebufferData = framebufferData;
+        device.SimulatedFramebufferWidth = width;
+        device.SimulatedFramebufferHeight = height;
+
+        var context = new MockGraphicsContext
+        {
+            IsInitialized = true,
+            Device = device,
+            Width = width,
+            Height = height
+        };
+
+        return (new CaptureControllerImpl(context), device);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.TestBridge.Tests/Capture/ImageEncoderTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Capture/ImageEncoderTests.cs
@@ -1,0 +1,197 @@
+using KeenEyes.TestBridge.Capture;
+using StbImageSharp;
+
+namespace KeenEyes.TestBridge.Tests.Capture;
+
+public class ImageEncoderTests
+{
+    #region PNG Encoding
+
+    [Fact]
+    public void EncodePng_WithValidPixels_ProducesValidPng()
+    {
+        // Create a simple 2x2 red image
+        var pixels = CreateSolidColorImage(2, 2, 255, 0, 0, 255);
+
+        var encoded = ImageEncoder.EncodePng(pixels, 2, 2);
+
+        encoded.ShouldNotBeEmpty();
+        // Verify PNG magic bytes
+        encoded[0].ShouldBe((byte)0x89);
+        encoded[1].ShouldBe((byte)'P');
+        encoded[2].ShouldBe((byte)'N');
+        encoded[3].ShouldBe((byte)'G');
+    }
+
+    [Fact]
+    public void EncodePng_RoundTrips_WithCorrectPixels()
+    {
+        const int width = 4;
+        const int height = 4;
+        var originalPixels = CreateGradientImage(width, height);
+
+        var encoded = ImageEncoder.EncodePng(originalPixels, width, height);
+
+        // Decode and verify
+        using var stream = new MemoryStream(encoded);
+        var result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+
+        result.Width.ShouldBe(width);
+        result.Height.ShouldBe(height);
+        result.Data.Length.ShouldBe(originalPixels.Length);
+
+        // Verify pixels match
+        for (var i = 0; i < originalPixels.Length; i++)
+        {
+            result.Data[i].ShouldBe(originalPixels[i], $"Pixel mismatch at index {i}");
+        }
+    }
+
+    #endregion
+
+    #region JPEG Encoding
+
+    [Fact]
+    public void EncodeJpeg_WithValidPixels_ProducesValidJpeg()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 0, 255, 0, 255);
+
+        var encoded = ImageEncoder.EncodeJpeg(pixels, 2, 2);
+
+        encoded.ShouldNotBeEmpty();
+        // Verify JPEG magic bytes (FFD8FF)
+        encoded[0].ShouldBe((byte)0xFF);
+        encoded[1].ShouldBe((byte)0xD8);
+        encoded[2].ShouldBe((byte)0xFF);
+    }
+
+    [Fact]
+    public void EncodeJpeg_DropsAlphaChannel_ProducesRgb()
+    {
+        const int width = 4;
+        const int height = 4;
+        // Create image with alpha channel
+        var pixels = CreateSolidColorImage(width, height, 100, 150, 200, 128);
+
+        var encoded = ImageEncoder.EncodeJpeg(pixels, width, height);
+
+        // Decode and verify - JPEG should have RGB only
+        using var stream = new MemoryStream(encoded);
+        var result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlue);
+
+        result.Comp.ShouldBe(ColorComponents.RedGreenBlue);
+    }
+
+    [Fact]
+    public void EncodeJpeg_WithCustomQuality_ProducesValidJpeg()
+    {
+        var pixels = CreateGradientImage(8, 8);
+
+        var highQuality = ImageEncoder.EncodeJpeg(pixels, 8, 8, 100);
+        var lowQuality = ImageEncoder.EncodeJpeg(pixels, 8, 8, 10);
+
+        highQuality.ShouldNotBeEmpty();
+        lowQuality.ShouldNotBeEmpty();
+        // Higher quality typically produces larger files
+        highQuality.Length.ShouldBeGreaterThan(lowQuality.Length);
+    }
+
+    #endregion
+
+    #region BMP Encoding
+
+    [Fact]
+    public void EncodeBmp_WithValidPixels_ProducesValidBmp()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 0, 0, 255, 255);
+
+        var encoded = ImageEncoder.EncodeBmp(pixels, 2, 2);
+
+        encoded.ShouldNotBeEmpty();
+        // Verify BMP magic bytes (BM)
+        encoded[0].ShouldBe((byte)'B');
+        encoded[1].ShouldBe((byte)'M');
+    }
+
+    #endregion
+
+    #region Format Selection
+
+    [Fact]
+    public void Encode_WithPngFormat_CallsEncodePng()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 255, 255, 255, 255);
+
+        var encoded = ImageEncoder.Encode(pixels, 2, 2, ImageFormat.Png);
+
+        // Verify PNG magic bytes
+        encoded[0].ShouldBe((byte)0x89);
+    }
+
+    [Fact]
+    public void Encode_WithJpegFormat_CallsEncodeJpeg()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 255, 255, 255, 255);
+
+        var encoded = ImageEncoder.Encode(pixels, 2, 2, ImageFormat.Jpeg);
+
+        // Verify JPEG magic bytes
+        encoded[0].ShouldBe((byte)0xFF);
+    }
+
+    [Fact]
+    public void Encode_WithBmpFormat_CallsEncodeBmp()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 255, 255, 255, 255);
+
+        var encoded = ImageEncoder.Encode(pixels, 2, 2, ImageFormat.Bmp);
+
+        // Verify BMP magic bytes
+        encoded[0].ShouldBe((byte)'B');
+    }
+
+    [Fact]
+    public void Encode_WithInvalidFormat_ThrowsArgumentOutOfRange()
+    {
+        var pixels = CreateSolidColorImage(2, 2, 255, 255, 255, 255);
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            ImageEncoder.Encode(pixels, 2, 2, (ImageFormat)999));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static byte[] CreateSolidColorImage(int width, int height, byte r, byte g, byte b, byte a)
+    {
+        var pixels = new byte[width * height * 4];
+        for (var i = 0; i < pixels.Length; i += 4)
+        {
+            pixels[i] = r;
+            pixels[i + 1] = g;
+            pixels[i + 2] = b;
+            pixels[i + 3] = a;
+        }
+        return pixels;
+    }
+
+    private static byte[] CreateGradientImage(int width, int height)
+    {
+        var pixels = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var i = (y * width + x) * 4;
+                pixels[i] = (byte)(x * 255 / Math.Max(1, width - 1));
+                pixels[i + 1] = (byte)(y * 255 / Math.Max(1, height - 1));
+                pixels[i + 2] = 128;
+                pixels[i + 3] = 255;
+            }
+        }
+        return pixels;
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.TestBridge.Tests/KeenEyes.TestBridge.Tests.csproj
+++ b/tests/KeenEyes.TestBridge.Tests/KeenEyes.TestBridge.Tests.csproj
@@ -5,10 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="StbImageSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.TestBridge\KeenEyes.TestBridge.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.TestBridge.Ipc\KeenEyes.TestBridge.Ipc.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.TestBridge.Client\KeenEyes.TestBridge.Client.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/KeenEyes.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.TestBridge.Tests/packages.lock.json
@@ -54,6 +54,12 @@
           "EmptyFiles": "4.4.0"
         }
       },
+      "StbImageSharp": {
+        "type": "Direct",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
         "requested": "[3.2.1, )",
@@ -220,7 +226,10 @@
         }
       },
       "keeneyes.logging": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.network.abstractions": {
         "type": "Project",
@@ -239,8 +248,10 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
-          "KeenEyes.Testing": "[1.0.0, )"
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
         }
       },
       "keeneyes.testbridge.abstractions": {
@@ -277,6 +288,12 @@
           "KeenEyes.Network.Abstractions": "[1.0.0, )",
           "KeenEyes.Persistence": "[1.0.0, )"
         }
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
       }
     }
   }


### PR DESCRIPTION
## Summary
- Implements GPU framebuffer capture using `ReadFramebuffer` via OpenGL `gl.ReadPixels`
- Adds image encoding support for PNG, JPEG, and BMP formats using StbImageWriteSharp
- Integrates graphics context with TestBridgePlugin via extension pattern
- Full implementation of `CaptureControllerImpl` with graceful degradation for headless scenarios

## Changes
| File | Description |
|------|-------------|
| `IGraphicsDevice.cs` | Added `ReadFramebuffer` method |
| `OpenGLDevice.cs` | Implemented `gl.ReadPixels` wrapper |
| `ImageEncoder.cs` | New file - PNG/JPEG/BMP encoding |
| `CaptureControllerImpl.cs` | Full GPU capture implementation |
| `TestBridgePlugin.cs` | Request `IGraphicsContext` extension |
| `InProcessBridge.cs` | Pass graphics context to capture controller |
| `MockGraphicsDevice.cs` | Added framebuffer simulation for tests |

## Features
- `CaptureFrameAsync()` - Capture raw RGBA pixel data
- `GetScreenshotBytesAsync()` - Encode to PNG/JPEG/BMP
- `SaveScreenshotAsync()` - Save to file with auto-directory creation
- Frame recording with configurable FIFO buffer
- Vertical flip handling for OpenGL coordinate system

## Test plan
- [x] 38 new unit tests for ImageEncoder and CaptureController
- [x] PNG/JPEG/BMP encoding round-trip verification
- [x] Mock graphics context integration tests
- [x] All 12,887 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)