### PR TITLE
feat(assets): Add ModelAsset and ModelLoader for complete glTF loading

### DIFF
--- a/src/KeenEyes.Assets/Assets/AlphaMode.cs
+++ b/src/KeenEyes.Assets/Assets/AlphaMode.cs
@@ -1,0 +1,28 @@
+namespace KeenEyes.Assets;
+
+/// <summary>
+/// Defines how the alpha channel is interpreted for rendering.
+/// </summary>
+/// <remarks>
+/// These modes correspond to the glTF 2.0 alpha modes and control how
+/// transparency is handled during rendering.
+/// </remarks>
+public enum AlphaMode
+{
+    /// <summary>
+    /// Alpha value is ignored and the rendered output is fully opaque.
+    /// </summary>
+    Opaque,
+
+    /// <summary>
+    /// Alpha value is used to determine whether pixels are fully opaque or fully transparent.
+    /// Pixels with alpha below <see cref="MaterialData.AlphaCutoff"/> are discarded.
+    /// </summary>
+    Mask,
+
+    /// <summary>
+    /// Alpha value is used for blending the source and destination colors.
+    /// Requires proper depth sorting for correct rendering.
+    /// </summary>
+    Blend
+}

--- a/src/KeenEyes.Assets/Assets/MaterialData.cs
+++ b/src/KeenEyes.Assets/Assets/MaterialData.cs
@@ -1,0 +1,131 @@
+using System.Numerics;
+
+namespace KeenEyes.Assets;
+
+/// <summary>
+/// CPU-side PBR material properties extracted from a glTF file.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="MaterialData"/> is a data-only record that does not hold GPU resources.
+/// Texture indices reference the <see cref="TextureData"/> array in the parent
+/// <see cref="ModelAsset"/>.
+/// </para>
+/// <para>
+/// Material properties follow the glTF 2.0 PBR metallic-roughness model:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Base color - RGBA diffuse/albedo color</description></item>
+/// <item><description>Metallic - 0.0 (dielectric) to 1.0 (metallic)</description></item>
+/// <item><description>Roughness - 0.0 (smooth) to 1.0 (rough)</description></item>
+/// <item><description>Emissive - Self-illumination color and intensity</description></item>
+/// <item><description>Normal map - Tangent-space surface perturbation</description></item>
+/// <item><description>Occlusion - Ambient occlusion factor</description></item>
+/// </list>
+/// </remarks>
+/// <param name="Name">The material name from the glTF file.</param>
+/// <param name="BaseColorFactor">Base color multiplier (RGBA). Default is white (1,1,1,1).</param>
+/// <param name="MetallicFactor">Metallic multiplier. 0 = dielectric, 1 = metallic.</param>
+/// <param name="RoughnessFactor">Roughness multiplier. 0 = smooth/mirror, 1 = rough/diffuse.</param>
+/// <param name="EmissiveFactor">Emissive color (RGB). Default is black (no emission).</param>
+/// <param name="AlphaCutoff">Alpha cutoff threshold for <see cref="AlphaMode.Mask"/> mode.</param>
+/// <param name="AlphaMode">How alpha channel affects rendering.</param>
+/// <param name="DoubleSided">Whether the material is rendered on both sides.</param>
+/// <param name="BaseColorTextureIndex">Index into texture array, or -1 if none.</param>
+/// <param name="NormalTextureIndex">Index into texture array, or -1 if none.</param>
+/// <param name="MetallicRoughnessTextureIndex">Index into texture array, or -1 if none. G=roughness, B=metallic.</param>
+/// <param name="OcclusionTextureIndex">Index into texture array, or -1 if none. R=occlusion.</param>
+/// <param name="EmissiveTextureIndex">Index into texture array, or -1 if none.</param>
+/// <param name="NormalScale">Scale factor for normal map. Default is 1.0.</param>
+/// <param name="OcclusionStrength">Strength of occlusion effect. Default is 1.0.</param>
+public sealed record MaterialData(
+    string Name,
+    Vector4 BaseColorFactor,
+    float MetallicFactor,
+    float RoughnessFactor,
+    Vector3 EmissiveFactor,
+    float AlphaCutoff,
+    AlphaMode AlphaMode,
+    bool DoubleSided,
+    int BaseColorTextureIndex,
+    int NormalTextureIndex,
+    int MetallicRoughnessTextureIndex,
+    int OcclusionTextureIndex,
+    int EmissiveTextureIndex,
+    float NormalScale = 1.0f,
+    float OcclusionStrength = 1.0f)
+{
+    /// <summary>
+    /// Default PBR material with white base color and no textures.
+    /// </summary>
+    /// <remarks>
+    /// Default values:
+    /// <list type="bullet">
+    /// <item><description>Base color: White (1, 1, 1, 1)</description></item>
+    /// <item><description>Metallic: 0 (dielectric)</description></item>
+    /// <item><description>Roughness: 0.5 (medium)</description></item>
+    /// <item><description>Emissive: Black (no emission)</description></item>
+    /// <item><description>Alpha mode: Opaque</description></item>
+    /// <item><description>All texture indices: -1 (no texture)</description></item>
+    /// </list>
+    /// </remarks>
+    public static MaterialData Default => new(
+        Name: "Default",
+        BaseColorFactor: Vector4.One,
+        MetallicFactor: 0f,
+        RoughnessFactor: 0.5f,
+        EmissiveFactor: Vector3.Zero,
+        AlphaCutoff: 0.5f,
+        AlphaMode: AlphaMode.Opaque,
+        DoubleSided: false,
+        BaseColorTextureIndex: -1,
+        NormalTextureIndex: -1,
+        MetallicRoughnessTextureIndex: -1,
+        OcclusionTextureIndex: -1,
+        EmissiveTextureIndex: -1);
+
+    /// <summary>
+    /// Gets whether this material has a base color texture.
+    /// </summary>
+    public bool HasBaseColorTexture => BaseColorTextureIndex >= 0;
+
+    /// <summary>
+    /// Gets whether this material has a normal map texture.
+    /// </summary>
+    public bool HasNormalTexture => NormalTextureIndex >= 0;
+
+    /// <summary>
+    /// Gets whether this material has a metallic-roughness texture.
+    /// </summary>
+    public bool HasMetallicRoughnessTexture => MetallicRoughnessTextureIndex >= 0;
+
+    /// <summary>
+    /// Gets whether this material has an occlusion texture.
+    /// </summary>
+    public bool HasOcclusionTexture => OcclusionTextureIndex >= 0;
+
+    /// <summary>
+    /// Gets whether this material has an emissive texture.
+    /// </summary>
+    public bool HasEmissiveTexture => EmissiveTextureIndex >= 0;
+
+    /// <summary>
+    /// Gets whether this material uses any textures.
+    /// </summary>
+    public bool HasAnyTexture =>
+        HasBaseColorTexture ||
+        HasNormalTexture ||
+        HasMetallicRoughnessTexture ||
+        HasOcclusionTexture ||
+        HasEmissiveTexture;
+
+    /// <summary>
+    /// Gets whether this material requires alpha blending.
+    /// </summary>
+    public bool RequiresBlending => AlphaMode == AlphaMode.Blend;
+
+    /// <summary>
+    /// Gets whether this material requires alpha testing.
+    /// </summary>
+    public bool RequiresAlphaTest => AlphaMode == AlphaMode.Mask;
+}

