### PR TITLE
feat(ui): Add UI theming system with OS theme detection

### DIFF
--- a/src/KeenEyes.UI.Themes.Abstractions/ColorPalette.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/ColorPalette.cs
@@ -1,0 +1,136 @@
+using System.Numerics;
+
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Defines a complete color palette for a theme.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All colors use Vector4 in RGBA format with values from 0 to 1.
+/// This matches the format used by <see cref="KeenEyes.UI.Abstractions.UIStyle"/>.
+/// </para>
+/// <para>
+/// The palette uses semantic color names that describe purpose rather than appearance.
+/// This allows themes to define colors appropriate for their light or dark base.
+/// </para>
+/// </remarks>
+public sealed class ColorPalette
+{
+    // Semantic background colors
+
+    /// <summary>
+    /// Primary background color for the application.
+    /// </summary>
+    public required Vector4 Background { get; init; }
+
+    /// <summary>
+    /// Background color for elevated surfaces like panels and cards.
+    /// </summary>
+    public required Vector4 Surface { get; init; }
+
+    /// <summary>
+    /// Background color for surfaces that appear above other surfaces (e.g., modals).
+    /// </summary>
+    public required Vector4 SurfaceElevated { get; init; }
+
+    // Brand colors
+
+    /// <summary>
+    /// Primary brand/accent color for important UI elements.
+    /// </summary>
+    public required Vector4 Primary { get; init; }
+
+    /// <summary>
+    /// Variant of primary color for hover or secondary emphasis.
+    /// </summary>
+    public required Vector4 PrimaryVariant { get; init; }
+
+    /// <summary>
+    /// Secondary brand color for less prominent accents.
+    /// </summary>
+    public required Vector4 Secondary { get; init; }
+
+    /// <summary>
+    /// Accent color for highlights and selections.
+    /// </summary>
+    public required Vector4 Accent { get; init; }
+
+    // Text colors
+
+    /// <summary>
+    /// Primary text color for body text and most content.
+    /// </summary>
+    public required Vector4 TextPrimary { get; init; }
+
+    /// <summary>
+    /// Secondary text color for captions and less important text.
+    /// </summary>
+    public required Vector4 TextSecondary { get; init; }
+
+    /// <summary>
+    /// Text color for disabled or placeholder content.
+    /// </summary>
+    public required Vector4 TextDisabled { get; init; }
+
+    /// <summary>
+    /// Text color for content on primary-colored backgrounds.
+    /// </summary>
+    public required Vector4 TextOnPrimary { get; init; }
+
+    // State colors
+
+    /// <summary>
+    /// Color indicating success or positive state.
+    /// </summary>
+    public required Vector4 Success { get; init; }
+
+    /// <summary>
+    /// Color indicating a warning or cautionary state.
+    /// </summary>
+    public required Vector4 Warning { get; init; }
+
+    /// <summary>
+    /// Color indicating an error or negative state.
+    /// </summary>
+    public required Vector4 Error { get; init; }
+
+    /// <summary>
+    /// Color indicating informational content.
+    /// </summary>
+    public required Vector4 Info { get; init; }
+
+    // Border colors
+
+    /// <summary>
+    /// Default border color for UI elements.
+    /// </summary>
+    public required Vector4 Border { get; init; }
+
+    /// <summary>
+    /// Border color for focused elements.
+    /// </summary>
+    public required Vector4 BorderFocused { get; init; }
+
+    /// <summary>
+    /// Subtle divider/separator color.
+    /// </summary>
+    public required Vector4 Divider { get; init; }
+
+    // Interaction state overlays
+
+    /// <summary>
+    /// Semi-transparent overlay for hover state.
+    /// </summary>
+    public required Vector4 HoverOverlay { get; init; }
+
+    /// <summary>
+    /// Semi-transparent overlay for pressed state.
+    /// </summary>
+    public required Vector4 PressedOverlay { get; init; }
+
+    /// <summary>
+    /// Semi-transparent overlay for disabled state.
+    /// </summary>
+    public required Vector4 DisabledOverlay { get; init; }
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/Events/SystemThemeChangedEvent.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/Events/SystemThemeChangedEvent.cs
@@ -1,0 +1,10 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Event raised when the operating system's theme preference changes.
+/// </summary>
+/// <param name="PreviousTheme">The theme before the change.</param>
+/// <param name="CurrentTheme">The new active theme.</param>
+public readonly record struct SystemThemeChangedEvent(
+    SystemTheme PreviousTheme,
+    SystemTheme CurrentTheme);

--- a/src/KeenEyes.UI.Themes.Abstractions/Events/ThemeChangedEvent.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/Events/ThemeChangedEvent.cs
@@ -1,0 +1,10 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Event raised when the application theme changes.
+/// </summary>
+/// <param name="PreviousTheme">The theme before the change, or null if this is the initial theme.</param>
+/// <param name="NewTheme">The new active theme.</param>
+public readonly record struct ThemeChangedEvent(
+    ITheme? PreviousTheme,
+    ITheme NewTheme);

--- a/src/KeenEyes.UI.Themes.Abstractions/ISystemThemeProvider.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/ISystemThemeProvider.cs
@@ -1,0 +1,60 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Provides access to the operating system's theme preference.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface abstracts platform-specific theme detection mechanisms.
+/// Implementations exist for Windows (registry/UISettings), macOS (NSApplication.effectiveAppearance),
+/// and Linux (XDG portal or gsettings).
+/// </para>
+/// <para>
+/// The provider supports both polling and event-driven notification models.
+/// Call <see cref="GetCurrentTheme"/> for immediate queries, or subscribe to
+/// <see cref="OnThemeChanged"/> for runtime notifications.
+/// </para>
+/// </remarks>
+public interface ISystemThemeProvider : IDisposable
+{
+    /// <summary>
+    /// Gets whether theme detection is available on this platform.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>false</c> on unsupported platforms or when detection fails.
+    /// When <c>false</c>, <see cref="GetCurrentTheme"/> returns <see cref="SystemTheme.Unknown"/>.
+    /// </remarks>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets whether this provider supports runtime theme change notifications.
+    /// </summary>
+    /// <remarks>
+    /// When <c>false</c>, the provider can only detect the theme at startup.
+    /// Use polling-based detection by periodically calling <see cref="GetCurrentTheme"/>.
+    /// </remarks>
+    bool SupportsRuntimeNotification { get; }
+
+    /// <summary>
+    /// Gets the current operating system theme.
+    /// </summary>
+    /// <returns>
+    /// The current theme, or <see cref="SystemTheme.Unknown"/> if detection is unavailable.
+    /// </returns>
+    SystemTheme GetCurrentTheme();
+
+    /// <summary>
+    /// Event raised when the operating system theme changes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This event is only raised when <see cref="SupportsRuntimeNotification"/> is <c>true</c>.
+    /// On platforms without runtime support, this event will never fire.
+    /// </para>
+    /// <para>
+    /// Handlers are invoked on an unspecified thread. UI updates should be marshaled
+    /// to the appropriate thread if necessary.
+    /// </para>
+    /// </remarks>
+    event Action<SystemThemeChangedEvent>? OnThemeChanged;
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/ITheme.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/ITheme.cs
@@ -1,0 +1,98 @@
+using KeenEyes.UI.Abstractions;
+
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Defines a complete visual theme for the UI system.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A theme provides both a color palette and component-specific styles.
+/// Component styles incorporate the palette colors with additional properties
+/// like borders, corner radius, and padding.
+/// </para>
+/// <para>
+/// Built-in themes (<see cref="SystemTheme.Light"/> and <see cref="SystemTheme.Dark"/>)
+/// are provided by the theme plugin. Custom themes can be created by implementing
+/// this interface and registering them with <see cref="IThemeContext.RegisterTheme"/>.
+/// </para>
+/// </remarks>
+public interface ITheme
+{
+    /// <summary>
+    /// Gets the display name of this theme.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets whether this is a light or dark theme.
+    /// </summary>
+    /// <remarks>
+    /// This is used to determine the appropriate system theme variant and
+    /// to select correct text contrast colors.
+    /// </remarks>
+    SystemTheme BaseTheme { get; }
+
+    /// <summary>
+    /// Gets the color palette for this theme.
+    /// </summary>
+    ColorPalette Colors { get; }
+
+    /// <summary>
+    /// Gets the style for button components.
+    /// </summary>
+    /// <param name="state">The current interaction state of the button.</param>
+    /// <returns>A UIStyle configured for the button's current state.</returns>
+    UIStyle GetButtonStyle(UIInteractionState state);
+
+    /// <summary>
+    /// Gets the style for panel/container components.
+    /// </summary>
+    /// <returns>A UIStyle configured for panels.</returns>
+    UIStyle GetPanelStyle();
+
+    /// <summary>
+    /// Gets the style for text input components.
+    /// </summary>
+    /// <param name="state">The current interaction state of the input.</param>
+    /// <returns>A UIStyle configured for the input's current state.</returns>
+    UIStyle GetInputStyle(UIInteractionState state);
+
+    /// <summary>
+    /// Gets the style for menu components (dropdowns, context menus).
+    /// </summary>
+    /// <returns>A UIStyle configured for menus.</returns>
+    UIStyle GetMenuStyle();
+
+    /// <summary>
+    /// Gets the style for menu item components.
+    /// </summary>
+    /// <param name="state">The current interaction state of the menu item.</param>
+    /// <returns>A UIStyle configured for the menu item's current state.</returns>
+    UIStyle GetMenuItemStyle(UIInteractionState state);
+
+    /// <summary>
+    /// Gets the style for modal/dialog components.
+    /// </summary>
+    /// <returns>A UIStyle configured for modals.</returns>
+    UIStyle GetModalStyle();
+
+    /// <summary>
+    /// Gets the style for scrollbar track components.
+    /// </summary>
+    /// <returns>A UIStyle configured for scrollbar tracks.</returns>
+    UIStyle GetScrollbarTrackStyle();
+
+    /// <summary>
+    /// Gets the style for scrollbar thumb components.
+    /// </summary>
+    /// <param name="state">The current interaction state of the scrollbar thumb.</param>
+    /// <returns>A UIStyle configured for the thumb's current state.</returns>
+    UIStyle GetScrollbarThumbStyle(UIInteractionState state);
+
+    /// <summary>
+    /// Gets the style for tooltip components.
+    /// </summary>
+    /// <returns>A UIStyle configured for tooltips.</returns>
+    UIStyle GetTooltipStyle();
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/IThemeContext.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/IThemeContext.cs
@@ -1,0 +1,105 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Provides access to theme management and OS theme detection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the primary interface for working with themes. Access it via
+/// <c>world.GetExtension&lt;IThemeContext&gt;()</c> after installing the theme plugin.
+/// </para>
+/// <para>
+/// The context supports automatic theme switching based on OS preference when
+/// <see cref="FollowSystemTheme"/> is enabled. When enabled, theme changes from
+/// <see cref="ISystemThemeProvider"/> automatically trigger the appropriate
+/// built-in theme.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var theme = world.GetExtension&lt;IThemeContext&gt;();
+///
+/// // Get current theme
+/// var isDark = theme.CurrentTheme.BaseTheme == SystemTheme.Dark;
+///
+/// // Switch themes manually
+/// theme.SetTheme(theme.GetTheme("Dark")!);
+///
+/// // Or follow system preference
+/// theme.FollowSystemTheme = true;
+/// </code>
+/// </example>
+public interface IThemeContext
+{
+    /// <summary>
+    /// Gets the currently active theme.
+    /// </summary>
+    ITheme CurrentTheme { get; }
+
+    /// <summary>
+    /// Gets the current OS system theme preference.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="SystemTheme.Unknown"/> if OS theme detection is not available.
+    /// </remarks>
+    SystemTheme SystemTheme { get; }
+
+    /// <summary>
+    /// Gets or sets whether the application should automatically follow the OS theme.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <c>true</c>, theme changes are automatic based on OS preference.
+    /// The built-in "Light" and "Dark" themes are selected based on
+    /// <see cref="ISystemThemeProvider.GetCurrentTheme"/>.
+    /// </para>
+    /// <para>
+    /// When <c>false</c>, themes must be changed manually via <see cref="SetTheme(ITheme)"/>.
+    /// </para>
+    /// </remarks>
+    bool FollowSystemTheme { get; set; }
+
+    /// <summary>
+    /// Sets the active theme.
+    /// </summary>
+    /// <param name="theme">The theme to activate.</param>
+    /// <remarks>
+    /// Setting a theme manually sets <see cref="FollowSystemTheme"/> to <c>false</c>.
+    /// </remarks>
+    void SetTheme(ITheme theme);
+
+    /// <summary>
+    /// Sets the active theme by name.
+    /// </summary>
+    /// <param name="name">The name of a registered theme.</param>
+    /// <returns><c>true</c> if the theme was found and activated; otherwise <c>false</c>.</returns>
+    bool SetTheme(string name);
+
+    /// <summary>
+    /// Registers a custom theme.
+    /// </summary>
+    /// <param name="name">A unique name for the theme.</param>
+    /// <param name="theme">The theme to register.</param>
+    /// <remarks>
+    /// Built-in "Light" and "Dark" themes are registered automatically.
+    /// Custom themes can override built-in themes by using the same name.
+    /// </remarks>
+    void RegisterTheme(string name, ITheme theme);
+
+    /// <summary>
+    /// Gets a registered theme by name.
+    /// </summary>
+    /// <param name="name">The name of the theme to retrieve.</param>
+    /// <returns>The theme, or <c>null</c> if not found.</returns>
+    ITheme? GetTheme(string name);
+
+    /// <summary>
+    /// Gets all registered theme names.
+    /// </summary>
+    IReadOnlyCollection<string> RegisteredThemes { get; }
+
+    /// <summary>
+    /// Event raised when the active theme changes.
+    /// </summary>
+    event Action<ThemeChangedEvent>? OnThemeChanged;
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/KeenEyes.UI.Themes.Abstractions.csproj
+++ b/src/KeenEyes.UI.Themes.Abstractions/KeenEyes.UI.Themes.Abstractions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>KeenEyes.UI.Themes.Abstractions</PackageId>
+    <Description>UI theming system abstractions with OS theme detection for KeenEyes</Description>
+    <PackageTags>ecs;ui;themes;darkmode;abstractions</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.UI.Abstractions\KeenEyes.UI.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/KeenEyes.UI.Themes.Abstractions/SystemTheme.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/SystemTheme.cs
@@ -1,0 +1,31 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Represents the operating system's color theme preference.
+/// </summary>
+public enum SystemTheme
+{
+    /// <summary>
+    /// Theme could not be detected (unsupported platform or detection failed).
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The system is using a light color scheme.
+    /// </summary>
+    Light = 1,
+
+    /// <summary>
+    /// The system is using a dark color scheme.
+    /// </summary>
+    Dark = 2,
+
+    /// <summary>
+    /// The system has high contrast mode enabled.
+    /// </summary>
+    /// <remarks>
+    /// On Windows, this indicates High Contrast mode is active.
+    /// On other platforms, this may indicate an accessibility theme.
+    /// </remarks>
+    HighContrast = 3
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/UIComponentType.cs
+++ b/src/KeenEyes.UI.Themes.Abstractions/UIComponentType.cs
@@ -1,0 +1,57 @@
+namespace KeenEyes.UI.Themes.Abstractions;
+
+/// <summary>
+/// Identifies the type of UI component for theme styling purposes.
+/// </summary>
+public enum UIComponentType
+{
+    /// <summary>
+    /// No specific component type; uses default styling.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// A button component.
+    /// </summary>
+    Button,
+
+    /// <summary>
+    /// A panel or container component.
+    /// </summary>
+    Panel,
+
+    /// <summary>
+    /// A text input field component.
+    /// </summary>
+    Input,
+
+    /// <summary>
+    /// A menu component (dropdown, context menu).
+    /// </summary>
+    Menu,
+
+    /// <summary>
+    /// A menu item within a menu.
+    /// </summary>
+    MenuItem,
+
+    /// <summary>
+    /// A modal or dialog component.
+    /// </summary>
+    Modal,
+
+    /// <summary>
+    /// A scrollbar track component.
+    /// </summary>
+    ScrollbarTrack,
+
+    /// <summary>
+    /// A scrollbar thumb component.
+    /// </summary>
+    ScrollbarThumb,
+
+    /// <summary>
+    /// A tooltip component.
+    /// </summary>
+    Tooltip
+}

--- a/src/KeenEyes.UI.Themes.Abstractions/packages.lock.json
+++ b/src/KeenEyes.UI.Themes.Abstractions/packages.lock.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/src/KeenEyes.UI.Themes/Components/UIThemed.cs
+++ b/src/KeenEyes.UI.Themes/Components/UIThemed.cs
@@ -1,0 +1,60 @@
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes;
+
+/// <summary>
+/// Component that marks a UI entity for automatic theme styling.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Entities with this component will have their <see cref="KeenEyes.UI.Abstractions.UIStyle"/>
+/// automatically updated by the ThemeApplicatorSystem when the theme changes.
+/// </para>
+/// <para>
+/// The <see cref="ComponentType"/> determines which style method is called on the theme
+/// (e.g., <see cref="ITheme.GetButtonStyle"/> for <see cref="UIComponentType.Button"/>).
+/// </para>
+/// </remarks>
+public struct UIThemed : IComponent
+{
+    /// <summary>
+    /// The type of UI component for style resolution.
+    /// </summary>
+    public UIComponentType ComponentType;
+
+    /// <summary>
+    /// Creates a themed component marker for the specified component type.
+    /// </summary>
+    /// <param name="componentType">The type of UI component.</param>
+    public static UIThemed For(UIComponentType componentType) => new() { ComponentType = componentType };
+
+    /// <summary>
+    /// Creates a themed button marker.
+    /// </summary>
+    public static UIThemed Button => new() { ComponentType = UIComponentType.Button };
+
+    /// <summary>
+    /// Creates a themed panel marker.
+    /// </summary>
+    public static UIThemed Panel => new() { ComponentType = UIComponentType.Panel };
+
+    /// <summary>
+    /// Creates a themed input marker.
+    /// </summary>
+    public static UIThemed Input => new() { ComponentType = UIComponentType.Input };
+
+    /// <summary>
+    /// Creates a themed menu marker.
+    /// </summary>
+    public static UIThemed Menu => new() { ComponentType = UIComponentType.Menu };
+
+    /// <summary>
+    /// Creates a themed menu item marker.
+    /// </summary>
+    public static UIThemed MenuItem => new() { ComponentType = UIComponentType.MenuItem };
+
+    /// <summary>
+    /// Creates a themed modal marker.
+    /// </summary>
+    public static UIThemed Modal => new() { ComponentType = UIComponentType.Modal };
+}

--- a/src/KeenEyes.UI.Themes/KeenEyes.UI.Themes.csproj
+++ b/src/KeenEyes.UI.Themes/KeenEyes.UI.Themes.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>KeenEyes.UI.Themes</PackageId>
+    <Description>UI theming system with OS theme detection for KeenEyes (Windows, macOS, Linux)</Description>
+    <PackageTags>ecs;ui;themes;darkmode;windows;macos;linux</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KeenEyes.UI.Themes.Abstractions\KeenEyes.UI.Themes.Abstractions.csproj" />
+    <ProjectReference Include="..\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\KeenEyes.UI\KeenEyes.UI.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/KeenEyes.UI.Themes/Providers/FallbackThemeProvider.cs
+++ b/src/KeenEyes.UI.Themes/Providers/FallbackThemeProvider.cs
@@ -1,0 +1,34 @@
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Providers;
+
+/// <summary>
+/// Fallback provider for platforms where theme detection is not available.
+/// </summary>
+/// <remarks>
+/// This provider always returns <see cref="SystemTheme.Unknown"/> and never fires
+/// change notifications. It is used on unsupported platforms or when all platform-specific
+/// detection methods fail.
+/// </remarks>
+internal sealed class FallbackThemeProvider : ISystemThemeProvider
+{
+    /// <inheritdoc />
+    public bool SupportsRuntimeNotification => false;
+
+    /// <inheritdoc />
+    public bool IsAvailable => false;
+
+    /// <inheritdoc />
+#pragma warning disable CS0067 // Event is never used - required by interface, but fallback never fires it
+    public event Action<SystemThemeChangedEvent>? OnThemeChanged;
+#pragma warning restore CS0067
+
+    /// <inheritdoc />
+    public SystemTheme GetCurrentTheme() => SystemTheme.Unknown;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Nothing to dispose
+    }
+}

--- a/src/KeenEyes.UI.Themes/Providers/LinuxThemeProvider.cs
+++ b/src/KeenEyes.UI.Themes/Providers/LinuxThemeProvider.cs
@@ -1,0 +1,333 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Providers;
+
+/// <summary>
+/// Linux implementation using XDG portal D-Bus interface or gsettings fallback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attempts detection in this order:
+/// 1. XDG Desktop Portal (org.freedesktop.portal.Settings) - works across DEs
+/// 2. gsettings (GNOME/GTK applications)
+/// 3. KDE global configuration file
+/// </para>
+/// <para>
+/// Change detection uses dbus-monitor when available, otherwise falls back to polling.
+/// </para>
+/// </remarks>
+[SupportedOSPlatform("linux")]
+internal sealed class LinuxThemeProvider : ISystemThemeProvider
+{
+    private const int PollingIntervalMs = 1000;
+
+    private SystemTheme currentTheme;
+    private Thread? watcherThread;
+    private Process? dbusMonitorProcess;
+    private volatile bool disposed;
+
+    /// <inheritdoc />
+    public bool SupportsRuntimeNotification { get; private set; }
+
+    /// <inheritdoc />
+    public bool IsAvailable { get; }
+
+    /// <inheritdoc />
+    public event Action<SystemThemeChangedEvent>? OnThemeChanged;
+
+    public LinuxThemeProvider()
+    {
+        currentTheme = DetectTheme();
+        IsAvailable = currentTheme != SystemTheme.Unknown;
+
+        if (IsAvailable)
+        {
+            // Try to start dbus-monitor for efficient change detection
+            if (TryStartDbusMonitor())
+            {
+                SupportsRuntimeNotification = true;
+            }
+            else
+            {
+                // Fall back to polling
+                SupportsRuntimeNotification = true;
+                StartPolling();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public SystemTheme GetCurrentTheme() => currentTheme;
+
+    private static SystemTheme DetectTheme()
+    {
+        // Try XDG portal first (most universal)
+        var xdgTheme = TryXdgPortal();
+        if (xdgTheme != SystemTheme.Unknown)
+        {
+            return xdgTheme;
+        }
+
+        // Try gsettings (GNOME)
+        var gsettingsTheme = TryGsettings();
+        if (gsettingsTheme != SystemTheme.Unknown)
+        {
+            return gsettingsTheme;
+        }
+
+        // Try KDE settings
+        var kdeTheme = TryKde();
+        if (kdeTheme != SystemTheme.Unknown)
+        {
+            return kdeTheme;
+        }
+
+        return SystemTheme.Unknown;
+    }
+
+    private static SystemTheme TryXdgPortal()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dbus-send",
+                Arguments = "--session --print-reply --dest=org.freedesktop.portal.Desktop " +
+                    "/org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read " +
+                    "string:org.freedesktop.appearance string:color-scheme",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(1000);
+
+            if (process.ExitCode != 0)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // XDG portal color-scheme values:
+            // 0 = no preference (treat as light)
+            // 1 = prefer dark
+            // 2 = prefer light
+            if (output.Contains("uint32 1"))
+            {
+                return SystemTheme.Dark;
+            }
+
+            if (output.Contains("uint32 2") || output.Contains("uint32 0"))
+            {
+                return SystemTheme.Light;
+            }
+        }
+        catch
+        {
+            // dbus-send not available or failed
+        }
+
+        return SystemTheme.Unknown;
+    }
+
+    private static SystemTheme TryGsettings()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "gsettings",
+                Arguments = "get org.gnome.desktop.interface color-scheme",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit(1000);
+
+            if (process.ExitCode != 0)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // Values: 'default', 'prefer-dark', 'prefer-light'
+            if (output.Contains("prefer-dark", StringComparison.OrdinalIgnoreCase))
+            {
+                return SystemTheme.Dark;
+            }
+
+            if (output.Contains("prefer-light", StringComparison.OrdinalIgnoreCase) ||
+                output.Contains("default", StringComparison.OrdinalIgnoreCase))
+            {
+                return SystemTheme.Light;
+            }
+        }
+        catch
+        {
+            // gsettings not available or failed
+        }
+
+        return SystemTheme.Unknown;
+    }
+
+    private static SystemTheme TryKde()
+    {
+        try
+        {
+            // Read KDE global config
+            var configPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".config/kdeglobals");
+
+            if (!File.Exists(configPath))
+            {
+                return SystemTheme.Unknown;
+            }
+
+            var content = File.ReadAllText(configPath);
+
+            // Look for LookAndFeelPackage or ColorScheme containing "dark"
+            if (content.Contains("dark", StringComparison.OrdinalIgnoreCase))
+            {
+                return SystemTheme.Dark;
+            }
+
+            // If we can read the file but no dark indicator, assume light
+            return SystemTheme.Light;
+        }
+        catch
+        {
+            // File read failed
+        }
+
+        return SystemTheme.Unknown;
+    }
+
+    private bool TryStartDbusMonitor()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dbus-monitor",
+                Arguments = "--session type=signal,interface=org.freedesktop.portal.Settings",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            dbusMonitorProcess = Process.Start(startInfo);
+            if (dbusMonitorProcess is null)
+            {
+                return false;
+            }
+
+            watcherThread = new Thread(() =>
+            {
+                try
+                {
+                    while (!disposed && dbusMonitorProcess is { HasExited: false })
+                    {
+                        var line = dbusMonitorProcess.StandardOutput.ReadLine();
+                        if (line is null)
+                        {
+                            continue;
+                        }
+
+                        // Look for color-scheme signals
+                        if (line.Contains("color-scheme", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var previousTheme = currentTheme;
+                            currentTheme = DetectTheme();
+
+                            if (previousTheme != currentTheme)
+                            {
+                                OnThemeChanged?.Invoke(new SystemThemeChangedEvent(previousTheme, currentTheme));
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Monitor process exited or read failed
+                }
+            })
+            {
+                IsBackground = true,
+                Name = "KeenEyes-LinuxDbusMonitor"
+            };
+            watcherThread.Start();
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void StartPolling()
+    {
+        watcherThread = new Thread(() =>
+        {
+            while (!disposed)
+            {
+                Thread.Sleep(PollingIntervalMs);
+
+                if (disposed)
+                {
+                    break;
+                }
+
+                var previousTheme = currentTheme;
+                currentTheme = DetectTheme();
+
+                if (previousTheme != currentTheme)
+                {
+                    OnThemeChanged?.Invoke(new SystemThemeChangedEvent(previousTheme, currentTheme));
+                }
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "KeenEyes-LinuxThemePoller"
+        };
+        watcherThread.Start();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        disposed = true;
+
+        try
+        {
+            dbusMonitorProcess?.Kill();
+            dbusMonitorProcess?.Dispose();
+        }
+        catch
+        {
+            // Process already exited
+        }
+
+        watcherThread?.Join(TimeSpan.FromSeconds(2));
+    }
+}

--- a/src/KeenEyes.UI.Themes/Providers/MacOSThemeProvider.cs
+++ b/src/KeenEyes.UI.Themes/Providers/MacOSThemeProvider.cs
@@ -1,0 +1,172 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Providers;
+
+/// <summary>
+/// macOS implementation using NSApplication.effectiveAppearance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Uses Objective-C runtime P/Invoke to query NSApplication for the effective appearance.
+/// Supports both "NSAppearanceNameDarkAqua" (dark mode) and "NSAppearanceNameAqua" (light mode).
+/// </para>
+/// <para>
+/// Change detection uses polling since KVO blocks require complex Objective-C interop.
+/// The polling interval is 500ms to balance responsiveness with resource usage.
+/// </para>
+/// </remarks>
+[SupportedOSPlatform("macos")]
+internal sealed partial class MacOSThemeProvider : ISystemThemeProvider
+{
+    private const int PollingIntervalMs = 500;
+
+    private SystemTheme currentTheme;
+    private Thread? pollingThread;
+    private volatile bool disposed;
+
+    /// <inheritdoc />
+    public bool SupportsRuntimeNotification => true;
+
+    /// <inheritdoc />
+    public bool IsAvailable { get; }
+
+    /// <inheritdoc />
+    public event Action<SystemThemeChangedEvent>? OnThemeChanged;
+
+    public MacOSThemeProvider()
+    {
+        try
+        {
+            currentTheme = DetectTheme();
+            IsAvailable = currentTheme != SystemTheme.Unknown;
+
+            if (IsAvailable)
+            {
+                StartPolling();
+            }
+        }
+        catch
+        {
+            IsAvailable = false;
+            currentTheme = SystemTheme.Unknown;
+        }
+    }
+
+    /// <inheritdoc />
+    public SystemTheme GetCurrentTheme() => currentTheme;
+
+    private static SystemTheme DetectTheme()
+    {
+        try
+        {
+            // Get NSApplication class
+            var nsAppClass = objc_getClass("NSApplication"u8);
+            if (nsAppClass == nint.Zero)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // Get [NSApplication sharedApplication]
+            var sharedAppSel = sel_registerName("sharedApplication"u8);
+            var sharedApp = objc_msgSend(nsAppClass, sharedAppSel);
+            if (sharedApp == nint.Zero)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // Get effectiveAppearance
+            var effectiveAppearanceSel = sel_registerName("effectiveAppearance"u8);
+            var appearance = objc_msgSend(sharedApp, effectiveAppearanceSel);
+            if (appearance == nint.Zero)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // Get appearance name
+            var nameSel = sel_registerName("name"u8);
+            var name = objc_msgSend(appearance, nameSel);
+            if (name == nint.Zero)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            // Convert NSString to managed string
+            var nameStr = GetNSStringValue(name);
+
+            // Check for dark mode variants
+            if (nameStr.Contains("Dark", StringComparison.OrdinalIgnoreCase))
+            {
+                return SystemTheme.Dark;
+            }
+
+            // Check for high contrast
+            if (nameStr.Contains("HighContrast", StringComparison.OrdinalIgnoreCase) ||
+                nameStr.Contains("Accessibility", StringComparison.OrdinalIgnoreCase))
+            {
+                return SystemTheme.HighContrast;
+            }
+
+            // Default to light for "Aqua" and other variants
+            return SystemTheme.Light;
+        }
+        catch
+        {
+            return SystemTheme.Unknown;
+        }
+    }
+
+    private static string GetNSStringValue(nint nsString)
+    {
+        var utf8StringSel = sel_registerName("UTF8String"u8);
+        var utf8Ptr = objc_msgSend(nsString, utf8StringSel);
+        return utf8Ptr != nint.Zero ? Marshal.PtrToStringUTF8(utf8Ptr) ?? string.Empty : string.Empty;
+    }
+
+    private void StartPolling()
+    {
+        pollingThread = new Thread(() =>
+        {
+            while (!disposed)
+            {
+                Thread.Sleep(PollingIntervalMs);
+
+                if (disposed)
+                {
+                    break;
+                }
+
+                var previousTheme = currentTheme;
+                currentTheme = DetectTheme();
+
+                if (previousTheme != currentTheme)
+                {
+                    OnThemeChanged?.Invoke(new SystemThemeChangedEvent(previousTheme, currentTheme));
+                }
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "KeenEyes-MacOSThemePoller"
+        };
+        pollingThread.Start();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        disposed = true;
+        pollingThread?.Join(TimeSpan.FromSeconds(2));
+    }
+
+    // Objective-C runtime P/Invoke declarations
+    [LibraryImport("libobjc.dylib")]
+    private static partial nint objc_getClass(ReadOnlySpan<byte> name);
+
+    [LibraryImport("libobjc.dylib")]
+    private static partial nint sel_registerName(ReadOnlySpan<byte> name);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    private static partial nint objc_msgSend(nint receiver, nint selector);
+}

--- a/src/KeenEyes.UI.Themes/Providers/PlatformDetection.cs
+++ b/src/KeenEyes.UI.Themes/Providers/PlatformDetection.cs
@@ -1,0 +1,46 @@
+namespace KeenEyes.UI.Themes.Providers;
+
+/// <summary>
+/// Provides runtime platform detection for theme provider selection.
+/// </summary>
+internal static class PlatformDetection
+{
+    /// <summary>
+    /// Gets whether the current platform is Windows.
+    /// </summary>
+    public static bool IsWindows => OperatingSystem.IsWindows();
+
+    /// <summary>
+    /// Gets whether the current platform is macOS.
+    /// </summary>
+    public static bool IsMacOS => OperatingSystem.IsMacOS();
+
+    /// <summary>
+    /// Gets whether the current platform is Linux.
+    /// </summary>
+    public static bool IsLinux => OperatingSystem.IsLinux();
+
+    /// <summary>
+    /// Gets the Windows build number for feature detection.
+    /// </summary>
+    /// <remarks>
+    /// Returns 0 on non-Windows platforms. Theme detection requires Windows 10 (build 10240+).
+    /// </remarks>
+    public static int WindowsBuildNumber
+    {
+        get
+        {
+            if (!IsWindows)
+            {
+                return 0;
+            }
+
+            return Environment.OSVersion.Version.Build;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether Windows theme APIs are available (Windows 10+).
+    /// </summary>
+    public static bool SupportsWindowsThemeDetection => IsWindows && WindowsBuildNumber >= 10240;
+}

--- a/src/KeenEyes.UI.Themes/Providers/WindowsThemeProvider.cs
+++ b/src/KeenEyes.UI.Themes/Providers/WindowsThemeProvider.cs
@@ -1,0 +1,204 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using KeenEyes.UI.Themes.Abstractions;
+using Microsoft.Win32;
+
+namespace KeenEyes.UI.Themes.Providers;
+
+/// <summary>
+/// Windows implementation using registry watching for theme changes.
+/// </summary>
+/// <remarks>
+/// Uses the Personalize registry key for maximum compatibility across Windows 10+.
+/// Also detects Windows High Contrast mode for accessibility.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal sealed partial class WindowsThemeProvider : ISystemThemeProvider
+{
+    private const string PersonalizeKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+    private const string AppsUseLightThemeValue = "AppsUseLightTheme";
+
+    private SystemTheme currentTheme;
+    private Thread? watcherThread;
+    private volatile bool disposed;
+
+    /// <inheritdoc />
+    public bool SupportsRuntimeNotification => true;
+
+    /// <inheritdoc />
+    public bool IsAvailable { get; }
+
+    /// <inheritdoc />
+    public event Action<SystemThemeChangedEvent>? OnThemeChanged;
+
+    public WindowsThemeProvider()
+    {
+        currentTheme = DetectTheme();
+        IsAvailable = currentTheme != SystemTheme.Unknown;
+
+        if (IsAvailable)
+        {
+            StartRegistryWatcher();
+        }
+    }
+
+    /// <inheritdoc />
+    public SystemTheme GetCurrentTheme() => currentTheme;
+
+    private static SystemTheme DetectTheme()
+    {
+        // Check high contrast first (accessibility takes priority)
+        if (IsHighContrastEnabled())
+        {
+            return SystemTheme.HighContrast;
+        }
+
+        // Read from registry
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(PersonalizeKeyPath);
+            if (key is null)
+            {
+                return SystemTheme.Unknown;
+            }
+
+            var value = key.GetValue(AppsUseLightThemeValue);
+            if (value is int intValue)
+            {
+                return intValue == 0 ? SystemTheme.Dark : SystemTheme.Light;
+            }
+        }
+        catch
+        {
+            // Registry access failed - return unknown
+        }
+
+        return SystemTheme.Unknown;
+    }
+
+    private static bool IsHighContrastEnabled()
+    {
+        var info = new HighContrastInfo { cbSize = (uint)Marshal.SizeOf<HighContrastInfo>() };
+        if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, info.cbSize, ref info, 0))
+        {
+            return (info.dwFlags & HCF_HIGHCONTRASTON) != 0;
+        }
+
+        return false;
+    }
+
+    private void StartRegistryWatcher()
+    {
+        watcherThread = new Thread(RegistryWatchLoop)
+        {
+            IsBackground = true,
+            Name = "KeenEyes-ThemeWatcher"
+        };
+        watcherThread.Start();
+    }
+
+    private void RegistryWatchLoop()
+    {
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, PersonalizeKeyPath, 0, KEY_NOTIFY, out var hKey) != 0)
+        {
+            return;
+        }
+
+        var hEvent = CreateEventW(nint.Zero, false, false, null);
+        if (hEvent == nint.Zero)
+        {
+            RegCloseKey(hKey);
+            return;
+        }
+
+        try
+        {
+            while (!disposed)
+            {
+                // Register for notification on value changes
+                if (RegNotifyChangeKeyValue(hKey, false, REG_NOTIFY_CHANGE_LAST_SET, hEvent, true) != 0)
+                {
+                    break;
+                }
+
+                // Wait for change (1 second timeout to check disposed flag)
+                var result = WaitForSingleObject(hEvent, 1000);
+
+                if (result == WAIT_OBJECT_0 && !disposed)
+                {
+                    var previousTheme = currentTheme;
+                    currentTheme = DetectTheme();
+
+                    if (previousTheme != currentTheme)
+                    {
+                        OnThemeChanged?.Invoke(new SystemThemeChangedEvent(previousTheme, currentTheme));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            CloseHandle(hEvent);
+            RegCloseKey(hKey);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        disposed = true;
+        watcherThread?.Join(TimeSpan.FromSeconds(2));
+    }
+
+    // P/Invoke declarations for High Contrast detection
+    private const uint SPI_GETHIGHCONTRAST = 0x0042;
+    private const uint HCF_HIGHCONTRASTON = 0x00000001;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HighContrastInfo
+    {
+        public uint cbSize;
+        public uint dwFlags;
+        public nint lpszDefaultScheme;
+    }
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SystemParametersInfoW(
+        uint uiAction, uint uiParam, ref HighContrastInfo pvParam, uint fWinIni);
+
+    // P/Invoke declarations for registry watching
+    private static readonly nint HKEY_CURRENT_USER = unchecked((nint)0x80000001);
+    private const uint KEY_NOTIFY = 0x0010;
+    private const uint REG_NOTIFY_CHANGE_LAST_SET = 0x00000004;
+    private const uint WAIT_OBJECT_0 = 0x00000000;
+
+    [LibraryImport("advapi32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int RegOpenKeyExW(
+        nint hKey, string lpSubKey, uint ulOptions, uint samDesired, out nint phkResult);
+
+    [LibraryImport("advapi32.dll", SetLastError = true)]
+    private static partial int RegNotifyChangeKeyValue(
+        nint hKey,
+        [MarshalAs(UnmanagedType.Bool)] bool bWatchSubtree,
+        uint dwNotifyFilter,
+        nint hEvent,
+        [MarshalAs(UnmanagedType.Bool)] bool fAsynchronous);
+
+    [LibraryImport("advapi32.dll", SetLastError = true)]
+    private static partial int RegCloseKey(nint hKey);
+
+    [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial nint CreateEventW(
+        nint lpEventAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool bManualReset,
+        [MarshalAs(UnmanagedType.Bool)] bool bInitialState,
+        string? lpName);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial uint WaitForSingleObject(nint hHandle, uint dwMilliseconds);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(nint hObject);
+}

--- a/src/KeenEyes.UI.Themes/Systems/ThemeApplicatorSystem.cs
+++ b/src/KeenEyes.UI.Themes/Systems/ThemeApplicatorSystem.cs
@@ -1,0 +1,70 @@
+using KeenEyes.UI.Abstractions;
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Systems;
+
+/// <summary>
+/// System that applies theme styles to UI components marked with <see cref="UIThemed"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs in the LateUpdate phase before layout and rendering systems.
+/// It updates <see cref="UIStyle"/> components based on the current theme and
+/// interaction state of each UI element.
+/// </para>
+/// <para>
+/// Only entities with both <see cref="UIStyle"/> and <see cref="UIThemed"/> components
+/// are processed. The <see cref="UIThemed.ComponentType"/> determines which style
+/// method is called on the theme.
+/// </para>
+/// </remarks>
+public sealed class ThemeApplicatorSystem : SystemBase
+{
+    private IThemeContext? themeContext;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Lazy initialization to avoid issues during plugin install
+        themeContext ??= World.GetExtension<IThemeContext>();
+
+        var theme = themeContext.CurrentTheme;
+
+        // Query entities that need theme styling
+        foreach (var entity in World.Query<UIStyle, UIThemed>())
+        {
+            ref var style = ref World.Get<UIStyle>(entity);
+            ref readonly var themed = ref World.Get<UIThemed>(entity);
+
+            // Get interaction state if available
+            var interactionState = UIInteractionState.None;
+            if (World.Has<UIInteractable>(entity))
+            {
+                ref readonly var interactable = ref World.Get<UIInteractable>(entity);
+                interactionState = interactable.State;
+            }
+
+            // Check if disabled
+            if (World.Has<UIDisabledTag>(entity))
+            {
+                // Keep existing style but could apply disabled overlay in future
+                continue;
+            }
+
+            // Apply theme style based on component type
+            style = themed.ComponentType switch
+            {
+                UIComponentType.Button => theme.GetButtonStyle(interactionState),
+                UIComponentType.Panel => theme.GetPanelStyle(),
+                UIComponentType.Input => theme.GetInputStyle(interactionState),
+                UIComponentType.Menu => theme.GetMenuStyle(),
+                UIComponentType.MenuItem => theme.GetMenuItemStyle(interactionState),
+                UIComponentType.Modal => theme.GetModalStyle(),
+                UIComponentType.ScrollbarTrack => theme.GetScrollbarTrackStyle(),
+                UIComponentType.ScrollbarThumb => theme.GetScrollbarThumbStyle(interactionState),
+                UIComponentType.Tooltip => theme.GetTooltipStyle(),
+                _ => style // Keep existing style for unknown types
+            };
+        }
+    }
+}

--- a/src/KeenEyes.UI.Themes/ThemeContext.cs
+++ b/src/KeenEyes.UI.Themes/ThemeContext.cs
@@ -1,0 +1,175 @@
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes;
+
+/// <summary>
+/// Provides access to theme management and OS theme detection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the primary interface for working with themes. Access it via
+/// <c>world.GetExtension&lt;IThemeContext&gt;()</c> after installing the theme plugin.
+/// </para>
+/// </remarks>
+[PluginExtension("UI.Themes")]
+public sealed class ThemeContext : IThemeContext, IDisposable
+{
+    private readonly IWorld world;
+    private readonly ISystemThemeProvider systemThemeProvider;
+    private readonly Dictionary<string, ITheme> themes = new(StringComparer.OrdinalIgnoreCase);
+    private ITheme currentTheme = null!;
+    private bool followSystemTheme;
+    private bool disposed;
+
+    /// <inheritdoc />
+    public ITheme CurrentTheme => currentTheme;
+
+    /// <inheritdoc />
+    public SystemTheme SystemTheme => systemThemeProvider.GetCurrentTheme();
+
+    /// <inheritdoc />
+    public bool FollowSystemTheme
+    {
+        get => followSystemTheme;
+        set
+        {
+            if (followSystemTheme == value)
+            {
+                return;
+            }
+
+            followSystemTheme = value;
+
+            if (value)
+            {
+                ApplySystemTheme();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> RegisteredThemes => themes.Keys;
+
+    /// <inheritdoc />
+    public event Action<ThemeChangedEvent>? OnThemeChanged;
+
+    internal ThemeContext(IWorld world, ISystemThemeProvider systemThemeProvider)
+    {
+        this.world = world;
+        this.systemThemeProvider = systemThemeProvider;
+
+        if (systemThemeProvider.SupportsRuntimeNotification)
+        {
+            systemThemeProvider.OnThemeChanged += HandleSystemThemeChanged;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetTheme(ITheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(theme);
+
+        // Setting a theme manually disables follow system
+        followSystemTheme = false;
+
+        ApplyTheme(theme);
+    }
+
+    /// <inheritdoc />
+    public bool SetTheme(string name)
+    {
+        if (!themes.TryGetValue(name, out var theme))
+        {
+            return false;
+        }
+
+        SetTheme(theme);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void RegisterTheme(string name, ITheme theme)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(theme);
+
+        themes[name] = theme;
+    }
+
+    /// <inheritdoc />
+    public ITheme? GetTheme(string name)
+    {
+        return themes.TryGetValue(name, out var theme) ? theme : null;
+    }
+
+    internal void SetInitialTheme(ITheme theme)
+    {
+        currentTheme = theme;
+    }
+
+    private void ApplyTheme(ITheme theme)
+    {
+        var previous = currentTheme;
+        currentTheme = theme;
+
+        if (previous != theme)
+        {
+            var evt = new ThemeChangedEvent(previous, theme);
+            OnThemeChanged?.Invoke(evt);
+            world.Send(evt);
+        }
+    }
+
+    private void HandleSystemThemeChanged(SystemThemeChangedEvent evt)
+    {
+        if (!followSystemTheme)
+        {
+            return;
+        }
+
+        // Forward system theme change to ECS messaging
+        world.Send(evt);
+
+        ApplySystemTheme();
+    }
+
+    private void ApplySystemTheme()
+    {
+        var systemTheme = systemThemeProvider.GetCurrentTheme();
+        var themeName = systemTheme switch
+        {
+            SystemTheme.Dark => "Dark",
+            SystemTheme.HighContrast => "HighContrast",
+            _ => "Light"
+        };
+
+        // Try to find a matching theme, fall back to Light/Dark if HighContrast not found
+        if (!themes.TryGetValue(themeName, out var theme) && systemTheme == SystemTheme.HighContrast)
+        {
+            theme = themes.GetValueOrDefault("Dark") ?? themes.GetValueOrDefault("Light");
+        }
+
+        if (theme is not null && theme != currentTheme)
+        {
+            ApplyTheme(theme);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        if (systemThemeProvider.SupportsRuntimeNotification)
+        {
+            systemThemeProvider.OnThemeChanged -= HandleSystemThemeChanged;
+        }
+
+        systemThemeProvider.Dispose();
+    }
+}

--- a/src/KeenEyes.UI.Themes/ThemePlugin.cs
+++ b/src/KeenEyes.UI.Themes/ThemePlugin.cs
@@ -1,0 +1,117 @@
+using KeenEyes.UI.Themes.Abstractions;
+using KeenEyes.UI.Themes.Providers;
+using KeenEyes.UI.Themes.Systems;
+using KeenEyes.UI.Themes.Themes;
+
+namespace KeenEyes.UI.Themes;
+
+/// <summary>
+/// Plugin that provides UI theming with OS theme detection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin enables automatic theme switching based on OS preferences and provides
+/// a theming system for UI components. It detects light/dark mode on Windows, macOS,
+/// and Linux, and can automatically switch themes when the OS preference changes.
+/// </para>
+/// <para>
+/// Built-in "Light" and "Dark" themes are registered automatically. Custom themes
+/// can be registered via <see cref="IThemeContext.RegisterTheme"/>.
+/// </para>
+/// <para>
+/// <b>Dependencies:</b> This plugin should be installed after <see cref="KeenEyes.UI.UIPlugin"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var world = new World();
+///
+/// // Install plugins (order matters: UI before Themes)
+/// world.InstallPlugin(new UIPlugin());
+/// world.InstallPlugin(new ThemePlugin());
+///
+/// // Access theme context
+/// var theme = world.GetExtension&lt;IThemeContext&gt;();
+///
+/// // Enable automatic OS theme following
+/// theme.FollowSystemTheme = true;
+///
+/// // Or manually switch themes
+/// theme.SetTheme("Dark");
+///
+/// // Create themed buttons
+/// var button = world.Spawn()
+///     .WithUIElement()
+///     .WithUIRect(...)
+///     .WithUIStyle(theme.CurrentTheme.GetButtonStyle(UIInteractionState.None))
+///     .With(UIThemed.Button)
+///     .Build();
+/// </code>
+/// </example>
+public sealed class ThemePlugin : IWorldPlugin
+{
+    private ThemeContext? themeContext;
+    private ISystemThemeProvider? systemThemeProvider;
+
+    /// <inheritdoc />
+    public string Name => "UI.Themes";
+
+    /// <inheritdoc />
+    public void Install(IPluginContext context)
+    {
+        // Create platform-specific theme provider
+        systemThemeProvider = CreatePlatformProvider();
+
+        // Create theme context
+        themeContext = new ThemeContext(context.World, systemThemeProvider);
+
+        // Register built-in themes
+        themeContext.RegisterTheme("Light", new LightTheme());
+        themeContext.RegisterTheme("Dark", new DarkTheme());
+
+        // Set initial theme based on OS preference
+        var systemTheme = systemThemeProvider.GetCurrentTheme();
+        var initialThemeName = systemTheme == SystemTheme.Dark ? "Dark" : "Light";
+        var initialTheme = themeContext.GetTheme(initialThemeName)!;
+        themeContext.SetInitialTheme(initialTheme);
+
+        // Expose context as extension
+        context.SetExtension<IThemeContext>(themeContext);
+
+        // Register UIThemed component
+        context.RegisterComponent<UIThemed>();
+
+        // Add theme applicator system (runs before UI layout)
+        context.AddSystem<ThemeApplicatorSystem>(SystemPhase.LateUpdate, order: -20);
+    }
+
+    /// <inheritdoc />
+    public void Uninstall(IPluginContext context)
+    {
+        context.RemoveExtension<IThemeContext>();
+        themeContext?.Dispose();
+        themeContext = null;
+        systemThemeProvider = null;
+    }
+
+    private static ISystemThemeProvider CreatePlatformProvider()
+    {
+        // Use OperatingSystem.IsX() directly so CA1416 analyzer recognizes the platform guards
+        if (OperatingSystem.IsWindows() && PlatformDetection.SupportsWindowsThemeDetection)
+        {
+            return new WindowsThemeProvider();
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return new MacOSThemeProvider();
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return new LinuxThemeProvider();
+        }
+
+        return new FallbackThemeProvider();
+    }
+}

--- a/src/KeenEyes.UI.Themes/Themes/DarkTheme.cs
+++ b/src/KeenEyes.UI.Themes/Themes/DarkTheme.cs
@@ -1,0 +1,227 @@
+using System.Numerics;
+using KeenEyes.UI.Abstractions;
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Themes;
+
+/// <summary>
+/// Built-in dark theme optimized for low-light environments.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This theme uses a dark color palette that reduces eye strain in dim environments
+/// and is suitable for extended use. Text is light on dark backgrounds.
+/// </para>
+/// <para>
+/// The color scheme follows dark mode best practices with appropriate contrast ratios
+/// for accessibility (WCAG 2.1 AA compliant).
+/// </para>
+/// </remarks>
+public sealed class DarkTheme : ITheme
+{
+    /// <inheritdoc />
+    public string Name => "Dark";
+
+    /// <inheritdoc />
+    public SystemTheme BaseTheme => SystemTheme.Dark;
+
+    /// <inheritdoc />
+    public ColorPalette Colors { get; } = new()
+    {
+        // Backgrounds
+        Background = new Vector4(0.12f, 0.12f, 0.12f, 1f),        // #1E1E1E
+        Surface = new Vector4(0.18f, 0.18f, 0.18f, 1f),           // #2D2D2D
+        SurfaceElevated = new Vector4(0.22f, 0.22f, 0.22f, 1f),   // #383838
+
+        // Brand colors (lighter variants for dark backgrounds)
+        Primary = new Vector4(0.39f, 0.71f, 1f, 1f),              // #64B5F6
+        PrimaryVariant = new Vector4(0.56f, 0.79f, 1f, 1f),       // #90CAF9
+        Secondary = new Vector4(0.50f, 0.80f, 0.50f, 1f),         // #81C784
+        Accent = new Vector4(0.31f, 0.76f, 0.97f, 1f),            // #4FC3F7
+
+        // Text colors
+        TextPrimary = new Vector4(0.93f, 0.93f, 0.93f, 1f),       // #EDEDED
+        TextSecondary = new Vector4(0.70f, 0.70f, 0.70f, 1f),     // #B3B3B3
+        TextDisabled = new Vector4(0.50f, 0.50f, 0.50f, 1f),      // #808080
+        TextOnPrimary = new Vector4(0.13f, 0.13f, 0.13f, 1f),     // #212121
+
+        // State colors (adjusted for dark backgrounds)
+        Success = new Vector4(0.50f, 0.80f, 0.50f, 1f),           // #81C784
+        Warning = new Vector4(1f, 0.76f, 0.28f, 1f),              // #FFC247
+        Error = new Vector4(0.94f, 0.50f, 0.45f, 1f),             // #EF8073
+        Info = new Vector4(0.39f, 0.71f, 1f, 1f),                 // #64B5F6
+
+        // Borders
+        Border = new Vector4(0.30f, 0.30f, 0.30f, 1f),            // #4D4D4D
+        BorderFocused = new Vector4(0.39f, 0.71f, 1f, 1f),        // #64B5F6
+        Divider = new Vector4(0.25f, 0.25f, 0.25f, 1f),           // #404040
+
+        // Overlays
+        HoverOverlay = new Vector4(1f, 1f, 1f, 0.05f),            // 5% white
+        PressedOverlay = new Vector4(1f, 1f, 1f, 0.10f),          // 10% white
+        DisabledOverlay = new Vector4(1f, 1f, 1f, 0.12f)          // 12% white
+    };
+
+    /// <inheritdoc />
+    public UIStyle GetButtonStyle(UIInteractionState state)
+    {
+        var baseColor = Colors.Primary;
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            baseColor = Colors.PrimaryVariant;
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            baseColor = BlendColor(Colors.Primary, Colors.HoverOverlay);
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = baseColor,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = new UIEdges(12, 8, 12, 8)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetPanelStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.Surface,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 8, 8, 8)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetInputStyle(UIInteractionState state)
+    {
+        var borderColor = state.HasFlag(UIInteractionState.Focused)
+            ? Colors.BorderFocused
+            : Colors.Border;
+
+        return new UIStyle
+        {
+            BackgroundColor = Colors.Background,
+            BorderColor = borderColor,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 6, 8, 6)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetMenuStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.SurfaceElevated,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(4, 4, 4, 4)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetMenuItemStyle(UIInteractionState state)
+    {
+        var bgColor = Vector4.Zero;
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            bgColor = Colors.PressedOverlay;
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            bgColor = Colors.HoverOverlay;
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = bgColor,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 2,
+            Padding = new UIEdges(12, 6, 12, 6)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetModalStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.SurfaceElevated,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 8,
+            Padding = new UIEdges(16, 16, 16, 16)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetScrollbarTrackStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = new Vector4(0.15f, 0.15f, 0.15f, 1f),
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = UIEdges.Zero
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetScrollbarThumbStyle(UIInteractionState state)
+    {
+        var color = new Vector4(0.4f, 0.4f, 0.4f, 1f);
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            color = new Vector4(0.55f, 0.55f, 0.55f, 1f);
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            color = new Vector4(0.5f, 0.5f, 0.5f, 1f);
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = color,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = UIEdges.Zero
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetTooltipStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = new Vector4(0.9f, 0.9f, 0.9f, 0.95f),
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 4, 8, 4)
+        };
+    }
+
+    private static Vector4 BlendColor(Vector4 baseColor, Vector4 overlay)
+    {
+        return new Vector4(
+            baseColor.X + (overlay.X - baseColor.X) * overlay.W,
+            baseColor.Y + (overlay.Y - baseColor.Y) * overlay.W,
+            baseColor.Z + (overlay.Z - baseColor.Z) * overlay.W,
+            baseColor.W);
+    }
+}

--- a/src/KeenEyes.UI.Themes/Themes/LightTheme.cs
+++ b/src/KeenEyes.UI.Themes/Themes/LightTheme.cs
@@ -1,0 +1,227 @@
+using System.Numerics;
+using KeenEyes.UI.Abstractions;
+using KeenEyes.UI.Themes.Abstractions;
+
+namespace KeenEyes.UI.Themes.Themes;
+
+/// <summary>
+/// Built-in light theme with a clean, modern appearance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This theme uses a light color palette suitable for well-lit environments.
+/// Text is dark on light backgrounds for optimal readability.
+/// </para>
+/// <para>
+/// The color scheme is based on Material Design guidelines with some customizations
+/// for game UI contexts.
+/// </para>
+/// </remarks>
+public sealed class LightTheme : ITheme
+{
+    /// <inheritdoc />
+    public string Name => "Light";
+
+    /// <inheritdoc />
+    public SystemTheme BaseTheme => SystemTheme.Light;
+
+    /// <inheritdoc />
+    public ColorPalette Colors { get; } = new()
+    {
+        // Backgrounds
+        Background = new Vector4(0.96f, 0.96f, 0.96f, 1f),       // #F5F5F5
+        Surface = new Vector4(1f, 1f, 1f, 1f),                    // #FFFFFF
+        SurfaceElevated = new Vector4(1f, 1f, 1f, 1f),            // #FFFFFF
+
+        // Brand colors
+        Primary = new Vector4(0.13f, 0.59f, 0.95f, 1f),           // #2196F3
+        PrimaryVariant = new Vector4(0.10f, 0.46f, 0.82f, 1f),    // #1976D2
+        Secondary = new Vector4(0.30f, 0.69f, 0.31f, 1f),         // #4CAF50
+        Accent = new Vector4(0.01f, 0.66f, 0.96f, 1f),            // #03A9F4
+
+        // Text colors
+        TextPrimary = new Vector4(0.13f, 0.13f, 0.13f, 1f),       // #212121
+        TextSecondary = new Vector4(0.46f, 0.46f, 0.46f, 1f),     // #757575
+        TextDisabled = new Vector4(0.62f, 0.62f, 0.62f, 1f),      // #9E9E9E
+        TextOnPrimary = new Vector4(1f, 1f, 1f, 1f),              // #FFFFFF
+
+        // State colors
+        Success = new Vector4(0.30f, 0.69f, 0.31f, 1f),           // #4CAF50
+        Warning = new Vector4(1f, 0.60f, 0f, 1f),                 // #FF9800
+        Error = new Vector4(0.96f, 0.26f, 0.21f, 1f),             // #F44336
+        Info = new Vector4(0.13f, 0.59f, 0.95f, 1f),              // #2196F3
+
+        // Borders
+        Border = new Vector4(0.88f, 0.88f, 0.88f, 1f),            // #E0E0E0
+        BorderFocused = new Vector4(0.13f, 0.59f, 0.95f, 1f),     // #2196F3
+        Divider = new Vector4(0.88f, 0.88f, 0.88f, 1f),           // #E0E0E0
+
+        // Overlays
+        HoverOverlay = new Vector4(0f, 0f, 0f, 0.04f),            // 4% black
+        PressedOverlay = new Vector4(0f, 0f, 0f, 0.08f),          // 8% black
+        DisabledOverlay = new Vector4(0f, 0f, 0f, 0.12f)          // 12% black
+    };
+
+    /// <inheritdoc />
+    public UIStyle GetButtonStyle(UIInteractionState state)
+    {
+        var baseColor = Colors.Primary;
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            baseColor = Colors.PrimaryVariant;
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            baseColor = BlendColor(Colors.Primary, Colors.HoverOverlay);
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = baseColor,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = new UIEdges(12, 8, 12, 8)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetPanelStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.Surface,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 8, 8, 8)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetInputStyle(UIInteractionState state)
+    {
+        var borderColor = state.HasFlag(UIInteractionState.Focused)
+            ? Colors.BorderFocused
+            : Colors.Border;
+
+        return new UIStyle
+        {
+            BackgroundColor = Colors.Surface,
+            BorderColor = borderColor,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 6, 8, 6)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetMenuStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.Surface,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 4,
+            Padding = new UIEdges(4, 4, 4, 4)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetMenuItemStyle(UIInteractionState state)
+    {
+        var bgColor = Vector4.Zero;
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            bgColor = Colors.PressedOverlay;
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            bgColor = Colors.HoverOverlay;
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = bgColor,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 2,
+            Padding = new UIEdges(12, 6, 12, 6)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetModalStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = Colors.SurfaceElevated,
+            BorderColor = Colors.Border,
+            BorderWidth = 1,
+            CornerRadius = 8,
+            Padding = new UIEdges(16, 16, 16, 16)
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetScrollbarTrackStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = new Vector4(0.9f, 0.9f, 0.9f, 1f),
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = UIEdges.Zero
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetScrollbarThumbStyle(UIInteractionState state)
+    {
+        var color = new Vector4(0.7f, 0.7f, 0.7f, 1f);
+
+        if (state.HasFlag(UIInteractionState.Pressed))
+        {
+            color = new Vector4(0.5f, 0.5f, 0.5f, 1f);
+        }
+        else if (state.HasFlag(UIInteractionState.Hovered))
+        {
+            color = new Vector4(0.6f, 0.6f, 0.6f, 1f);
+        }
+
+        return new UIStyle
+        {
+            BackgroundColor = color,
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = UIEdges.Zero
+        };
+    }
+
+    /// <inheritdoc />
+    public UIStyle GetTooltipStyle()
+    {
+        return new UIStyle
+        {
+            BackgroundColor = new Vector4(0.2f, 0.2f, 0.2f, 0.9f),
+            BorderColor = Vector4.Zero,
+            BorderWidth = 0,
+            CornerRadius = 4,
+            Padding = new UIEdges(8, 4, 8, 4)
+        };
+    }
+
+    private static Vector4 BlendColor(Vector4 baseColor, Vector4 overlay)
+    {
+        return new Vector4(
+            baseColor.X + (overlay.X - baseColor.X) * overlay.W,
+            baseColor.Y + (overlay.Y - baseColor.Y) * overlay.W,
+            baseColor.Z + (overlay.Z - baseColor.Z) * overlay.W,
+            baseColor.W);
+    }
+}

--- a/src/KeenEyes.UI.Themes/packages.lock.json
+++ b/src/KeenEyes.UI.Themes/packages.lock.json
@@ -1,0 +1,136 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.10",
+        "contentHash": "u7gAG7JgxF8VSJUGPSudAcPxOt+ymJKQCSxNRxiuKV+klCQbHljQR75SilpedCTfhPWDhtUwIJpnDVtspr9nMg=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NVorbis": "[0.10.5, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[7.1.3, )"
+        }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.themes.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "go1/KHij1AB5K3nKiKKzSuSVIAKivgAnC3P6FAOOhB/WMg7y6lw9n95LCyABVuoewk4CNI8S0RZVvC6gkeTp7g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10"
+        }
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive UI theming support with automatic OS theme detection
- Support Windows, macOS, and Linux platforms with runtime change notification
- Include built-in Light and Dark themes with semantic color palettes
- Provide ThemePlugin for easy integration with existing UI system

## New Packages

### `KeenEyes.UI.Themes.Abstractions`
- `ISystemThemeProvider` - OS theme detection interface
- `ITheme` - Application theme with color palette and component styles
- `IThemeContext` - Theme management and switching
- `ColorPalette` - Semantic color definitions
- `SystemTheme` enum - Unknown, Light, Dark, HighContrast

### `KeenEyes.UI.Themes`
- Platform providers: Windows, macOS, Linux, Fallback
- Built-in themes: LightTheme, DarkTheme
- `UIThemed` component for automatic styling
- `ThemeApplicatorSystem` - applies styles based on current theme
- `ThemePlugin` - registers everything

## Platform Detection

| Platform | Detection Method | Change Notification |
|----------|------------------|---------------------|
| Windows | Registry `AppsUseLightTheme` + High Contrast API | `RegNotifyChangeKeyValue` |
| macOS | `NSApplication.effectiveAppearance` via ObjC P/Invoke | Polling (500ms) |
| Linux | XDG portal D-Bus / gsettings | `dbus-monitor` or polling |

## Usage

```csharp
world.InstallPlugin(new UIPlugin());
world.InstallPlugin(new ThemePlugin());

var theme = world.GetExtension<IThemeContext>();
theme.FollowSystemTheme = true;  // Auto-switch on OS change

var button = world.Spawn()
    .WithUIStyle(theme.CurrentTheme.GetButtonStyle(UIInteractionState.None))
    .With(UIThemed.Button)
    .Build();
```

## Test plan
- [x] Build passes with zero warnings
- [ ] Manual testing on Windows (toggle dark mode)
- [ ] Manual testing on macOS
- [ ] Manual testing on Linux

## Related Issues
Closes #870, #871, #872, #873

🤖 Generated with [Claude Code](https://claude.ai/code)