### PR TITLE
feat(sample): Add 9-slice rendering demo to UI sample

### DIFF
--- a/samples/KeenEyes.Sample.UI/KeenEyes.Sample.UI.csproj
+++ b/samples/KeenEyes.Sample.UI/KeenEyes.Sample.UI.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="Assets\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />


### PR DESCRIPTION
## Summary
- Add 9-slice rendering demonstration to the UI sample gallery
- Load `dialog-texture.png` and display it at multiple sizes using 9-slice scaling
- Demonstrates that corners stay sharp while edges and center stretch

## Changes
- Update `KeenEyes.Sample.UI.csproj` to copy Assets folder to output
- Load dialog texture via `IGraphicsContext.LoadTexture()`
- Add "9-Slice Rendering" section to Layout tab with 4 demo panels:
  - Small (100x80)
  - Medium (200x120)
  - Large (350x160)
  - Wide (250x60)
- Uses 16px borders on all sides

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All tests pass
- [ ] Manual testing: Run sample and verify 9-slice panels render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)