### PR TITLE
fix(mcp): Fix EntitySnapshot serialization and screenshot capture threading

### DIFF
--- a/src/KeenEyes.Abstractions/ILoopProvider.cs
+++ b/src/KeenEyes.Abstractions/ILoopProvider.cs
@@ -68,4 +68,26 @@ public interface ILoopProvider
     /// Gets whether the loop provider is initialized.
     /// </summary>
     bool IsInitialized { get; }
+
+    /// <summary>
+    /// Queues an action to run on the render thread and waits for completion.
+    /// </summary>
+    /// <typeparam name="T">The return type of the action.</typeparam>
+    /// <param name="action">The action to execute on the render thread.</param>
+    /// <returns>A task that completes with the result when the action has executed.</returns>
+    /// <remarks>
+    /// Use this method when you need to perform operations that require the render thread's
+    /// OpenGL context (e.g., reading framebuffers, creating textures). The action will be
+    /// executed during the next render frame.
+    /// </remarks>
+    Task<T> InvokeOnRenderThreadAsync<T>(Func<T> action);
+
+    /// <summary>
+    /// Queues an action to run on the render thread (fire-and-forget).
+    /// </summary>
+    /// <param name="action">The action to execute on the render thread.</param>
+    /// <remarks>
+    /// Use this for render thread operations where you don't need to wait for completion.
+    /// </remarks>
+    void InvokeOnRenderThread(Action action);
 }

--- a/src/KeenEyes.TestBridge.Abstractions/State/IStateController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/State/IStateController.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace KeenEyes.TestBridge.State;
 
 /// <summary>
@@ -50,12 +52,11 @@ public interface IStateController
     /// </summary>
     /// <param name="entityId">The entity ID.</param>
     /// <param name="componentTypeName">The component type name.</param>
-    /// <returns>The component data as a dictionary of field names to values.</returns>
+    /// <returns>The component data as a JSON element, or null if not found.</returns>
     /// <remarks>
-    /// For IPC mode, component data is serialized as a dictionary. For in-process mode,
-    /// this may return the actual component object.
+    /// Component data is serialized as a JSON element containing field names and values.
     /// </remarks>
-    Task<IReadOnlyDictionary<string, object?>?> GetComponentAsync(int entityId, string componentTypeName);
+    Task<JsonElement?> GetComponentAsync(int entityId, string componentTypeName);
 
     /// <summary>
     /// Gets world statistics.
@@ -189,9 +190,9 @@ public sealed record EntitySnapshot
     /// Gets the component data for each component type.
     /// </summary>
     /// <remarks>
-    /// Keys are component type names. Values are dictionaries of field names to values.
+    /// Keys are component type names. Values are JSON elements containing field data.
     /// </remarks>
-    public required IReadOnlyDictionary<string, IReadOnlyDictionary<string, object?>> Components { get; init; }
+    public required IReadOnlyDictionary<string, JsonElement> Components { get; init; }
 
     /// <summary>
     /// Gets the component type names (without full data).

--- a/src/KeenEyes.TestBridge.Client/RemoteStateController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteStateController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using KeenEyes.TestBridge.Ipc.Protocol;
 using KeenEyes.TestBridge.State;
 
