### PR TITLE
fix(samples): Address code review issues C1 and C3

### DIFF
--- a/samples/KeenEyes.Sample.AIProximity/Program.cs
+++ b/samples/KeenEyes.Sample.AIProximity/Program.cs
@@ -230,12 +230,13 @@ public class PlayerMovementSystem : SystemBase
             }
 
             // Randomly change direction occasionally
-            if (Random.Shared.NextSingle() < 0.02f)
+            // Use World's seeded RNG for deterministic replay support
+            if (World.NextFloat() < 0.02f)
             {
                 velocity.Value = new Vector3(
-                    Random.Shared.NextSingle() * 20f - 10f,
+                    World.NextFloat() * 20f - 10f,
                     0,
-                    Random.Shared.NextSingle() * 20f - 10f);
+                    World.NextFloat() * 20f - 10f);
             }
         }
     }

--- a/samples/KeenEyes.Sample.Multiplayer/NetworkSerializers.cs
+++ b/samples/KeenEyes.Sample.Multiplayer/NetworkSerializers.cs
@@ -1,0 +1,147 @@
+using KeenEyes.Common;
+using KeenEyes.Network.Serialization;
+
+namespace KeenEyes.Sample.Multiplayer;
+
+/// <summary>
+/// Static serialization helpers for network components.
+/// Follows ECS principle: components are pure data, logic lives elsewhere.
+/// </summary>
+/// <remarks>
+/// This pattern separates serialization logic from component data, maintaining
+/// the ECS principle that components should be pure data structures.
+/// The <see cref="GameSerializer"/> uses these helpers to serialize components
+/// for network transmission.
+/// </remarks>
+public static class PositionSerializer
+{
+    private const float NetworkDeltaEpsilon = 0.001f;
+
+    /// <summary>
+    /// Serializes a position to the network stream.
+    /// </summary>
+    public static void Serialize(ref BitWriter writer, in Position position)
+    {
+        writer.WriteFloat(position.X);
+        writer.WriteFloat(position.Y);
+    }
+
+    /// <summary>
+    /// Deserializes a position from the network stream.
+    /// </summary>
+    public static Position Deserialize(ref BitReader reader)
+    {
+        return new Position
+        {
+            X = reader.ReadFloat(),
+            Y = reader.ReadFloat()
+        };
+    }
+
+    /// <summary>
+    /// Computes a dirty mask indicating which fields changed between current and baseline.
+    /// </summary>
+    public static uint GetDirtyMask(in Position current, in Position baseline)
+    {
+        uint mask = 0;
+        if (!current.X.ApproximatelyEquals(baseline.X, NetworkDeltaEpsilon))
+        {
+            mask |= 1;
+        }
+
+        if (!current.Y.ApproximatelyEquals(baseline.Y, NetworkDeltaEpsilon))
+        {
+            mask |= 2;
+        }
+
+        return mask;
+    }
+
+    /// <summary>
+    /// Serializes only the fields that changed (indicated by dirty mask).
+    /// </summary>
+    public static void SerializeDelta(ref BitWriter writer, in Position position, in Position baseline, uint dirtyMask)
+    {
+        if ((dirtyMask & 1) != 0)
+        {
+            writer.WriteFloat(position.X);
+        }
+
+        if ((dirtyMask & 2) != 0)
+        {
+            writer.WriteFloat(position.Y);
+        }
+    }
+
+    /// <summary>
+    /// Deserializes only the fields indicated by the dirty mask, updating the position in place.
+    /// </summary>
+    public static void DeserializeDelta(ref BitReader reader, ref Position position, uint dirtyMask)
+    {
+        if ((dirtyMask & 1) != 0)
+        {
+            position.X = reader.ReadFloat();
+        }
+
+        if ((dirtyMask & 2) != 0)
+        {
+            position.Y = reader.ReadFloat();
+        }
+    }
+}
+
+/// <summary>
+/// Static serialization helpers for the Velocity component.
+/// </summary>
+public static class VelocitySerializer
+{
+    /// <summary>
+    /// Serializes a velocity to the network stream.
+    /// </summary>
+    public static void Serialize(ref BitWriter writer, in Velocity velocity)
+    {
+        writer.WriteFloat(velocity.X);
+        writer.WriteFloat(velocity.Y);
+    }
+
+    /// <summary>
+    /// Deserializes a velocity from the network stream.
+    /// </summary>
+    public static Velocity Deserialize(ref BitReader reader)
+    {
+        return new Velocity
+        {
+            X = reader.ReadFloat(),
+            Y = reader.ReadFloat()
+        };
+    }
+}
+
+/// <summary>
+/// Static serialization helpers for the PlayerInput struct.
+/// </summary>
+public static class PlayerInputSerializer
+{
+    /// <summary>
+    /// Serializes a player input to the network stream.
+    /// </summary>
+    public static void Serialize(ref BitWriter writer, in PlayerInput input)
+    {
+        writer.WriteUInt32(input.Tick);
+        writer.WriteFloat(input.MoveX);
+        writer.WriteFloat(input.MoveY);
+    }
+
+    /// <summary>
+    /// Deserializes a player input from the network stream.
+    /// </summary>
+    public static PlayerInput Deserialize(ref BitReader reader)
+    {
+        return new PlayerInput
+        {
+            Tick = reader.ReadUInt32(),
+            MoveX = reader.ReadFloat(),
+            MoveY = reader.ReadFloat()
+        };
+    }
+}

--- a/samples/KeenEyes.Sample.Multiplayer/Program.cs
+++ b/samples/KeenEyes.Sample.Multiplayer/Program.cs
@@ -205,7 +205,7 @@ async Task RunLocalDemo()
         var baseline = new Position { X = 100, Y = 100 };
         var current = new Position { X = 110, Y = 100 };
 
-        var dirtyMask = current.GetDirtyMask(baseline);
+        var dirtyMask = PositionSerializer.GetDirtyMask(current, baseline);
         Console.WriteLine($"  Baseline: {baseline}");
         Console.WriteLine($"  Current:  {current}");
         Console.WriteLine($"  Dirty Mask: 0b{Convert.ToString(dirtyMask, 2).PadLeft(2, '0')} (bit 0=X, bit 1=Y)");


### PR DESCRIPTION
## Summary

- **C1 (Component Logic in Multiplayer Sample):** Move serialization logic from component structs to static helper classes
  - Created `NetworkSerializers.cs` with `PositionSerializer`, `VelocitySerializer`, `PlayerInputSerializer`
  - Simplified `Components.cs` to pure data structures (ECS-compliant)
  - Updated `GameSerializer.cs` to use static helpers

- **C3 (Random.Shared in AIProximity):** Replace with `World.NextFloat()` for deterministic replay support

- **C2 (Readonly on Components):** Clarified as not applicable - `[Component]` generator cannot use `readonly` modifier

## Test plan

- [x] Build passes with zero warnings
- [x] All 12,849 tests pass
- [x] Pre-commit hooks (dotnet-format) pass

Closes #811
Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)