### PR TITLE
feat(testbridge): Add hybrid input mode for MCP integration

### DIFF
--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -244,7 +244,12 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
 
         // Start TestBridge for the editor world (allows debugging editor UI)
         // Pass the log provider so MCP tools can query editor logs
-        _editorTestBridge = new TestBridgeManager(_editorWorld, logQueryable: _logProvider);
+        // Pass the real input context for hybrid mode (both real + virtual input work)
+        var editorInputContext = _editorWorld.GetExtension<IInputContext>();
+        _editorTestBridge = new TestBridgeManager(
+            _editorWorld,
+            logQueryable: _logProvider,
+            realInputContext: editorInputContext);
         _ = StartEditorTestBridgeAsync();
 
         // Force initial layout calculation so UI bounds are ready for first frame input
@@ -304,7 +309,12 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
         Console.WriteLine("Hot reload service initialized for scene");
 
         // Initialize TestBridge for scene world (game debugging)
-        _sceneTestBridge = new TestBridgeManager(sceneWorld, "KeenEyes.Editor.Scene.TestBridge");
+        // Pass the scene input context for hybrid mode (both real + virtual input work)
+        var sceneInputContext = sceneWorld.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        _sceneTestBridge = new TestBridgeManager(
+            sceneWorld,
+            pipeName: "KeenEyes.Editor.Scene.TestBridge",
+            realInputContext: sceneInputContext);
         _ = StartSceneTestBridgeAsync();
     }
 

--- a/editor/KeenEyes.Editor/PlayMode/TestBridgeManager.cs
+++ b/editor/KeenEyes.Editor/PlayMode/TestBridgeManager.cs
@@ -1,3 +1,4 @@
+using KeenEyes.Input.Abstractions;
 using KeenEyes.Logging;
 using KeenEyes.TestBridge;
 using KeenEyes.TestBridge.Ipc;
@@ -36,7 +37,16 @@ public sealed class TestBridgeManager : IAsyncDisposable
     /// <param name="sceneWorld">The scene world to bridge.</param>
     /// <param name="pipeName">The named pipe name for IPC connections. If null, uses <see cref="DefaultPipeName"/>.</param>
     /// <param name="logQueryable">Optional log queryable provider for log browsing via MCP.</param>
