### PR TITLE
feat(assets): Enhance MeshVertex with PBR and animation attributes

### DIFF
--- a/src/KeenEyes.Assets/Assets/MeshAsset.cs
+++ b/src/KeenEyes.Assets/Assets/MeshAsset.cs
@@ -3,12 +3,84 @@ using System.Numerics;
 namespace KeenEyes.Assets;
 
 /// <summary>
-/// Represents a vertex in a mesh with position, normal, and texture coordinates.
+/// Represents bone joint indices for skeletal animation (up to 4 bone influences per vertex).
 /// </summary>
+/// <remarks>
+/// Joint indices reference bones in a skeleton hierarchy. Each vertex can be influenced
+/// by up to 4 bones, with corresponding weights in <see cref="MeshVertex.Weights"/>.
+/// </remarks>
+/// <param name="Joint0">First bone index.</param>
+/// <param name="Joint1">Second bone index.</param>
+/// <param name="Joint2">Third bone index.</param>
+/// <param name="Joint3">Fourth bone index.</param>
+public readonly record struct JointIndices(ushort Joint0, ushort Joint1, ushort Joint2, ushort Joint3)
+{
+    /// <summary>
+    /// Default joint indices (all zero, typically the root bone).
+    /// </summary>
+    public static JointIndices Default => new(0, 0, 0, 0);
+}
+
+/// <summary>
+/// Represents a vertex in a mesh with all attributes needed for PBR rendering and skeletal animation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The vertex structure includes all standard glTF vertex attributes:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Position, Normal, TexCoord - Basic geometry</description></item>
+/// <item><description>Tangent - For normal mapping (w component is bitangent sign)</description></item>
+/// <item><description>Color - Per-vertex color</description></item>
+/// <item><description>Joints, Weights - For skeletal animation</description></item>
+/// </list>
+/// </remarks>
+/// <param name="Position">Vertex position in object space.</param>
+/// <param name="Normal">Vertex normal vector (normalized).</param>
+/// <param name="TexCoord">Texture coordinates (UV).</param>
+/// <param name="Tangent">Tangent vector for normal mapping. XYZ is the tangent direction, W is the bitangent sign (+1 or -1).</param>
+/// <param name="Color">Per-vertex color (RGBA). Defaults to white if not present in source mesh.</param>
+/// <param name="Joints">Bone indices for skeletal animation (up to 4 influences).</param>
+/// <param name="Weights">Bone weights for skeletal animation (must sum to 1.0).</param>
 public readonly record struct MeshVertex(
     Vector3 Position,
     Vector3 Normal,
-    Vector2 TexCoord);
+    Vector2 TexCoord,
+    Vector4 Tangent,
+    Vector4 Color,
+    JointIndices Joints,
+    Vector4 Weights)
+{
+    /// <summary>
+    /// Creates a basic vertex with only position, normal, and texture coordinates.
+    /// Other attributes are set to sensible defaults.
+    /// </summary>
+    /// <param name="position">Vertex position.</param>
+    /// <param name="normal">Vertex normal.</param>
+    /// <param name="texCoord">Texture coordinates.</param>
+    /// <returns>A new vertex with default tangent, color, and bone data.</returns>
+    public static MeshVertex CreateBasic(Vector3 position, Vector3 normal, Vector2 texCoord)
+        => new(
+            position,
+            normal,
+            texCoord,
+            new Vector4(1, 0, 0, 1),  // Default tangent along X axis, positive bitangent sign
+            Vector4.One,               // White color
+            JointIndices.Default,      // Root bone
+            new Vector4(1, 0, 0, 0));  // Full weight on first joint
+}
+
+/// <summary>
+/// Represents a submesh within a mesh, defining a range of indices that share the same material.
+/// </summary>
+/// <remarks>
+/// A mesh can contain multiple submeshes, each rendered with a different material.
+/// This maps to glTF primitives within a mesh.
+/// </remarks>
+/// <param name="StartIndex">The starting index in the mesh's index buffer.</param>
+/// <param name="IndexCount">The number of indices in this submesh.</param>
+/// <param name="MaterialIndex">The index of the material to use for this submesh. -1 means no material (use default).</param>
+public readonly record struct Submesh(int StartIndex, int IndexCount, int MaterialIndex);
 
 /// <summary>
 /// A loaded mesh asset containing vertex and index data.