--- a/src/KeenEyes.Assets/Assets/ModelAsset.cs
+++ b/src/KeenEyes.Assets/Assets/ModelAsset.cs
@@ -1,0 +1,199 @@
+using System.Numerics;
+
+namespace KeenEyes.Assets;
+
+/// <summary>
+/// A complete 3D model containing meshes, materials, and texture data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ModelAsset"/> is the aggregate asset for loading complete glTF/GLB files.
+/// Unlike <see cref="MeshAsset"/> (single mesh) or <see cref="TextureAsset"/> (GPU resource),
+/// ModelAsset bundles all CPU-side data needed to instantiate a 3D model in a scene.
+/// </para>
+/// <para>
+/// The asset includes:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="Meshes"/> - All mesh geometry with submeshes</description></item>
+/// <item><description><see cref="Materials"/> - PBR material properties</description></item>
+/// <item><description><see cref="Textures"/> - Embedded or referenced texture data</description></item>
+/// </list>
+/// <para>
+/// Each <see cref="Submesh"/> in a mesh references a material by index into the
+/// <see cref="Materials"/> array. Materials reference textures by index into the
+/// <see cref="Textures"/> array. This allows efficient sharing of textures across materials.
+/// </para>
+/// </remarks>
+/// <param name="name">The model name (usually the filename without extension).</param>
+/// <param name="meshes">All meshes in the model.</param>
+/// <param name="materials">All materials in the model.</param>
+/// <param name="textures">All embedded/external texture data.</param>
+public sealed class ModelAsset(
+    string name,
+    MeshAsset[] meshes,
+    MaterialData[] materials,
+    TextureData[] textures) : IDisposable
+{
+    private bool disposed;
+
+    /// <summary>
+    /// Gets the model name.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets all meshes in the model.
+    /// </summary>
+    /// <remarks>
+    /// Each mesh may contain multiple <see cref="Submesh"/> entries,
+    /// each referencing a different material by index.
+    /// </remarks>
+    public MeshAsset[] Meshes { get; } = meshes;
+
+    /// <summary>
+    /// Gets all materials in the model.
+    /// </summary>
+    /// <remarks>
+    /// Materials are referenced by <see cref="Submesh.MaterialIndex"/>.
+    /// A material index of -1 means no material (use default).
+    /// </remarks>
+    public MaterialData[] Materials { get; } = materials;
+
+    /// <summary>
+    /// Gets all texture data in the model.
+    /// </summary>
+    /// <remarks>
+    /// Textures are referenced by material texture indices
+    /// (e.g., <see cref="MaterialData.BaseColorTextureIndex"/>).
+    /// This contains CPU-side pixel data, not GPU resources.
+    /// </remarks>
+    public TextureData[] Textures { get; } = textures;
+
+    /// <summary>
+    /// Gets the total size of all model data in bytes.
+    /// </summary>
+    /// <remarks>
+    /// This includes all mesh vertex/index data and all texture pixel data.
+    /// Use this for memory budgeting and cache management.
+    /// </remarks>
+    public long SizeBytes
+    {
+        get
+        {
+            long size = 0;
+
+            foreach (var mesh in Meshes)
+            {
+                size += mesh.SizeBytes;
+            }
+
+            foreach (var texture in Textures)
+            {
+                size += texture.SizeBytes;
+            }
+
+            // Materials are small records, estimate ~100 bytes each
+            size += Materials.Length * 100;
+
+            return size;
+        }
+    }
+
+    /// <summary>
+    /// Gets the axis-aligned bounding box minimum point encompassing all meshes.
+    /// </summary>
+    public Vector3 BoundsMin
+    {
+        get
+        {
+            if (Meshes.Length == 0)
+            {
+                return Vector3.Zero;
+            }
+
+            var min = new Vector3(float.MaxValue);
+            foreach (var mesh in Meshes)
+            {
+                min = Vector3.Min(min, mesh.BoundsMin);
+            }
+
+            return min;
+        }
+    }
+
+    /// <summary>
+    /// Gets the axis-aligned bounding box maximum point encompassing all meshes.
+    /// </summary>
+    public Vector3 BoundsMax
+    {
+        get
+        {
+            if (Meshes.Length == 0)
+            {
+                return Vector3.Zero;
+            }
+
+            var max = new Vector3(float.MinValue);
+            foreach (var mesh in Meshes)
+            {
+                max = Vector3.Max(max, mesh.BoundsMax);
+            }
+
+            return max;
+        }
+    }
+
+    /// <summary>
+    /// Gets the material for a submesh, or <see cref="MaterialData.Default"/> if not found.
+    /// </summary>
+    /// <param name="materialIndex">The material index from <see cref="Submesh.MaterialIndex"/>.</param>
+    /// <returns>The material data, or default if index is out of range or -1.</returns>
+    public MaterialData GetMaterial(int materialIndex)
+    {
+        if (materialIndex < 0 || materialIndex >= Materials.Length)
+        {
+            return MaterialData.Default;
+        }
+
+        return Materials[materialIndex];
+    }
+
+    /// <summary>
+    /// Gets the texture data for a texture index, or null if not found.
+    /// </summary>
+    /// <param name="textureIndex">The texture index from material properties.</param>
+    /// <returns>The texture data, or null if index is out of range or -1.</returns>
+    public TextureData? GetTexture(int textureIndex)
+    {
+        if (textureIndex < 0 || textureIndex >= Textures.Length)
+        {
+            return null;
+        }
+
+        return Textures[textureIndex];
+    }
+
+    /// <summary>
+    /// Releases all model resources including meshes and textures.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        foreach (var mesh in Meshes)
+        {
+            mesh.Dispose();
+        }
+
+        foreach (var texture in Textures)
+        {
+            texture.Dispose();
+        }
+    }
+}

