### PR TITLE
feat: Add MCP state query and game tools (Phase 3: State & Game Tools)

### DIFF
--- a/tools/KeenEyes.Mcp.TestBridge/Program.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Program.cs
@@ -39,7 +39,8 @@ builder.Services
     })
     .WithStdioServerTransport()
     .WithTools<GameTools>()
-    .WithTools<InputTools>();
+    .WithTools<InputTools>()
+    .WithTools<StateTools>();
 
 var app = builder.Build();
 

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using KeenEyes.Mcp.TestBridge.Connection;
 using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.State;
 using ModelContextProtocol.Server;
 
 namespace KeenEyes.Mcp.TestBridge.Tools;
@@ -95,6 +96,137 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
     {
         return connection.GetStatus();
     }
+
+    [McpServerTool(Name = "game_get_screen_size")]
+    [Description("Get the current game window dimensions in pixels.")]
+    public async Task<ScreenSizeResult> GameGetScreenSize()
+    {
+        var bridge = connection.GetBridge();
+        var (width, height) = await bridge.Capture.GetFrameSizeAsync();
+
+        return new ScreenSizeResult
+        {
+            Width = width,
+            Height = height
+        };
+    }
+
+    [McpServerTool(Name = "game_wait_for_condition")]
+    [Description("Wait for a game state condition. Useful for waiting after input before checking state.")]
+    public async Task<WaitResult> GameWaitForCondition(
+        [Description("Condition: 'entity_exists', 'entity_gone', 'component_exists', 'component_gone'")]
+        string condition,
+        [Description("Timeout in milliseconds (default: 5000)")]
+        int timeoutMs = 5000,
+        [Description("Entity ID to check (use this or entityName)")]
+        int? entityId = null,
+        [Description("Entity name to check (use this or entityId)")]
+        string? entityName = null,
+        [Description("Component type name (for component conditions)")]
+        string? componentType = null)
+    {
+        var bridge = connection.GetBridge();
+        var timeout = TimeSpan.FromMilliseconds(timeoutMs);
+        var startTime = DateTime.UtcNow;
+
+        Func<IStateController, Task<bool>> conditionFunc = condition.ToLowerInvariant() switch
+        {
+            "entity_exists" => async state =>
+            {
+                if (entityId.HasValue)
+                {
+                    return await state.GetEntityAsync(entityId.Value) != null;
+                }
+
+                if (!string.IsNullOrEmpty(entityName))
+                {
+                    return await state.GetEntityByNameAsync(entityName) != null;
+                }
+
+                throw new ArgumentException("Either entityId or entityName must be provided for 'entity_exists' condition.");
+            }
+            ,
+            "entity_gone" => async state =>
+            {
+                if (entityId.HasValue)
+                {
+                    return await state.GetEntityAsync(entityId.Value) == null;
+                }
+
+                if (!string.IsNullOrEmpty(entityName))
+                {
+                    return await state.GetEntityByNameAsync(entityName) == null;
+                }
+
+                throw new ArgumentException("Either entityId or entityName must be provided for 'entity_gone' condition.");
+            }
+            ,
+            "component_exists" => async state =>
+            {
+                if (string.IsNullOrEmpty(componentType))
+                {
+                    throw new ArgumentException("componentType must be provided for 'component_exists' condition.");
+                }
+
+                var id = await ResolveEntityIdAsync(state, entityId, entityName);
+                if (id == null)
+                {
+                    return false;
+                }
+
+                var component = await state.GetComponentAsync(id.Value, componentType);
+                return component != null;
+            }
+            ,
+            "component_gone" => async state =>
+            {
+                if (string.IsNullOrEmpty(componentType))
+                {
+                    throw new ArgumentException("componentType must be provided for 'component_gone' condition.");
+                }
+
+                var id = await ResolveEntityIdAsync(state, entityId, entityName);
+                if (id == null)
+                {
+                    return true; // Entity gone means component is also gone
+                }
+
+                var component = await state.GetComponentAsync(id.Value, componentType);
+                return component == null;
+            }
+            ,
+            _ => throw new ArgumentException($"Invalid condition: '{condition}'. Valid conditions: entity_exists, entity_gone, component_exists, component_gone.")
+        };
+
+        var success = await bridge.WaitForAsync(conditionFunc, timeout);
+        var elapsed = (int)(DateTime.UtcNow - startTime).TotalMilliseconds;
+
+        return new WaitResult
+        {
+            Success = success,
+            Message = success ? $"Condition '{condition}' met" : $"Timeout waiting for '{condition}'",
+            ElapsedMs = elapsed
+        };
+    }
+
+    private static async Task<int?> ResolveEntityIdAsync(
+        IStateController state,
+        int? entityId,
+        string? entityName)
+    {
+        if (entityId.HasValue)
+        {
+            return entityId.Value;
+        }
+
+        if (!string.IsNullOrEmpty(entityName))
+        {
+            var entity = await state.GetEntityByNameAsync(entityName);
+            return entity?.Id;
+        }
+
+        throw new ArgumentException("Either entityId or entityName must be provided.");
+    }
 }
 
 /// <summary>