-    public TestBridgeManager(World sceneWorld, string? pipeName = null, ILogQueryable? logQueryable = null)
+    /// <param name="realInputContext">
+    /// Optional real hardware input context to merge with virtual input.
+    /// When provided, enables hybrid input mode where both real hardware input
+    /// and virtual TestBridge-injected input work together.
+    /// </param>
+    public TestBridgeManager(
+        World sceneWorld,
+        string? pipeName = null,
+        ILogQueryable? logQueryable = null,
+        IInputContext? realInputContext = null)
     {
         ArgumentNullException.ThrowIfNull(sceneWorld);
 
@@ -46,6 +56,7 @@ public sealed class TestBridgeManager : IAsyncDisposable
             EnableIpc = true,
             EnableCapture = true,
             LogQueryable = logQueryable,
+            RealInputContext = realInputContext,
             IpcOptions = new IpcOptions
             {
                 PipeName = pipeName ?? DefaultPipeName,

--- a/samples/KeenEyes.Sample.InputDebugger/Components.cs
+++ b/samples/KeenEyes.Sample.InputDebugger/Components.cs
@@ -1,0 +1,81 @@
+using System.Numerics;
+
+namespace KeenEyes.Sample.InputDebugger;
+
+/// <summary>
+/// Tag for the mouse position marker.
+/// </summary>
+[TagComponent]
+public partial struct MouseMarkerTag;
+
+/// <summary>
+/// Tag for click markers that spawn on mouse clicks.
+/// </summary>
+[TagComponent]
+public partial struct ClickMarkerTag;
+
+/// <summary>
+/// Component for markers that fade out over time.
+/// </summary>
+[Component]
+public partial struct FadeOut
+{
+    /// <summary>
+    /// Time remaining before marker is removed.
+    /// </summary>
+    public float TimeRemaining;
+
+    /// <summary>
+    /// Total fade duration for alpha calculation.
+    /// </summary>
+    public float TotalDuration;
+}
+
+/// <summary>
+/// Tag for keyboard key visualization cubes.
+/// </summary>
+[TagComponent]
+public partial struct KeyVisualizerTag;
+
+/// <summary>
+/// Component associating a visual element with a keyboard key.
+/// </summary>
+[Component]
+public partial struct KeyBinding
+{
+    /// <summary>
+    /// The keyboard key this element represents.
+    /// </summary>
+    public KeenEyes.Input.Abstractions.Key Key;
+}
+
+/// <summary>
+/// Tag for the left stick marker.
+/// </summary>
+[TagComponent]
+public partial struct LeftStickMarkerTag;
+
+/// <summary>
+/// Tag for the right stick marker.
+/// </summary>
+[TagComponent]
+public partial struct RightStickMarkerTag;
+
+/// <summary>
+/// Tag for gamepad button indicators.
+/// </summary>
+[TagComponent]
+public partial struct GamepadButtonTag;
+
+/// <summary>
+/// Component associating a visual with a gamepad button.
+/// </summary>
+[Component]
+public partial struct GamepadButtonBinding
+{
+    /// <summary>
+    /// The gamepad button this element represents.
+    /// </summary>
+    public KeenEyes.Input.Abstractions.GamepadButton Button;
+}
+

--- a/samples/KeenEyes.Sample.InputDebugger/KeenEyes.Sample.InputDebugger.csproj
+++ b/samples/KeenEyes.Sample.InputDebugger/KeenEyes.Sample.InputDebugger.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Silk\KeenEyes.Graphics.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics\KeenEyes.Graphics.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Abstractions\KeenEyes.Input.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Silk\KeenEyes.Input.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input\KeenEyes.Input.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk\KeenEyes.Platform.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Runtime\KeenEyes.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.TestBridge\KeenEyes.TestBridge.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.TestBridge.Ipc\KeenEyes.TestBridge.Ipc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/KeenEyes.Sample.InputDebugger/Program.cs
+++ b/samples/KeenEyes.Sample.InputDebugger/Program.cs
@@ -1,0 +1,405 @@
+// KeenEyes Input Debugger Sample
+// Visualizes keyboard, mouse, and gamepad input for debugging and testing.
+//
+// Features:
+//   - Console logging of all input events
+//   - Mouse position marker (cube following cursor)
+//   - Click markers (cubes spawned on click that fade out)
+//   - Keyboard visualization (WASD keys light up when pressed)
+//   - Gamepad stick position markers
+//   - Gamepad button indicators
+//
+// TestBridge Integration:
+//   - Installs TestBridgePlugin for MCP tool integration
+//   - Starts IPC server on pipe: KeenEyes.InputDebugger.TestBridge
+//   - Both real hardware input AND virtual MCP input work together (hybrid mode)
+//
+// MCP Testing:
+//   1. Run this sample
+//   2. Connect via MCP: mcp__keeneyes-bridge__game_connect pipeName="KeenEyes.InputDebugger.TestBridge"
+//   3. Inject input: mcp__keeneyes-bridge__input_key_press key="W"
+//   4. See both console output and visual feedback
+//
+// NOTE: This sample requires a display to run.
+
+using System.Numerics;
+using KeenEyes;
+using KeenEyes.Common;
+using KeenEyes.Graphics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Input.Silk;
+using KeenEyes.Platform.Silk;
+using KeenEyes.Runtime;
+using KeenEyes.Sample.InputDebugger;
+using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.Ipc;
+
+Console.WriteLine("KeenEyes Input Debugger");
+Console.WriteLine("=======================");
+Console.WriteLine();
+Console.WriteLine("This sample visualizes all input for debugging:");
+Console.WriteLine("- Keyboard: WASD keys shown, all keys logged to console");
+Console.WriteLine("- Mouse: Position marker, click markers spawn on click");
+Console.WriteLine("- Gamepad: Stick position markers, button indicators");
+Console.WriteLine();
+Console.WriteLine("TestBridge Integration:");
+Console.WriteLine("- IPC Pipe: KeenEyes.InputDebugger.TestBridge");
+Console.WriteLine("- Hybrid mode: Real AND virtual input both work");
+Console.WriteLine();
+Console.WriteLine("Press Escape to exit.");
+Console.WriteLine();
+
+// Configure window
+var windowConfig = new WindowConfig
+{
+    Title = "KeenEyes Input Debugger - Escape to exit",
+    Width = 1280,
+    Height = 720,
+    VSync = true
+};
+
+// Configure graphics
+var graphicsConfig = new SilkGraphicsConfig
+{
+    ClearColor = new Vector4(0.15f, 0.15f, 0.2f, 1f),
+    EnableDepthTest = true,
+    EnableCulling = true
+};
+
+// Configure input
+var inputConfig = new SilkInputConfig
+{
+    EnableGamepads = true,
+    MaxGamepads = 4,
+    GamepadDeadzone = 0.15f,
+    CaptureMouseOnClick = false
+};
+
+using var world = new World();
+
+// Install core plugins
+world.InstallPlugin(new SilkWindowPlugin(windowConfig));
+world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
+world.InstallPlugin(new SilkInputPlugin(inputConfig));
+
+// Install TestBridge for MCP integration
+// This enables external tools to inject input via IPC
+var testBridgeOptions = new TestBridgeOptions
+{
+    EnableIpc = true,
+    IpcOptions = new IpcOptions
+    {
+        PipeName = "KeenEyes.InputDebugger.TestBridge",
+        TransportMode = IpcTransportMode.NamedPipe
+    }
+};
+world.InstallPlugin(new TestBridgePlugin(testBridgeOptions));
+
+// Register systems (use fully-qualified names to avoid ambiguity with KeenEyes.Graphics systems)
+world.AddSystem<KeenEyes.Graphics.CameraSystem>(SystemPhase.EarlyUpdate, order: 0);
+world.AddSystem<InputLogSystem>(SystemPhase.Update, order: 0);
+world.AddSystem<MouseVisualizerSystem>(SystemPhase.Update, order: 10);
+world.AddSystem<KeyboardVisualizerSystem>(SystemPhase.Update, order: 20);
+world.AddSystem<GamepadVisualizerSystem>(SystemPhase.Update, order: 30);
+world.AddSystem<FadeOutSystem>(SystemPhase.Update, order: 100);
+world.AddSystem<KeenEyes.Graphics.RenderSystem>(SystemPhase.Render, order: 0);
+
+// IPC server reference for cleanup
+IpcBridgeServer? ipcServer = null;
+
+Console.WriteLine("Starting...");
+
+try
+{
+    world.CreateRunner()
+        .OnReady(() =>
+        {
+            Console.WriteLine("Input system initialized!");
+
+            var input = world.GetExtension<IInputContext>();
+            var graphics = world.GetExtension<IGraphicsContext>();
+            var bridge = world.GetExtension<InProcessBridge>();
+
+            Console.WriteLine($"Keyboards: {input.Keyboards.Length}");
+            Console.WriteLine($"Mice: {input.Mice.Length}");
+            Console.WriteLine($"Gamepads: {input.ConnectedGamepadCount}");
+
+            // Set up escape handler
+            SetupInputEvents(input);
+
+            // Create the debug scene (must be on render thread)
+            CreateDebugScene(world, graphics);
+
+            // Start IPC server for external connections (fire and forget - runs on background thread)
+            ipcServer = new IpcBridgeServer(bridge, testBridgeOptions.IpcOptions);
+            _ = ipcServer.StartAsync().ContinueWith(t =>
+            {
+                if (t.IsCompletedSuccessfully)
+                {
+                    Console.WriteLine($"IPC server started on pipe: {testBridgeOptions.IpcOptions.PipeName}");
+                }
+                else if (t.IsFaulted)
+                {
+                    Console.WriteLine($"IPC server failed to start: {t.Exception?.InnerException?.Message}");
+                }
+            });
+
+            Console.WriteLine();
+            Console.WriteLine("Ready! Try:");
+            Console.WriteLine("  - Press WASD to see key visualization");
+            Console.WriteLine("  - Click mouse to spawn markers");
+            Console.WriteLine("  - Connect gamepad to see stick markers");
+            Console.WriteLine("  - Use MCP tools to inject virtual input");
+            Console.WriteLine();
+        })
+        .Run();
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Error: {ex.Message}");
+    Console.WriteLine("This sample requires a display.");
+}
+finally
+{
+    // Clean up IPC server
+    if (ipcServer is not null)
+    {
+        ipcServer.StopAsync().GetAwaiter().GetResult();
+        ipcServer.Dispose();
+    }
+}
+
+Console.WriteLine("Sample complete!");
+
+void SetupInputEvents(IInputContext input)
+{
+    var keyboard = input.Keyboard;
+
+    keyboard.OnKeyDown += args =>
+    {
+        if (args.Key == Key.Escape)
+        {
+            Console.WriteLine("Escape pressed - closing...");
+            Environment.Exit(0);
+        }
+    };
+
+    input.OnGamepadConnected += gp =>
+    {
+        Console.WriteLine($"Gamepad connected: {gp.Name} (index {gp.Index})");
+    };
+
+    input.OnGamepadDisconnected += gp =>
+    {
+        Console.WriteLine($"Gamepad disconnected: {gp.Name}");
+    };
+}
+
+void CreateDebugScene(World world, IGraphicsContext graphics)
+{
+    // Create meshes
+    var groundMesh = graphics.CreateQuad(30f, 20f);
+    var cubeMesh = graphics.CreateCube(0.8f);
+    var smallCubeMesh = graphics.CreateCube(0.4f);
+    var markerMesh = graphics.CreateCube(0.5f);
+    var stickMarkerMesh = graphics.CreateCube(0.6f);
+
+    // Camera - top-down view
+    var cameraPos = new Vector3(0, 15, 8);
+    var lookAt = new Vector3(0, 0, 0);
+    var dir = Vector3.Normalize(lookAt - cameraPos);
+    var right = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, dir));
+    var up = Vector3.Cross(dir, right);
+
+    world.Spawn()
+        .With(new Transform3D(
+            cameraPos,
+            Quaternion.CreateFromRotationMatrix(new Matrix4x4(
+                right.X, right.Y, right.Z, 0,
+                up.X, up.Y, up.Z, 0,
+                -dir.X, -dir.Y, -dir.Z, 0,
+                0, 0, 0, 1)),
+            Vector3.One))
+        .With(Camera.CreatePerspective(60f, 16f / 9f, 0.1f, 1000f))
+        .WithTag<MainCameraTag>()
+        .Build();
+
+    // Light
+    world.Spawn()
+        .With(new Transform3D(
+            Vector3.Zero,
+            Quaternion.CreateFromYawPitchRoll(0.3f, -0.7f, 0),
+            Vector3.One))
+        .With(Light.Directional(new Vector3(1f, 0.98f, 0.9f), 1.2f))
+        .Build();
+
+    // Ground
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(0, -0.01f, 0),
+            Quaternion.CreateFromAxisAngle(Vector3.UnitX, -MathF.PI / 2f),
+            Vector3.One))
+        .With(new Renderable(groundMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.2f, 0.25f, 0.2f, 1f),
+            Metallic = 0f,
+            Roughness = 0.95f
+        })
+        .Build();
+
+    // Mouse position marker
+    world.Spawn()
+        .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+        .With(new Renderable(markerMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(1f, 1f, 0f, 1f),
+            Metallic = 0.5f,
+            Roughness = 0.3f
+        })
+        .WithTag<MouseMarkerTag>()
+        .Build();
+
+    // Keyboard visualizers - WASD layout
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.W, new Vector3(0, 0.2f, -3f));
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.A, new Vector3(-0.5f, 0.2f, -2.5f));
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.S, new Vector3(0, 0.2f, -2.5f));
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.D, new Vector3(0.5f, 0.2f, -2.5f));
+
+    // Additional common keys
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.Space, new Vector3(0, 0.2f, -2f));
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.LeftShift, new Vector3(-1f, 0.2f, -2f));
+    CreateKeyVisualizer(world, graphics, smallCubeMesh, Key.LeftControl, new Vector3(-1.5f, 0.2f, -2f));
+
+    // Label cube for keyboard section
+    world.Spawn()
+        .With(new Transform3D(new Vector3(0, 0.01f, -3.6f), Quaternion.Identity, new Vector3(2f, 0.05f, 0.3f)))
+        .With(new Renderable(cubeMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.5f, 0.5f, 0.5f, 1f),
+            Metallic = 0f,
+            Roughness = 0.9f
+        })
+        .Build();
+
+    // Gamepad stick markers
+    // Left stick base
+    world.Spawn()
+        .With(new Transform3D(new Vector3(-6f, 0.05f, 3f), Quaternion.Identity, new Vector3(4.5f, 0.1f, 4.5f)))
+        .With(new Renderable(cubeMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.25f, 0.25f, 0.3f, 1f),
+            Metallic = 0f,
+            Roughness = 0.9f
+        })
+        .Build();
+
+    // Left stick marker
+    world.Spawn()
+        .With(new Transform3D(new Vector3(-6f, 0.5f, 3f), Quaternion.Identity, Vector3.One))
+        .With(new Renderable(stickMarkerMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.3f, 0.7f, 1f, 1f),
+            Metallic = 0.6f,
+            Roughness = 0.3f
+        })
+        .WithTag<LeftStickMarkerTag>()
+        .Build();
+
+    // Right stick base
+    world.Spawn()
+        .With(new Transform3D(new Vector3(-3f, 0.05f, 3f), Quaternion.Identity, new Vector3(4.5f, 0.1f, 4.5f)))
+        .With(new Renderable(cubeMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.25f, 0.25f, 0.3f, 1f),
+            Metallic = 0f,
+            Roughness = 0.9f
+        })
+        .Build();
+
+    // Right stick marker
+    world.Spawn()
+        .With(new Transform3D(new Vector3(-3f, 0.5f, 3f), Quaternion.Identity, Vector3.One))
+        .With(new Renderable(stickMarkerMesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(1f, 0.5f, 0.3f, 1f),
+            Metallic = 0.6f,
+            Roughness = 0.3f
+        })
+        .WithTag<RightStickMarkerTag>()
+        .Build();
+
+    // Gamepad button indicators
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.South, new Vector3(6f, 0.2f, 3f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.East, new Vector3(6.5f, 0.2f, 3.5f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.West, new Vector3(5.5f, 0.2f, 3.5f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.North, new Vector3(6f, 0.2f, 4f));
+
+    // D-pad indicators
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.DPadUp, new Vector3(4f, 0.2f, 4f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.DPadDown, new Vector3(4f, 0.2f, 3f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.DPadLeft, new Vector3(3.5f, 0.2f, 3.5f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.DPadRight, new Vector3(4.5f, 0.2f, 3.5f));
+
+    // Shoulder buttons
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.LeftShoulder, new Vector3(3f, 0.2f, 5f));
+    CreateGamepadButtonVisualizer(world, graphics, smallCubeMesh, GamepadButton.RightShoulder, new Vector3(7f, 0.2f, 5f));
+}
+
+void CreateKeyVisualizer(World world, IGraphicsContext graphics, MeshHandle mesh, Key key, Vector3 position)
+{
+    world.Spawn()
+        .With(new Transform3D(position, Quaternion.Identity, Vector3.One))
+        .With(new Renderable(mesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.4f, 0.4f, 0.4f, 1f),
+            Metallic = 0.2f,
+            Roughness = 0.6f
+        })
+        .WithTag<KeyVisualizerTag>()
+        .With(new KeyBinding { Key = key })
+        .Build();
+}
+
+void CreateGamepadButtonVisualizer(World world, IGraphicsContext graphics, MeshHandle mesh, GamepadButton button, Vector3 position)
+{
+    world.Spawn()
+        .With(new Transform3D(position, Quaternion.Identity, Vector3.One))
+        .With(new Renderable(mesh.Id, 0))
+        .With(new Material
+        {
+            ShaderId = graphics.LitShader.Id,
+            TextureId = graphics.WhiteTexture.Id,
+            Color = new Vector4(0.3f, 0.3f, 0.3f, 1f),
+            Metallic = 0.2f,
+            Roughness = 0.6f
+        })
+        .WithTag<GamepadButtonTag>()
+        .With(new GamepadButtonBinding { Button = button })
+        .Build();
+}

--- a/samples/KeenEyes.Sample.InputDebugger/Systems.cs
+++ b/samples/KeenEyes.Sample.InputDebugger/Systems.cs
@@ -1,0 +1,333 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graphics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.Sample.InputDebugger;
+
+/// <summary>
+/// System that logs input state to the console.
+/// </summary>
+public class InputLogSystem : SystemBase
+{
+    private IInputContext? input;
+    private IGamepad? cachedGamepad;
+    private HashSet<Key> lastPressedKeys = [];
+    private HashSet<Key> currentPressedKeys = [];
+    private MouseButtons lastMouseButtons;
+    private float logTimer;
+    private const float LogInterval = 0.1f;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        input ??= World.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        if (input is null)
+        {
+            return;
+        }
+
+        var keyboard = input.Keyboard;
+        var mouse = input.Mouse;
+
+        // Check for key state changes using GetState() which only returns valid keys
+        currentPressedKeys.Clear();
+        var keyboardState = keyboard.GetState();
+        foreach (var key in keyboardState.PressedKeys)
+        {
+            currentPressedKeys.Add(key);
+        }
+
+        // Log newly pressed keys
+        foreach (var key in currentPressedKeys)
+        {
+            if (!lastPressedKeys.Contains(key))
+            {
+                Console.WriteLine($"[KEY DOWN] {key}");
+            }
+        }
+
+        // Log released keys
+        foreach (var key in lastPressedKeys)
+        {
+            if (!currentPressedKeys.Contains(key))
+            {
+                Console.WriteLine($"[KEY UP] {key}");
+            }
+        }
+
+        // Swap buffers
+        (lastPressedKeys, currentPressedKeys) = (currentPressedKeys, lastPressedKeys);
+
+        // Check mouse button changes
+        var mouseState = mouse.GetState();
+        if (mouseState.PressedButtons != lastMouseButtons)
+        {
+            var changed = mouseState.PressedButtons ^ lastMouseButtons;
+            foreach (MouseButton button in Enum.GetValues<MouseButton>())
+            {
+                var buttonFlag = (MouseButtons)(1 << (int)button);
+                if ((changed & buttonFlag) != 0)
+                {
+                    bool isDown = (mouseState.PressedButtons & buttonFlag) != 0;
+                    Console.WriteLine($"[MOUSE {(isDown ? "DOWN" : "UP")}] {button} at ({mouseState.Position.X:F0}, {mouseState.Position.Y:F0})");
+                }
+            }
+            lastMouseButtons = mouseState.PressedButtons;
+        }
+
+        // Periodic status log
+        logTimer += deltaTime;
+        if (logTimer >= LogInterval)
+        {
+            logTimer = 0;
+
+            cachedGamepad = GetConnectedGamepad(input, cachedGamepad);
+
+            if (cachedGamepad is not null && cachedGamepad.IsConnected)
+            {
+                var left = cachedGamepad.LeftStick;
+                var right = cachedGamepad.RightStick;
+
+                if (left.LengthSquared() > 0.01f || right.LengthSquared() > 0.01f ||
+                    cachedGamepad.LeftTrigger > 0.01f || cachedGamepad.RightTrigger > 0.01f)
+                {
+                    Console.WriteLine($"[GAMEPAD] L:({left.X:+0.00;-0.00},{left.Y:+0.00;-0.00}) R:({right.X:+0.00;-0.00},{right.Y:+0.00;-0.00}) LT:{cachedGamepad.LeftTrigger:F2} RT:{cachedGamepad.RightTrigger:F2}");
+                }
+            }
+        }
+    }
+
+    private static IGamepad? GetConnectedGamepad(IInputContext input, IGamepad? cached)
+    {
+        if (cached is not null && cached.IsConnected)
+        {
+            return cached;
+        }
+
+        var gamepads = input.Gamepads;
+        for (int i = 0; i < gamepads.Length; i++)
+        {
+            if (gamepads[i].IsConnected)
+            {
+                return gamepads[i];
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// System that updates the mouse marker position and spawns click markers.
+/// </summary>
+public class MouseVisualizerSystem : SystemBase
+{
+    private IInputContext? input;
+    private IGraphicsContext? graphics;
+    private MeshHandle? clickMarkerMesh;
+    private const float ClickMarkerDuration = 1.0f;
+    private bool wasLeftDown;
+    private bool wasRightDown;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        input ??= World.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        graphics ??= World.TryGetExtension<IGraphicsContext>(out var gfx) ? gfx : null;
+
+        if (input is null || graphics is null)
+        {
+            return;
+        }
+
+        var mouse = input.Mouse;
+
+        // Convert screen position to world position (on XZ plane at Y=0.1)
+        var normalizedX = (mouse.Position.X / graphics.Width) * 2f - 1f;
+        var normalizedY = -((mouse.Position.Y / graphics.Height) * 2f - 1f);
+        var worldPos = new Vector3(normalizedX * 10f, 0.1f, normalizedY * 5f);
+
+        // Update mouse marker position
+        foreach (var entity in World.Query<Transform3D, MouseMarkerTag>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            transform.Position = worldPos;
+        }
+
+        // Detect click edges (press, not hold)
+        bool isLeftDown = mouse.IsButtonDown(MouseButton.Left);
+        bool isRightDown = mouse.IsButtonDown(MouseButton.Right);
+        bool leftClicked = isLeftDown && !wasLeftDown;
+        bool rightClicked = isRightDown && !wasRightDown;
+        wasLeftDown = isLeftDown;
+        wasRightDown = isRightDown;
+
+        // Spawn click markers on mouse button press
+        if (leftClicked || rightClicked)
+        {
+            clickMarkerMesh ??= graphics.CreateCube(0.3f);
+
+            var color = leftClicked
+                ? new Vector4(1f, 0.2f, 0.2f, 1f)
+                : new Vector4(0.2f, 0.2f, 1f, 1f);
+
+            World.Spawn()
+                .With(new Transform3D(worldPos + Vector3.UnitY * 0.2f, Quaternion.Identity, Vector3.One * 0.5f))
+                .With(new Renderable(clickMarkerMesh.Value.Id, 0))
+                .With(new Material
+                {
+                    ShaderId = graphics.LitShader.Id,
+                    TextureId = graphics.WhiteTexture.Id,
+                    Color = color,
+                    Metallic = 0.8f,
+                    Roughness = 0.2f
+                })
+                .WithTag<ClickMarkerTag>()
+                .With(new FadeOut { TimeRemaining = ClickMarkerDuration, TotalDuration = ClickMarkerDuration })
+                .Build();
+        }
+    }
+}
+
+/// <summary>
+/// System that updates keyboard key visualizers.
+/// </summary>
+public class KeyboardVisualizerSystem : SystemBase
+{
+    private IInputContext? input;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        input ??= World.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        if (input is null)
+        {
+            return;
+        }
+
+        var keyboard = input.Keyboard;
+
+        foreach (var entity in World.Query<KeyBinding, Material, KeyVisualizerTag>())
+        {
+            ref readonly var binding = ref World.Get<KeyBinding>(entity);
+            ref var material = ref World.Get<Material>(entity);
+
+            bool isPressed = keyboard.IsKeyDown(binding.Key);
+
+            material.Color = isPressed
+                ? new Vector4(0.2f, 1f, 0.2f, 1f)
+                : new Vector4(0.4f, 0.4f, 0.4f, 1f);
+        }
+    }
+}
+
+/// <summary>
+/// System that updates gamepad visualizers.
+/// </summary>
+public class GamepadVisualizerSystem : SystemBase
+{
+    private IInputContext? input;
+    private IGamepad? cachedGamepad;
+    private const float StickRange = 2f;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        input ??= World.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        if (input is null)
+        {
+            return;
+        }
+
+        cachedGamepad = GetConnectedGamepad(input, cachedGamepad);
+        if (cachedGamepad is null)
+        {
+            return;
+        }
+
+        var leftStick = cachedGamepad.LeftStick;
+        var rightStick = cachedGamepad.RightStick;
+
+        foreach (var entity in World.Query<Transform3D, LeftStickMarkerTag>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            transform.Position = new Vector3(-6f + leftStick.X * StickRange, 0.5f, 3f + leftStick.Y * StickRange);
+        }
+
+        foreach (var entity in World.Query<Transform3D, RightStickMarkerTag>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            transform.Position = new Vector3(-3f + rightStick.X * StickRange, 0.5f, 3f + rightStick.Y * StickRange);
+        }
+
+        foreach (var entity in World.Query<GamepadButtonBinding, Material, GamepadButtonTag>())
+        {
+            ref readonly var binding = ref World.Get<GamepadButtonBinding>(entity);
+            ref var material = ref World.Get<Material>(entity);
+
+            bool isPressed = cachedGamepad.IsButtonDown(binding.Button);
+
+            material.Color = isPressed
+                ? new Vector4(1f, 0.8f, 0.2f, 1f)
+                : new Vector4(0.3f, 0.3f, 0.3f, 1f);
+        }
+    }
+
+    private static IGamepad? GetConnectedGamepad(IInputContext input, IGamepad? cached)
+    {
+        if (cached is not null && cached.IsConnected)
+        {
+            return cached;
+        }
+
+        var gamepads = input.Gamepads;
+        for (int i = 0; i < gamepads.Length; i++)
+        {
+            if (gamepads[i].IsConnected)
+            {
+                return gamepads[i];
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// System that handles fading out and removing click markers.
+/// </summary>
+public class FadeOutSystem : SystemBase
+{
+    private readonly List<Entity> toRemove = [];
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        toRemove.Clear();
+
+        foreach (var entity in World.Query<FadeOut, Material>())
+        {
+            ref var fadeOut = ref World.Get<FadeOut>(entity);
+            ref var material = ref World.Get<Material>(entity);
+
+            fadeOut.TimeRemaining -= deltaTime;
+
+            if (fadeOut.TimeRemaining <= 0)
+            {
+                toRemove.Add(entity);
+            }
+            else
+            {
+                float alpha = fadeOut.TimeRemaining / fadeOut.TotalDuration;
+                material.Color = new Vector4(material.Color.X, material.Color.Y, material.Color.Z, alpha);
+            }
+        }
+
+        foreach (var entity in toRemove)
+        {
+            World.Despawn(entity);
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.InputDebugger/packages.lock.json
+++ b/samples/KeenEyes.Sample.InputDebugger/packages.lock.json
@@ -1,0 +1,308 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
+      "Cyotek.Drawing.BitmapFont": {
+        "type": "Transitive",
+        "resolved": "2.0.4",
+        "contentHash": "iA6WehGVdMUuNbfsQQDq/Bt+mMd/OqHjiMUtKFLIQd/0pyYh4ehT7FEjTxN9/4OXNKQZsp9bAJgltP2nnswUJg=="
+      },
+      "FontStashSharp.Base": {
+        "type": "Transitive",
+        "resolved": "1.2.2",
+        "contentHash": "t2PT+/Sat9WPLm4AVYU1Aa/PrOgNQ4npSUGDHTYufXzLUHxrN3+BaRhAU0DZXkJNfuGCS5iKaQNopNXe9ES24g=="
+      },
+      "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.2.2",
+        "contentHash": "OoXoGkxNMhyQeYR/wjeN6Bs8Guea7FisKXLcVJdeNtSYT+5iKxIh4ETi9x9OIk7GEQtNbE0yVhG3rb8RS04Kmg==",
+        "dependencies": {
+          "FontStashSharp.Base": "1.2.2",
+          "StbTrueTypeSharp": "1.26.12"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "NSmDw3K0ozNDgShSIpsZcbFIzBX4w28nDag+TfaQujkXGazBm+lid5onlWoCBy4VsLxqnnKjEBbGSJVWJMf43g=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "XbDilPmvsQIrvxZkeVCNNX3LyRtA3hN6UykAiyZjlu/JkYh68U3WQummpP+j7jsxlX8s/pOrrU3vbN8LnMl0VA==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "8.0.0"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "I1u6CmwwtD+5OIHditbMBVHRQUHZWhfW3Z38mvydxwkZpAvjs5BCxyen6ecOVpbYD6I0EOjZ42M3IsaZbwiYUg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "DZy30akJABBmTnn8OICik0TFEuXrkd7YCQvoq+oh50eJzXt8JgEYYa+sJYBib/Phs5WULZg/QR7fM8Gi1G3tXg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "LZPZT1e/RxnjKfkqlp2Wp8KJFP1Av/ErTCZ00EzZpFR1lhUSBgSmgJwXg6XlWoEJHyeJcsXV688zjoEe6YW0BA==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "ynasHSQ4jGrmpn/07UagE3qVNRLzWvg+fbM8uHI0d5LF95y++Kuno42QLkP/UEruC1YovI+NRhMfGJy0gDQaZg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Maths": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "hBNxNSLvx/jdfvbU6oCsXcgLfqf9hMlEc6Mq/rllJ0eUTLloacuOZHTM8V702QGf7hOR+Mo4bTFqTqBnC0CM7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.22.0",
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.26.12",
+        "contentHash": "hCc6/OsfcPa5VsLECcEU2m78WOshBrKwK42nAodSm9Z5wH68f7n66SoiRLCdGCkDaqbWz2TlX4zYHIjogj1HJA=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.silk": {
+        "type": "Project",
+        "dependencies": {
+          "FontStashSharp.PlatformAgnostic": "[1.5.2, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Maths": "[2.22.0, )",
+          "Silk.NET.OpenGL": "[2.22.0, )"
+        }
+      },
+      "keeneyes.input": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.22.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.22.0, )",
+          "Silk.NET.Windowing": "[2.22.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.22.0, )",
+          "Silk.NET.Windowing": "[2.22.0, )"
+        }
+      },
+      "keeneyes.runtime": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
+        }
+      },
+      "keeneyes.testbridge.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge.ipc": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "FontStashSharp.PlatformAgnostic": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "/Srtf2DyIBBTbaZ4jpOQZnGFoEcbiXPMZnPuSft8MkMdbMYgCXPD5S123a992qTGVFKQjD9IGapd7Kyg2GD6sw==",
+        "dependencies": {
+          "Cyotek.Drawing.BitmapFont": "2.0.4",
+          "FontStashSharp.Base": "1.2.2",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.2",
+          "StbImageSharp": "2.30.15"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "1gqbKHrKpBv2Vk983kVpMqXL4Uj36NaUIQ2YbQosFVa3pXJE8UMGiWqKtaeoMqnzItusZ1WYgDHKge37EvNm/w==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Input.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "W9b5UlUGCu5Ywb5f8ZyIWJ475ucY+mT/nEiSTo3JH098VxHaZS/02bYr9f29VWBaJhh3DwMkfxQvgTyXzTrHyw=="
+      },
+      "Silk.NET.OpenGL": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "AmbtflPvaGWw7fHEHrcFTd54OTAj0bemzx4WV2ELJdW2NBPSvtyz31nhyuBVTml20+NtW4Z3yhDGUpM6uouVDQ==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Maths": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "yKGe/8REdm+T43LdtfUpFUx9eQARwx6wTmEoJ2bANVGQPCvWYC2Qi1+haT6n63dyNIX+iJWKg4++F4TFjg0/Fw==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
+      }
+    }
+  }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -1,3 +1,4 @@
+using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -69,6 +70,22 @@ public interface ITestBridge : IDisposable
     /// Gets the log controller for querying application logs.
     /// </summary>
     ILogController Logs { get; }