--- a/src/KeenEyes.Assets/Assets/TextureData.cs
+++ b/src/KeenEyes.Assets/Assets/TextureData.cs
@@ -1,0 +1,114 @@
+namespace KeenEyes.Assets;
+
+/// <summary>
+/// Raw texture image data extracted from a model (not a GPU resource).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="TextureData"/> holds CPU-side pixel data that can later be uploaded to GPU
+/// via <see cref="TextureLoader"/>. This allows <see cref="ModelAsset"/> to remain
+/// graphics-context-independent.
+/// </para>
+/// <para>
+/// Textures can be embedded in glTF files (base64 encoded) or referenced as external files.
+/// For external textures, <see cref="SourcePath"/> contains the resolved file path.
+/// </para>
+/// </remarks>
+/// <param name="name">The texture name from the glTF file.</param>
+/// <param name="pixels">Raw pixel data in row-major order, top-to-bottom.</param>
+/// <param name="width">Texture width in pixels.</param>
+/// <param name="height">Texture height in pixels.</param>
+/// <param name="components">Number of color components (3 for RGB, 4 for RGBA).</param>
+/// <param name="sourcePath">Original file path for external textures, or null for embedded.</param>
+public sealed class TextureData(
+    string name,
+    byte[] pixels,
+    int width,
+    int height,
+    int components,
+    string? sourcePath = null) : IDisposable
+{
+    private bool disposed;
+
+    /// <summary>
+    /// Gets the texture name.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Gets the raw pixel data.
+    /// </summary>
+    /// <remarks>
+    /// Pixel data is stored in row-major order, top-to-bottom.
+    /// Each pixel has <see cref="Components"/> bytes (RGB or RGBA).
+    /// Total size is <c>Width * Height * Components</c> bytes.
+    /// </remarks>
+    public byte[] Pixels { get; } = pixels;
+
+    /// <summary>
+    /// Gets the texture width in pixels.
+    /// </summary>
+    public int Width { get; } = width;
+
+    /// <summary>
+    /// Gets the texture height in pixels.
+    /// </summary>
+    public int Height { get; } = height;
+
+    /// <summary>
+    /// Gets the number of color components per pixel.
+    /// </summary>
+    /// <remarks>
+    /// Common values:
+    /// <list type="bullet">
+    /// <item><description>3 - RGB (no alpha)</description></item>
+    /// <item><description>4 - RGBA (with alpha)</description></item>
+    /// </list>
+    /// </remarks>
+    public int Components { get; } = components;
+
+    /// <summary>
+    /// Gets the original file path for external textures.
+    /// </summary>
+    /// <remarks>
+    /// This is null for embedded textures (base64 in glTF).
+    /// For external textures, this is the resolved absolute path.
+    /// </remarks>
+    public string? SourcePath { get; } = sourcePath;
+
+    /// <summary>
+    /// Gets the size of the texture data in bytes.
+    /// </summary>
+    public long SizeBytes => Pixels.LongLength;
+
+    /// <summary>
+    /// Gets whether this texture has an alpha channel.
+    /// </summary>
+    public bool HasAlpha => Components == 4;
+
+    /// <summary>
+    /// Creates a span over the pixel data.
+    /// </summary>
+    /// <returns>A read-only span of the pixel bytes.</returns>
+    public ReadOnlySpan<byte> AsSpan() => Pixels;
+
+    /// <summary>
+    /// Creates a memory region over the pixel data.
+    /// </summary>
+    /// <returns>A read-only memory of the pixel bytes.</returns>
+    public ReadOnlyMemory<byte> AsMemory() => Pixels;
+
+    /// <summary>
+    /// Releases the texture data.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        // Pixel array will be collected by GC
+    }
+}

