### PR TITLE
feat: Add MCP resources for read-only game state access (Phase 5: Resources)

### DIFF
--- a/tools/KeenEyes.Mcp.TestBridge/Program.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Program.cs
@@ -1,5 +1,6 @@
 using KeenEyes.Mcp.TestBridge;
 using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.Mcp.TestBridge.Resources;
 using KeenEyes.Mcp.TestBridge.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,7 +42,10 @@ builder.Services
     .WithTools<GameTools>()
     .WithTools<InputTools>()
     .WithTools<StateTools>()
-    .WithTools<CaptureTools>();
+    .WithTools<CaptureTools>()
+    .WithResources<ConnectionResources>()
+    .WithResources<WorldResources>()
+    .WithResources<CaptureResources>();
 
 var app = builder.Build();
 

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/CaptureResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/CaptureResources.cs
@@ -1,0 +1,41 @@
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Capture;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Resources;
+
+/// <summary>
+/// MCP resources for capture and screenshot access.
+/// </summary>
+[McpServerResourceType]
+public sealed class CaptureResources(BridgeConnectionManager connection)
+{
+    // S1075: MCP protocol requires these URIs for resource identification
+#pragma warning disable S1075
+    private const string ScreenshotUri = "keeneyes://capture/screenshot";
+#pragma warning restore S1075
+
+    [McpServerResource(
+        UriTemplate = ScreenshotUri,
+        Name = "screenshot",
+        Title = "Screenshot",
+        MimeType = "image/png")]
+    public async Task<BlobResourceContents> GetScreenshot()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Capture.IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        var bytes = await bridge.Capture.GetScreenshotBytesAsync(ImageFormat.Png);
+        return new BlobResourceContents
+        {
+            Uri = ScreenshotUri,
+            MimeType = "image/png",
+            Blob = Convert.ToBase64String(bytes)
+        };
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/ConnectionResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/ConnectionResources.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using KeenEyes.Mcp.TestBridge.Connection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Resources;
+
+/// <summary>
+/// MCP resources for connection status information.
+/// </summary>
+[McpServerResourceType]
+public sealed class ConnectionResources(BridgeConnectionManager connection)
+{
+    // S1075: MCP protocol requires these URIs for resource identification
+#pragma warning disable S1075
+    private const string ConnectionStatusUri = "keeneyes://connection/status";
+#pragma warning restore S1075
+
+    [McpServerResource(
+        UriTemplate = ConnectionStatusUri,
+        Name = "connection-status",
+        Title = "Connection Status",
+        MimeType = "application/json")]
+    public TextResourceContents GetConnectionStatus()
+    {
+        var status = connection.GetStatus();
+        var json = JsonSerializer.Serialize(status, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = ConnectionStatusUri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/JsonOptions.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/JsonOptions.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace KeenEyes.Mcp.TestBridge.Resources;
+
+/// <summary>
+/// Shared JSON serialization options for MCP resources.
+/// </summary>
+internal static class JsonOptions
+{
+    /// <summary>
+    /// Default serialization options with camelCase naming.
+    /// </summary>
+    public static JsonSerializerOptions Default { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
@@ -1,0 +1,101 @@
+using System.ComponentModel;
+using System.Text.Json;
+using KeenEyes.Mcp.TestBridge.Connection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Resources;
+
+/// <summary>
+/// MCP resources for world and entity state information.
+/// </summary>
+[McpServerResourceType]
+public sealed class WorldResources(BridgeConnectionManager connection)
+{
+    // S1075: MCP protocol requires these URIs for resource identification
+#pragma warning disable S1075
+    private const string WorldStatsUri = "keeneyes://world/stats";
+    private const string EntityByIdUriTemplate = "keeneyes://entity/{id}";
+    private const string EntityByNameUriTemplate = "keeneyes://entity/name/{name}";
+#pragma warning restore S1075
+
+    [McpServerResource(
+        UriTemplate = WorldStatsUri,
+        Name = "world-stats",
+        Title = "World Statistics",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetWorldStats()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.State.GetWorldStatsAsync();
+        var json = JsonSerializer.Serialize(stats, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = WorldStatsUri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+
+    [McpServerResource(
+        UriTemplate = EntityByIdUriTemplate,
+        Name = "entity-by-id",
+        Title = "Entity by ID",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetEntityById(
+        [Description("Entity ID")] int id)
+    {
+        var bridge = connection.GetBridge();
+        var entity = await bridge.State.GetEntityAsync(id);
+        var uri = $"keeneyes://entity/{id}";
+
+        if (entity == null)
+        {
+            return new TextResourceContents
+            {
+                Uri = uri,
+                MimeType = "application/json",
+                Text = JsonSerializer.Serialize(new { error = $"Entity {id} not found" }, JsonOptions.Default)
+            };
+        }
+
+        var json = JsonSerializer.Serialize(entity, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = uri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+
+    [McpServerResource(
+        UriTemplate = EntityByNameUriTemplate,
+        Name = "entity-by-name",
+        Title = "Entity by Name",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetEntityByName(
+        [Description("Entity name")] string name)
+    {
+        var bridge = connection.GetBridge();
+        var entity = await bridge.State.GetEntityByNameAsync(name);
+        var uri = $"keeneyes://entity/name/{name}";
+
+        if (entity == null)
+        {
+            return new TextResourceContents
+            {
+                Uri = uri,
+                MimeType = "application/json",
+                Text = JsonSerializer.Serialize(new { error = $"Entity '{name}' not found" }, JsonOptions.Default)
+            };
+        }
+
+        var json = JsonSerializer.Serialize(entity, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = uri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add 5 MCP resources providing browsable, read-only data URIs for game state
- Resources complement tools by enabling data discovery and polling for MCP clients
- Implements `keeneyes://` URI scheme for resource identification

## Resources Added

| URI | Type | Description |
|-----|------|-------------|
| `keeneyes://connection/status` | JSON | Connection status with latency, uptime |
| `keeneyes://world/stats` | JSON | World statistics (entity/component counts) |
| `keeneyes://entity/{id}` | JSON | Entity snapshot by numeric ID |
| `keeneyes://entity/name/{name}` | JSON | Entity snapshot by name |
| `keeneyes://capture/screenshot` | PNG blob | Current frame screenshot |

## Files Added
- `Resources/JsonOptions.cs` - Shared JSON serialization options
- `Resources/ConnectionResources.cs` - Connection status resource  
- `Resources/WorldResources.cs` - World stats and entity template resources
- `Resources/CaptureResources.cs` - Screenshot resource

## Test plan
- [x] Build passes with zero warnings
- [x] Code formatted per .editorconfig
- [ ] Manual testing with MCP client

## Related Issues
Part of #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)