@@ -34,9 +35,9 @@ internal sealed class RemoteStateController(TestBridgeClient client) : IStateCon
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyDictionary<string, object?>?> GetComponentAsync(int entityId, string componentTypeName)
+    public async Task<JsonElement?> GetComponentAsync(int entityId, string componentTypeName)
     {
-        return await client.SendRequestAsync<Dictionary<string, object?>?>(
+        return await client.SendRequestAsync<JsonElement?>(
             "state.getComponent",
             new ComponentArgs { EntityId = entityId, ComponentTypeName = componentTypeName },
             CancellationToken.None);

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -39,7 +39,8 @@ public sealed class InProcessBridge : ITestBridge
     /// <param name="world">The world to bridge.</param>
     /// <param name="options">Configuration options.</param>
     /// <param name="graphicsContext">Optional graphics context for screenshot capture.</param>
-    public InProcessBridge(World world, TestBridgeOptions? options = null, IGraphicsContext? graphicsContext = null)
+    /// <param name="loopProvider">Optional loop provider for render thread marshalling.</param>
+    public InProcessBridge(World world, TestBridgeOptions? options = null, IGraphicsContext? graphicsContext = null, ILoopProvider? loopProvider = null)
     {
         this.world = world;
         this.options = options ?? new TestBridgeOptions();
@@ -50,7 +51,7 @@ public sealed class InProcessBridge : ITestBridge
 
         inputController = new InputControllerImpl(inputContext);
         stateController = new StateControllerImpl(world);
-        captureController = new CaptureControllerImpl(graphicsContext);
+        captureController = new CaptureControllerImpl(graphicsContext, loopProvider);
         processController = new ProcessControllerImpl();
     }
 

--- a/src/KeenEyes.TestBridge/TestBridgePlugin.cs
+++ b/src/KeenEyes.TestBridge/TestBridgePlugin.cs
@@ -40,8 +40,11 @@ public sealed class TestBridgePlugin(TestBridgeOptions? options = null) : IWorld
         // Try to get graphics context (optional - may not exist in headless mode)
         context.TryGetExtension<IGraphicsContext>(out var graphicsContext);
 
+        // Try to get loop provider (optional - needed for render thread marshalling)
+        context.TryGetExtension<ILoopProvider>(out var loopProvider);
+
         // Create the in-process bridge
-        bridge = new InProcessBridge(world, options, graphicsContext);
+        bridge = new InProcessBridge(world, options, graphicsContext, loopProvider);
 
         // Expose the bridge as an extension
         context.SetExtension<ITestBridge>(bridge);

--- a/src/KeenEyes.Testing/Platform/MockLoopProvider.cs
+++ b/src/KeenEyes.Testing/Platform/MockLoopProvider.cs
@@ -54,6 +54,25 @@ public sealed class MockLoopProvider : ILoopProvider, IDisposable
     /// <inheritdoc />
     public bool IsInitialized => isInitialized;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// In the mock, this executes the action synchronously (for testing purposes).
+    /// </remarks>
+    public Task<T> InvokeOnRenderThreadAsync<T>(Func<T> action)
+    {
+        var result = action();
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// In the mock, this executes the action synchronously (for testing purposes).
+    /// </remarks>
+    public void InvokeOnRenderThread(Action action)
+    {
+        action();
+    }
+
     /// <summary>
     /// Gets whether the loop is currently running.
     /// </summary>

--- a/tests/KeenEyes.TestBridge.Tests/State/StateControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/State/StateControllerImplTests.cs
@@ -188,8 +188,8 @@ public class StateControllerImplTests
         var component = await state.GetComponentAsync(entity.Id, "TestPosition");
 
         component.ShouldNotBeNull();
-        component["X"].ShouldBe(42f);
-        component["Y"].ShouldBe(99f);
+        component.Value.GetProperty("X").GetSingle().ShouldBe(42f);
+        component.Value.GetProperty("Y").GetSingle().ShouldBe(99f);
     }
 
     [Fact]

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
@@ -81,36 +81,20 @@ public sealed class StateTools(BridgeConnectionManager connection)
 
     #region Components
 
-    [McpServerTool(Name = "state_get_component")]
-    [Description("Get component data from an entity. Returns field names and values as a dictionary.")]
-    public async Task<ComponentResult> StateGetComponent(
-        [Description("The entity ID")]
-        int entityId,
-        [Description("The component type name (e.g., 'Position', 'Health')")]
-        string componentType)
-    {
-        var bridge = connection.GetBridge();
-        var data = await bridge.State.GetComponentAsync(entityId, componentType);
-
-        if (data == null)
-        {
-            return new ComponentResult
-            {
-                Found = false,
-                EntityId = entityId,
-                ComponentType = componentType,
-                Data = null
-            };
-        }
-
-        return new ComponentResult
-        {
-            Found = true,
-            EntityId = entityId,
-            ComponentType = componentType,
-            Data = data
-        };
-    }
+    // TODO: Issue #853 - state_get_component fails with MCP serialization error
+    // The MCP framework cannot serialize JsonElement? return types.
+    // Use state_get_entity instead which returns full component data.
+    // [McpServerTool(Name = "state_get_component")]
+    // [Description("Get component data from an entity. Returns field names and values as a dictionary.")]
+    // public async Task<JsonElement?> StateGetComponent(
+    //     [Description("The entity ID")]
+    //     int entityId,
+    //     [Description("The component type name (e.g., 'Position', 'Health')")]
+    //     string componentType)
+    // {
+    //     var bridge = connection.GetBridge();
+    //     return await bridge.State.GetComponentAsync(entityId, componentType);
+    // }
 
     #endregion
 
@@ -208,17 +192,6 @@ public sealed class StateTools(BridgeConnectionManager connection)
 public sealed record EntityCountResult
 {
     public required int Count { get; init; }
-}
-
-/// <summary>
-/// Result of a component query.
-/// </summary>
-public sealed record ComponentResult
-{
-    public required bool Found { get; init; }
-    public required int EntityId { get; init; }
-    public required string ComponentType { get; init; }
-    public IReadOnlyDictionary<string, object?>? Data { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Fix EntitySnapshot JSON serialization by using `JsonElement` instead of `object?` (Issue #843)
- Fix screenshot capture by marshalling OpenGL operations to the render thread (Issue #844)
- Disabled `state_get_component` MCP tool due to MCP framework serialization limitations (Issue #853)

## Changes

### Issue #843 - EntitySnapshot Serialization
- Changed `EntitySnapshot.Components` type from `IReadOnlyDictionary<string, IReadOnlyDictionary<string, object?>>` to `IReadOnlyDictionary<string, JsonElement>`
- Updated `SerializeComponent()` to return `JsonElement` via `JsonSerializer.SerializeToElement()`
- Added AOT suppression attributes for dynamic serialization in TestBridge debug infrastructure
- `state_query_entities` and `state_get_entity` MCP tools now correctly return component data

### Issue #844 - Screenshot Capture Threading  
- Added `InvokeOnRenderThreadAsync<T>()` and `InvokeOnRenderThread()` to `ILoopProvider` interface
- Implemented render thread queue in `SilkLoopProvider` using `ConcurrentQueue<Action>`
- Updated `CaptureControllerImpl` to marshal GL operations to render thread
- `capture_screenshot` MCP tool now works correctly from IPC/MCP requests

### Known Issue
- `state_get_component` MCP tool is disabled (see Issue #853) - use `state_get_entity` as workaround

## Test plan
- [x] Unit tests pass for StateControllerImpl
- [x] Build completes with zero warnings
- [x] Manual testing: `state_query_entities` with `includeComponentData: true` works
- [x] Manual testing: `capture_screenshot` returns valid base64 image

Closes #843
Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)