### PR TITLE
feat: Add MCP TestBridge server (Phase 1: Core Infrastructure)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,4 +47,8 @@
   <ItemGroup Label="Localization">
     <PackageVersion Include="MessageFormat" Version="7.1.3" />
   </ItemGroup>
+  <ItemGroup Label="MCP">
+    <PackageVersion Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+  </ItemGroup>
 </Project>

--- a/tools/KeenEyes.Mcp.TestBridge/Connection/BridgeConnectionManager.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Connection/BridgeConnectionManager.cs
@@ -1,0 +1,354 @@
+using System.Diagnostics;
+using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.Client;
+
+namespace KeenEyes.Mcp.TestBridge.Connection;
+
+/// <summary>
+/// Manages the lifecycle of a TestBridge IPC connection with heartbeat monitoring.
+/// </summary>
+public sealed class BridgeConnectionManager : IAsyncDisposable
+{
+    private readonly SemaphoreSlim connectionLock = new(1, 1);
+    private readonly CancellationTokenSource heartbeatCts = new();
+
+    private TestBridgeClient? client;
+    private IpcOptions? currentOptions;
+    private Task? heartbeatTask;
+    private DateTimeOffset? connectedAt;
+    private bool disposed;
+
+    /// <summary>
+    /// Gets the heartbeat interval.
+    /// </summary>
+    public TimeSpan HeartbeatInterval { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets the ping timeout.
+    /// </summary>
+    public TimeSpan PingTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets the maximum consecutive ping failures before disconnection.
+    /// </summary>
+    public int MaxPingFailures { get; init; } = 3;
+
+    /// <summary>
+    /// Gets whether the connection is currently active.
+    /// </summary>
+    public bool IsConnected => client?.IsConnected == true;
+
+    /// <summary>
+    /// Gets the last measured ping latency in milliseconds.
+    /// </summary>
+    public double? LastPingLatencyMs { get; private set; }
+
+    /// <summary>
+    /// Gets the time of the last successful ping.
+    /// </summary>
+    public DateTimeOffset? LastPingTime { get; private set; }
+
+    /// <summary>
+    /// Gets the current pipe name (if using named pipe transport).
+    /// </summary>
+    public string? PipeName => currentOptions?.PipeName;
+
+    /// <summary>
+    /// Gets the current host (if using TCP transport).
+    /// </summary>
+    public string? Host => currentOptions?.TcpBindAddress;
+
+    /// <summary>
+    /// Gets the current port (if using TCP transport).
+    /// </summary>
+    public int? Port => currentOptions?.TcpPort;
+
+    /// <summary>
+    /// Gets the current transport mode.
+    /// </summary>
+    public string? TransportMode => currentOptions?.TransportMode.ToString();
+
+    /// <summary>
+    /// Gets the connection uptime.
+    /// </summary>
+    public TimeSpan? ConnectionUptime => connectedAt.HasValue
+        ? DateTimeOffset.UtcNow - connectedAt.Value
+        : null;
+
+    /// <summary>
+    /// Gets the number of consecutive ping failures.
+    /// </summary>
+    public int ConsecutivePingFailures { get; private set; }
+
+    /// <summary>
+    /// Raised when the connection state changes.
+    /// </summary>
+    public event Func<Task>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Gets the current connection status.
+    /// </summary>
+    public ConnectionStatus GetStatus()
+    {
+        return new ConnectionStatus
+        {
+            IsConnected = IsConnected,
+            LastPingMs = LastPingLatencyMs,
+            LastPingTime = LastPingTime,
+            PipeName = PipeName,
+            Host = Host,
+            Port = Port,
+            TransportMode = TransportMode,
+            ConnectionUptime = ConnectionUptime,
+            ConsecutivePingFailures = ConsecutivePingFailures
+        };
+    }
+
+    /// <summary>
+    /// Connects to a TestBridge server with the specified options.
+    /// </summary>
+    /// <param name="options">IPC connection options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task ConnectAsync(IpcOptions options, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        await connectionLock.WaitAsync(cancellationToken);
+        try
+        {
+            // Disconnect existing connection if any
+            if (client != null)
+            {
+                await DisconnectInternalAsync();
+            }
+
+            currentOptions = options;
+            client = new TestBridgeClient(options);
+            client.ConnectionChanged += OnClientConnectionChanged;
+
+            await client.ConnectAsync(cancellationToken);
+            connectedAt = DateTimeOffset.UtcNow;
+            ConsecutivePingFailures = 0;
+
+            // Start heartbeat
+            StartHeartbeat();
+
+            await NotifyConnectionStateChangedAsync();
+        }
+        finally
+        {
+            connectionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Gets the TestBridge client, throwing if not connected.
+    /// </summary>
+    /// <returns>The active TestBridge client.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
+    public ITestBridge GetBridge()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        if (client == null || !client.IsConnected)
+        {
+            throw new InvalidOperationException(
+                "Not connected to game. Call game_connect first.");
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// Tries to get the TestBridge client.
+    /// </summary>
+    /// <param name="bridge">The bridge if connected.</param>
+    /// <returns>True if connected and bridge is available.</returns>
+    public bool TryGetBridge(out ITestBridge? bridge)
+    {
+        if (disposed || client == null || !client.IsConnected)
+        {
+            bridge = null;
+            return false;
+        }
+
+        bridge = client;
+        return true;
+    }
+
+    /// <summary>
+    /// Disconnects from the TestBridge server.
+    /// </summary>
+    public async Task DisconnectAsync()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        await connectionLock.WaitAsync();
+        try
+        {
+            await DisconnectInternalAsync();
+            await NotifyConnectionStateChangedAsync();
+        }
+        finally
+        {
+            connectionLock.Release();
+        }
+    }
+
+    private async Task DisconnectInternalAsync()
+    {
+        StopHeartbeat();
+
+        if (client != null)
+        {
+            client.ConnectionChanged -= OnClientConnectionChanged;
+            await client.DisposeAsync();
+            client = null;
+        }
+
+        connectedAt = null;
+        LastPingLatencyMs = null;
+        LastPingTime = null;
+        ConsecutivePingFailures = 0;
+    }
+
+    private void StartHeartbeat()
+    {
+        if (heartbeatTask == null || heartbeatTask.IsCompleted)
+        {
+            heartbeatTask = RunHeartbeatAsync(heartbeatCts.Token);
+        }
+    }
+
+    private void StopHeartbeat()
+    {
+        // Heartbeat will stop on next iteration when it checks IsConnected
+    }
+
+    private async Task RunHeartbeatAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(HeartbeatInterval, ct);
+
+                if (client == null || !client.IsConnected)
+                {
+                    break;
+                }
+
+                // Send a lightweight query to verify connection is truly alive
+                var sw = Stopwatch.StartNew();
+                try
+                {
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    timeoutCts.CancelAfter(PingTimeout);
+
+                    // Use entity count as a lightweight ping
+                    await client.State.GetEntityCountAsync();
+                    sw.Stop();
+
+                    LastPingLatencyMs = sw.Elapsed.TotalMilliseconds;
+                    LastPingTime = DateTimeOffset.UtcNow;
+                    ConsecutivePingFailures = 0;
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    // Ping timeout
+                    ConsecutivePingFailures++;
+                    await HandlePingFailureAsync();
+                }
+                catch (Exception)
+                {
+                    ConsecutivePingFailures++;
+                    await HandlePingFailureAsync();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task HandlePingFailureAsync()
+    {
+        if (ConsecutivePingFailures >= MaxPingFailures)
+        {
+            await connectionLock.WaitAsync();
+            try
+            {
+                await DisconnectInternalAsync();
+                await NotifyConnectionStateChangedAsync();
+            }
+            finally
+            {
+                connectionLock.Release();
+            }
+        }
+    }
+
+    private void OnClientConnectionChanged(bool isConnected)
+    {
+        if (!isConnected)
+        {
+            // Connection lost - clean up
+            _ = Task.Run(async () =>
+            {
+                await connectionLock.WaitAsync();
+                try
+                {
+                    connectedAt = null;
+                    LastPingLatencyMs = null;
+                    await NotifyConnectionStateChangedAsync();
+                }
+                finally
+                {
+                    connectionLock.Release();
+                }
+            });
+        }
+    }
+
+    private async Task NotifyConnectionStateChangedAsync()
+    {
+        if (ConnectionStateChanged != null)
+        {
+            await ConnectionStateChanged.Invoke();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        await heartbeatCts.CancelAsync();
+
+        if (heartbeatTask != null)
+        {
+            try
+            {
+                await heartbeatTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+        }
+
+        if (client != null)
+        {
+            await client.DisposeAsync();
+        }
+
+        connectionLock.Dispose();
+        heartbeatCts.Dispose();
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Connection/ConnectionStatus.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Connection/ConnectionStatus.cs
@@ -1,0 +1,52 @@
+namespace KeenEyes.Mcp.TestBridge.Connection;
+
+/// <summary>
+/// Connection status information for the TestBridge IPC connection.
+/// </summary>
+public sealed record ConnectionStatus
+{
+    /// <summary>
+    /// Gets whether the connection is currently active.
+    /// </summary>
+    public required bool IsConnected { get; init; }
+
+    /// <summary>
+    /// Gets the last measured ping latency in milliseconds.
+    /// </summary>
+    public double? LastPingMs { get; init; }
+
+    /// <summary>
+    /// Gets the time of the last successful ping.
+    /// </summary>
+    public DateTimeOffset? LastPingTime { get; init; }
+
+    /// <summary>
+    /// Gets the configured pipe name (for named pipe transport).
+    /// </summary>
+    public string? PipeName { get; init; }
+
+    /// <summary>
+    /// Gets the configured host (for TCP transport).
+    /// </summary>
+    public string? Host { get; init; }
+
+    /// <summary>
+    /// Gets the configured port (for TCP transport).
+    /// </summary>
+    public int? Port { get; init; }
+
+    /// <summary>
+    /// Gets the transport mode being used.
+    /// </summary>
+    public string? TransportMode { get; init; }
+
+    /// <summary>
+    /// Gets how long the connection has been active.
+    /// </summary>
+    public TimeSpan? ConnectionUptime { get; init; }
+
+    /// <summary>
+    /// Gets the number of consecutive ping failures.
+    /// </summary>
+    public int ConsecutivePingFailures { get; init; }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
+++ b/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Tool doesn't need XML docs -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- MCP server name -->
+    <AssemblyTitle>KeenEyes MCP TestBridge Server</AssemblyTitle>
+    <Description>MCP server bridging LLM clients to KeenEyes games via TestBridge IPC</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.TestBridge.Client\KeenEyes.TestBridge.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/KeenEyes.Mcp.TestBridge/Program.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Program.cs
@@ -1,0 +1,130 @@
+using KeenEyes.Mcp.TestBridge;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.Mcp.TestBridge.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Server;
+
+// Parse configuration from environment variables and command line
+var config = ConfigurationParser.Parse(args);
+
+// Build and run the MCP server
+var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
+
+// Register the connection manager as singleton
+builder.Services.AddSingleton<BridgeConnectionManager>(sp =>
+{
+    return new BridgeConnectionManager
+    {
+        HeartbeatInterval = TimeSpan.FromMilliseconds(config.HeartbeatInterval),
+        PingTimeout = TimeSpan.FromMilliseconds(config.HeartbeatTimeout),
+        MaxPingFailures = config.MaxPingFailures
+    };
+});
+
+// Configure MCP server
+builder.Services
+    .AddMcpServer(options =>
+    {
+        options.ServerInfo = new()
+        {
+            Name = "KeenEyes TestBridge",
+            Version = "1.0.0"
+        };
+        options.Capabilities = new()
+        {
+            Tools = new() { ListChanged = true },
+            Resources = new() { ListChanged = true, Subscribe = true }
+        };
+    })
+    .WithStdioServerTransport()
+    .WithTools<GameTools>();
+
+var app = builder.Build();
+
+// Wire up connection state change notifications
+var connectionManager = app.Services.GetRequiredService<BridgeConnectionManager>();
+var mcpServer = app.Services.GetRequiredService<McpServer>();
+
+connectionManager.ConnectionStateChanged += async () =>
+{
+    try
+    {
+        await mcpServer.SendNotificationAsync("notifications/tools/list_changed");
+        await mcpServer.SendNotificationAsync("notifications/resources/list_changed");
+    }
+    catch
+    {
+        // Ignore notification errors
+    }
+};
+
+// Log to stderr (stdout is for MCP protocol)
+Console.Error.WriteLine($"KeenEyes MCP TestBridge Server starting...");
+Console.Error.WriteLine($"Default pipe: {config.PipeName}");
+Console.Error.WriteLine($"Default transport: {config.Transport}");
+Console.Error.WriteLine($"Heartbeat interval: {config.HeartbeatInterval}ms");
+
+await app.RunAsync();
+
+// Cleanup
+await connectionManager.DisposeAsync();
+
+namespace KeenEyes.Mcp.TestBridge
+{
+    internal static class ConfigurationParser
+    {
+        public static McpConfiguration Parse(string[] args)
+        {
+            var pipeName = Environment.GetEnvironmentVariable("KEENEYES_PIPE_NAME") ?? "KeenEyes.TestBridge";
+            var tcpHost = Environment.GetEnvironmentVariable("KEENEYES_HOST") ?? "127.0.0.1";
+            var port = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_PORT"), out var p) ? p : 19283;
+            var transport = Environment.GetEnvironmentVariable("KEENEYES_TRANSPORT") ?? "pipe";
+            var heartbeatInterval = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_INTERVAL"), out var hi) ? hi : 5000;
+            var heartbeatTimeout = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_TIMEOUT"), out var ht) ? ht : 10000;
+            var maxPingFailures = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_MAX_PING_FAILURES"), out var mpf) ? mpf : 3;
+
+            // Parse command line arguments
+            var i = 0;
+            while (i < args.Length)
+            {
+                var arg = args[i];
+                if (arg == "--pipe" && i + 1 < args.Length)
+                {
+                    pipeName = args[i + 1];
+                    i += 2;
+                }
+                else if (arg == "--host" && i + 1 < args.Length)
+                {
+                    tcpHost = args[i + 1];
+                    i += 2;
+                }
+                else if (arg == "--port" && i + 1 < args.Length)
+                {
+                    port = int.Parse(args[i + 1]);
+                    i += 2;
+                }
+                else if (arg == "--transport" && i + 1 < args.Length)
+                {
+                    transport = args[i + 1];
+                    i += 2;
+                }
+                else
+                {
+                    i++;
+                }
+            }
+
+            return new McpConfiguration(pipeName, tcpHost, port, transport, heartbeatInterval, heartbeatTimeout, maxPingFailures);
+        }
+    }
+
+    internal sealed record McpConfiguration(
+        string PipeName,
+        string TcpHost,
+        int Port,
+        string Transport,
+        int HeartbeatInterval,
+        int HeartbeatTimeout,
+        int MaxPingFailures);
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
@@ -1,0 +1,111 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for game connection management.
+/// </summary>
+[McpServerToolType]
+public sealed class GameTools(BridgeConnectionManager connection, McpServer server)
+{
+    [McpServerTool(Name = "game_connect")]
+    [Description("Connect to a running KeenEyes game. Must be called before using other tools. Returns connection status.")]
+    public async Task<ConnectionResult> GameConnect(
+        [Description("Named pipe name (default: from KEENEYES_PIPE_NAME env var or 'KeenEyes.TestBridge')")]
+        string? pipeName = null,
+        [Description("TCP host for network connection (default: '127.0.0.1')")]
+        string? host = null,
+        [Description("TCP port for network connection (default: 19283)")]
+        int? port = null,
+        [Description("Transport mode: 'pipe' or 'tcp' (default: 'pipe')")]
+        string transport = "pipe")
+    {
+        try
+        {
+            var options = new IpcOptions
+            {
+                PipeName = pipeName
+                    ?? Environment.GetEnvironmentVariable("KEENEYES_PIPE_NAME")
+                    ?? "KeenEyes.TestBridge",
+                TransportMode = transport.Equals("tcp", StringComparison.OrdinalIgnoreCase)
+                    ? IpcTransportMode.Tcp
+                    : IpcTransportMode.NamedPipe,
+                TcpBindAddress = host ?? "127.0.0.1",
+                TcpPort = port ?? 19283
+            };
+
+            await connection.ConnectAsync(options);
+
+            // Notify MCP client that tool/resource lists have changed
+            await server.SendNotificationAsync("notifications/tools/list_changed");
+            await server.SendNotificationAsync("notifications/resources/list_changed");
+
+            return new ConnectionResult
+            {
+                Success = true,
+                Message = $"Connected to game via {transport}",
+                PipeName = options.PipeName,
+                Host = options.TcpBindAddress,
+                Port = options.TcpPort,
+                Transport = options.TransportMode.ToString()
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ConnectionResult
+            {
+                Success = false,
+                Message = $"Failed to connect: {ex.Message}"
+            };
+        }
+    }
+
+    [McpServerTool(Name = "game_disconnect")]
+    [Description("Disconnect from the game.")]
+    public async Task<ConnectionResult> GameDisconnect()
+    {
+        if (!connection.IsConnected)
+        {
+            return new ConnectionResult
+            {
+                Success = false,
+                Message = "Not connected to any game"
+            };
+        }
+
+        await connection.DisconnectAsync();
+
+        // Notify MCP client that tool/resource lists have changed
+        await server.SendNotificationAsync("notifications/tools/list_changed");
+        await server.SendNotificationAsync("notifications/resources/list_changed");
+
+        return new ConnectionResult
+        {
+            Success = true,
+            Message = "Disconnected from game"
+        };
+    }
+
+    [McpServerTool(Name = "game_status")]
+    [Description("Get detailed connection status including latency and uptime.")]
+    public ConnectionStatus GameStatus()
+    {
+        return connection.GetStatus();
+    }
+}
+
+/// <summary>
+/// Result of a connection operation.
+/// </summary>
+public sealed record ConnectionResult
+{
+    public required bool Success { get; init; }
+    public required string Message { get; init; }
+    public string? PipeName { get; init; }
+    public string? Host { get; init; }
+    public int? Port { get; init; }
+    public string? Transport { get; init; }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -1,0 +1,421 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "ModelContextProtocol": {
+        "type": "Direct",
+        "requested": "[0.5.0-preview.1, )",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "QJpuNEnMZLJmvASbZ2nvMqENTZk3HYF83IihoHs3EJ5vTlz4sYjji9bXh2HP5UxpXIdHGn0iuHu0X2Tpq2zilw==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "ModelContextProtocol.Core": "0.5.0-preview.1"
+        }
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "PHeuDm2tC6wJPEQvleUr2kNQaIMNqSf3aEbzkIPlZyQ0+0SYI9SwXVLdGD1NPBI+xB+Vb2lxZKhrFlIf9kP9WA=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "L3AdmZ1WOK4XXT5YFPEwyt0ep6l8lGIPs7F5OOBZc77Zqeo01Of7XXICy47628sdVl0v/owxYJTe86DTgFwKCA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "FU/IfjDfwaMuKr414SSQNTIti/69bHEMb+QKrskRb26oVqpx3lNFXMjs/RC9ZUuhBhcwDM2BwOgoMw+PZ+beqQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "ModelContextProtocol.Core": {
+        "type": "Transitive",
+        "resolved": "0.5.0-preview.1",
+        "contentHash": "33V1Druluweou6x2LN6MSMbhiwHOYZxTUEJ1okFKjYDRIthctTVe0EJi//nifl4MRld2b5D5LnuV9sezz54p6g==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
+        }
+      },
+      "keeneyes.testbridge.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge.client": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge.Ipc": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge.ipc": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements MCP (Model Context Protocol) server with stdio transport for bridging LLM clients to KeenEyes games
- Adds BridgeConnectionManager with heartbeat monitoring and automatic disconnect on failure
- Provides connection management tools: `game_connect`, `game_disconnect`, `game_status`
- Supports both named pipe and TCP transport modes with environment/CLI configuration

## Implementation Details

### Files Added
| File | Purpose |
|------|---------|
| `tools/KeenEyes.Mcp.TestBridge/Program.cs` | MCP server entry point with stdio transport |
| `tools/KeenEyes.Mcp.TestBridge/Connection/BridgeConnectionManager.cs` | Connection lifecycle with heartbeat |
| `tools/KeenEyes.Mcp.TestBridge/Connection/ConnectionStatus.cs` | Status record |
| `tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs` | MCP tools for connection management |

### Configuration
- `KEENEYES_PIPE_NAME` / `--pipe`: Named pipe name (default: `KeenEyes.TestBridge`)
- `KEENEYES_HOST` / `--host`: TCP host (default: `127.0.0.1`)
- `KEENEYES_PORT` / `--port`: TCP port (default: `19283`)
- `KEENEYES_TRANSPORT` / `--transport`: Transport mode (`pipe`/`tcp`)
- `KEENEYES_HEARTBEAT_INTERVAL`: Ping interval in ms (default: `5000`)
- `KEENEYES_MAX_PING_FAILURES`: Max failures before disconnect (default: `3`)

## Test plan
- [x] Build passes with zero warnings
- [x] Code formatted correctly
- [ ] Manual testing with MCP client

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)