@@ -23,19 +95,29 @@ public readonly record struct MeshVertex(
 /// For static meshes that are rendered frequently, consider caching the GPU buffers
 /// separately to avoid re-uploading data each frame.
 /// </para>
+/// <para>
+/// A mesh may contain multiple <see cref="Submeshes"/>, each with its own material.
+/// This corresponds to glTF primitives within a mesh.
+/// </para>
 /// </remarks>
 /// <param name="name">The mesh name.</param>
 /// <param name="vertices">The vertex array.</param>
 /// <param name="indices">The index array.</param>
+/// <param name="submeshes">The submesh definitions. If empty, the entire mesh is treated as a single submesh.</param>
 /// <param name="boundsMin">AABB minimum.</param>
 /// <param name="boundsMax">AABB maximum.</param>
 public sealed class MeshAsset(
     string name,
     MeshVertex[] vertices,
     uint[] indices,
+    Submesh[] submeshes,
     Vector3 boundsMin,
     Vector3 boundsMax) : IDisposable
 {
+    // Vertex size in bytes: Position(3) + Normal(3) + TexCoord(2) + Tangent(4) + Color(4) + Joints(4 ushorts = 2 floats) + Weights(4)
+    private const int VertexFloatCount = 3 + 3 + 2 + 4 + 4 + 4;
+    private const int JointsBytesCount = 4 * sizeof(ushort);
+
     private bool disposed;
 
     /// <summary>
@@ -54,6 +136,15 @@ public sealed class MeshAsset(
     public uint[] Indices { get; } = indices;
 
     /// <summary>
+    /// Gets the submesh definitions.
+    /// </summary>
+    /// <remarks>
+    /// Each submesh defines a range of indices that should be rendered with a specific material.
+    /// If empty, treat the entire index buffer as a single submesh with material index -1.
+    /// </remarks>
+    public Submesh[] Submeshes { get; } = submeshes;
+
+    /// <summary>
     /// Gets the axis-aligned bounding box minimum point.
     /// </summary>
     public Vector3 BoundsMin { get; } = boundsMin;
@@ -67,16 +158,18 @@ public sealed class MeshAsset(
     /// Gets the size of the mesh data in bytes.
     /// </summary>
     public long SizeBytes =>
-        (Vertices.Length * (3 + 3 + 2) * sizeof(float)) +
-        (Indices.Length * sizeof(uint));
+        (Vertices.Length * VertexFloatCount * sizeof(float)) +
+        (Vertices.Length * JointsBytesCount) +
+        (Indices.Length * sizeof(uint)) +
+        (Submeshes.Length * 3 * sizeof(int));
 
     /// <summary>
-    /// Creates a mesh asset with automatically computed bounds.
+    /// Creates a mesh asset with automatically computed bounds and a single submesh.
     /// </summary>
     /// <param name="name">The mesh name.</param>
     /// <param name="vertices">The vertex array.</param>
     /// <param name="indices">The index array.</param>
-    /// <returns>A new mesh asset with computed bounds.</returns>
+    /// <returns>A new mesh asset with computed bounds and a single submesh.</returns>
     public static MeshAsset Create(string name, MeshVertex[] vertices, uint[] indices)
     {
         var min = new Vector3(float.MaxValue);
@@ -88,7 +181,32 @@ public sealed class MeshAsset(
             max = Vector3.Max(max, vertex.Position);
         }
 
-        return new MeshAsset(name, vertices, indices, min, max);
+        // Single submesh covering all indices with default material
+        var submeshes = new[] { new Submesh(0, indices.Length, -1) };
+
+        return new MeshAsset(name, vertices, indices, submeshes, min, max);
+    }
+
+    /// <summary>
+    /// Creates a mesh asset with automatically computed bounds and specified submeshes.
+    /// </summary>
+    /// <param name="name">The mesh name.</param>
+    /// <param name="vertices">The vertex array.</param>
+    /// <param name="indices">The index array.</param>
+    /// <param name="submeshes">The submesh definitions.</param>
+    /// <returns>A new mesh asset with computed bounds.</returns>
+    public static MeshAsset Create(string name, MeshVertex[] vertices, uint[] indices, Submesh[] submeshes)
+    {
+        var min = new Vector3(float.MaxValue);
+        var max = new Vector3(float.MinValue);
+
+        foreach (var vertex in vertices)
+        {
+            min = Vector3.Min(min, vertex.Position);
+            max = Vector3.Max(max, vertex.Position);
+        }
+
+        return new MeshAsset(name, vertices, indices, submeshes, min, max);
     }
 
     /// <summary>

--- a/src/KeenEyes.Assets/Loaders/MeshLoader.cs
+++ b/src/KeenEyes.Assets/Loaders/MeshLoader.cs
@@ -13,8 +13,16 @@ namespace KeenEyes.Assets;
 /// binary format.
 /// </para>
 /// <para>
-/// For models with multiple meshes, each mesh is extracted and stored as a separate
-/// <see cref="MeshAsset"/>. The first mesh in the file is returned.
+/// The loader extracts all standard vertex attributes:
+/// </para>
+/// <list type="bullet">
+/// <item><description>POSITION, NORMAL, TEXCOORD_0 - Basic geometry</description></item>
+/// <item><description>TANGENT - For normal mapping (computed if missing)</description></item>
+/// <item><description>COLOR_0 - Per-vertex color</description></item>
+/// <item><description>JOINTS_0, WEIGHTS_0 - Skeletal animation data</description></item>
+/// </list>
+/// <para>
+/// Each primitive in the glTF mesh becomes a <see cref="Submesh"/> with its material index.
 /// </para>
 /// </remarks>
 public sealed class MeshLoader : IAssetLoader<MeshAsset>
@@ -58,17 +66,23 @@ public sealed class MeshLoader : IAssetLoader<MeshAsset>
     {
         var vertices = new List<MeshVertex>();
         var indices = new List<uint>();
+        var submeshes = new List<Submesh>();
         var boundsMin = new Vector3(float.MaxValue);
         var boundsMax = new Vector3(float.MinValue);
 
         foreach (var primitive in logicalMesh.Primitives)
         {
             var baseVertex = (uint)vertices.Count;
+            var startIndex = indices.Count;
 
             // Get vertex accessors
             var positions = primitive.GetVertexAccessor("POSITION")?.AsVector3Array();
             var normals = primitive.GetVertexAccessor("NORMAL")?.AsVector3Array();
             var texCoords = primitive.GetVertexAccessor("TEXCOORD_0")?.AsVector2Array();
+            var tangents = primitive.GetVertexAccessor("TANGENT")?.AsVector4Array();
+            var colors = primitive.GetVertexAccessor("COLOR_0")?.AsVector4Array();
+            var joints = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array();
+            var weights = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array();
 
             if (positions == null)
             {
@@ -79,14 +93,21 @@ public sealed class MeshLoader : IAssetLoader<MeshAsset>
             for (var i = 0; i < positions.Count; i++)
             {
                 var position = positions[i];
-                var normal = normals != null && i < normals.Count
-                    ? normals[i]
-                    : Vector3.UnitY;
-                var texCoord = texCoords != null && i < texCoords.Count
-                    ? texCoords[i]
-                    : Vector2.Zero;
+                var normal = GetValueOrDefault(normals, i, Vector3.UnitY);
+                var texCoord = GetValueOrDefault(texCoords, i, Vector2.Zero);
+                var tangent = GetValueOrDefault(tangents, i, new Vector4(1, 0, 0, 1));
+                var color = GetValueOrDefault(colors, i, Vector4.One);
+                var jointVec = GetValueOrDefault(joints, i, Vector4.Zero);
+                var weight = GetValueOrDefault(weights, i, new Vector4(1, 0, 0, 0));
 
-                vertices.Add(new MeshVertex(position, normal, texCoord));
+                // Convert joint indices from float to ushort
+                var jointIndices = new JointIndices(
+                    (ushort)jointVec.X,
+                    (ushort)jointVec.Y,
+                    (ushort)jointVec.Z,
+                    (ushort)jointVec.W);
+
+                vertices.Add(new MeshVertex(position, normal, texCoord, tangent, color, jointIndices, weight));
 
                 // Update bounds
                 boundsMin = Vector3.Min(boundsMin, position);
@@ -110,6 +131,12 @@ public sealed class MeshLoader : IAssetLoader<MeshAsset>
                     indices.Add(baseVertex + i);
                 }
             }
+
+            // Get material index (-1 if no material assigned)
+            var materialIndex = primitive.Material?.LogicalIndex ?? -1;
+            var indexCount = indices.Count - startIndex;
+
+            submeshes.Add(new Submesh(startIndex, indexCount, materialIndex));
         }
 
         if (vertices.Count == 0)
@@ -117,11 +144,132 @@ public sealed class MeshLoader : IAssetLoader<MeshAsset>
             throw new InvalidDataException("Mesh contains no vertices");
         }
 
+        // Compute tangents if they weren't provided in the mesh
+        var vertexArray = vertices.ToArray();
+        var indexArray = indices.ToArray();
+
+        if (!HasValidTangents(vertexArray))
+        {
+            ComputeTangents(vertexArray, indexArray);
+        }
+
         return new MeshAsset(
             logicalMesh.Name ?? "Mesh",
-            [.. vertices],
-            [.. indices],
+            vertexArray,
+            indexArray,
+            [.. submeshes],
             boundsMin,
             boundsMax);
+    }
+
+    private static T GetValueOrDefault<T>(IList<T>? array, int index, T defaultValue)
+        => array != null && index < array.Count ? array[index] : defaultValue;
+
+    /// <summary>
+    /// Checks if the mesh has valid tangents (not all default values).
+    /// </summary>
+    private static bool HasValidTangents(MeshVertex[] vertices)
+    {
+        var defaultTangent = new Vector4(1, 0, 0, 1);
+
+        foreach (var vertex in vertices)
+        {
+            if (vertex.Tangent != defaultTangent)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Computes tangent vectors for normal mapping using a simplified MikkTSpace-like algorithm.
+    /// </summary>
+    /// <remarks>
+    /// This implements a basic tangent computation based on UV gradients across triangle edges.
+    /// For production use, consider integrating the full MikkTSpace algorithm for better results
+    /// with mirrored UVs and edge cases.
+    /// </remarks>
+    private static void ComputeTangents(MeshVertex[] vertices, uint[] indices)
+    {
+        // Allocate tangent and bitangent accumulators
+        var tangents = new Vector3[vertices.Length];
+        var bitangents = new Vector3[vertices.Length];
+
+        // Process each triangle
+        for (var i = 0; i < indices.Length; i += 3)
+        {
+            var i0 = (int)indices[i];
+            var i1 = (int)indices[i + 1];
+            var i2 = (int)indices[i + 2];
+
+            var v0 = vertices[i0];
+            var v1 = vertices[i1];
+            var v2 = vertices[i2];
+
+            // Position deltas
+            var edge1 = v1.Position - v0.Position;
+            var edge2 = v2.Position - v0.Position;
+
+            // UV deltas
+            var deltaUv1 = v1.TexCoord - v0.TexCoord;
+            var deltaUv2 = v2.TexCoord - v0.TexCoord;
+
+            // Calculate tangent and bitangent
+            var r = deltaUv1.X * deltaUv2.Y - deltaUv2.X * deltaUv1.Y;
+
+            // Avoid division by zero for degenerate triangles
+            if (Math.Abs(r) < 1e-6f)
+            {
+                continue;
+            }
+
+            r = 1.0f / r;
+
+            var tangent = new Vector3(
+                (deltaUv2.Y * edge1.X - deltaUv1.Y * edge2.X) * r,
+                (deltaUv2.Y * edge1.Y - deltaUv1.Y * edge2.Y) * r,
+                (deltaUv2.Y * edge1.Z - deltaUv1.Y * edge2.Z) * r);
+
+            var bitangent = new Vector3(
+                (-deltaUv2.X * edge1.X + deltaUv1.X * edge2.X) * r,
+                (-deltaUv2.X * edge1.Y + deltaUv1.X * edge2.Y) * r,
+                (-deltaUv2.X * edge1.Z + deltaUv1.X * edge2.Z) * r);
+
+            // Accumulate for each vertex of the triangle
+            tangents[i0] += tangent;
+            tangents[i1] += tangent;
+            tangents[i2] += tangent;
+
+            bitangents[i0] += bitangent;
+            bitangents[i1] += bitangent;
+            bitangents[i2] += bitangent;
+        }
+
+        // Orthonormalize and store tangents
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var n = vertices[i].Normal;
+            var t = tangents[i];
+            var b = bitangents[i];
+
+            // Gram-Schmidt orthogonalize: t' = normalize(t - n * dot(n, t))
+            var tangentOrtho = Vector3.Normalize(t - n * Vector3.Dot(n, t));
+
+            // Handle degenerate case
+            if (float.IsNaN(tangentOrtho.X))
+            {
+                tangentOrtho = new Vector3(1, 0, 0);
+            }
+
+            // Calculate handedness (bitangent sign)
+            // w = sign of dot(cross(n, t), b)
+            var cross = Vector3.Cross(n, t);
+            var handedness = Vector3.Dot(cross, b) < 0 ? -1.0f : 1.0f;
+
+            // Update vertex with computed tangent
+            vertices[i] = vertices[i] with { Tangent = new Vector4(tangentOrtho, handedness) };
+        }
     }
 }

--- a/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
@@ -144,16 +144,18 @@ public class BuiltInAssetTests
     {
         var vertices = new MeshVertex[]
         {
-            new(new Vector3(0, 0, 0), Vector3.UnitY, Vector2.Zero),
-            new(new Vector3(1, 1, 1), Vector3.UnitY, Vector2.One)
+            MeshVertex.CreateBasic(new Vector3(0, 0, 0), Vector3.UnitY, Vector2.Zero),
+            MeshVertex.CreateBasic(new Vector3(1, 1, 1), Vector3.UnitY, Vector2.One)
         };
         var indices = new uint[] { 0, 1, 0 };
+        var submeshes = new[] { new Submesh(0, 3, -1) };
 
-        using var asset = new MeshAsset("test", vertices, indices, Vector3.Zero, Vector3.One);
+        using var asset = new MeshAsset("test", vertices, indices, submeshes, Vector3.Zero, Vector3.One);
 
         Assert.Equal("test", asset.Name);
         Assert.Equal(vertices, asset.Vertices);
         Assert.Equal(indices, asset.Indices);
+        Assert.Equal(submeshes, asset.Submeshes);
         Assert.Equal(Vector3.Zero, asset.BoundsMin);
         Assert.Equal(Vector3.One, asset.BoundsMax);
     }
@@ -163,8 +165,8 @@ public class BuiltInAssetTests
     {
         var vertices = new MeshVertex[]
         {
-            new(new Vector3(-1, 0, 0), Vector3.UnitY, Vector2.Zero),
-            new(new Vector3(1, 2, 3), Vector3.UnitY, Vector2.One)
+            MeshVertex.CreateBasic(new Vector3(-1, 0, 0), Vector3.UnitY, Vector2.Zero),
+            MeshVertex.CreateBasic(new Vector3(1, 2, 3), Vector3.UnitY, Vector2.One)
         };
         var indices = new uint[] { 0, 1 };
 
@@ -179,21 +181,27 @@ public class BuiltInAssetTests
     {
         var vertices = new MeshVertex[]
         {
-            new(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
-            new(Vector3.One, Vector3.UnitY, Vector2.One)
+            MeshVertex.CreateBasic(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            MeshVertex.CreateBasic(Vector3.One, Vector3.UnitY, Vector2.One)
         };
         var indices = new uint[] { 0, 1, 0 };
+        var submeshes = new[] { new Submesh(0, 3, -1) };
 
-        using var asset = new MeshAsset("test", vertices, indices, Vector3.Zero, Vector3.One);
+        using var asset = new MeshAsset("test", vertices, indices, submeshes, Vector3.Zero, Vector3.One);
 
-        // 2 vertices * (3+3+2) floats * 4 bytes + 3 indices * 4 bytes
-        Assert.Equal(2 * 8 * 4 + 3 * 4, asset.SizeBytes);
+        // Each vertex: (3+3+2+4+4+4) floats = 20 floats * 4 bytes = 80 bytes
+        // Plus joints: 4 ushorts * 2 bytes = 8 bytes per vertex
+        // 2 vertices = (80 + 8) * 2 = 176 bytes
+        // 3 indices * 4 bytes = 12 bytes
+        // 1 submesh * 3 ints * 4 bytes = 12 bytes
+        // Total = 176 + 12 + 12 = 200 bytes
+        Assert.Equal(200, asset.SizeBytes);
     }
 
     [Fact]
     public void MeshAsset_Dispose_IsIdempotent()
     {
-        var asset = new MeshAsset("test", [], [], Vector3.Zero, Vector3.Zero);
+        var asset = new MeshAsset("test", [], [], [], Vector3.Zero, Vector3.Zero);
         asset.Dispose();
         asset.Dispose(); // Should not throw
     }

--- a/tests/KeenEyes.Assets.Tests/MeshAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/MeshAssetTests.cs
@@ -7,6 +7,13 @@ namespace KeenEyes.Assets.Tests;
 /// </summary>
 public class MeshAssetTests
 {
+    #region Helper Methods
+
+    private static MeshVertex CreateBasicVertex(Vector3 position, Vector3 normal, Vector2 texCoord)
+        => MeshVertex.CreateBasic(position, normal, texCoord);
+
+    #endregion
+
     #region MeshVertex Tests
 
     [Fact]
@@ -15,19 +22,45 @@ public class MeshAssetTests
         var position = new Vector3(1, 2, 3);
         var normal = new Vector3(0, 1, 0);
         var texCoord = new Vector2(0.5f, 0.5f);
+        var tangent = new Vector4(1, 0, 0, 1);
+        var color = new Vector4(1, 0, 0, 1);
+        var joints = new JointIndices(0, 1, 2, 3);
+        var weights = new Vector4(0.5f, 0.3f, 0.2f, 0);
 
-        var vertex = new MeshVertex(position, normal, texCoord);
+        var vertex = new MeshVertex(position, normal, texCoord, tangent, color, joints, weights);
 
         Assert.Equal(position, vertex.Position);
         Assert.Equal(normal, vertex.Normal);
         Assert.Equal(texCoord, vertex.TexCoord);
+        Assert.Equal(tangent, vertex.Tangent);
+        Assert.Equal(color, vertex.Color);
+        Assert.Equal(joints, vertex.Joints);
+        Assert.Equal(weights, vertex.Weights);
+    }
+
+    [Fact]
+    public void MeshVertex_CreateBasic_SetsDefaults()
+    {
+        var position = new Vector3(1, 2, 3);
+        var normal = new Vector3(0, 1, 0);
+        var texCoord = new Vector2(0.5f, 0.5f);
+
+        var vertex = MeshVertex.CreateBasic(position, normal, texCoord);
+
+        Assert.Equal(position, vertex.Position);
+        Assert.Equal(normal, vertex.Normal);
+        Assert.Equal(texCoord, vertex.TexCoord);
+        Assert.Equal(new Vector4(1, 0, 0, 1), vertex.Tangent);
+        Assert.Equal(Vector4.One, vertex.Color);
+        Assert.Equal(JointIndices.Default, vertex.Joints);
+        Assert.Equal(new Vector4(1, 0, 0, 0), vertex.Weights);
     }
 
     [Fact]
     public void MeshVertex_Equality_SameValues_AreEqual()
     {
-        var v1 = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
-        var v2 = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
+        var v1 = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
+        var v2 = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
 
         Assert.Equal(v1, v2);
         Assert.True(v1 == v2);
@@ -36,8 +69,8 @@ public class MeshAssetTests
     [Fact]
     public void MeshVertex_Equality_DifferentPosition_NotEqual()
     {
-        var v1 = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
-        var v2 = new MeshVertex(new Vector3(4, 5, 6), new Vector3(0, 1, 0), new Vector2(0, 0));
+        var v1 = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0, 0));
+        var v2 = CreateBasicVertex(new Vector3(4, 5, 6), new Vector3(0, 1, 0), new Vector2(0, 0));
 
         Assert.NotEqual(v1, v2);
         Assert.True(v1 != v2);
@@ -46,8 +79,8 @@ public class MeshAssetTests
     [Fact]
     public void MeshVertex_GetHashCode_SameForEqualVertices()
     {
-        var v1 = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
-        var v2 = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
+        var v1 = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
+        var v2 = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
 
         Assert.Equal(v1.GetHashCode(), v2.GetHashCode());
     }
@@ -55,13 +88,244 @@ public class MeshAssetTests
     [Fact]
     public void MeshVertex_ToString_ContainsValues()
     {
-        var vertex = new MeshVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
+        var vertex = CreateBasicVertex(new Vector3(1, 2, 3), new Vector3(0, 1, 0), new Vector2(0.5f, 0.5f));
 
         var str = vertex.ToString();
 
         Assert.Contains("Position", str);
         Assert.Contains("Normal", str);
         Assert.Contains("TexCoord", str);
+        Assert.Contains("Tangent", str);
+        Assert.Contains("Color", str);
+    }
+
+    [Fact]
+    public void MeshVertex_Equality_DifferentTangent_NotEqual()
+    {
+        var joints = JointIndices.Default;
+        var weights = new Vector4(1, 0, 0, 0);
+
+        var v1 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), Vector4.One, joints, weights);
+        var v2 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(0, 1, 0, -1), Vector4.One, joints, weights);
+
+        Assert.NotEqual(v1, v2);
+    }
+
+    [Fact]
+    public void MeshVertex_Equality_DifferentColor_NotEqual()
+    {
+        var joints = JointIndices.Default;
+        var weights = new Vector4(1, 0, 0, 0);
+
+        var v1 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), new Vector4(1, 0, 0, 1), joints, weights);
+        var v2 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), new Vector4(0, 1, 0, 1), joints, weights);
+
+        Assert.NotEqual(v1, v2);
+    }
+
+    [Fact]
+    public void MeshVertex_Equality_DifferentJoints_NotEqual()
+    {
+        var weights = new Vector4(1, 0, 0, 0);
+
+        var v1 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), Vector4.One, new JointIndices(0, 1, 2, 3), weights);
+        var v2 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), Vector4.One, new JointIndices(4, 5, 6, 7), weights);
+
+        Assert.NotEqual(v1, v2);
+    }
+
+    [Fact]
+    public void MeshVertex_Equality_DifferentWeights_NotEqual()
+    {
+        var joints = JointIndices.Default;
+
+        var v1 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), Vector4.One, joints, new Vector4(1, 0, 0, 0));
+        var v2 = new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero,
+            new Vector4(1, 0, 0, 1), Vector4.One, joints, new Vector4(0.5f, 0.3f, 0.2f, 0));
+
+        Assert.NotEqual(v1, v2);
+    }
+
+    [Fact]
+    public void MeshVertex_FullPBRVertex_StoresAllAttributes()
+    {
+        var position = new Vector3(1, 2, 3);
+        var normal = Vector3.UnitZ;
+        var texCoord = new Vector2(0.25f, 0.75f);
+        var tangent = new Vector4(1, 0, 0, -1);
+        var color = new Vector4(0.8f, 0.2f, 0.1f, 1.0f);
+        var joints = new JointIndices(5, 10, 15, 20);
+        var weights = new Vector4(0.4f, 0.3f, 0.2f, 0.1f);
+
+        var vertex = new MeshVertex(position, normal, texCoord, tangent, color, joints, weights);
+
+        Assert.Equal(position, vertex.Position);
+        Assert.Equal(normal, vertex.Normal);
+        Assert.Equal(texCoord, vertex.TexCoord);
+        Assert.Equal(tangent, vertex.Tangent);
+        Assert.Equal(color, vertex.Color);
+        Assert.Equal(joints, vertex.Joints);
+        Assert.Equal(weights, vertex.Weights);
+    }
+
+    [Fact]
+    public void MeshVertex_CreateBasic_TangentHasPositiveBitangentSign()
+    {
+        var vertex = MeshVertex.CreateBasic(Vector3.Zero, Vector3.UnitY, Vector2.Zero);
+
+        Assert.Equal(1.0f, vertex.Tangent.W);
+    }
+
+    [Fact]
+    public void MeshVertex_CreateBasic_WeightsFullyOnFirstJoint()
+    {
+        var vertex = MeshVertex.CreateBasic(Vector3.Zero, Vector3.UnitY, Vector2.Zero);
+
+        Assert.Equal(1.0f, vertex.Weights.X);
+        Assert.Equal(0.0f, vertex.Weights.Y);
+        Assert.Equal(0.0f, vertex.Weights.Z);
+        Assert.Equal(0.0f, vertex.Weights.W);
+    }
+
+    #endregion
+
+    #region JointIndices Tests
+
+    [Fact]
+    public void JointIndices_Default_IsAllZeros()
+    {
+        var joints = JointIndices.Default;
+
+        Assert.Equal((ushort)0, joints.Joint0);
+        Assert.Equal((ushort)0, joints.Joint1);
+        Assert.Equal((ushort)0, joints.Joint2);
+        Assert.Equal((ushort)0, joints.Joint3);
+    }
+
+    [Fact]
+    public void JointIndices_Constructor_SetsAllValues()
+    {
+        var joints = new JointIndices(1, 2, 3, 4);
+
+        Assert.Equal((ushort)1, joints.Joint0);
+        Assert.Equal((ushort)2, joints.Joint1);
+        Assert.Equal((ushort)3, joints.Joint2);
+        Assert.Equal((ushort)4, joints.Joint3);
+    }
+
+    [Fact]
+    public void JointIndices_Equality_SameValues_AreEqual()
+    {
+        var j1 = new JointIndices(1, 2, 3, 4);
+        var j2 = new JointIndices(1, 2, 3, 4);
+
+        Assert.Equal(j1, j2);
+        Assert.True(j1 == j2);
+    }
+
+    [Fact]
+    public void JointIndices_Equality_DifferentValues_NotEqual()
+    {
+        var j1 = new JointIndices(1, 2, 3, 4);
+        var j2 = new JointIndices(5, 6, 7, 8);
+
+        Assert.NotEqual(j1, j2);
+        Assert.True(j1 != j2);
+    }
+
+    [Fact]
+    public void JointIndices_GetHashCode_SameForEqualValues()
+    {
+        var j1 = new JointIndices(10, 20, 30, 40);
+        var j2 = new JointIndices(10, 20, 30, 40);
+
+        Assert.Equal(j1.GetHashCode(), j2.GetHashCode());
+    }
+
+    [Fact]
+    public void JointIndices_MaxValue_HandlesFullRange()
+    {
+        var joints = new JointIndices(ushort.MaxValue, ushort.MaxValue, ushort.MaxValue, ushort.MaxValue);
+
+        Assert.Equal(ushort.MaxValue, joints.Joint0);
+        Assert.Equal(ushort.MaxValue, joints.Joint1);
+        Assert.Equal(ushort.MaxValue, joints.Joint2);
+        Assert.Equal(ushort.MaxValue, joints.Joint3);
+    }
+
+    #endregion
+
+    #region Submesh Tests
+
+    [Fact]
+    public void Submesh_Constructor_SetsAllProperties()
+    {
+        var submesh = new Submesh(10, 100, 5);
+
+        Assert.Equal(10, submesh.StartIndex);
+        Assert.Equal(100, submesh.IndexCount);
+        Assert.Equal(5, submesh.MaterialIndex);
+    }
+
+    [Fact]
+    public void Submesh_NegativeMaterialIndex_RepresentsNoMaterial()
+    {
+        var submesh = new Submesh(0, 50, -1);
+
+        Assert.Equal(-1, submesh.MaterialIndex);
+    }
+
+    [Fact]
+    public void Submesh_Equality_SameValues_AreEqual()
+    {
+        var s1 = new Submesh(10, 100, 5);
+        var s2 = new Submesh(10, 100, 5);
+
+        Assert.Equal(s1, s2);
+        Assert.True(s1 == s2);
+    }
+
+    [Fact]
+    public void Submesh_Equality_DifferentStartIndex_NotEqual()
+    {
+        var s1 = new Submesh(10, 100, 5);
+        var s2 = new Submesh(20, 100, 5);
+
+        Assert.NotEqual(s1, s2);
+    }
+
+    [Fact]
+    public void Submesh_Equality_DifferentIndexCount_NotEqual()
+    {
+        var s1 = new Submesh(10, 100, 5);
+        var s2 = new Submesh(10, 200, 5);
+
+        Assert.NotEqual(s1, s2);
+    }
+
+    [Fact]
+    public void Submesh_Equality_DifferentMaterialIndex_NotEqual()
+    {
+        var s1 = new Submesh(10, 100, 5);
+        var s2 = new Submesh(10, 100, 6);
+
+        Assert.NotEqual(s1, s2);
+    }
+
+    [Fact]
+    public void Submesh_GetHashCode_SameForEqualValues()
+    {
+        var s1 = new Submesh(10, 100, 5);
+        var s2 = new Submesh(10, 100, 5);
+
+        Assert.Equal(s1.GetHashCode(), s2.GetHashCode());
     }
 
     #endregion