--- a/src/KeenEyes.Assets/Loaders/ModelLoader.cs
+++ b/src/KeenEyes.Assets/Loaders/ModelLoader.cs
@@ -1,0 +1,483 @@
+using System.Numerics;
+using SharpGLTF.Schema2;
+using StbImageSharp;
+
+namespace KeenEyes.Assets;
+
+/// <summary>
+/// Loader for complete 3D models from glTF/GLB files.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="MeshLoader"/> which extracts only the first mesh, <see cref="ModelLoader"/>
+/// extracts the complete model including:
+/// </para>
+/// <list type="bullet">
+/// <item><description>All meshes in the file with full PBR vertex data</description></item>
+/// <item><description>All materials with PBR properties (metallic-roughness workflow)</description></item>
+/// <item><description>Embedded textures (base64 decoded from glTF)</description></item>
+/// <item><description>External texture references (paths resolved relative to model)</description></item>
+/// </list>
+/// <para>
+/// Use <see cref="ModelLoader"/> when you need access to materials and textures.
+/// Use <see cref="MeshLoader"/> for simple mesh-only loading.
+/// </para>
+/// </remarks>
+public sealed class ModelLoader : IAssetLoader<ModelAsset>
+{
+    /// <inheritdoc />
+    public IReadOnlyList<string> Extensions => [".gltf", ".glb"];
+
+    /// <inheritdoc />
+    public ModelAsset Load(Stream stream, AssetLoadContext context)
+    {
+        // Read the entire stream into memory (SharpGLTF needs random access)
+        using var memoryStream = new MemoryStream();
+        stream.CopyTo(memoryStream);
+        memoryStream.Position = 0;
+
+        // Load the glTF model
+        var model = ModelRoot.ReadGLB(memoryStream);
+
+        // Extract all components
+        var textures = ExtractTextures(model, context);
+        var materials = ExtractMaterials(model, textures);
+        var meshes = ExtractMeshes(model);
+
+        // Get model name from context path
+        var name = Path.GetFileNameWithoutExtension(context.Path) ?? "Model";
+
+        return new ModelAsset(name, meshes, materials, textures);
+    }
+
+    /// <inheritdoc />
+    public async Task<ModelAsset> LoadAsync(
+        Stream stream,
+        AssetLoadContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // glTF parsing is CPU-bound, so run on thread pool
+        return await Task.Run(() => Load(stream, context), cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public long EstimateSize(ModelAsset asset)
+        => asset.SizeBytes;
+
+    /// <summary>
+    /// Extracts all textures from the glTF model.
+    /// </summary>
+    private static TextureData[] ExtractTextures(ModelRoot model, AssetLoadContext context)
+    {
+        var textures = new List<TextureData>();
+        var imageToTextureIndex = new Dictionary<int, int>();
+
+        foreach (var image in model.LogicalImages)
+        {
+            var textureData = ExtractImage(image, context);
+            if (textureData != null)
+            {
+                imageToTextureIndex[image.LogicalIndex] = textures.Count;
+                textures.Add(textureData);
+            }
+        }
+
+        return [.. textures];
+    }
+
+    /// <summary>
+    /// Extracts a single image from the glTF model.
+    /// </summary>
+    private static TextureData? ExtractImage(Image image, AssetLoadContext context)
+    {
+        try
+        {
+            var content = image.Content;
+            if (content.Content.Length == 0)
+            {
+                return null;
+            }
+
+            // Decode the image using StbImageSharp
+            var imageBytes = content.Content.ToArray();
+            var result = ImageResult.FromMemory(imageBytes, ColorComponents.RedGreenBlueAlpha);
+
+            var name = image.Name ?? $"Texture_{image.LogicalIndex}";
+
+            // Determine source path for external textures
+            string? sourcePath = null;
+            if (!string.IsNullOrEmpty(image.Content.SourcePath))
+            {
+                var basePath = Path.GetDirectoryName(context.Path) ?? string.Empty;
+                sourcePath = Path.Combine(basePath, image.Content.SourcePath);
+            }
+
+            return new TextureData(
+                name,
+                result.Data,
+                result.Width,
+                result.Height,
+                4, // RGBA
+                sourcePath);
+        }
+        catch
+        {
+            // Failed to decode image, skip it
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Extracts all materials from the glTF model.
+    /// </summary>
+    private static MaterialData[] ExtractMaterials(ModelRoot model, TextureData[] textures)
+    {
+        var materials = new List<MaterialData>();
+
+        foreach (var material in model.LogicalMaterials)
+        {
+            materials.Add(ExtractMaterial(material, model));
+        }
+
+        // Add a default material if none exist
+        if (materials.Count == 0)
+        {
+            materials.Add(MaterialData.Default);
+        }
+
+        return [.. materials];
+    }
+
+    /// <summary>
+    /// Extracts PBR properties from a single glTF material.
+    /// </summary>
+    private static MaterialData ExtractMaterial(Material material, ModelRoot model)
+    {
+        var name = material.Name ?? $"Material_{material.LogicalIndex}";
+
+        // Base color (albedo)
+        var baseColorFactor = Vector4.One;
+        var baseColorTextureIndex = -1;
+
+        var baseColorChannel = material.FindChannel("BaseColor");
+        if (baseColorChannel.HasValue)
+        {
+            baseColorFactor = baseColorChannel.Value.Color;
+            baseColorTextureIndex = GetTextureIndex(baseColorChannel.Value.Texture);
+        }
+
+        // Metallic-roughness
+        var metallicFactor = 1.0f;
+        var roughnessFactor = 1.0f;
+        var metallicRoughnessTextureIndex = -1;
+
+        var mrChannel = material.FindChannel("MetallicRoughness");
+        if (mrChannel.HasValue)
+        {
+            // SharpGLTF stores metallic in Parameter.X and roughness in Parameter.Y
+            var param = mrChannel.Value.Color;
+            metallicFactor = param.X;
+            roughnessFactor = param.Y;
+            metallicRoughnessTextureIndex = GetTextureIndex(mrChannel.Value.Texture);
+        }
+
+        // Normal map
+        var normalTextureIndex = -1;
+        var normalScale = 1.0f;
+
+        var normalChannel = material.FindChannel("Normal");
+        if (normalChannel.HasValue)
+        {
+            normalTextureIndex = GetTextureIndex(normalChannel.Value.Texture);
+            normalScale = normalChannel.Value.Color.X; // Scale stored in X component
+        }
+
+        // Occlusion
+        var occlusionTextureIndex = -1;
+        var occlusionStrength = 1.0f;
+
+        var occlusionChannel = material.FindChannel("Occlusion");
+        if (occlusionChannel.HasValue)
+        {
+            occlusionTextureIndex = GetTextureIndex(occlusionChannel.Value.Texture);
+            occlusionStrength = occlusionChannel.Value.Color.X; // Strength stored in X component
+        }
+
+        // Emissive
+        var emissiveFactor = Vector3.Zero;
+        var emissiveTextureIndex = -1;
+
+        var emissiveChannel = material.FindChannel("Emissive");
+        if (emissiveChannel.HasValue)
+        {
+            var emColor = emissiveChannel.Value.Color;
+            emissiveFactor = new Vector3(emColor.X, emColor.Y, emColor.Z);
+            emissiveTextureIndex = GetTextureIndex(emissiveChannel.Value.Texture);
+        }
+
+        // Alpha mode
+        var alphaMode = material.Alpha switch
+        {
+            SharpGLTF.Schema2.AlphaMode.OPAQUE => AlphaMode.Opaque,
+            SharpGLTF.Schema2.AlphaMode.MASK => AlphaMode.Mask,
+            SharpGLTF.Schema2.AlphaMode.BLEND => AlphaMode.Blend,
+            _ => AlphaMode.Opaque
+        };
+
+        var alphaCutoff = material.AlphaCutoff;
+        var doubleSided = material.DoubleSided;
+
+        return new MaterialData(
+            name,
+            baseColorFactor,
+            metallicFactor,
+            roughnessFactor,
+            emissiveFactor,
+            alphaCutoff,
+            alphaMode,
+            doubleSided,
+            baseColorTextureIndex,
+            normalTextureIndex,
+            metallicRoughnessTextureIndex,
+            occlusionTextureIndex,
+            emissiveTextureIndex,
+            normalScale,
+            occlusionStrength);
+    }
+
+    /// <summary>
+    /// Gets the logical texture index, or -1 if no texture.
+    /// </summary>
+    private static int GetTextureIndex(Texture? texture)
+    {
+        if (texture?.PrimaryImage == null)
+        {
+            return -1;
+        }
+
+        return texture.PrimaryImage.LogicalIndex;
+    }
+
+    /// <summary>
+    /// Extracts all meshes from the glTF model.
+    /// </summary>
+    private static MeshAsset[] ExtractMeshes(ModelRoot model)
+    {
+        var meshes = new List<MeshAsset>();
+
+        foreach (var logicalMesh in model.LogicalMeshes)
+        {
+            meshes.Add(ExtractMesh(logicalMesh));
+        }
+
+        return [.. meshes];
+    }
+
+    /// <summary>
+    /// Extracts a single mesh with all primitives as submeshes.
+    /// </summary>
+    private static MeshAsset ExtractMesh(Mesh logicalMesh)
+    {
+        var vertices = new List<MeshVertex>();
+        var indices = new List<uint>();
+        var submeshes = new List<Submesh>();
+        var boundsMin = new Vector3(float.MaxValue);
+        var boundsMax = new Vector3(float.MinValue);
+
+        foreach (var primitive in logicalMesh.Primitives)
+        {
+            var baseVertex = (uint)vertices.Count;
+            var startIndex = indices.Count;
+
+            // Get vertex accessors
+            var positions = primitive.GetVertexAccessor("POSITION")?.AsVector3Array();
+            var normals = primitive.GetVertexAccessor("NORMAL")?.AsVector3Array();
+            var texCoords = primitive.GetVertexAccessor("TEXCOORD_0")?.AsVector2Array();
+            var tangents = primitive.GetVertexAccessor("TANGENT")?.AsVector4Array();
+            var colors = primitive.GetVertexAccessor("COLOR_0")?.AsVector4Array();
+            var joints = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array();
+            var weights = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array();
+
+            if (positions == null)
+            {
+                continue;
+            }
+
+            // Extract vertices
+            for (var i = 0; i < positions.Count; i++)
+            {
+                var position = positions[i];
+                var normal = GetValueOrDefault(normals, i, Vector3.UnitY);
+                var texCoord = GetValueOrDefault(texCoords, i, Vector2.Zero);
+                var tangent = GetValueOrDefault(tangents, i, new Vector4(1, 0, 0, 1));
+                var color = GetValueOrDefault(colors, i, Vector4.One);
+                var jointVec = GetValueOrDefault(joints, i, Vector4.Zero);
+                var weight = GetValueOrDefault(weights, i, new Vector4(1, 0, 0, 0));
+
+                // Convert joint indices from float to ushort
+                var jointIndices = new JointIndices(
+                    (ushort)jointVec.X,
+                    (ushort)jointVec.Y,
+                    (ushort)jointVec.Z,
+                    (ushort)jointVec.W);
+
+                vertices.Add(new MeshVertex(position, normal, texCoord, tangent, color, jointIndices, weight));
+
+                // Update bounds
+                boundsMin = Vector3.Min(boundsMin, position);
+                boundsMax = Vector3.Max(boundsMax, position);
+            }
+
+            // Extract indices
+            var indexAccessor = primitive.GetIndexAccessor();
+            if (indexAccessor != null)
+            {
+                foreach (var index in indexAccessor.AsIndicesArray())
+                {
+                    indices.Add(baseVertex + index);
+                }
+            }
+            else
+            {
+                // No indices, create sequential indices
+                for (uint i = 0; i < positions.Count; i++)
+                {
+                    indices.Add(baseVertex + i);
+                }
+            }
+
+            // Get material index (-1 if no material assigned)
+            var materialIndex = primitive.Material?.LogicalIndex ?? -1;
+            var indexCount = indices.Count - startIndex;
+
+            submeshes.Add(new Submesh(startIndex, indexCount, materialIndex));
+        }
+
+        if (vertices.Count == 0)
+        {
+            throw new InvalidDataException("Mesh contains no vertices");
+        }
+
+        // Compute tangents if they weren't provided in the mesh
+        var vertexArray = vertices.ToArray();
+        var indexArray = indices.ToArray();
+
+        if (!HasValidTangents(vertexArray))
+        {
+            ComputeTangents(vertexArray, indexArray);
+        }
+
+        return new MeshAsset(
+            logicalMesh.Name ?? "Mesh",
+            vertexArray,
+            indexArray,
+            [.. submeshes],
+            boundsMin,
+            boundsMax);
+    }
+
+    private static T GetValueOrDefault<T>(IList<T>? array, int index, T defaultValue)
+        => array != null && index < array.Count ? array[index] : defaultValue;
+
+    /// <summary>
+    /// Checks if the mesh has valid tangents (not all default values).
+    /// </summary>
+    private static bool HasValidTangents(MeshVertex[] vertices)
+    {
+        var defaultTangent = new Vector4(1, 0, 0, 1);
+
+        foreach (var vertex in vertices)
+        {
+            if (vertex.Tangent != defaultTangent)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Computes tangent vectors for normal mapping using a simplified MikkTSpace-like algorithm.
+    /// </summary>
+    private static void ComputeTangents(MeshVertex[] vertices, uint[] indices)
+    {
+        // Allocate tangent and bitangent accumulators
+        var tangents = new Vector3[vertices.Length];
+        var bitangents = new Vector3[vertices.Length];
+
+        // Process each triangle
+        for (var i = 0; i < indices.Length; i += 3)
+        {
+            var i0 = (int)indices[i];
+            var i1 = (int)indices[i + 1];
+            var i2 = (int)indices[i + 2];
+
+            var v0 = vertices[i0];
+            var v1 = vertices[i1];
+            var v2 = vertices[i2];
+
+            // Position deltas
+            var edge1 = v1.Position - v0.Position;
+            var edge2 = v2.Position - v0.Position;
+
+            // UV deltas
+            var deltaUv1 = v1.TexCoord - v0.TexCoord;
+            var deltaUv2 = v2.TexCoord - v0.TexCoord;
+
+            // Calculate tangent and bitangent
+            var r = deltaUv1.X * deltaUv2.Y - deltaUv2.X * deltaUv1.Y;
+
+            // Avoid division by zero for degenerate triangles
+            if (Math.Abs(r) < 1e-6f)
+            {
+                continue;
+            }
+
+            r = 1.0f / r;
+
+            var tangent = new Vector3(
+                (deltaUv2.Y * edge1.X - deltaUv1.Y * edge2.X) * r,
+                (deltaUv2.Y * edge1.Y - deltaUv1.Y * edge2.Y) * r,
+                (deltaUv2.Y * edge1.Z - deltaUv1.Y * edge2.Z) * r);
+
+            var bitangent = new Vector3(
+                (-deltaUv2.X * edge1.X + deltaUv1.X * edge2.X) * r,
+                (-deltaUv2.X * edge1.Y + deltaUv1.X * edge2.Y) * r,
+                (-deltaUv2.X * edge1.Z + deltaUv1.X * edge2.Z) * r);
+
+            // Accumulate for each vertex of the triangle
+            tangents[i0] += tangent;
+            tangents[i1] += tangent;
+            tangents[i2] += tangent;
+
+            bitangents[i0] += bitangent;
+            bitangents[i1] += bitangent;
+            bitangents[i2] += bitangent;
+        }
+
+        // Orthonormalize and store tangents
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var n = vertices[i].Normal;
+            var t = tangents[i];
+            var b = bitangents[i];
+
+            // Gram-Schmidt orthogonalize: t' = normalize(t - n * dot(n, t))
+            var tangentOrtho = Vector3.Normalize(t - n * Vector3.Dot(n, t));
+
+            // Handle degenerate case
+            if (float.IsNaN(tangentOrtho.X))
+            {
+                tangentOrtho = new Vector3(1, 0, 0);
+            }
+
+            // Calculate handedness (bitangent sign)
+            var cross = Vector3.Cross(n, t);
+            var handedness = Vector3.Dot(cross, b) < 0 ? -1.0f : 1.0f;
+
+            // Update vertex with computed tangent
+            vertices[i] = vertices[i] with { Tangent = new Vector4(tangentOrtho, handedness) };
+        }
+    }
+}

--- a/tests/KeenEyes.Assets.Tests/ModelAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/ModelAssetTests.cs
@@ -1,0 +1,409 @@
+using System.Numerics;
+
+namespace KeenEyes.Assets.Tests;
+
+/// <summary>
+/// Tests for ModelAsset, MaterialData, TextureData, and related types.
+/// </summary>
+public class ModelAssetTests
+{
+    #region AlphaMode Tests
+
+    [Fact]
+    public void AlphaMode_HasExpectedValues()
+    {
+        Assert.Equal(0, (int)AlphaMode.Opaque);
+        Assert.Equal(1, (int)AlphaMode.Mask);
+        Assert.Equal(2, (int)AlphaMode.Blend);
+    }
+
+    #endregion
+
+    #region TextureData Tests
+
+    [Fact]
+    public void TextureData_StoresProperties()
+    {
+        var pixels = new byte[] { 255, 0, 0, 255, 0, 255, 0, 255 }; // 2 RGBA pixels
+        using var texture = new TextureData("test", pixels, 2, 1, 4, "/path/to/texture.png");
+
+        Assert.Equal("test", texture.Name);
+        Assert.Equal(pixels, texture.Pixels);
+        Assert.Equal(2, texture.Width);
+        Assert.Equal(1, texture.Height);
+        Assert.Equal(4, texture.Components);
+        Assert.Equal("/path/to/texture.png", texture.SourcePath);
+    }
+
+    [Fact]
+    public void TextureData_SizeBytes_ReturnsPixelArrayLength()
+    {
+        var pixels = new byte[256 * 128 * 4]; // 256x128 RGBA
+        using var texture = new TextureData("test", pixels, 256, 128, 4);
+
+        Assert.Equal(256 * 128 * 4, texture.SizeBytes);
+    }
+
+    [Fact]
+    public void TextureData_HasAlpha_ReturnsCorrectly()
+    {
+        var rgbaPixels = new byte[4];
+        var rgbPixels = new byte[3];
+
+        using var rgbaTexture = new TextureData("rgba", rgbaPixels, 1, 1, 4);
+        using var rgbTexture = new TextureData("rgb", rgbPixels, 1, 1, 3);
+
+        Assert.True(rgbaTexture.HasAlpha);
+        Assert.False(rgbTexture.HasAlpha);
+    }
+
+    [Fact]
+    public void TextureData_SourcePath_NullForEmbedded()
+    {
+        var pixels = new byte[4];
+        using var texture = new TextureData("embedded", pixels, 1, 1, 4);
+
+        Assert.Null(texture.SourcePath);
+    }
+
+    [Fact]
+    public void TextureData_AsSpan_ReturnsPixelData()
+    {
+        var pixels = new byte[] { 1, 2, 3, 4 };
+        using var texture = new TextureData("test", pixels, 1, 1, 4);
+
+        var span = texture.AsSpan();
+
+        Assert.Equal(4, span.Length);
+        Assert.Equal(1, span[0]);
+        Assert.Equal(4, span[3]);
+    }
+
+    [Fact]
+    public void TextureData_AsMemory_ReturnsPixelData()
+    {
+        var pixels = new byte[] { 1, 2, 3, 4 };
+        using var texture = new TextureData("test", pixels, 1, 1, 4);
+
+        var memory = texture.AsMemory();
+
+        Assert.Equal(4, memory.Length);
+    }
+
+    [Fact]
+    public void TextureData_Dispose_IsIdempotent()
+    {
+        var texture = new TextureData("test", [1, 2, 3, 4], 1, 1, 4);
+        texture.Dispose();
+        texture.Dispose(); // Should not throw
+    }
+
+    #endregion
+
+    #region MaterialData Tests
+
+    [Fact]
+    public void MaterialData_Default_HasExpectedValues()
+    {
+        var material = MaterialData.Default;
+
+        Assert.Equal("Default", material.Name);
+        Assert.Equal(Vector4.One, material.BaseColorFactor);
+        Assert.Equal(0f, material.MetallicFactor);
+        Assert.Equal(0.5f, material.RoughnessFactor);
+        Assert.Equal(Vector3.Zero, material.EmissiveFactor);
+        Assert.Equal(0.5f, material.AlphaCutoff);
+        Assert.Equal(AlphaMode.Opaque, material.AlphaMode);
+        Assert.False(material.DoubleSided);
+        Assert.Equal(-1, material.BaseColorTextureIndex);
+        Assert.Equal(-1, material.NormalTextureIndex);
+        Assert.Equal(-1, material.MetallicRoughnessTextureIndex);
+        Assert.Equal(-1, material.OcclusionTextureIndex);
+        Assert.Equal(-1, material.EmissiveTextureIndex);
+        Assert.Equal(1.0f, material.NormalScale);
+        Assert.Equal(1.0f, material.OcclusionStrength);
+    }
+
+    [Fact]
+    public void MaterialData_HasTextureProperties_ReturnCorrectly()
+    {
+        var withTextures = new MaterialData(
+            "WithTextures",
+            Vector4.One, 0.5f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Opaque, false,
+            0, 1, 2, 3, 4);
+
+        var withoutTextures = MaterialData.Default;
+
+        Assert.True(withTextures.HasBaseColorTexture);
+        Assert.True(withTextures.HasNormalTexture);
+        Assert.True(withTextures.HasMetallicRoughnessTexture);
+        Assert.True(withTextures.HasOcclusionTexture);
+        Assert.True(withTextures.HasEmissiveTexture);
+        Assert.True(withTextures.HasAnyTexture);
+
+        Assert.False(withoutTextures.HasBaseColorTexture);
+        Assert.False(withoutTextures.HasNormalTexture);
+        Assert.False(withoutTextures.HasMetallicRoughnessTexture);
+        Assert.False(withoutTextures.HasOcclusionTexture);
+        Assert.False(withoutTextures.HasEmissiveTexture);
+        Assert.False(withoutTextures.HasAnyTexture);
+    }
+
+    [Fact]
+    public void MaterialData_RequiresBlending_ReturnsTrueForBlendMode()
+    {
+        var blendMaterial = new MaterialData(
+            "Blend", Vector4.One, 0f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Blend, false,
+            -1, -1, -1, -1, -1);
+
+        var opaqueMaterial = MaterialData.Default;
+        var maskMaterial = new MaterialData(
+            "Mask", Vector4.One, 0f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Mask, false,
+            -1, -1, -1, -1, -1);
+
+        Assert.True(blendMaterial.RequiresBlending);
+        Assert.False(opaqueMaterial.RequiresBlending);
+        Assert.False(maskMaterial.RequiresBlending);
+    }
+
+    [Fact]
+    public void MaterialData_RequiresAlphaTest_ReturnsTrueForMaskMode()
+    {
+        var maskMaterial = new MaterialData(
+            "Mask", Vector4.One, 0f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Mask, false,
+            -1, -1, -1, -1, -1);
+
+        var opaqueMaterial = MaterialData.Default;
+        var blendMaterial = new MaterialData(
+            "Blend", Vector4.One, 0f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Blend, false,
+            -1, -1, -1, -1, -1);
+
+        Assert.True(maskMaterial.RequiresAlphaTest);
+        Assert.False(opaqueMaterial.RequiresAlphaTest);
+        Assert.False(blendMaterial.RequiresAlphaTest);
+    }
+
+    [Fact]
+    public void MaterialData_Equality_WorksCorrectly()
+    {
+        var material1 = new MaterialData(
+            "Test", Vector4.One, 0.5f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Opaque, false,
+            0, 1, 2, 3, 4);
+
+        var material2 = new MaterialData(
+            "Test", Vector4.One, 0.5f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Opaque, false,
+            0, 1, 2, 3, 4);
+
+        var material3 = new MaterialData(
+            "Different", Vector4.One, 0.5f, 0.5f, Vector3.Zero, 0.5f,
+            AlphaMode.Opaque, false,
+            0, 1, 2, 3, 4);
+
+        Assert.Equal(material1, material2);
+        Assert.NotEqual(material1, material3);
+    }
+
+    [Fact]
+    public void MaterialData_WithExpression_CreatesModifiedCopy()
+    {
+        var original = MaterialData.Default;
+        var modified = original with { MetallicFactor = 1.0f, RoughnessFactor = 0.0f };
+
+        Assert.Equal(0f, original.MetallicFactor);
+        Assert.Equal(0.5f, original.RoughnessFactor);
+
+        Assert.Equal(1.0f, modified.MetallicFactor);
+        Assert.Equal(0.0f, modified.RoughnessFactor);
+    }
+
+    #endregion
+
+    #region ModelAsset Tests
+
+    [Fact]
+    public void ModelAsset_StoresProperties()
+    {
+        var meshes = new[] { CreateTestMesh("Mesh1"), CreateTestMesh("Mesh2") };
+        var materials = new[] { MaterialData.Default };
+        var textures = Array.Empty<TextureData>();
+
+        using var model = new ModelAsset("TestModel", meshes, materials, textures);
+
+        Assert.Equal("TestModel", model.Name);
+        Assert.Equal(2, model.Meshes.Length);
+        Assert.Single(model.Materials);
+        Assert.Empty(model.Textures);
+    }
+
+    [Fact]
+    public void ModelAsset_SizeBytes_IncludesMeshesAndTextures()
+    {
+        var meshes = new[] { CreateTestMesh("Mesh1") };
+        var materials = new[] { MaterialData.Default };
+        var pixels = new byte[64 * 64 * 4];
+        var textures = new[] { new TextureData("Tex", pixels, 64, 64, 4) };
+
+        using var model = new ModelAsset("Test", meshes, materials, textures);
+
+        // Mesh size + texture size + material estimate (100 bytes each)
+        var expectedMinSize = meshes[0].SizeBytes + textures[0].SizeBytes + 100;
+        Assert.True(model.SizeBytes >= expectedMinSize);
+    }
+
+    [Fact]
+    public void ModelAsset_BoundsMin_ReturnsMinOfAllMeshes()
+    {
+        var mesh1 = CreateTestMeshWithBounds(new Vector3(-1, -2, -3), new Vector3(0, 0, 0));
+        var mesh2 = CreateTestMeshWithBounds(new Vector3(-5, 0, -1), new Vector3(1, 1, 1));
+
+        using var model = new ModelAsset("Test", [mesh1, mesh2], [], []);
+
+        Assert.Equal(new Vector3(-5, -2, -3), model.BoundsMin);
+    }
+
+    [Fact]
+    public void ModelAsset_BoundsMax_ReturnsMaxOfAllMeshes()
+    {
+        var mesh1 = CreateTestMeshWithBounds(new Vector3(-1, -2, -3), new Vector3(5, 3, 2));
+        var mesh2 = CreateTestMeshWithBounds(new Vector3(0, 0, 0), new Vector3(2, 4, 1));
+
+        using var model = new ModelAsset("Test", [mesh1, mesh2], [], []);
+
+        Assert.Equal(new Vector3(5, 4, 2), model.BoundsMax);
+    }
+
+    [Fact]
+    public void ModelAsset_BoundsWithNoMeshes_ReturnsZero()
+    {
+        using var model = new ModelAsset("Empty", [], [], []);
+
+        Assert.Equal(Vector3.Zero, model.BoundsMin);
+        Assert.Equal(Vector3.Zero, model.BoundsMax);
+    }
+
+    [Fact]
+    public void ModelAsset_GetMaterial_ReturnsCorrectMaterial()
+    {
+        var materials = new[]
+        {
+            MaterialData.Default with { Name = "Mat0" },
+            MaterialData.Default with { Name = "Mat1" }
+        };
+
+        using var model = new ModelAsset("Test", [], materials, []);
+
+        Assert.Equal("Mat0", model.GetMaterial(0).Name);
+        Assert.Equal("Mat1", model.GetMaterial(1).Name);
+    }
+
+    [Fact]
+    public void ModelAsset_GetMaterial_ReturnsDefaultForInvalidIndex()
+    {
+        using var model = new ModelAsset("Test", [], [], []);
+
+        Assert.Equal(MaterialData.Default, model.GetMaterial(-1));
+        Assert.Equal(MaterialData.Default, model.GetMaterial(0));
+        Assert.Equal(MaterialData.Default, model.GetMaterial(100));
+    }
+
+    [Fact]
+    public void ModelAsset_GetTexture_ReturnsCorrectTexture()
+    {
+        var textures = new[]
+        {
+            new TextureData("Tex0", [1, 2, 3, 4], 1, 1, 4),
+            new TextureData("Tex1", [5, 6, 7, 8], 1, 1, 4)
+        };
+
+        using var model = new ModelAsset("Test", [], [], textures);
+
+        Assert.Equal("Tex0", model.GetTexture(0)?.Name);
+        Assert.Equal("Tex1", model.GetTexture(1)?.Name);
+    }
+
+    [Fact]
+    public void ModelAsset_GetTexture_ReturnsNullForInvalidIndex()
+    {
+        using var model = new ModelAsset("Test", [], [], []);
+
+        Assert.Null(model.GetTexture(-1));
+        Assert.Null(model.GetTexture(0));
+        Assert.Null(model.GetTexture(100));
+    }
+
+    [Fact]
+    public void ModelAsset_Dispose_DisposesAllResources()
+    {
+        var meshes = new[] { CreateTestMesh("Mesh") };
+        var textures = new[] { new TextureData("Tex", [1, 2, 3, 4], 1, 1, 4) };
+
+        var model = new ModelAsset("Test", meshes, [], textures);
+        model.Dispose();
+
+        // Verify dispose is idempotent
+        model.Dispose(); // Should not throw
+    }
+
+    #endregion
+
+    #region ModelLoader Tests
+
+    [Fact]
+    public void ModelLoader_Extensions_IncludesGltfAndGlb()
+    {
+        var loader = new ModelLoader();
+
+        Assert.Contains(".gltf", loader.Extensions);
+        Assert.Contains(".glb", loader.Extensions);
+    }
+
+    [Fact]
+    public void ModelLoader_EstimateSize_ReturnsModelSizeBytes()
+    {
+        var loader = new ModelLoader();
+        using var model = new ModelAsset("Test", [], [], []);
+
+        var estimate = loader.EstimateSize(model);
+
+        Assert.Equal(model.SizeBytes, estimate);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static MeshAsset CreateTestMesh(string name)
+    {
+        var vertices = new[]
+        {
+            MeshVertex.CreateBasic(Vector3.Zero, Vector3.UnitY, Vector2.Zero),
+            MeshVertex.CreateBasic(Vector3.UnitX, Vector3.UnitY, Vector2.UnitX),
+            MeshVertex.CreateBasic(Vector3.UnitZ, Vector3.UnitY, Vector2.UnitY)
+        };
+        var indices = new uint[] { 0, 1, 2 };
+
+        return MeshAsset.Create(name, vertices, indices);
+    }
+
+    private static MeshAsset CreateTestMeshWithBounds(Vector3 boundsMin, Vector3 boundsMax)
+    {
+        var vertices = new[]
+        {
+            MeshVertex.CreateBasic(boundsMin, Vector3.UnitY, Vector2.Zero),
+            MeshVertex.CreateBasic(boundsMax, Vector3.UnitY, Vector2.One)
+        };
+        var indices = new uint[] { 0, 1 };
+        var submeshes = new[] { new Submesh(0, 2, -1) };
+
+        return new MeshAsset("TestMesh", vertices, indices, submeshes, boundsMin, boundsMax);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Adds `ModelAsset` class that bundles all meshes, materials, and textures from a glTF file
- Adds `ModelLoader` for comprehensive glTF/GLB loading (extracts all meshes, not just first)
- Adds `MaterialData` record with full PBR material properties (metallic-roughness workflow)
- Adds `TextureData` class for CPU-side texture data from embedded/external sources
- Adds `AlphaMode` enum (Opaque, Mask, Blend) matching glTF 2.0 spec

## Key Features
- Extracts ALL meshes from glTF file with submesh-to-material mapping
- Full PBR material extraction: base color, metallic, roughness, normal, occlusion, emissive
- Embedded texture decoding via StbImageSharp
- External texture path resolution relative to model file
- Alpha mode and double-sided material support
- Computed tangents when not present in source mesh

## Test plan
- [x] 26 new unit tests for all new types
- [x] All 13,139 tests pass
- [x] Build succeeds with zero warnings

Closes #882

Part of the PBR rendering pipeline (Phase 2/6).

🤖 Generated with [Claude Code](https://claude.ai/code)