### PR TITLE
docs: Consolidate CLAUDE.md by removing duplicated content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,34 +8,30 @@ For contribution guidelines, design philosophy, and PR requirements, see [CONTRI
 
 KeenEyes is a high-performance Entity Component System (ECS) framework for .NET 10, reimplementing [OrionECS](https://github.com/tyevco/OrionECS) in C#.
 
+## Quick Reference Links
+
+| Topic | Documentation |
+|-------|---------------|
+| Design Philosophy | [docs/philosophy/](docs/philosophy/) |
+| Contribution Guidelines | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Architecture Decisions | [docs/adr/](docs/adr/) |
+| SDK Documentation | [docs/sdk.md](docs/sdk.md) |
+| MCP Server Reference | [docs/mcp-server.md](docs/mcp-server.md) |
+
 ## Architecture Principles
+
+> For detailed rationale, see [docs/philosophy/](docs/philosophy/).
 
 ### No Static State
 
-All state must be instance-based. Each `World` is completely isolated with its own:
-- Component registry (component IDs are per-world)
-- Entity storage
-- Systems
+All state must be instance-based. Each `World` is completely isolated with its own component registry, entity storage, and systems.
 
-This enables:
-- Multiple independent ECS worlds in one process
-- Easy testing with isolated worlds
-- No hidden initialization order dependencies
-
-**Bad:**
 ```csharp
-public static class ComponentRegistry
-{
-    private static readonly Dictionary<Type, int> ids = new();  // NO!
-}
-```
+// ❌ BAD: Static state
+public static class ComponentRegistry { private static readonly Dictionary<Type, int> ids = new(); }
 
-**Good:**
-```csharp
-public sealed class World
-{
-    public ComponentRegistry Components { get; } = new();  // Per-world
-}
+// ✅ GOOD: Per-world state
+public sealed class World { public ComponentRegistry Components { get; } = new(); }
 ```
 
 ### Respect User Intent
@@ -44,22 +40,6 @@ Don't generate code that assumes how users will structure their application:
 - Don't auto-register all systems (users may want different systems per world)
 - Don't force global singletons
 - Provide metadata and helpers, but let users wire things up explicitly
-
-**Bad:**
-```csharp
-// Generated - forces all systems into every world
-public static World RegisterAll(this World world) { ... }
-```
-
-**Good:**
-```csharp
-// Generated - provides metadata, user decides registration
-public partial class MovementSystem
-{
-    public static SystemPhase Phase => SystemPhase.Update;
-    public static int Order => 0;
-}
-```
 
 ### Source Generators for Ergonomics
 
@@ -75,66 +55,19 @@ Use Roslyn source generators to reduce boilerplate while maintaining performance
 
 **Prohibited patterns:**
 - `Type.GetField()`, `Type.GetMethod()`, `Type.GetProperty()`
-- `Type.GetFields()`, `Type.GetMethods()`, `Type.GetProperties()`
 - `Activator.CreateInstance()` for dynamic object creation
 - `System.Reflection.BindingFlags`
 - Assembly scanning or type discovery at runtime
 
 **AOT-compatible alternatives:**
+- Factory delegates instead of `Activator.CreateInstance()`
+- Static abstract interface members instead of reflection on static fields
+- Source generators for type metadata
+- Explicit registration instead of assembly scanning
 
-1. **Factory delegates** instead of `Activator.CreateInstance()`:
-```csharp
-// ❌ BAD: Reflection-based creation
-var component = Activator.CreateInstance(componentType);
+**Exceptions:** Test code may use reflection. `object.GetType()` on existing instances is allowed.
 
-// ✅ GOOD: Factory delegate stored at registration
-public delegate object ComponentFactory();
-var component = componentInfo.Factory();
-```
-
-2. **Static abstract interface members** instead of reflection on static fields:
-```csharp
-// ❌ BAD: Reflection to access static field
-var field = typeof(TBundle).GetField("ComponentTypes", BindingFlags.Static);
-var types = (Type[])field.GetValue(null);
-
-// ✅ GOOD: Static abstract interface member
-public interface IBundle
-{
-    static abstract Type[] ComponentTypes { get; }
-}
-var types = TBundle.ComponentTypes;  // Direct access, no reflection
-```
-
-3. **Source generators** for type metadata:
-```csharp
-// ❌ BAD: Runtime attribute reading
-var attrs = componentType.GetCustomAttributes<RequiresComponentAttribute>();
-
-// ✅ GOOD: Generated metadata lookup (per-world)
-var world = new World();
-world.ValidationManager.RegisterConstraintProvider(
-    ComponentValidationMetadata.TryGetConstraints);
-```
-
-4. **Explicit registration** instead of assembly scanning:
-```csharp
-// ❌ BAD: Assembly scanning
-var components = Assembly.GetExecutingAssembly()
-    .GetTypes()
-    .Where(t => typeof(IComponent).IsAssignableFrom(t));
-
-// ✅ GOOD: Explicit registration or generated registry
-world.Components.Register<Position>();
-// Or: use generated ComponentRegistry with all known components
-```
-
-**Exceptions:**
-- Test code may use reflection for test infrastructure
-- `object.GetType()` on existing instances is allowed (not assembly scanning)
-- Debug/diagnostic code with `#if DEBUG` guards
-
-When adding new features, always ask: "Would this work with Native AOT compilation?"
+See [docs/philosophy/native-aot.md](docs/philosophy/native-aot.md) for detailed examples of each alternative.
 
 ## Project Structure
 
@@ -194,190 +127,59 @@ Note: `*` indicates multiple related packages (e.g., `KeenEyes.Audio*` = `Audio`
 
 ## Custom MSBuild SDK
 
-KeenEyes provides custom MSBuild SDK packages that simplify project setup for consumers and enable future editor integration.
-
-### Why Custom SDKs?
-
-1. **Minimal boilerplate** - New projects need only the SDK reference
-2. **Convention enforcement** - C# 13, nullable, AOT enabled by default
-3. **Version coupling** - SDK version implies compatible package versions
-4. **Editor foundation** - Project detection, metadata, custom item types
-5. **Asset pipeline ready** - Custom ItemGroups for build-time processing
-
-### SDK Packages
-
-| Package | Use Case | Location |
-|---------|----------|----------|
-| `KeenEyes.Sdk` | Games/apps | `editor/KeenEyes.Sdk/` |
-| `KeenEyes.Sdk.Plugin` | Plugin libraries | `editor/KeenEyes.Sdk.Plugin/` |
-| `KeenEyes.Sdk.Library` | Reusable ECS libraries | `editor/KeenEyes.Sdk.Library/` |
-
-### Usage
-
-External consumers use the SDK like this:
-
-```xml
-<Project Sdk="KeenEyes.Sdk/0.1.0">
-  <!-- Everything configured automatically -->
-</Project>
-```
-
-This replaces 15+ lines of boilerplate (TFM, LangVersion, package references, etc.).
-
-### Custom ItemGroup Types
-
-The SDK defines item types for future editor integration:
-
-- `<KeenEyesScene>` - Scene files (`.kescene`)
-- `<KeenEyesPrefab>` - Prefab definitions (`.keprefab`)
-- `<KeenEyesAsset>` - Game assets (auto-copied to output)
-- `<KeenEyesWorld>` - World configuration (`.keworld`)
-
-### Project Metadata
-
-Each build generates `keeneyes.project.json` in the output directory with version info, enabling:
-- Editor project detection
-- Version compatibility checking
-- Upgrade path recommendations
-
-### Internal vs External Usage
-
-- **External consumers**: Use `<Project Sdk="KeenEyes.Sdk/0.1.0">`
-- **Monorepo samples**: Continue using `ProjectReference` (not SDK) for local development
-- **Templates**: Updated to use SDK for accurate external consumer experience
-
-See [ADR-006](docs/adr/006-custom-msbuild-sdk.md) and [SDK Documentation](docs/sdk.md) for details.
+KeenEyes provides custom MSBuild SDK packages (`KeenEyes.Sdk`, `KeenEyes.Sdk.Plugin`, `KeenEyes.Sdk.Library`) that simplify project setup. See [docs/sdk.md](docs/sdk.md) for full documentation.
 
 ## Coding Conventions
 
-- Target .NET 10 with C# 13+ features
-- Use file-scoped namespaces
-- Prefer `readonly record struct` for small value types
-- Use `ref` returns for component access (zero-copy)
-- Central package management via `Directory.Packages.props`
-- Nullable reference types enabled everywhere
-- Treat warnings as errors
+> For full style guide details, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Naming Conventions
-
-The project enforces strict naming conventions via `.editorconfig`:
 
 | Symbol Type | Convention | Example |
 |-------------|------------|---------|
 | Interfaces | `I` prefix + PascalCase | `IWorld`, `IComponent` |
 | Classes, Structs, Enums | PascalCase | `World`, `Entity`, `LogLevel` |
 | Methods, Properties, Events | PascalCase | `Spawn()`, `EntityCount`, `OnChanged` |
-| Private fields | camelCase (no underscore) | `entityCount`, `components` |
+| Private fields | camelCase (NO underscore) | `entityCount`, `components` |
 | Constants | PascalCase | `MaxEntities`, `DefaultCapacity` |
 | Local variables | camelCase | `entity`, `componentData` |
 | Parameters | camelCase | `world`, `deltaTime` |
 
-**Important:** Private fields do NOT use underscore prefix. This is enforced by the formatter.
-
-```csharp
-// ❌ BAD: Underscore prefix
-private readonly Dictionary<int, Entity> _entities;
-
-// ✅ GOOD: camelCase without underscore
-private readonly Dictionary<int, Entity> entities;
-```
-
 ### Code Style
 
-The following style rules are enforced:
-
-```csharp
-// File-scoped namespaces (required)
-namespace KeenEyes.Core;
-
-// Braces required for all control flow
-if (condition)
-{
-    DoSomething();
-}
-
-// Allman brace style (new line before opening brace)
-public void Method()
-{
-    // ...
-}
-
-// var preferred when type is apparent
-var entity = world.Spawn().Build();
-var components = new Dictionary<int, IComponent>();
-
-// Expression-bodied members for simple cases
-public int Count => entities.Count;
-public Entity Get(int id) => entities[id];
-
-// Pattern matching preferred
-if (obj is Entity entity)
-{
-    // use entity
-}
-
-// System usings first, then others alphabetically
-using System;
-using System.Collections.Generic;
-using KeenEyes.Core;
-```
-
-### Formatting Commands
-
-Before committing, ensure code is properly formatted:
-
-```bash
-dotnet format                        # Auto-fix formatting issues
-dotnet format --verify-no-changes    # Check without modifying (CI mode)
-```
+- File-scoped namespaces required
+- Braces required for all control flow (even single lines)
+- Allman brace style (new line before opening brace)
+- `var` preferred when type is apparent
+- Expression-bodied members for simple cases
+- Pattern matching preferred
 
 ### Floating-Point Comparisons
 
-**Never use `==` to compare floats.** Due to floating-point precision limitations, direct equality checks are unreliable.
-
-Use the extension methods from `KeenEyes.Common.FloatExtensions`:
+**Never use `==` to compare floats.** Use `KeenEyes.Common.FloatExtensions`:
 
 ```csharp
-using KeenEyes.Common;
+// ❌ BAD: if (value == 0)
+// ✅ GOOD: if (value.IsApproximatelyZero())
 
-// ❌ BAD: Direct equality (unreliable)
-if (activity.SleepThreshold == 0)
-
-// ✅ GOOD: Tolerance-based comparison
-if (activity.SleepThreshold.IsApproximatelyZero())
-
-// ❌ BAD: Direct comparison
-if (valueA == valueB)
-
-// ✅ GOOD: Approximate equality
-if (valueA.ApproximatelyEquals(valueB))
+// ❌ BAD: if (a == b)
+// ✅ GOOD: if (a.ApproximatelyEquals(b))
 ```
 
-**Available methods:**
-| Method | Description |
-|--------|-------------|
-| `IsApproximatelyZero()` | Check if value is close to zero (epsilon: 1e-6f) |
-| `IsApproximatelyZero(epsilon)` | Check with custom tolerance |
-| `ApproximatelyEquals(other)` | Compare two floats for near-equality |
-| `ApproximatelyEquals(other, epsilon)` | Compare with custom tolerance |
-
-The default epsilon (1e-6f) is suitable for most game development scenarios. Use custom epsilon for specific precision requirements.
+Methods: `IsApproximatelyZero()`, `ApproximatelyEquals(other)` (default epsilon: 1e-6f)
 
 ### C# 13 Extension Members
 
-This project uses C# 13 **extension members** (not to be confused with traditional extension methods). Extension members allow adding properties directly to types:
+This project uses C# 13 **extension members** syntax:
 
 ```csharp
-public static class WorldPluginExtensions
+extension(global::KeenEyes.IWorld world)
 {
-    extension(global::KeenEyes.IWorld world)
-    {
-        public MyExtension MyProperty => world.GetExtension<MyExtension>();
-    }
+    public MyExtension MyProperty => world.GetExtension<MyExtension>();
 }
 ```
 
-**Note for code review agents**: The `extension(Type paramName)` syntax is **valid C# 13/14 syntax**, not an error. It generates implicit extension members that appear as instance members on the extended type.
+**Note for code review agents**: The `extension(Type paramName)` syntax is **valid C# 13/14 syntax**, not an error.
 
 ## Build Commands
 
@@ -400,11 +202,7 @@ dotnet format --verify-no-changes  # Check formatting
 
 ## World Manager Architecture
 
-The `World` class uses a **facade pattern** with specialized internal managers. This keeps `World` as a thin coordinator (~300-400 lines) while delegating to focused managers.
-
-See [ADR-001](docs/adr/001-world-manager-architecture.md) for the full decision record.
-
-### Current Architecture
+The `World` class uses a **facade pattern** with specialized internal managers. See [ADR-001](docs/adr/001-world-manager-architecture.md) for design rules.
 
 ```
 World (facade)
@@ -431,119 +229,20 @@ World (facade)
 └── ComponentArrayPoolManager  - Component array pooling
 ```
 
-### Manager Design Rules
-
-When working with or creating managers:
-
-1. **Managers are `internal`** - Not part of public API; `World` is the only entry point
-2. **Single responsibility** - Each manager owns one concern completely
-3. **Minimal dependencies** - Managers take only what they need (World ref or specific collaborators)
-4. **No circular dependencies** - If A needs B, B cannot need A
-5. **Testable in isolation** - Each manager should be unit-testable without full World
-
-### Adding New Functionality
-
-When adding new features to World:
-
-1. **Identify the owner** - Which manager should own this feature?
-2. **Implement in manager** - Add the logic to the appropriate manager
-3. **Delegate from World** - World methods should be thin pass-throughs
-4. **Test the manager** - Write unit tests for the manager directly
-
-**Good:**
-```csharp
-// In World.cs - thin delegation
-public void SetParent(Entity child, Entity parent)
-    => hierarchyManager.SetParent(child, parent);
-
-// In HierarchyManager.cs - actual logic
-internal void SetParent(Entity child, Entity parent)
-{
-    // All the validation and state management here
-}
-```
-
-**Bad:**
-```csharp
-// In World.cs - logic in World (violates SRP)
-public void SetParent(Entity child, Entity parent)
-{
-    // 50 lines of validation and state management
-}
-```
-
 ## Work Tracking
 
-Agents must track their work to maintain visibility and enable collaboration:
+> For commit message format and PR guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Todo Lists
+### Todo Lists (Claude-specific)
+
 - Use `TodoWrite` for any task with 3+ steps
 - Mark todos `in_progress` before starting work
 - Mark todos `completed` immediately after finishing (don't batch)
 - Break complex features into granular, trackable items
 
-### Commit Messages
-- Write clear, descriptive commit messages explaining the "why"
-- Reference related features or issues when applicable
-- Group related changes into logical commits
-- Use Conventional Commits format: `<type>: <description>`
-
-### Pull Request Titles
-
-PR titles **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format. This is enforced by CI.
-
-**Format:** `<type>: <description>`
-
-**Valid types:**
-
-| Type | Use For |
-|------|---------|
-| `feat` | New feature or functionality |
-| `fix` | Bug fix |
-| `docs` | Documentation only changes |
-| `chore` | Maintenance tasks, dependencies |
-| `refactor` | Code restructuring without behavior change |
-| `test` | Adding or updating tests |
-| `ci` | CI/CD configuration changes |
-| `perf` | Performance improvements |
-| `style` | Code formatting, no logic change |
-| `build` | Build system or dependency changes |
-
-**Examples:**
-```
-feat: Add ComponentIntrospector for reflection-based inspection
-fix: Resolve entity despawn race condition in HierarchyManager
-docs: Update getting started guide with new API
-refactor: Extract SystemManager from World class
-test: Add integration tests for prefab spawning
-```
-
-**With optional scope:**
-```
-feat(editor): Add PropertyDrawer system
-fix(physics): Correct collision detection for rotated boxes
-```
-
-### Pull Request Description
-
-Use this template for PR descriptions:
-
-```markdown
-## Summary
-<1-3 bullet points explaining what changed and why>
-
-## Test plan
-- [ ] Unit tests added/updated
-- [ ] Manual testing performed
-- [ ] Build passes with zero warnings
-
-## Related Issues
-Closes #XXX
-```
-
 ### Progress Documentation
-- Update ROADMAP.md when completing roadmap items (check the box)
-- Note any deviations or design decisions in commit messages
+
+- Update ROADMAP.md when completing roadmap items
 - Document blockers or open questions for future agents
 
 ## XML Documentation
@@ -629,373 +328,53 @@ Future goal: Enable CS1591 warning to require docs on all public members.
 
 ## Code Quality Requirements
 
-All code contributions must meet strict quality standards. No exceptions.
-
-### Build Validation
-
-Before committing, ensure:
-
-```bash
-dotnet build                         # Zero warnings, zero errors (TreatWarningsAsErrors enabled)
-dotnet test                          # All tests pass
-dotnet format --verify-no-changes   # Code is formatted
-```
-
-Note: NuGet dependency warnings (NU1603) may appear during restore due to central
-package management pinning higher versions than some packages request. These are
-suppressed from being treated as errors via `NoWarn` in Directory.Build.props.
-
-**Non-negotiable rules:**
-- All existing tests must continue to pass
-- No new warnings introduced (warnings are errors)
-- No new analyzer violations
-- Code must be formatted per `.editorconfig`
-
-### Introducing Changes
-
-When modifying code:
-1. Run the full build before AND after changes
-2. If a warning exists, fix it - don't suppress it without justification
-3. If a test fails, fix the code or update the test with clear reasoning
-4. Never commit code that breaks the build
+> For full quality standards, testing guidelines, and coverage requirements, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### No Speculative Features
 
-Do not add speculative or "future nice to have" code unless specifically requested in an issue:
+Do not add "future nice to have" code:
 - Don't add unused methods "in case they're useful later"
-- Don't add extra parameters or overloads for hypothetical use cases
-- Don't add internal APIs that aren't immediately consumed
+- Don't add extra parameters for hypothetical use cases
 - If a feature isn't in the requirements, don't implement it
 
-Speculative code creates:
-- **Maintenance burden** - Code that must be tested, documented, and maintained
-- **Confusion** - Future developers wonder why unused code exists
-- **Tech debt** - Unused abstractions that complicate refactoring
-
-When you think "this might be useful later," stop. Either it's needed now (add it), or it's not (don't add it). YAGNI (You Aren't Gonna Need It).
+YAGNI: Either it's needed now (add it), or it's not (don't add it).
 
 ### No Backwards Compatibility Layers
 
-This is a **new engine** - there is no existing user base requiring backwards compatibility. Do not add:
+This is a **new engine** - no existing user base requires compatibility. Do not add:
 - Legacy overloads or fallback methods
 - Compatibility shims for "old" APIs
-- Multiple code paths to support "previous versions"
 - Deprecated alternatives alongside new implementations
 
-If you believe backwards compatibility is genuinely needed for a specific case, **ask the user first** before implementing it. This falls under the "no speculative features" rule - don't add compatibility code "just in case."
-
-**Bad:**
-```csharp
-// Don't add legacy overloads
-public static byte[] ToBinary(WorldSnapshot snapshot, IBinaryComponentSerializer serializer)
-{
-    // Legacy fallback path...
-}
-```
-
-**Good:**
-```csharp
-// Single, clean implementation
-public static byte[] ToBinary<TSerializer>(WorldSnapshot snapshot, TSerializer serializer)
-    where TSerializer : IComponentSerializer, IBinaryComponentSerializer
-{
-    // Native binary serialization
-}
-```
-
-### Suppressing Warnings
-
-Only suppress warnings when absolutely necessary:
-
-```csharp
-// GOOD: Documented justification
-#pragma warning disable CS8618 // Non-nullable field not initialized - set in Initialize()
-private World world;
-#pragma warning restore CS8618
-
-// BAD: No explanation
-#pragma warning disable CS8618
-private World world;
-#pragma warning restore CS8618
-```
-
-## Code Coverage Requirements
-
-Code coverage is enforced by CI. If coverage drops below the current baseline, the build fails.
-
-### Running Coverage Locally
-
-Use xUnit.net v3 with Microsoft Testing Platform (MTP) to generate coverage reports:
-
-```bash
-dotnet test -- --coverage --coverage-output-format cobertura --coverage-output coverage.xml
-```
-
-This generates Cobertura XML reports in each test project's `bin/Debug/net10.0/TestResults/` directory.
-
-### Coverage Rules
-
-1. **Coverage must not decrease** - CI fails if any PR reduces overall coverage percentage
-2. **New code must be covered** - All new functionality requires corresponding tests
-3. **Edge cases matter** - Cover error paths, boundary conditions, and exceptional flows
-4. **No artificial inflation** - Tests must verify behavior, not just execute code
-
-### Test Quality Standards
-
-Tests are as important as production code. Every test must be:
-
-**Meaningful:**
-- Test actual behavior, not implementation details
-- Verify outcomes, not just that code runs without throwing
-- Cover both happy paths and error conditions
-
-**Well-named:**
-- Use pattern: `MethodName_Scenario_ExpectedResult`
-- Names should describe what is being tested
-- A failing test's name should indicate what went wrong
-
-```csharp
-// ✅ GOOD: Clear, descriptive names
-[Fact]
-public void Despawn_WithValidEntity_RemovesEntityFromWorld()
-
-[Fact]
-public void Get_WithDeadEntity_ThrowsInvalidOperationException()
-
-[Fact]
-public void Query_WithNoMatchingArchetypes_ReturnsEmptyEnumerable()
-
-// ❌ BAD: Vague, unclear names
-[Fact]
-public void TestDespawn()
-
-[Fact]
-public void GetThrows()
-
-[Fact]
-public void QueryWorks()
-```
-
-**Properly organized:**
-- Group related tests using `#region` or separate test classes
-- One test class per unit under test (e.g., `WorldTests`, `QueryEnumeratorTests`)
-- Use nested classes or regions for method-specific tests when appropriate
-
-```csharp
-public class WorldTests
-{
-    #region Spawn Tests
-    [Fact]
-    public void Spawn_CreatesEntity() { ... }
-
-    [Fact]
-    public void Spawn_WithComponents_AddsComponents() { ... }
-    #endregion
-
-    #region Despawn Tests
-    [Fact]
-    public void Despawn_RemovesEntity() { ... }
-    #endregion
-}
-```
-
-**Self-contained:**
-- Each test should be independent (no shared mutable state)
-- Use `using` with `World` instances for proper cleanup
-- Create fresh test data in each test
-
-```csharp
-// ✅ GOOD: Self-contained, isolated test
-[Fact]
-public void Spawn_CreatesEntityWithUniqueId()
-{
-    using var world = new World();
-
-    var entity1 = world.Spawn().Build();
-    var entity2 = world.Spawn().Build();
-
-    Assert.NotEqual(entity1.Id, entity2.Id);
-}
-```
-
-## Sample & Tutorial Code Quality
-
-**All code is teaching code.** Samples, tutorials, examples, and documentation snippets are as important as production code - often more so.
-
-### Why This Matters
-
-- Users learn by copying examples
-- Bad habits in samples become bad habits in user code
-- First impressions establish patterns that persist
-- Examples are the most-read code in any project
-
-### Sample Code Standards
-
-Every code sample must:
-
-1. **Compile and run** - No pseudo-code in samples
-2. **Follow all conventions** - Same standards as production code
-3. **Demonstrate best practices** - Show the RIGHT way, not shortcuts
-4. **Be self-contained** - Runnable without hidden dependencies
-5. **Include error handling** - Show proper patterns, not happy-path only
-6. **Use meaningful names** - `Position`, `Velocity`, not `Foo`, `Bar`
-
-### Example Quality Checklist
-
-```csharp
-// ✅ GOOD: Complete, follows conventions, demonstrates patterns
-[Component]
-public partial struct Position
-{
-    public float X;
-    public float Y;
-}
-
-[Component]
-public partial struct Velocity
-{
-    public float X;
-    public float Y;
-}
-
-public class MovementSystem : SystemBase
-{
-    public override void Update(float deltaTime)
-    {
-        foreach (var entity in World.Query<Position, Velocity>())
-        {
-            ref var pos = ref World.Get<Position>(entity);
-            ref readonly var vel = ref World.Get<Velocity>(entity);
-
-            pos.X += vel.X * deltaTime;
-            pos.Y += vel.Y * deltaTime;
-        }
-    }
-}
-```
-
-```csharp
-// ❌ BAD: Incomplete, bad names, missing patterns
-public class MySystem : SystemBase
-{
-    public override void Update(float dt)
-    {
-        // TODO: implement
-        foreach (var e in World.Query<Foo>())
-        {
-            // do stuff
-        }
-    }
-}
-```
-
-### Establish Patterns Early
-
-When writing examples, reinforce core patterns:
-- Show `readonly record struct` for entities
-- Show `struct` for components
-- Show proper `ref` usage for zero-copy access
-- Show `using` statements for disposables
-- Show query patterns with `With<>()` and `Without<>()`
+Ask the user first if you believe backwards compatibility is genuinely needed.
 
 ## ECS Principles
 
-When implementing features, always keep ECS fundamentals in mind.
+> For detailed ECS philosophy, see [docs/philosophy/why-ecs.md](docs/philosophy/why-ecs.md).
 
 ### Core ECS Tenets
 
-1. **Composition over Inheritance**
-   - Entities are IDs, not objects
-   - Behavior comes from component combinations
-   - No entity base classes or inheritance hierarchies
-
-2. **Data-Oriented Design**
-   - Components are plain data (structs)
-   - Systems contain logic, components contain state
-   - Optimize for cache locality and iteration
-
-3. **Separation of Concerns**
-   - Components: WHAT an entity has (data only)
-   - Systems: HOW entities behave (logic only)
-   - Queries: WHICH entities to process (filtering)
-
-4. **Explicit over Implicit**
-   - No hidden registration or auto-wiring
-   - Users explicitly add systems to worlds
-   - No magic - behavior is traceable
+1. **Composition over Inheritance** - Entities are IDs, behavior comes from component combinations
+2. **Data-Oriented Design** - Components are structs (data only), systems contain logic
+3. **Separation of Concerns** - Components: WHAT, Systems: HOW, Queries: WHICH
+4. **Explicit over Implicit** - No hidden registration, users wire things up explicitly
 
 ### Anti-Patterns to Avoid
 
 ```csharp
 // ❌ BAD: Logic in components
-public struct Health
-{
-    public int Current;
-    public int Max;
+public struct Health { public int Current; public void TakeDamage(int amt) => Current -= amt; }
 
-    public void TakeDamage(int amount) => Current -= amount;  // NO!
-}
+// ✅ GOOD: Pure data, logic in systems
+public struct Health { public int Current; public int Max; }
 
-// ✅ GOOD: Pure data component
-public struct Health
-{
-    public int Current;
-    public int Max;
-}
-
-// Logic in systems
-public class DamageSystem : SystemBase { ... }
-```
-
-```csharp
-// ❌ BAD: Inheritance-based entities
-public class Enemy : Entity { }       // NO!
-public class Player : Enemy { }       // NO!
-
-// ✅ GOOD: Composition-based
-var enemy = world.Spawn()
-    .With(new Position { X = 0, Y = 0 })
-    .With(new Health { Current = 100, Max = 100 })
-    .WithTag<EnemyTag>()
-    .Build();
-```
-
-```csharp
-// ❌ BAD: God component with everything
-public struct Actor
-{
-    public float X, Y;
-    public float VelX, VelY;
-    public int Health, MaxHealth;
-    public int Damage;
-    public string Name;
-    // ... 50 more fields
-}
+// ❌ BAD: God component
+public struct Actor { public float X, Y, VelX, VelY; public int Health, Damage; /* 50 fields */ }
 
 // ✅ GOOD: Small, focused components
 public struct Position { public float X, Y; }
 public struct Velocity { public float X, Y; }
-public struct Health { public int Current, Max; }
-public struct Damage { public int Amount; }
-public struct Named { public string Name; }
 ```
-
-### Performance Mindset
-
-Always consider:
-- **Allocations**: Minimize heap allocations in hot paths
-- **Cache locality**: Keep related data together
-- **Iteration**: Optimize for bulk processing, not individual entity access
-- **Indirection**: Reduce pointer chasing, prefer contiguous arrays
-
-### When in Doubt
-
-Ask these questions:
-1. Is this component pure data with no logic?
-2. Is this system processing entities in bulk?
-3. Could this be composed from smaller components?
-4. Am I relying on implicit behavior?
-5. Would this work with 10,000 entities?
 
 ## System Hooks
 
@@ -1084,85 +463,35 @@ public class ProfilingPlugin : IWorldPlugin
 
 ## MCP TestBridge Integration
 
-The TestBridge enables external tools (like Claude Code) to inspect and control running KeenEyes applications via the Model Context Protocol (MCP).
+The TestBridge enables external tools (like Claude Code) to inspect and control running KeenEyes applications via MCP. See [docs/mcp-server.md](docs/mcp-server.md) for full tool reference.
 
 ### Architecture Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│ Claude Code                                                      │
-│   └── MCP Client                                                 │
-│         │                                                        │
-│         ▼ (stdio)                                                │
-│   ┌─────────────────────────────────────────────────────┐       │
-│   │ KeenEyes.Mcp.TestBridge (tools/KeenEyes.Mcp.TestBridge)     │
-│   │   - MCP Server (stdio transport)                     │       │
-│   │   - StateTools, InputTools, CaptureTools, GameTools  │       │
-│   └─────────────────────────────────────────────────────┘       │
-│         │                                                        │
-│         ▼ (named pipe IPC)                                       │
-│   ┌─────────────────────────────────────────────────────┐       │
-│   │ KeenEyes.TestBridge.Ipc (IpcBridgeServer)           │       │
-│   │   - Protocol: JSON over named pipes                  │       │
-│   │   - Handlers: StateCommandHandler, InputCommandHandler      │
-│   └─────────────────────────────────────────────────────┘       │
-│         │                                                        │
-│         ▼ (in-process)                                           │
-│   ┌─────────────────────────────────────────────────────┐       │
-│   │ KeenEyes.TestBridge (InProcessBridge)               │       │
-│   │   - StateControllerImpl → World state inspection     │       │
-│   │   - InputControllerImpl → Virtual input injection    │       │
-│   │   - CaptureControllerImpl → Screenshot capture       │       │
-│   └─────────────────────────────────────────────────────┘       │
-│         │                                                        │
-│         ▼                                                        │
-│   ┌─────────────────────────────────────────────────────┐       │
-│   │ World (ECS)                                          │       │
-│   │   - Entities, Components, Systems                    │       │
-│   └─────────────────────────────────────────────────────┘       │
-└─────────────────────────────────────────────────────────────────┘
+Claude Code → (stdio) → KeenEyes.Mcp.TestBridge
+                          ↓ (named pipe IPC)
+                        KeenEyes.TestBridge.Ipc
+                          ↓ (in-process)
+                        KeenEyes.TestBridge → World (ECS)
 ```
 
 ### Key Packages
 
 | Package | Purpose |
 |---------|---------|
-| `KeenEyes.TestBridge.Abstractions` | Interfaces: `ITestBridge`, `IStateController`, `IInputController`, `ICaptureController` |
-| `KeenEyes.TestBridge` | In-process implementation that directly accesses World |
-| `KeenEyes.TestBridge.Ipc` | IPC layer: named pipe server/client, JSON protocol |
-| `KeenEyes.Mcp.TestBridge` | MCP server exposing TestBridge as Claude Code tools |
+| `KeenEyes.TestBridge.Abstractions` | Interfaces |
+| `KeenEyes.TestBridge` | In-process implementation |
+| `KeenEyes.TestBridge.Ipc` | Named pipe IPC layer |
+| `KeenEyes.Mcp.TestBridge` | MCP server for Claude Code |
 
-### Editor Integration
+### Editor Named Pipes
 
-The editor (`KeenEyes.Editor`) integrates the TestBridge for both UI debugging and scene debugging:
-
-```csharp
-// In EditorApplication.cs
-private TestBridgeManager? editorTestBridge;   // For editor UI world
-private TestBridgeManager? sceneTestBridge;    // For loaded scene world
-
-// Editor TestBridge starts when editor launches
-private async Task StartEditorTestBridgeAsync()
-{
-    editorTestBridge = new TestBridgeManager(editorWorld);
-    await editorTestBridge.StartIpcServerAsync("KeenEyes.Editor.TestBridge");
-}
-
-// Scene TestBridge starts when a scene is opened
-private async Task StartSceneTestBridgeAsync()
-{
-    sceneTestBridge = new TestBridgeManager(sceneWorld);
-    await sceneTestBridge.StartIpcServerAsync("KeenEyes.Editor.Scene.TestBridge");
-}
-```
-
-**Named Pipes:**
-- `KeenEyes.Editor.TestBridge` - Connects to the editor UI world (menus, panels, etc.)
-- `KeenEyes.Editor.Scene.TestBridge` - Connects to the currently loaded scene world
+- `KeenEyes.Editor.TestBridge` - Editor UI world
+- `KeenEyes.Editor.Scene.TestBridge` - Currently loaded scene
 
 ### MCP Configuration
 
-The MCP server is configured in `.mcp.json`:
+Configured in `.mcp.json`:
 
 ```json
 {
@@ -1170,163 +499,28 @@ The MCP server is configured in `.mcp.json`:
     "keeneyes-bridge": {
       "type": "stdio",
       "command": ".mcp/KeenEyes.Mcp.TestBridge.exe",
-      "args": [],
       "env": {
         "KEENEYES_TRANSPORT": "pipe",
-        "KEENEYES_PIPE_NAME": "KeenEyes.Editor.TestBridge",
-        "KEENEYES_HEARTBEAT_INTERVAL": "5000",
-        "KEENEYES_HEARTBEAT_TIMEOUT": "10000"
+        "KEENEYES_PIPE_NAME": "KeenEyes.Editor.TestBridge"
       }
     }
   }
 }
 ```
 
-**Environment Variables:**
-- `KEENEYES_TRANSPORT`: `pipe` (named pipes) or `tcp` (network)
-- `KEENEYES_PIPE_NAME`: Named pipe to connect to
-- `KEENEYES_HOST`/`KEENEYES_PORT`: For TCP transport (default: 127.0.0.1:19283)
-
-### Publishing the MCP Server
-
-Before using the MCP tools, publish the server to `.mcp/`:
-
-```bash
-dotnet publish tools/KeenEyes.Mcp.TestBridge -c Release -o .mcp
-```
-
-### Launching the Editor for Debugging
-
-To debug the editor with MCP tools available:
-
-```bash
-# Terminal 1: Launch the editor
-dotnet run --project editor/KeenEyes.Editor -c Release
-
-# The editor starts and logs:
-# [TestBridge] IPC server started on pipe: KeenEyes.Editor.TestBridge
-```
-
-Claude Code will automatically connect via the MCP configuration. Use the tools to inspect state:
-
-```
-# In Claude Code, the tools become available after connection:
-mcp__keeneyes-bridge__game_connect        # Connect to the editor
-mcp__keeneyes-bridge__state_get_entity_count    # Query entity count
-mcp__keeneyes-bridge__state_query_entities      # List entities
-```
-
-### Available MCP Tools
-
-**Connection:**
-| Tool | Description |
-|------|-------------|
-| `game_connect` | Connect to running game/editor |
-| `game_disconnect` | Disconnect from game |
-| `game_status` | Get connection status with latency |
-| `game_get_screen_size` | Get window dimensions |
-| `game_wait_for_condition` | Wait for entity/component state |
-
-**State Inspection:**
-| Tool | Status | Description |
-|------|--------|-------------|
-| `state_get_entity_count` | ✓ | Total entity count |
-| `state_get_world_stats` | ✓ | Entity/archetype/memory stats |
-| `state_get_systems` | ✓ | List all systems with timing |
-| `state_get_performance` | ✓ | FPS and frame timing |
-| `state_query_entities` | ✓* | Query entities with filters |
-| `state_get_entity` | ✗ | Get entity by ID (see #843) |
-| `state_get_entity_by_name` | ✗ | Get entity by name (see #843) |
-| `state_get_component` | ✗ | Get component data (see #843) |
-| `state_get_children` | ✓ | Get child entity IDs |
-| `state_get_parent` | ✓ | Get parent entity ID |
-| `state_get_entities_with_tag` | ✓ | Find entities by tag |
-
-*`state_query_entities` works with `includeComponentData=false` only.
-
-**Input Injection:**
-| Tool | Description |
-|------|-------------|
-| `input_key_press` | Press and release a key |
-| `input_key_down` / `input_key_up` | Hold/release a key |
-| `input_type_text` | Type text string |
-| `input_mouse_move` | Move mouse to position |
-| `input_mouse_click` | Click at position |
-| `input_mouse_drag` | Drag from one point to another |
-| `input_mouse_scroll` | Scroll wheel |
-| `input_gamepad_*` | Gamepad button/stick/trigger |
-| `input_trigger_action` | Trigger named input action |
-| `input_reset` | Reset all input state |
-
-**Capture:**
-| Tool | Status | Description |
-|------|--------|-------------|
-| `capture_is_available` | ✓ | Check if capture is available |
-| `capture_screenshot` | ✗ | Capture screenshot (see #844) |
-| `capture_screenshot_to_file` | ✗ | Save screenshot to file |
-| `capture_start_recording` | ✓ | Start frame recording |
-| `capture_stop_recording` | ✓ | Stop recording |
-| `capture_is_recording` | ✓ | Check recording status |
-
-### Integrating TestBridge in Your Application
-
-To add TestBridge support to a KeenEyes game/application:
-
-```csharp
-using KeenEyes.TestBridge;
-using KeenEyes.TestBridge.Ipc;
-
-public class Game
-{
-    private TestBridgeManager? testBridge;
-
-    public void Initialize(World world)
-    {
-        // Create the bridge manager
-        testBridge = new TestBridgeManager(world);
-
-        // Start IPC server (optional - for external tool connections)
-        _ = testBridge.StartIpcServerAsync("MyGame.TestBridge");
-    }
-
-    public void Shutdown()
-    {
-        testBridge?.Dispose();
-    }
-}
-```
-
-For headless/CI testing, use the in-process bridge directly:
-
-```csharp
-using KeenEyes.TestBridge;
-
-var world = new World();
-var bridge = new InProcessBridge(world, inputContext, captureContext);
-
-// Inject input
-await bridge.Input.KeyPressAsync(Key.Space);
-
-// Query state
-var entities = await bridge.State.QueryEntitiesAsync(new EntityQuery
-{
-    WithComponents = ["Position", "Velocity"],
-    MaxResults = 100
-});
-```
+Publish the server: `dotnet publish tools/KeenEyes.Mcp.TestBridge -c Release -o .mcp`
 
 ### Known Issues
 
-- **#843**: `state_get_entity`, `state_get_component`, and `state_query_entities` with component data fail due to `Dictionary<string, object?>` not being AOT-serializable
-- **#844**: Screenshot capture fails with OpenGL context error (must run on render thread)
+- **#843**: `state_get_entity`, `state_get_component`, `state_query_entities` with component data fail (AOT serialization)
+- **#844**: Screenshot capture fails (must run on render thread)
 
 ### Debugging Tips
 
-1. **Check connection**: Use `game_status` to verify connection and latency
-2. **Query entity structure**: Use `state_query_entities` without component data to see entity hierarchy
-3. **Use hierarchical queries**: `state_get_children` and `state_get_parent` work reliably
-4. **Inject input for testing**: Use `input_*` tools to simulate user interaction
-5. **Monitor performance**: Use `state_get_performance` to track frame times
+1. Use `game_status` to verify connection and latency
+2. Use `state_query_entities` without component data to see entity hierarchy
+3. Use `state_get_children` and `state_get_parent` for hierarchy traversal
+4. Use `state_get_performance` to track frame times
 
 ## Claude Code Web Sessions
 


### PR DESCRIPTION
## Summary

- Reduce CLAUDE.md from 1,413 to 606 lines (57% reduction)
- Add Quick Reference Links table at top linking to key documentation
- Replace duplicated content with links to existing docs (philosophy/, sdk.md, CONTRIBUTING.md, mcp-server.md)
- Keep all essential rules Claude needs in context (naming, AOT, ECS, etc.)
- Keep unique content: System Hooks, Web Sessions, XML Documentation

## Changes by Section

| Section | Before | After | Action |
|---------|--------|-------|--------|
| Architecture Principles | ~140 lines | ~50 lines | Condensed, linked to docs/philosophy/ |
| Custom MSBuild SDK | ~55 lines | 3 lines | Replaced with link to docs/sdk.md |
| Coding Conventions | ~130 lines | ~50 lines | Kept essentials, linked to CONTRIBUTING.md |
| Code Quality/Coverage/Testing | ~270 lines | ~20 lines | Kept key rules, linked to CONTRIBUTING.md |
| ECS Principles | ~100 lines | ~25 lines | Condensed, linked to docs/philosophy/why-ecs.md |
| Work Tracking | ~75 lines | ~15 lines | Kept TodoWrite, removed PR format |
| World Manager | ~75 lines | ~30 lines | Kept manager list, linked to ADR-001 |
| MCP TestBridge | ~250 lines | ~60 lines | Kept architecture, linked to docs/mcp-server.md |

## Test plan

- [x] All builds pass
- [x] All tests pass
- [x] Essential content preserved:
  - No Static State rule with example
  - No Reflection/AOT prohibited patterns
  - Naming conventions table
  - Floating-point comparison methods
  - C# 13 extension members warning
  - Build command with parallel test warning
  - ECS core tenets
  - MCP configuration and known issues
  - Full Web Sessions section

🤖 Generated with [Claude Code](https://claude.ai/code)