@@ -73,19 +337,21 @@ public class MeshAssetTests
     {
         var vertices = new[]
         {
-            new MeshVertex(new Vector3(0, 0, 0), Vector3.UnitY, Vector2.Zero),
-            new MeshVertex(new Vector3(1, 0, 0), Vector3.UnitY, Vector2.UnitX),
-            new MeshVertex(new Vector3(0, 1, 0), Vector3.UnitY, Vector2.UnitY),
+            CreateBasicVertex(new Vector3(0, 0, 0), Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(new Vector3(1, 0, 0), Vector3.UnitY, Vector2.UnitX),
+            CreateBasicVertex(new Vector3(0, 1, 0), Vector3.UnitY, Vector2.UnitY),
         };
         var indices = new uint[] { 0, 1, 2 };
+        var submeshes = new[] { new Submesh(0, 3, 0) };
         var boundsMin = new Vector3(0, 0, 0);
         var boundsMax = new Vector3(1, 1, 0);
 
-        using var mesh = new MeshAsset("TestMesh", vertices, indices, boundsMin, boundsMax);
+        using var mesh = new MeshAsset("TestMesh", vertices, indices, submeshes, boundsMin, boundsMax);
 
         Assert.Equal("TestMesh", mesh.Name);
         Assert.Equal(vertices, mesh.Vertices);
         Assert.Equal(indices, mesh.Indices);
+        Assert.Equal(submeshes, mesh.Submeshes);
         Assert.Equal(boundsMin, mesh.BoundsMin);
         Assert.Equal(boundsMax, mesh.BoundsMax);
     }
@@ -95,18 +361,21 @@ public class MeshAssetTests
     {
         var vertices = new[]
         {
-            new MeshVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
-            new MeshVertex(Vector3.One, Vector3.UnitY, Vector2.One),
+            CreateBasicVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(Vector3.One, Vector3.UnitY, Vector2.One),
         };
         var indices = new uint[] { 0, 1 };
+        var submeshes = new[] { new Submesh(0, 2, -1) };
 
-        using var mesh = new MeshAsset("Test", vertices, indices, Vector3.Zero, Vector3.One);
+        using var mesh = new MeshAsset("Test", vertices, indices, submeshes, Vector3.Zero, Vector3.One);
 
-        // Each vertex: (3 + 3 + 2) floats = 8 floats * 4 bytes = 32 bytes
-        // 2 vertices = 64 bytes
+        // Each vertex: (3+3+2+4+4+4) floats = 20 floats * 4 bytes = 80 bytes
+        // Plus joints: 4 ushorts * 2 bytes = 8 bytes per vertex
+        // 2 vertices = (80 + 8) * 2 = 176 bytes
         // 2 indices * 4 bytes = 8 bytes
-        // Total = 72 bytes
-        Assert.Equal(72, mesh.SizeBytes);
+        // 1 submesh * 3 ints * 4 bytes = 12 bytes
+        // Total = 176 + 8 + 12 = 196 bytes
+        Assert.Equal(196, mesh.SizeBytes);
     }
 
     [Fact]
@@ -114,9 +383,9 @@ public class MeshAssetTests
     {
         var vertices = new[]
         {
-            new MeshVertex(new Vector3(-1, -2, -3), Vector3.UnitY, Vector2.Zero),
-            new MeshVertex(new Vector3(5, 6, 7), Vector3.UnitY, Vector2.Zero),
-            new MeshVertex(new Vector3(2, 3, 4), Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(new Vector3(-1, -2, -3), Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(new Vector3(5, 6, 7), Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(new Vector3(2, 3, 4), Vector3.UnitY, Vector2.Zero),
         };
         var indices = new uint[] { 0, 1, 2 };
 
@@ -127,9 +396,50 @@ public class MeshAssetTests
     }
 
     [Fact]
+    public void MeshAsset_Create_CreatesSingleSubmesh()
+    {
+        var vertices = new[]
+        {
+            CreateBasicVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(Vector3.One, Vector3.UnitY, Vector2.One),
+        };
+        var indices = new uint[] { 0, 1, 0 };
+
+        using var mesh = MeshAsset.Create("Test", vertices, indices);
+
+        Assert.Single(mesh.Submeshes);
+        Assert.Equal(0, mesh.Submeshes[0].StartIndex);
+        Assert.Equal(3, mesh.Submeshes[0].IndexCount);
+        Assert.Equal(-1, mesh.Submeshes[0].MaterialIndex);
+    }
+
+    [Fact]
+    public void MeshAsset_CreateWithSubmeshes_UsesProvidedSubmeshes()
+    {
+        var vertices = new[]
+        {
+            CreateBasicVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(Vector3.One, Vector3.UnitY, Vector2.One),
+            CreateBasicVertex(Vector3.UnitX, Vector3.UnitY, Vector2.UnitX),
+        };
+        var indices = new uint[] { 0, 1, 2, 0, 2, 1 };
+        var submeshes = new[]
+        {
+            new Submesh(0, 3, 0),
+            new Submesh(3, 3, 1),
+        };
+
+        using var mesh = MeshAsset.Create("MultiSubmesh", vertices, indices, submeshes);
+
+        Assert.Equal(2, mesh.Submeshes.Length);
+        Assert.Equal(0, mesh.Submeshes[0].MaterialIndex);
+        Assert.Equal(1, mesh.Submeshes[1].MaterialIndex);
+    }
+
+    [Fact]
     public void MeshAsset_Dispose_CanBeCalledMultipleTimes()
     {
-        var mesh = new MeshAsset("Test", [], [], Vector3.Zero, Vector3.One);
+        var mesh = new MeshAsset("Test", [], [], [], Vector3.Zero, Vector3.One);
 
         mesh.Dispose();
         mesh.Dispose(); // Should not throw
@@ -140,11 +450,76 @@ public class MeshAssetTests
     [Fact]
     public void MeshAsset_EmptyMesh_HasZeroSize()
     {
-        using var mesh = new MeshAsset("Empty", [], [], Vector3.Zero, Vector3.Zero);
+        using var mesh = new MeshAsset("Empty", [], [], [], Vector3.Zero, Vector3.Zero);
 
         Assert.Equal(0, mesh.SizeBytes);
         Assert.Empty(mesh.Vertices);
         Assert.Empty(mesh.Indices);
+        Assert.Empty(mesh.Submeshes);
+    }
+
+    [Fact]
+    public void MeshAsset_MultipleSubmeshes_SizeBytesIncludesAll()
+    {
+        var vertices = new[]
+        {
+            CreateBasicVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            CreateBasicVertex(Vector3.One, Vector3.UnitY, Vector2.One),
+        };
+        var indices = new uint[] { 0, 1 };
+        var submeshes = new[]
+        {
+            new Submesh(0, 1, 0),
+            new Submesh(1, 1, 1),
+            new Submesh(0, 2, 2),
+        };
+
+        using var mesh = new MeshAsset("Test", vertices, indices, submeshes, Vector3.Zero, Vector3.One);
+
+        // Each vertex: (3+3+2+4+4+4) floats = 20 floats * 4 bytes = 80 bytes
+        // Plus joints: 4 ushorts * 2 bytes = 8 bytes per vertex
+        // 2 vertices = (80 + 8) * 2 = 176 bytes
+        // 2 indices * 4 bytes = 8 bytes
+        // 3 submeshes * 3 ints * 4 bytes = 36 bytes
+        // Total = 176 + 8 + 36 = 220 bytes
+        Assert.Equal(220, mesh.SizeBytes);
+    }
+
+    #endregion
+
+    #region MeshLoader Tests
+
+    [Fact]
+    public void MeshLoader_Extensions_ContainsGltf()
+    {
+        var loader = new MeshLoader();
+
+        Assert.Contains(".gltf", loader.Extensions);
+    }
+
+    [Fact]
+    public void MeshLoader_Extensions_ContainsGlb()
+    {
+        var loader = new MeshLoader();
+
+        Assert.Contains(".glb", loader.Extensions);
+    }
+
+    [Fact]
+    public void MeshLoader_EstimateSize_ReturnsMeshSizeBytes()
+    {
+        var loader = new MeshLoader();
+        var vertices = new[]
+        {
+            CreateBasicVertex(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+        };
+        var indices = new uint[] { 0 };
+        var submeshes = new[] { new Submesh(0, 1, -1) };
+        using var mesh = new MeshAsset("Test", vertices, indices, submeshes, Vector3.Zero, Vector3.Zero);
+
+        var size = loader.EstimateSize(mesh);
+
+        Assert.Equal(mesh.SizeBytes, size);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Extend `MeshVertex` with Tangent, Color, JointIndices, and Weights for PBR rendering and skeletal animation
- Add `Submesh` struct for primitive-to-material mapping in multi-material meshes
- Update `MeshLoader` to extract all glTF vertex attributes (TANGENT, COLOR_0, JOINTS_0, WEIGHTS_0)
- Implement MikkTSpace-like tangent computation for meshes without tangent data

## Test plan
- [x] Unit tests for all new vertex attributes and equality
- [x] Unit tests for JointIndices struct (equality, hash code, max values)
- [x] Unit tests for Submesh struct (equality, hash code)
- [x] Unit tests for MeshLoader extensions and size estimation
- [x] All 270 KeenEyes.Assets.Tests pass
- [x] Full test suite passes (13,029 tests)
- [x] Build passes with zero warnings

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)