### PR TITLE
chore: Add MCP server configuration and publish scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ BenchmarkDotNet.Artifacts/
 _site/
 api/*.yml
 api/.manifest
+# MCP server published binaries
+.mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "keeneyes-bridge": {
+      "type": "stdio",
+      "command": ".mcp/KeenEyes.Mcp.TestBridge.exe",
+      "args": [],
+      "env": {
+        "KEENEYES_TRANSPORT": "pipe",
+        "KEENEYES_PIPE_NAME": "KeenEyes.TestBridge",
+        "KEENEYES_HEARTBEAT_INTERVAL": "5000",
+        "KEENEYES_HEARTBEAT_TIMEOUT": "10000"
+      }
+    }
+  }
+}

--- a/scripts/publish-mcp.ps1
+++ b/scripts/publish-mcp.ps1
@@ -1,0 +1,24 @@
+# Publish MCP TestBridge server
+# Usage: .\scripts\publish-mcp.ps1
+
+$ErrorActionPreference = "Stop"
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+$McpProject = Join-Path $ProjectRoot "tools\KeenEyes.Mcp.TestBridge\KeenEyes.Mcp.TestBridge.csproj"
+$OutputDir = Join-Path $ProjectRoot ".mcp"
+
+Write-Host "Publishing MCP TestBridge server..." -ForegroundColor Cyan
+Write-Host "  Project: $McpProject"
+Write-Host "  Output:  $OutputDir"
+Write-Host ""
+
+dotnet publish $McpProject -c Release -o $OutputDir --nologo
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "MCP server published successfully!" -ForegroundColor Green
+    Write-Host "Executable: $OutputDir\KeenEyes.Mcp.TestBridge.exe"
+} else {
+    Write-Host ""
+    Write-Host "Failed to publish MCP server" -ForegroundColor Red
+    exit 1
+}

--- a/scripts/publish-mcp.sh
+++ b/scripts/publish-mcp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Publish MCP TestBridge server
+# Usage: ./scripts/publish-mcp.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+MCP_PROJECT="$PROJECT_ROOT/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj"
+OUTPUT_DIR="$PROJECT_ROOT/.mcp"
+
+echo "Publishing MCP TestBridge server..."
+echo "  Project: $MCP_PROJECT"
+echo "  Output:  $OUTPUT_DIR"
+echo ""
+
+dotnet publish "$MCP_PROJECT" -c Release -o "$OUTPUT_DIR" --nologo
+
+echo ""
+echo "MCP server published successfully!"
+echo "Executable: $OUTPUT_DIR/KeenEyes.Mcp.TestBridge.exe"


### PR DESCRIPTION
## Summary
- Add `.mcp.json` for Claude Code MCP server configuration
- Add `scripts/publish-mcp.ps1` and `scripts/publish-mcp.sh` for easy publishing
- Add `.mcp/` to `.gitignore` (published binaries)

## Usage
1. Run `.\scripts\publish-mcp.ps1` (Windows) or `./scripts/publish-mcp.sh` (bash) to publish the MCP server
2. Claude Code automatically detects `.mcp.json` when started in the project
3. Use `/mcp` in Claude Code to verify the server is connected

## Test plan
- [x] Publish script runs successfully
- [x] Published executable exists at `.mcp/KeenEyes.Mcp.TestBridge.exe`
- [x] `.mcp/` is properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)