### PR TITLE
feat: Integrate TestBridge with TestWorldBuilder (Phase 5)

### DIFF
--- a/src/KeenEyes.Testing/KeenEyes.Testing.csproj
+++ b/src/KeenEyes.Testing/KeenEyes.Testing.csproj
@@ -14,6 +14,7 @@
 		<ProjectReference Include="..\KeenEyes.Logging\KeenEyes.Logging.csproj" />
 		<ProjectReference Include="..\KeenEyes.Network.Abstractions\KeenEyes.Network.Abstractions.csproj" />
 		<ProjectReference Include="..\KeenEyes.Persistence\KeenEyes.Persistence.csproj" />
+		<ProjectReference Include="..\KeenEyes.TestBridge.Abstractions\KeenEyes.TestBridge.Abstractions.csproj" />
 		<ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 

--- a/tests/KeenEyes.Testing.Tests/KeenEyes.Testing.Tests.csproj
+++ b/tests/KeenEyes.Testing.Tests/KeenEyes.Testing.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.TestBridge\KeenEyes.TestBridge.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Add `WithTestBridge()` method to TestWorldBuilder for unified test setup
- Uses factory pattern to avoid circular dependency between TestBridge and Testing projects
- Add `Bridge`, `HasTestBridge`, and `RequireBridge()` to TestWorld
- Add 13 comprehensive tests for TestBridge integration

## Usage

```csharp
using var testWorld = new TestWorldBuilder()
    .WithDeterministicIds()
    .WithManualTime()
    .WithMockInput()
    .WithTestBridge((world, mockInput) => new InProcessBridge(world, 
        new TestBridgeOptions { CustomInputContext = mockInput }))
    .Build();

// All features work together
await testWorld.Bridge!.Input.KeyPressAsync(Key.Space);
var count = await testWorld.Bridge.State.GetEntityCountAsync();
```

## Design Decision

Used a **factory pattern** rather than direct `InProcessBridge` instantiation to avoid circular dependency:
- TestBridge already references Testing (for `MockInputContext`)
- Testing now references TestBridge.Abstractions (not TestBridge)
- Test projects provide a factory function that creates the concrete bridge

## Test plan
- [x] All 1442 Testing.Tests pass
- [x] All 209 TestBridge.Tests pass
- [x] Build succeeds with 0 warnings

## Related
Completes TestBridge Phase 5 (Testing Integration)
- Phase 1: Core Infrastructure (PR #807) ✅
- Phase 2: IPC Layer (PR #813) ✅
- Phase 3: Screenshot Capture (PR #814) ✅
- Phase 4: Process Controller (PR #816) ✅
- **Phase 5: Testing Integration** ← This PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)