@@ -108,4 +240,23 @@ public sealed record ConnectionResult
     public string? Host { get; init; }
     public int? Port { get; init; }
     public string? Transport { get; init; }
+}
+
+/// <summary>
+/// Result containing screen dimensions.
+/// </summary>
+public sealed record ScreenSizeResult
+{
+    public required int Width { get; init; }
+    public required int Height { get; init; }
+}
+
+/// <summary>
+/// Result of a wait operation.
+/// </summary>
+public sealed record WaitResult
+{
+    public required bool Success { get; init; }
+    public required string Message { get; init; }
+    public required int ElapsedMs { get; init; }
 }

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
@@ -1,0 +1,251 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.State;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for querying game state (entities, components, systems, performance).
+/// </summary>
+[McpServerToolType]
+public sealed class StateTools(BridgeConnectionManager connection)
+{
+    #region Entity Queries
+
+    [McpServerTool(Name = "state_get_entity_count")]
+    [Description("Get the total number of entities in the world.")]
+    public async Task<EntityCountResult> StateGetEntityCount()
+    {
+        var bridge = connection.GetBridge();
+        var count = await bridge.State.GetEntityCountAsync();
+
+        return new EntityCountResult { Count = count };
+    }
+
+    [McpServerTool(Name = "state_query_entities")]
+    [Description("Query entities with filters. Returns entity snapshots matching the criteria.")]
+    public async Task<IReadOnlyList<EntitySnapshot>> StateQueryEntities(
+        [Description("Component types entities must have (e.g., ['Position', 'Velocity'])")]
+        string[]? withComponents = null,
+        [Description("Component types entities must NOT have")]
+        string[]? withoutComponents = null,
+        [Description("Tags entities must have")]
+        string[]? withTags = null,
+        [Description("Name pattern to match (supports * and ? wildcards)")]
+        string? namePattern = null,
+        [Description("Parent entity ID to filter by")]
+        int? parentId = null,
+        [Description("Maximum results to return (default: 100)")]
+        int maxResults = 100)
+    {
+        var bridge = connection.GetBridge();
+
+        var query = new EntityQuery
+        {
+            WithComponents = withComponents,
+            WithoutComponents = withoutComponents,
+            WithTags = withTags,
+            NamePattern = namePattern,
+            ParentId = parentId,
+            MaxResults = maxResults
+        };
+
+        return await bridge.State.QueryEntitiesAsync(query);
+    }
+
+    [McpServerTool(Name = "state_get_entity")]
+    [Description("Get detailed information about an entity by its ID.")]
+    public async Task<EntitySnapshot?> StateGetEntity(
+        [Description("The entity ID")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        return await bridge.State.GetEntityAsync(entityId);
+    }
+
+    [McpServerTool(Name = "state_get_entity_by_name")]
+    [Description("Find an entity by its name. Returns the first entity with the given name.")]
+    public async Task<EntitySnapshot?> StateGetEntityByName(
+        [Description("The entity name to search for")]
+        string name)
+    {
+        var bridge = connection.GetBridge();
+        return await bridge.State.GetEntityByNameAsync(name);
+    }
+
+    #endregion
+
+    #region Components
+
+    [McpServerTool(Name = "state_get_component")]
+    [Description("Get component data from an entity. Returns field names and values as a dictionary.")]
+    public async Task<ComponentResult> StateGetComponent(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The component type name (e.g., 'Position', 'Health')")]
+        string componentType)
+    {
+        var bridge = connection.GetBridge();
+        var data = await bridge.State.GetComponentAsync(entityId, componentType);
+
+        if (data == null)
+        {
+            return new ComponentResult
+            {
+                Found = false,
+                EntityId = entityId,
+                ComponentType = componentType,
+                Data = null
+            };
+        }
+
+        return new ComponentResult
+        {
+            Found = true,
+            EntityId = entityId,
+            ComponentType = componentType,
+            Data = data
+        };
+    }
+
+    #endregion
+
+    #region Hierarchy
+
+    [McpServerTool(Name = "state_get_children")]
+    [Description("Get the child entity IDs of an entity.")]
+    public async Task<ChildrenResult> StateGetChildren(
+        [Description("The parent entity ID")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var children = await bridge.State.GetChildrenAsync(entityId);
+
+        return new ChildrenResult
+        {
+            ParentId = entityId,
+            ChildIds = children.ToArray(),
+            Count = children.Count
+        };
+    }
+
+    [McpServerTool(Name = "state_get_parent")]
+    [Description("Get the parent entity ID of an entity. Returns null if entity has no parent.")]
+    public async Task<ParentResult> StateGetParent(
+        [Description("The entity ID")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var parentId = await bridge.State.GetParentAsync(entityId);
+
+        return new ParentResult
+        {
+            EntityId = entityId,
+            ParentId = parentId,
+            HasParent = parentId.HasValue
+        };
+    }
+
+    [McpServerTool(Name = "state_get_entities_with_tag")]
+    [Description("Find all entity IDs that have a specific tag.")]
+    public async Task<TagQueryResult> StateGetEntitiesWithTag(
+        [Description("The tag name to search for")]
+        string tag)
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.State.GetEntitiesWithTagAsync(tag);
+
+        return new TagQueryResult
+        {
+            Tag = tag,
+            EntityIds = entities.ToArray(),
+            Count = entities.Count
+        };
+    }
+
+    #endregion
+
+    #region World Info
+
+    [McpServerTool(Name = "state_get_world_stats")]
+    [Description("Get statistics about the world: entity count, archetype count, memory usage, etc.")]
+    public async Task<WorldStats> StateGetWorldStats()
+    {
+        var bridge = connection.GetBridge();
+        return await bridge.State.GetWorldStatsAsync();
+    }
+
+    [McpServerTool(Name = "state_get_systems")]
+    [Description("List all registered systems with their phase, order, and execution stats.")]
+    public async Task<IReadOnlyList<SystemInfo>> StateGetSystems()
+    {
+        var bridge = connection.GetBridge();
+        return await bridge.State.GetSystemsAsync();
+    }
+
+    [McpServerTool(Name = "state_get_performance")]
+    [Description("Get performance metrics: FPS, frame times, per-system timing.")]
+    public async Task<PerformanceMetrics> StateGetPerformance(
+        [Description("Number of frames to analyze (default: 60)")]
+        int frameCount = 60)
+    {
+        var bridge = connection.GetBridge();
+        return await bridge.State.GetPerformanceMetricsAsync(frameCount);
+    }
+
+    #endregion
+}
+
+#region Result Records
+
+/// <summary>
+/// Result containing entity count.
+/// </summary>
+public sealed record EntityCountResult
+{
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Result of a component query.
+/// </summary>
+public sealed record ComponentResult
+{
+    public required bool Found { get; init; }
+    public required int EntityId { get; init; }
+    public required string ComponentType { get; init; }
+    public IReadOnlyDictionary<string, object?>? Data { get; init; }
+}
+
+/// <summary>
+/// Result of a children query.
+/// </summary>
+public sealed record ChildrenResult
+{
+    public required int ParentId { get; init; }
+    public required int[] ChildIds { get; init; }
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Result of a parent query.
+/// </summary>
+public sealed record ParentResult
+{
+    public required int EntityId { get; init; }
+    public int? ParentId { get; init; }
+    public required bool HasParent { get; init; }
+}
+
+/// <summary>
+/// Result of a tag query.
+/// </summary>
+public sealed record TagQueryResult
+{
+    public required string Tag { get; init; }
+    public required int[] EntityIds { get; init; }
+    public required int Count { get; init; }
+}
+
+#endregion


### PR DESCRIPTION
## Summary

- Add StateTools.cs with 11 tools for querying game state via IStateController
- Add game_wait_for_condition tool for waiting on entity/component state changes
- Add game_get_screen_size tool for getting window dimensions

### State Tools (11 tools)
- `state_get_entity_count` - Get total entity count
- `state_query_entities` - Query entities with filters (components, tags, name pattern)
- `state_get_entity` - Get entity by ID
- `state_get_entity_by_name` - Find entity by name
- `state_get_component` - Get component data from entity
- `state_get_children` - Get child entity IDs
- `state_get_parent` - Get parent entity ID
- `state_get_entities_with_tag` - Find entities by tag
- `state_get_world_stats` - Get world statistics
- `state_get_systems` - List registered systems
- `state_get_performance` - Get performance metrics

### Game Tools Additions (2 tools)
- `game_get_screen_size` - Get window dimensions via ICaptureController
- `game_wait_for_condition` - Wait for entity_exists, entity_gone, component_exists, component_gone

## Test plan
- [ ] Build passes with zero warnings
- [ ] Tools register correctly with MCP server

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)