+
+    /// <summary>
+    /// Gets the input context used by this bridge.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the bridge is installed as a plugin, this context is registered as the
+    /// World's <see cref="IInputContext"/> extension. This enables both real hardware
+    /// input and virtual TestBridge-injected input to work together.
+    /// </para>
+    /// <para>
+    /// For in-process testing, you can use this directly to query input state or
+    /// inject virtual input via the underlying mock context.
+    /// </para>
+    /// </remarks>
+    IInputContext InputContext { get; }
 
     /// <summary>
     /// Executes a command and returns the result.

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -93,6 +94,14 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public ILogController Logs { get; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Direct input context access is not supported over IPC. Use the <see cref="Input"/>
+    /// controller to inject input events, which will be forwarded to the server.
+    /// </remarks>
+    public IInputContext InputContext => throw new NotSupportedException(
+        "Direct input context access is not supported over IPC. Use the Input controller to inject input events.");
 
     /// <summary>
     /// Raised when the connection state changes.

--- a/src/KeenEyes.TestBridge/Input/CompositeGamepad.cs
+++ b/src/KeenEyes.TestBridge/Input/CompositeGamepad.cs
@@ -1,0 +1,155 @@
+using System.Numerics;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.TestBridge.Input;
+
+/// <summary>
+/// A gamepad implementation that merges input from real and virtual sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CompositeGamepad allows both real hardware input and virtual (TestBridge-injected)
+/// input to work together. Button states return true if EITHER source has the button pressed.
+/// Analog values use the greater magnitude between real and virtual input.
+/// Events are forwarded from BOTH sources.
+/// </para>
+/// <para>
+/// This enables hybrid testing scenarios where real user input and automated test
+/// input can coexist.
+/// </para>
+/// </remarks>
+internal sealed class CompositeGamepad : IGamepad
+{
+    private readonly IGamepad real;
+    private readonly IGamepad virtual_;
+
+    /// <summary>
+    /// Creates a new composite gamepad merging real and virtual input.
+    /// </summary>
+    /// <param name="real">The real hardware gamepad.</param>
+    /// <param name="virtual_">The virtual (mock) gamepad for TestBridge injection.</param>
+    public CompositeGamepad(IGamepad real, IGamepad virtual_)
+    {
+        this.real = real;
+        this.virtual_ = virtual_;
+
+        // Forward events from both sources
+        real.OnButtonDown += args => OnButtonDown?.Invoke(args);
+        real.OnButtonUp += args => OnButtonUp?.Invoke(args);
+        real.OnAxisChanged += args => OnAxisChanged?.Invoke(args);
+        real.OnConnected += g => OnConnected?.Invoke(this);
+        real.OnDisconnected += g => OnDisconnected?.Invoke(this);
+
+        virtual_.OnButtonDown += args => OnButtonDown?.Invoke(args);
+        virtual_.OnButtonUp += args => OnButtonUp?.Invoke(args);
+        virtual_.OnAxisChanged += args => OnAxisChanged?.Invoke(args);
+        virtual_.OnConnected += g => OnConnected?.Invoke(this);
+        virtual_.OnDisconnected += g => OnDisconnected?.Invoke(this);
+    }
+
+    /// <inheritdoc />
+    public int Index => real.Index;
+
+    /// <inheritdoc />
+    public bool IsConnected => real.IsConnected || virtual_.IsConnected;
+
+    /// <inheritdoc />
+    public string Name => real.Name;
+
+    /// <inheritdoc />
+    public GamepadState GetState()
+    {
+        var realState = real.GetState();
+        var virtualState = virtual_.GetState();
+
+        // Merge button states (OR them together)
+        var mergedButtons = realState.PressedButtons | virtualState.PressedButtons;
+
+        // Merge sticks - use the one with greater magnitude
+        var leftStick = MergeSticks(realState.LeftStick, virtualState.LeftStick);
+        var rightStick = MergeSticks(realState.RightStick, virtualState.RightStick);
+
+        // Merge triggers - use the higher value
+        var leftTrigger = Math.Max(realState.LeftTrigger, virtualState.LeftTrigger);
+        var rightTrigger = Math.Max(realState.RightTrigger, virtualState.RightTrigger);
+
+        return new GamepadState(
+            Index,
+            IsConnected,
+            mergedButtons,
+            leftStick,
+            rightStick,
+            leftTrigger,
+            rightTrigger);
+    }
+
+    /// <inheritdoc />
+    public bool IsButtonDown(GamepadButton button) => real.IsButtonDown(button) || virtual_.IsButtonDown(button);
+
+    /// <inheritdoc />
+    public bool IsButtonUp(GamepadButton button) => real.IsButtonUp(button) && virtual_.IsButtonUp(button);
+
+    /// <inheritdoc />
+    public float GetAxis(GamepadAxis axis)
+    {
+        var realValue = real.GetAxis(axis);
+        var virtualValue = virtual_.GetAxis(axis);
+
+        // For triggers, use max value
+        if (axis is GamepadAxis.LeftTrigger or GamepadAxis.RightTrigger)
+        {
+            return Math.Max(realValue, virtualValue);
+        }
+
+        // For sticks, use the one with greater magnitude
+        return Math.Abs(virtualValue) > Math.Abs(realValue) ? virtualValue : realValue;
+    }
+
+    /// <inheritdoc />
+    public Vector2 LeftStick => MergeSticks(real.LeftStick, virtual_.LeftStick);
+
+    /// <inheritdoc />
+    public Vector2 RightStick => MergeSticks(real.RightStick, virtual_.RightStick);
+
+    /// <inheritdoc />
+    public float LeftTrigger => Math.Max(real.LeftTrigger, virtual_.LeftTrigger);
+
+    /// <inheritdoc />
+    public float RightTrigger => Math.Max(real.RightTrigger, virtual_.RightTrigger);
+
+    /// <inheritdoc />
+    public void SetVibration(float leftMotor, float rightMotor)
+    {
+        // Vibration goes to real hardware only
+        real.SetVibration(leftMotor, rightMotor);
+    }
+
+    /// <inheritdoc />
+    public void StopVibration()
+    {
+        real.StopVibration();
+    }
+
+    /// <inheritdoc />
+    public event Action<GamepadButtonEventArgs>? OnButtonDown;
+
+    /// <inheritdoc />
+    public event Action<GamepadButtonEventArgs>? OnButtonUp;
+
+    /// <inheritdoc />
+    public event Action<GamepadAxisEventArgs>? OnAxisChanged;
+
+    /// <inheritdoc />
+    public event Action<IGamepad>? OnConnected;
+
+    /// <inheritdoc />
+    public event Action<IGamepad>? OnDisconnected;
+
+    private static Vector2 MergeSticks(Vector2 real, Vector2 virtual_)
+    {
+        // Use the stick with greater magnitude
+        var realMag = real.LengthSquared();
+        var virtualMag = virtual_.LengthSquared();
+        return virtualMag > realMag ? virtual_ : real;
+    }
+}

--- a/src/KeenEyes.TestBridge/Input/CompositeInputContext.cs
+++ b/src/KeenEyes.TestBridge/Input/CompositeInputContext.cs
@@ -1,0 +1,376 @@
+using System.Collections.Immutable;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Testing.Input;
+
+namespace KeenEyes.TestBridge.Input;
+
+/// <summary>
+/// An input context that merges real hardware input with virtual TestBridge input.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CompositeInputContext enables hybrid testing scenarios where both real user input
+/// and TestBridge-injected input can work together. State queries return true if
+/// EITHER source has the input active. Events are forwarded from BOTH sources.
+/// </para>
+/// <para>
+/// This allows automated tests to inject input while still allowing manual interaction,
+/// which is useful for debugging and interactive testing scenarios.
+/// </para>
+/// <para>
+/// Device wrappers are created lazily to support input contexts that aren't
+/// initialized until a window loads (like SilkInputContext).
+/// </para>
+/// </remarks>
+public sealed class CompositeInputContext : IInputContext
+{
+    private readonly IInputContext real;
+    private readonly MockInputContext virtual_;
+    private CompositeKeyboard? keyboard;
+    private CompositeMouse? mouse;
+    private ImmutableArray<CompositeGamepad>? gamepads;
+    private bool eventsWired;
+    private bool disposed;
+
+    /// <summary>
+    /// Creates a new composite input context merging real and virtual input.
+    /// </summary>
+    /// <param name="real">The real hardware input context.</param>
+    /// <param name="virtual_">The virtual (mock) input context for TestBridge injection.</param>
+    public CompositeInputContext(IInputContext real, MockInputContext virtual_)
+    {
+        this.real = real;
+        this.virtual_ = virtual_;
+
+        // Wire virtual events immediately (mock is always ready)
+        WireVirtualEvents();
+    }
+
+    /// <summary>
+    /// Gets the underlying mock input context for direct TestBridge access.
+    /// </summary>
+    /// <remarks>
+    /// Use this to inject virtual input via the TestBridge.
+    /// </remarks>
+    public MockInputContext VirtualInput => virtual_;
+
+    #region Lazy Initialization
+
+    private void EnsureInitialized()
+    {
+        if (keyboard is not null)
+        {
+            return;
+        }
+
+        // Create composite devices
+        keyboard = new CompositeKeyboard(real.Keyboard, virtual_.Keyboard);
+        mouse = new CompositeMouse(real.Mouse, virtual_.Mouse);
+
+        // Create composite gamepads (match the count from virtual context)
+        var gamepadBuilder = ImmutableArray.CreateBuilder<CompositeGamepad>();
+        var virtualGamepads = virtual_.Gamepads;
+        var realGamepads = real.Gamepads;
+
+        for (int i = 0; i < virtualGamepads.Length; i++)
+        {
+            var realPad = i < realGamepads.Length ? realGamepads[i] : virtualGamepads[i];
+            gamepadBuilder.Add(new CompositeGamepad(realPad, virtualGamepads[i]));
+        }
+
+        gamepads = gamepadBuilder.ToImmutable();
+
+        // Wire up real events now that devices are available
+        if (!eventsWired)
+        {
+            eventsWired = true;
+            WireRealEvents();
+        }
+    }
+
+    #endregion
+
+    #region IInputContext Implementation
+
+    /// <inheritdoc />
+    public IKeyboard Keyboard
+    {
+        get
+        {
+            EnsureInitialized();
+            return keyboard!;
+        }
+    }
+
+    /// <inheritdoc />
+    public IMouse Mouse
+    {
+        get
+        {
+            EnsureInitialized();
+            return mouse!;
+        }
+    }
+
+    /// <inheritdoc />
+    public IGamepad Gamepad
+    {
+        get
+        {
+            EnsureInitialized();
+            return gamepads!.Value.Length > 0
+                ? gamepads!.Value[0]
+                : throw new InvalidOperationException("No gamepads available.");
+        }
+    }
+
+    /// <inheritdoc />
+    public ImmutableArray<IKeyboard> Keyboards
+    {
+        get
+        {
+            EnsureInitialized();
+            return [keyboard!];
+        }
+    }
+
+    /// <inheritdoc />
+    public ImmutableArray<IMouse> Mice
+    {
+        get
+        {
+            EnsureInitialized();
+            return [mouse!];
+        }
+    }
+
+    /// <inheritdoc />
+    public ImmutableArray<IGamepad> Gamepads
+    {
+        get
+        {
+            EnsureInitialized();
+            return gamepads!.Value.CastArray<IGamepad>();
+        }
+    }
+
+    /// <inheritdoc />
+    public int ConnectedGamepadCount
+    {
+        get
+        {
+            EnsureInitialized();
+            return gamepads!.Value.Count(g => g.IsConnected);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Update()
+    {
+        // Update both underlying contexts
+        real.Update();
+        virtual_.Update();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // Note: We don't dispose the underlying contexts here
+        // as they may be owned by other systems (plugins, etc.)
+        // The caller is responsible for disposing them appropriately.
+    }
+
+    #endregion
+
+    #region Global Events
+
+    /// <inheritdoc />
+    public event Action<IKeyboard, KeyEventArgs>? OnKeyDown;
+
+    /// <inheritdoc />
+    public event Action<IKeyboard, KeyEventArgs>? OnKeyUp;
+
+    /// <inheritdoc />
+    public event Action<IKeyboard, char>? OnTextInput;
+
+    /// <inheritdoc />
+    public event Action<IMouse, MouseButtonEventArgs>? OnMouseButtonDown;
+
+    /// <inheritdoc />
+    public event Action<IMouse, MouseButtonEventArgs>? OnMouseButtonUp;
+
+    /// <inheritdoc />
+    public event Action<IMouse, MouseMoveEventArgs>? OnMouseMove;
+
+    /// <inheritdoc />
+    public event Action<IMouse, MouseScrollEventArgs>? OnMouseScroll;
+
+    /// <inheritdoc />
+    public event Action<IGamepad, GamepadButtonEventArgs>? OnGamepadButtonDown;
+
+    /// <inheritdoc />
+    public event Action<IGamepad, GamepadButtonEventArgs>? OnGamepadButtonUp;
+
+    /// <inheritdoc />
+    public event Action<IGamepad>? OnGamepadConnected;
+
+    /// <inheritdoc />
+    public event Action<IGamepad>? OnGamepadDisconnected;
+
+    #endregion
+
+    #region Event Wiring
+
+    private void WireRealEvents()
+    {
+        real.OnKeyDown += (kb, args) => OnKeyDown?.Invoke(keyboard!, args);
+        real.OnKeyUp += (kb, args) => OnKeyUp?.Invoke(keyboard!, args);
+        real.OnTextInput += (kb, c) => OnTextInput?.Invoke(keyboard!, c);
+
+        real.OnMouseButtonDown += (m, args) => OnMouseButtonDown?.Invoke(mouse!, args);
+        real.OnMouseButtonUp += (m, args) => OnMouseButtonUp?.Invoke(mouse!, args);
+        real.OnMouseMove += (m, args) => OnMouseMove?.Invoke(mouse!, args);
+        real.OnMouseScroll += (m, args) => OnMouseScroll?.Invoke(mouse!, args);
+
+        real.OnGamepadButtonDown += (g, args) => OnGamepadButtonDown?.Invoke(GetCompositeGamepad(g.Index), args);
+        real.OnGamepadButtonUp += (g, args) => OnGamepadButtonUp?.Invoke(GetCompositeGamepad(g.Index), args);
+        real.OnGamepadConnected += g => OnGamepadConnected?.Invoke(GetCompositeGamepad(g.Index));
+        real.OnGamepadDisconnected += g => OnGamepadDisconnected?.Invoke(GetCompositeGamepad(g.Index));
+    }
+
+    private void WireVirtualEvents()
+    {
+        // Wire virtual events with null checks for lazy keyboard/mouse
+        virtual_.OnKeyDown += (kb, args) =>
+        {
+            if (keyboard is not null)
+            {
+                OnKeyDown?.Invoke(keyboard, args);
+            }
+            else
+            {
+                // Forward with virtual keyboard if composite not yet initialized
+                OnKeyDown?.Invoke(kb, args);
+            }
+        };
+
+        virtual_.OnKeyUp += (kb, args) =>
+        {
+            if (keyboard is not null)
+            {
+                OnKeyUp?.Invoke(keyboard, args);
+            }
+            else
+            {
+                OnKeyUp?.Invoke(kb, args);
+            }
+        };
+
+        virtual_.OnTextInput += (kb, c) =>
+        {
+            if (keyboard is not null)
+            {
+                OnTextInput?.Invoke(keyboard, c);
+            }
+            else
+            {
+                OnTextInput?.Invoke(kb, c);
+            }
+        };
+
+        virtual_.OnMouseButtonDown += (m, args) =>
+        {
+            if (mouse is not null)
+            {
+                OnMouseButtonDown?.Invoke(mouse, args);
+            }
+            else
+            {
+                OnMouseButtonDown?.Invoke(m, args);
+            }
+        };
+
+        virtual_.OnMouseButtonUp += (m, args) =>
+        {
+            if (mouse is not null)
+            {
+                OnMouseButtonUp?.Invoke(mouse, args);
+            }
+            else
+            {
+                OnMouseButtonUp?.Invoke(m, args);
+            }
+        };
+
+        virtual_.OnMouseMove += (m, args) =>
+        {
+            if (mouse is not null)
+            {
+                OnMouseMove?.Invoke(mouse, args);
+            }
+            else
+            {
+                OnMouseMove?.Invoke(m, args);
+            }
+        };
+
+        virtual_.OnMouseScroll += (m, args) =>
+        {
+            if (mouse is not null)
+            {
+                OnMouseScroll?.Invoke(mouse, args);
+            }
+            else
+            {
+                OnMouseScroll?.Invoke(m, args);
+            }
+        };
+
+        virtual_.OnGamepadButtonDown += (g, args) =>
+        {
+            var composite = gamepads.HasValue && g.Index < gamepads.Value.Length
+                ? gamepads.Value[g.Index]
+                : g;
+            OnGamepadButtonDown?.Invoke(composite, args);
+        };
+
+        virtual_.OnGamepadButtonUp += (g, args) =>
+        {
+            var composite = gamepads.HasValue && g.Index < gamepads.Value.Length
+                ? gamepads.Value[g.Index]
+                : g;
+            OnGamepadButtonUp?.Invoke(composite, args);
+        };
+
+        virtual_.OnGamepadConnected += g =>
+        {
+            var composite = gamepads.HasValue && g.Index < gamepads.Value.Length
+                ? gamepads.Value[g.Index]
+                : g;
+            OnGamepadConnected?.Invoke(composite);
+        };
+
+        virtual_.OnGamepadDisconnected += g =>
+        {
+            var composite = gamepads.HasValue && g.Index < gamepads.Value.Length
+                ? gamepads.Value[g.Index]
+                : g;
+            OnGamepadDisconnected?.Invoke(composite);
+        };
+    }
+
+    private IGamepad GetCompositeGamepad(int index)
+    {
+        EnsureInitialized();
+        return index >= 0 && index < gamepads!.Value.Length ? gamepads!.Value[index] : Gamepad;
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/Input/CompositeKeyboard.cs
+++ b/src/KeenEyes.TestBridge/Input/CompositeKeyboard.cs
@@ -1,0 +1,77 @@
+using System.Collections.Immutable;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.TestBridge.Input;
+
+/// <summary>
+/// A keyboard implementation that merges input from real and virtual sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CompositeKeyboard allows both real hardware input and virtual (TestBridge-injected)
+/// input to work together. State queries return true if EITHER source has the key pressed.
+/// Events are forwarded from BOTH sources.
+/// </para>
+/// <para>
+/// This enables hybrid testing scenarios where real user input and automated test
+/// input can coexist.
+/// </para>
+/// </remarks>
+internal sealed class CompositeKeyboard : IKeyboard
+{
+    private readonly IKeyboard real;
+    private readonly IKeyboard virtual_;
+
+    /// <summary>
+    /// Creates a new composite keyboard merging real and virtual input.
+    /// </summary>
+    /// <param name="real">The real hardware keyboard.</param>
+    /// <param name="virtual_">The virtual (mock) keyboard for TestBridge injection.</param>
+    public CompositeKeyboard(IKeyboard real, IKeyboard virtual_)
+    {
+        this.real = real;
+        this.virtual_ = virtual_;
+
+        // Forward events from both sources
+        real.OnKeyDown += args => OnKeyDown?.Invoke(args);
+        real.OnKeyUp += args => OnKeyUp?.Invoke(args);
+        real.OnTextInput += c => OnTextInput?.Invoke(c);
+
+        virtual_.OnKeyDown += args => OnKeyDown?.Invoke(args);
+        virtual_.OnKeyUp += args => OnKeyUp?.Invoke(args);
+        virtual_.OnTextInput += c => OnTextInput?.Invoke(c);
+    }
+
+    /// <inheritdoc />
+    public KeyboardState GetState()
+    {
+        var realState = real.GetState();
+        var virtualState = virtual_.GetState();
+
+        // Merge pressed keys from both sources
+        var mergedKeys = realState.PressedKeys.Union(virtualState.PressedKeys);
+
+        // Merge modifiers (OR them together)
+        var mergedModifiers = realState.Modifiers | virtualState.Modifiers;
+
+        return new KeyboardState(mergedKeys, mergedModifiers);
+    }
+
+    /// <inheritdoc />
+    public bool IsKeyDown(Key key) => real.IsKeyDown(key) || virtual_.IsKeyDown(key);
+
+    /// <inheritdoc />
+    public bool IsKeyUp(Key key) => real.IsKeyUp(key) && virtual_.IsKeyUp(key);
+
+    /// <inheritdoc />
+    public KeyModifiers Modifiers => real.Modifiers | virtual_.Modifiers;
+
+    /// <inheritdoc />
+    public event Action<KeyEventArgs>? OnKeyDown;
+
+    /// <inheritdoc />
+    public event Action<KeyEventArgs>? OnKeyUp;
+
+    /// <inheritdoc />
+    public event Action<char>? OnTextInput;
+}

--- a/src/KeenEyes.TestBridge/Input/CompositeMouse.cs
+++ b/src/KeenEyes.TestBridge/Input/CompositeMouse.cs
@@ -1,0 +1,130 @@
+using System.Numerics;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.TestBridge.Input;
+
+/// <summary>
+/// A mouse implementation that merges input from real and virtual sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CompositeMouse allows both real hardware input and virtual (TestBridge-injected)
+/// input to work together. Button states return true if EITHER source has the button pressed.
+/// Position uses virtual if explicitly set, otherwise real.
+/// Events are forwarded from BOTH sources.
+/// </para>
+/// <para>
+/// This enables hybrid testing scenarios where real user input and automated test
+/// input can coexist.
+/// </para>
+/// </remarks>
+internal sealed class CompositeMouse : IMouse
+{
+    private readonly IMouse real;
+    private readonly IMouse virtual_;
+    private bool virtualPositionActive;
+
+    /// <summary>
+    /// Creates a new composite mouse merging real and virtual input.
+    /// </summary>
+    /// <param name="real">The real hardware mouse.</param>
+    /// <param name="virtual_">The virtual (mock) mouse for TestBridge injection.</param>
+    public CompositeMouse(IMouse real, IMouse virtual_)
+    {
+        this.real = real;
+        this.virtual_ = virtual_;
+
+        // Forward events from both sources
+        real.OnButtonDown += args => OnButtonDown?.Invoke(args);
+        real.OnButtonUp += args => OnButtonUp?.Invoke(args);
+        real.OnMove += args => OnMove?.Invoke(args);
+        real.OnScroll += args => OnScroll?.Invoke(args);
+        real.OnEnter += () => OnEnter?.Invoke();
+        real.OnLeave += () => OnLeave?.Invoke();
+
+        virtual_.OnButtonDown += args => OnButtonDown?.Invoke(args);
+        virtual_.OnButtonUp += args => OnButtonUp?.Invoke(args);
+        virtual_.OnMove += args =>
+        {
+            virtualPositionActive = true;
+            OnMove?.Invoke(args);
+        };
+        virtual_.OnScroll += args => OnScroll?.Invoke(args);
+        virtual_.OnEnter += () => OnEnter?.Invoke();
+        virtual_.OnLeave += () => OnLeave?.Invoke();
+    }
+
+    /// <inheritdoc />
+    public MouseState GetState()
+    {
+        var realState = real.GetState();
+        var virtualState = virtual_.GetState();
+
+        // Use virtual position if it's been set, otherwise real
+        var position = virtualPositionActive ? virtualState.Position : realState.Position;
+
+        // Merge button states (OR them together)
+        var mergedButtons = realState.PressedButtons | virtualState.PressedButtons;
+
+        // Merge scroll deltas (add them)
+        var mergedScroll = realState.ScrollDelta + virtualState.ScrollDelta;
+
+        return new MouseState(position, mergedButtons, mergedScroll);
+    }
+
+    /// <inheritdoc />
+    public Vector2 Position => virtualPositionActive ? virtual_.Position : real.Position;
+
+    /// <inheritdoc />
+    public bool IsButtonDown(MouseButton button) => real.IsButtonDown(button) || virtual_.IsButtonDown(button);
+
+    /// <inheritdoc />
+    public bool IsButtonUp(MouseButton button) => real.IsButtonUp(button) && virtual_.IsButtonUp(button);
+
+    /// <inheritdoc />
+    public bool IsCursorVisible
+    {
+        get => real.IsCursorVisible;
+        set => real.IsCursorVisible = value;
+    }
+
+    /// <inheritdoc />
+    public bool IsCursorCaptured
+    {
+        get => real.IsCursorCaptured;
+        set => real.IsCursorCaptured = value;
+    }
+
+    /// <inheritdoc />
+    public void SetPosition(Vector2 position)
+    {
+        // Setting position explicitly goes to real mouse (hardware cursor)
+        real.SetPosition(position);
+    }
+
+    /// <summary>
+    /// Resets the virtual position tracking, allowing real position to be used.
+    /// </summary>
+    public void ResetVirtualPosition()
+    {
+        virtualPositionActive = false;
+    }
+
+    /// <inheritdoc />
+    public event Action<MouseButtonEventArgs>? OnButtonDown;
+
+    /// <inheritdoc />
+    public event Action<MouseButtonEventArgs>? OnButtonUp;
+
+    /// <inheritdoc />
+    public event Action<MouseMoveEventArgs>? OnMove;
+
+    /// <inheritdoc />
+    public event Action<MouseScrollEventArgs>? OnScroll;
+
+    /// <inheritdoc />
+    public event Action? OnEnter;
+
+    /// <inheritdoc />
+    public event Action? OnLeave;
+}

--- a/src/KeenEyes.TestBridge/Input/InputControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/Input/InputControllerImpl.cs
@@ -10,6 +10,11 @@ namespace KeenEyes.TestBridge.Input;
 /// </summary>
 internal sealed class InputControllerImpl(MockInputContext inputContext) : IInputController
 {
+    /// <summary>
+    /// Default hold duration for key presses (50ms, roughly 3 frames at 60fps).
+    /// This ensures the key press spans at least one frame and is detected by polling-based systems.
+    /// </summary>
+    private static readonly TimeSpan defaultKeyHoldDuration = TimeSpan.FromMilliseconds(50);
     private readonly Dictionary<string, bool> actionStates = [];
     private readonly Dictionary<string, float> actionValues = [];
     private readonly Dictionary<string, (float X, float Y)> actionVectors = [];
@@ -30,13 +35,10 @@ internal sealed class InputControllerImpl(MockInputContext inputContext) : IInpu
 
     public async Task KeyPressAsync(Key key, KeyModifiers modifiers = KeyModifiers.None, TimeSpan? holdDuration = null)
     {
+        var actualDuration = holdDuration ?? defaultKeyHoldDuration;
+
         await KeyDownAsync(key, modifiers);
-
-        if (holdDuration.HasValue && holdDuration.Value > TimeSpan.Zero)
-        {
-            await Task.Delay(holdDuration.Value);
-        }
-
+        await Task.Delay(actualDuration);
         await KeyUpAsync(key, modifiers);
     }
 

--- a/src/KeenEyes.TestBridge/TestBridgeOptions.cs
+++ b/src/KeenEyes.TestBridge/TestBridgeOptions.cs
@@ -58,6 +58,21 @@ public sealed record TestBridgeOptions
     /// </para>
     /// </remarks>
     public ILogQueryable? LogQueryable { get; init; }
+
+    /// <summary>
+    /// Gets or sets the real hardware input context to merge with virtual input.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, the TestBridge creates a composite input context that merges
+    /// both real hardware input and virtual TestBridge-injected input. This enables
+    /// hybrid testing scenarios where both can work together.
+    /// </para>
+    /// <para>
+    /// If null, only virtual input is available (useful for headless testing).
+    /// </para>
+    /// </remarks>
+    public IInputContext? RealInputContext { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Add CompositeInputContext that merges real hardware input with virtual TestBridge-injected input, enabling MCP tools to inject input while real hardware input continues working
- Add InputDebugger sample (`samples/KeenEyes.Sample.InputDebugger`) for testing and visualizing input from both sources
- Enable hybrid input mode in the editor for both editor UI and scene TestBridges

## Changes
- **New composite input wrappers**: `CompositeInputContext`, `CompositeKeyboard`, `CompositeMouse`, `CompositeGamepad` in `src/KeenEyes.TestBridge/Input/`
- **TestBridge API**: Added `InputContext` property to `ITestBridge` interface and `RealInputContext` option to `TestBridgeOptions`
- **Default key hold duration**: Added 50ms default for `KeyPressAsync` to ensure key presses are detected by polling-based systems
- **Editor integration**: Updated `TestBridgeManager` to accept real input context, enabled hybrid mode for both editor and scene TestBridges

## Test plan
- [x] All 12,981 tests pass (61 skipped as expected)
- [x] Manual testing with InputDebugger sample confirms hybrid mode works:
  - Physical keyboard/mouse input is detected
  - MCP-injected input via `input_key_press` is detected
  - Both sources work simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)