### PR TITLE
feat: Complete Phase 5 MCP resources with missing endpoints

### DIFF
--- a/tools/KeenEyes.Mcp.TestBridge/Program.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Program.cs
@@ -48,6 +48,7 @@ builder.Services
     .WithTools<CaptureTools>()
     .WithResources<ConnectionResources>()
     .WithResources<WorldResources>()
+    .WithResources<ExtensionResources>()
     .WithResources<CaptureResources>()
     .WithPrompts<WorkflowPrompts>();
 

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/ExtensionResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/ExtensionResources.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Text.Json;
+using KeenEyes.Mcp.TestBridge.Connection;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Resources;
+
+/// <summary>
+/// MCP resources for world extensions (singletons).
+/// </summary>
+[McpServerResourceType]
+public sealed class ExtensionResources(BridgeConnectionManager connection)
+{
+    // S1075: MCP protocol requires these URIs for resource identification
+#pragma warning disable S1075
+    private const string ExtensionUriTemplate = "keeneyes://extension/{typeName}";
+#pragma warning restore S1075
+
+    [McpServerResource(
+        UriTemplate = ExtensionUriTemplate,
+        Name = "extension",
+        Title = "World Extension",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetExtension(
+        [Description("Extension type name")] string typeName)
+    {
+        var bridge = connection.GetBridge();
+        var extension = await bridge.State.GetExtensionAsync(typeName);
+        var uri = $"keeneyes://extension/{typeName}";
+
+        if (extension == null)
+        {
+            return new TextResourceContents
+            {
+                Uri = uri,
+                MimeType = "application/json",
+                Text = JsonSerializer.Serialize(new { error = $"Extension '{typeName}' not found" }, JsonOptions.Default)
+            };
+        }
+
+        var json = JsonSerializer.Serialize(extension, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = uri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
@@ -15,8 +15,11 @@ public sealed class WorldResources(BridgeConnectionManager connection)
     // S1075: MCP protocol requires these URIs for resource identification
 #pragma warning disable S1075
     private const string WorldStatsUri = "keeneyes://world/stats";
+    private const string WorldSystemsUri = "keeneyes://world/systems";
+    private const string WorldPerformanceUri = "keeneyes://world/performance";
     private const string EntityByIdUriTemplate = "keeneyes://entity/{id}";
     private const string EntityByNameUriTemplate = "keeneyes://entity/name/{name}";
+    private const string EntityComponentUriTemplate = "keeneyes://entity/{id}/component/{type}";
 #pragma warning restore S1075
 
     [McpServerResource(
@@ -94,6 +97,75 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         return new TextResourceContents
         {
             Uri = uri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+
+    [McpServerResource(
+        UriTemplate = EntityComponentUriTemplate,
+        Name = "entity-component",
+        Title = "Entity Component",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetEntityComponent(
+        [Description("Entity ID")] int id,
+        [Description("Component type name")] string type)
+    {
+        var bridge = connection.GetBridge();
+        var component = await bridge.State.GetComponentAsync(id, type);
+        var uri = $"keeneyes://entity/{id}/component/{type}";
+
+        if (component == null)
+        {
+            return new TextResourceContents
+            {
+                Uri = uri,
+                MimeType = "application/json",
+                Text = JsonSerializer.Serialize(new { error = $"Component '{type}' not found on entity {id}" }, JsonOptions.Default)
+            };
+        }
+
+        var json = JsonSerializer.Serialize(component, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = uri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+
+    [McpServerResource(
+        UriTemplate = WorldSystemsUri,
+        Name = "world-systems",
+        Title = "World Systems",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetWorldSystems()
+    {
+        var bridge = connection.GetBridge();
+        var systems = await bridge.State.GetSystemsAsync();
+        var json = JsonSerializer.Serialize(systems, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = WorldSystemsUri,
+            MimeType = "application/json",
+            Text = json
+        };
+    }
+
+    [McpServerResource(
+        UriTemplate = WorldPerformanceUri,
+        Name = "world-performance",
+        Title = "World Performance",
+        MimeType = "application/json")]
+    public async Task<TextResourceContents> GetWorldPerformance(
+        [Description("Number of frames to analyze (default: 60)")] int frameCount = 60)
+    {
+        var bridge = connection.GetBridge();
+        var metrics = await bridge.State.GetPerformanceMetricsAsync(frameCount);
+        var json = JsonSerializer.Serialize(metrics, JsonOptions.Default);
+        return new TextResourceContents
+        {
+            Uri = WorldPerformanceUri,
             MimeType = "application/json",
             Text = json
         };


### PR DESCRIPTION
## Summary
Complete Phase 5 resource requirements by adding missing endpoints:
- Add entity component resource (`keeneyes://entity/{id}/component/{type}`)
- Add world systems resource (`keeneyes://world/systems`)
- Add world performance resource (`keeneyes://world/performance`)
- Add extension resources (`keeneyes://extension/{typeName}`) for singletons

## Phase 5 Requirements Checklist

| Required URI | Status |
|--------------|--------|
| `entity://{id}` | ✅ Already implemented |
| `entity://{id}/component/{type}` | ✅ **Added in this PR** |
| `entity://name/{name}` | ✅ Already implemented |
| `world://stats` | ✅ Already implemented |
| `world://systems` | ✅ **Added in this PR** |
| `world://performance` | ✅ **Added in this PR** |
| `extension://{typeName}` | ✅ **Added in this PR** |
| `connection://status` | ✅ Already implemented |
| `screenshot://current` | ✅ Already implemented |

## Test plan
- [x] Build passes with zero warnings
- [x] Code formatting verified

## Related Issues
Completes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)