### PR TITLE
refactor(core): Move ISerializationCapability to Abstractions

### DIFF
--- a/benchmarks/KeenEyes.Benchmarks/SerializationBenchmarks.cs
+++ b/benchmarks/KeenEyes.Benchmarks/SerializationBenchmarks.cs
@@ -367,32 +367,32 @@ internal sealed class BenchmarkComponentSerializer : IComponentSerializer, IBina
     {
         if (typeName.Contains(nameof(Position)))
         {
-            return serialization.Components.Register<Position>();
+            return (ComponentInfo)serialization.Components.Register<Position>();
         }
 
         if (typeName.Contains(nameof(Velocity)))
         {
-            return serialization.Components.Register<Velocity>();
+            return (ComponentInfo)serialization.Components.Register<Velocity>();
         }
 
         if (typeName.Contains(nameof(Health)))
         {
-            return serialization.Components.Register<Health>();
+            return (ComponentInfo)serialization.Components.Register<Health>();
         }
 
         if (typeName.Contains(nameof(Rotation)))
         {
-            return serialization.Components.Register<Rotation>();
+            return (ComponentInfo)serialization.Components.Register<Rotation>();
         }
 
         if (typeName.Contains(nameof(ActiveTag)))
         {
-            return serialization.Components.Register<ActiveTag>(isTag: true);
+            return (ComponentInfo)serialization.Components.Register<ActiveTag>(isTag: true);
         }
 
         if (typeName.Contains(nameof(FrozenTag)))
         {
-            return serialization.Components.Register<FrozenTag>(isTag: true);
+            return (ComponentInfo)serialization.Components.Register<FrozenTag>(isTag: true);
         }
 
         return null;

--- a/editor/KeenEyes.Editor.Common/Serialization/EntitySerializer.cs
+++ b/editor/KeenEyes.Editor.Common/Serialization/EntitySerializer.cs
@@ -79,19 +79,22 @@ public static class EntitySerializer
                 .ToDictionary(c => c.Type, c => c.IsTag);
         }
 
-        // Capture all components
+        // Capture all components using snapshot capability
         var components = new List<ComponentSnapshot>();
-        foreach (var (type, value) in world.GetComponents(entity))
+        if (world is ISnapshotCapability snapshotCapability)
         {
-            // Determine if it's a tag component
-            var isTag = tagLookup?.TryGetValue(type, out var tag) == true && tag;
-
-            components.Add(new ComponentSnapshot
+            foreach (var (type, value) in snapshotCapability.GetComponents(entity))
             {
-                ComponentType = type,
-                Value = isTag ? null : CloneValue(value),
-                IsTag = isTag
-            });
+                // Determine if it's a tag component
+                var isTag = tagLookup?.TryGetValue(type, out var tag) == true && tag;
+
+                components.Add(new ComponentSnapshot
+                {
+                    ComponentType = type,
+                    Value = isTag ? null : CloneValue(value),
+                    IsTag = isTag
+                });
+            }
         }
 
         // Capture children recursively if requested

--- a/editor/KeenEyes.Editor/Panels/InspectorPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/InspectorPanel.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Reflection;
 
+using KeenEyes.Capabilities;
 using KeenEyes.Editor.Abstractions.Inspector;
 using KeenEyes.Editor.Application;
 using KeenEyes.Editor.Common.Inspector;
@@ -144,11 +145,12 @@ public static class InspectorPanel
         IWorld sceneWorld,
         Entity entity)
     {
-        var components = sceneWorld.GetComponents(entity);
-
-        foreach (var (componentType, componentValue) in components)
+        if (sceneWorld is ISnapshotCapability snapshot)
         {
-            CreateComponentSection(editorWorld, contentArea, font, componentType, componentValue);
+            foreach (var (componentType, componentValue) in snapshot.GetComponents(entity))
+            {
+                CreateComponentSection(editorWorld, contentArea, font, componentType, componentValue);
+            }
         }
     }
 

--- a/editor/KeenEyes.Editor/Plugins/BuiltIn/InspectorPlugin.cs
+++ b/editor/KeenEyes.Editor/Plugins/BuiltIn/InspectorPlugin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Keen Eye, LLC. All rights reserved.
 // Licensed under the MIT License.
 
+using KeenEyes.Capabilities;
 using KeenEyes.Editor.Abstractions;
 using KeenEyes.Editor.Abstractions.Capabilities;
 using KeenEyes.Editor.Application;
@@ -332,11 +333,12 @@ internal sealed class InspectorPanelImpl : IEditorPanel
             return;
         }
 
-        var components = sceneWorld.GetComponents(entity);
-
-        foreach (var (componentType, componentValue) in components)
+        if (sceneWorld is ISnapshotCapability snapshot)
         {
-            CreateComponentSection(componentType, componentValue);
+            foreach (var (componentType, componentValue) in snapshot.GetComponents(entity))
+            {
+                CreateComponentSection(componentType, componentValue);
+            }
         }
     }
 

--- a/editor/KeenEyes.Generators/SerializationGenerator.cs
+++ b/editor/KeenEyes.Generators/SerializationGenerator.cs
@@ -374,7 +374,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
             sb.AppendLine($"            value => Serialize_{component.Name}(({component.FullName})value),");
             sb.AppendLine($"            DeserializeBinary_{component.Name},");
             sb.AppendLine($"            (value, writer) => SerializeBinary_{component.Name}(({component.FullName})value, writer),");
-            sb.AppendLine($"            (serialization, isTag) => serialization.Components.Register<{component.FullName}>(isTag),");
+            sb.AppendLine($"            (serialization, isTag) => (ComponentInfo)serialization.Components.Register<{component.FullName}>(isTag),");
             sb.AppendLine($"            (serialization, value) => serialization.SetSingleton(({component.FullName})value),");
             sb.AppendLine($"            static () => new {component.FullName}(),");
             sb.AppendLine($"            {component.Version});");

--- a/src/KeenEyes.Abstractions/Capabilities/IComponentInfo.cs
+++ b/src/KeenEyes.Abstractions/Capabilities/IComponentInfo.cs
@@ -1,0 +1,38 @@
+namespace KeenEyes.Capabilities;
+
+/// <summary>
+/// Interface for component type metadata used in serialization operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface provides read-only access to component metadata needed
+/// for serialization, without exposing internal implementation details.
+/// </para>
+/// </remarks>
+public interface IComponentInfo
+{
+    /// <summary>
+    /// Gets the CLR type of this component.
+    /// </summary>
+    Type Type { get; }
+
+    /// <summary>
+    /// Gets the size of the component in bytes. Zero for tag components.
+    /// </summary>
+    int Size { get; }
+
+    /// <summary>
+    /// Gets whether this is a tag component (zero-size marker).
+    /// </summary>
+    bool IsTag { get; }
+
+    /// <summary>
+    /// Gets the schema version of this component for migration support.
+    /// </summary>
+    int Version { get; }
+
+    /// <summary>
+    /// Gets the name of the component type.
+    /// </summary>
+    string Name { get; }
+}

--- a/src/KeenEyes.Abstractions/Capabilities/ISerializationCapability.cs
+++ b/src/KeenEyes.Abstractions/Capabilities/ISerializationCapability.cs
@@ -10,7 +10,7 @@ namespace KeenEyes.Capabilities;
 /// and singleton setting during deserialization.
 /// </para>
 /// <para>
-/// The <see cref="World"/> class implements this capability. Serialization code
+/// The World class implements this capability. Serialization code
 /// should use this interface instead of the base <see cref="ISnapshotCapability"/>
 /// when component registration is needed.
 /// </para>
@@ -29,7 +29,7 @@ public interface ISerializationCapability : ISnapshotCapability
 /// <remarks>
 /// <para>
 /// This interface allows snapshot and serialization code to work with component registries
-/// without depending on the concrete <see cref="ComponentRegistry"/> type.
+/// without depending on the concrete ComponentRegistry type.
 /// </para>
 /// </remarks>
 public interface IComponentRegistry
@@ -37,7 +37,7 @@ public interface IComponentRegistry
     /// <summary>
     /// Gets all registered component types.
     /// </summary>
-    IReadOnlyList<ComponentInfo> All { get; }
+    IReadOnlyList<IComponentInfo> All { get; }
 
     /// <summary>
     /// Gets the number of registered component types.
@@ -49,7 +49,7 @@ public interface IComponentRegistry
     /// </summary>
     /// <param name="type">The component type.</param>
     /// <returns>The component info, or null if not registered.</returns>
-    ComponentInfo? Get(Type type);
+    IComponentInfo? Get(Type type);
 
     /// <summary>
     /// Registers a component type.
@@ -57,5 +57,5 @@ public interface IComponentRegistry
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="isTag">Whether the component is a tag component.</param>
     /// <returns>The component info.</returns>
-    ComponentInfo Register<T>(bool isTag = false) where T : struct, IComponent;
+    IComponentInfo Register<T>(bool isTag = false) where T : struct, IComponent;
 }

--- a/src/KeenEyes.Core/Components/ComponentInfo.cs
+++ b/src/KeenEyes.Core/Components/ComponentInfo.cs
@@ -1,11 +1,12 @@
 using System.Runtime.CompilerServices;
+using KeenEyes.Capabilities;
 
 namespace KeenEyes;
 
 /// <summary>
 /// Runtime metadata for a registered component type within a specific World.
 /// </summary>
-public sealed class ComponentInfo
+public sealed class ComponentInfo : IComponentInfo
 {
     /// <summary>Unique identifier for this component type within the owning World.</summary>
     public ComponentId Id { get; }

--- a/src/KeenEyes.Core/Components/ComponentRegistry.cs
+++ b/src/KeenEyes.Core/Components/ComponentRegistry.cs
@@ -38,6 +38,20 @@ public sealed class ComponentRegistry : IComponentRegistry
     }
 
     /// <summary>
+    /// Gets all registered component types as <see cref="IComponentInfo"/>.
+    /// </summary>
+    IReadOnlyList<IComponentInfo> IComponentRegistry.All
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return all.Cast<IComponentInfo>().ToList();
+            }
+        }
+    }
+
+    /// <summary>
     /// Number of registered component types.
     /// </summary>
     public int Count
@@ -117,6 +131,11 @@ public sealed class ComponentRegistry : IComponentRegistry
     }
 
     /// <summary>
+    /// Registers a component type as <see cref="IComponentInfo"/>.
+    /// </summary>
+    IComponentInfo IComponentRegistry.Register<T>(bool isTag) => Register<T>(isTag);
+
+    /// <summary>
     /// Gets the component info for a type, or null if not registered.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -138,6 +157,11 @@ public sealed class ComponentRegistry : IComponentRegistry
             return byType.TryGetValue(type, out var info) ? info : null;
         }
     }
+
+    /// <summary>
+    /// Gets the component info for a type as <see cref="IComponentInfo"/>, or null if not registered.
+    /// </summary>
+    IComponentInfo? IComponentRegistry.Get(Type type) => Get(type);
 
     /// <summary>
     /// Gets or registers a component type.

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -1,3 +1,4 @@
+using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Protocol;
 using KeenEyes.Network.Replication;
@@ -256,11 +257,14 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
 
             // Write all replicated components
             var toSend = new List<(Type, object)>();
-            foreach (var (type, value) in context.World.GetComponents(entity))
+            if (context.World is ISnapshotCapability snapshot)
             {
-                if (serializer.IsNetworkSerializable(type))
+                foreach (var (type, value) in snapshot.GetComponents(entity))
                 {
-                    toSend.Add((type, value));
+                    if (serializer.IsNetworkSerializable(type))
+                    {
+                        toSend.Add((type, value));
+                    }
                 }
             }
 

--- a/src/KeenEyes.Network/Protocol/NetworkMessageReader.cs
+++ b/src/KeenEyes.Network/Protocol/NetworkMessageReader.cs
@@ -1,4 +1,5 @@
 using KeenEyes;
+using KeenEyes.Capabilities;
 using KeenEyes.Network.Serialization;
 
 namespace KeenEyes.Network.Protocol;
@@ -136,12 +137,15 @@ public ref struct NetworkMessageReader(ReadOnlySpan<byte> data)
 
         // Look up current component value as baseline
         object? baseline = null;
-        foreach (var (type, value) in world.GetComponents(entity))
+        if (world is ISnapshotCapability snapshot)
         {
-            if (type == componentType)
+            foreach (var (type, value) in snapshot.GetComponents(entity))
             {
-                baseline = value;
-                break;
+                if (type == componentType)
+                {
+                    baseline = value;
+                    break;
+                }
             }
         }
 

--- a/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
+++ b/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
@@ -1,3 +1,4 @@
+using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Prediction;
 using KeenEyes.Network.Serialization;
@@ -120,12 +121,15 @@ public sealed class ClientPredictionSystem(
             return;
         }
 
-        foreach (var (type, value) in World.GetComponents(entity))
+        if (World is ISnapshotCapability snapshot)
         {
-            if (serializer.IsNetworkSerializable(type))
+            foreach (var (type, value) in snapshot.GetComponents(entity))
             {
-                // Clone the value to avoid storing a reference
-                buffer.SaveState(tick, type, CloneValue(type, value));
+                if (serializer.IsNetworkSerializable(type))
+                {
+                    // Clone the value to avoid storing a reference
+                    buffer.SaveState(tick, type, CloneValue(type, value));
+                }
             }
         }
 

--- a/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
+++ b/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
@@ -22,7 +22,7 @@ namespace KeenEyes.Persistence;
 /// </remarks>
 public sealed class EncryptedPersistenceApi
 {
-    private readonly World world;
+    private readonly IWorld world;
     private readonly IEncryptionProvider encryptionProvider;
     private readonly string saveDirectory;
 
@@ -31,14 +31,29 @@ public sealed class EncryptedPersistenceApi
     /// </summary>
     /// <param name="world">The world to save/load.</param>
     /// <param name="config">The persistence configuration.</param>
-    internal EncryptedPersistenceApi(World world, PersistenceConfig config)
+    internal EncryptedPersistenceApi(IWorld world, PersistenceConfig config)
     {
         ArgumentNullException.ThrowIfNull(world);
         ArgumentNullException.ThrowIfNull(config);
 
         this.world = world;
         encryptionProvider = config.EncryptionProvider;
-        saveDirectory = config.SaveDirectory ?? world.SaveDirectory;
+
+        // Use configured directory, or fall back to World's default if available
+        if (config.SaveDirectory is not null)
+        {
+            saveDirectory = config.SaveDirectory;
+        }
+        else if (world is World concreteWorld)
+        {
+            saveDirectory = concreteWorld.SaveDirectory;
+        }
+        else
+        {
+            throw new ArgumentException(
+                "SaveDirectory must be specified in PersistenceConfig when using an IWorld implementation that doesn't provide a default save directory.",
+                nameof(config));
+        }
     }
 
     /// <summary>

--- a/src/KeenEyes.Persistence/PersistencePlugin.cs
+++ b/src/KeenEyes.Persistence/PersistencePlugin.cs
@@ -1,8 +1,5 @@
 using KeenEyes.Capabilities;
 
-// TODO: Remove this suppression after refactoring to use IWorld interface
-#pragma warning disable KEEN050 // IWorld to World cast - legacy code pending refactoring
-
 namespace KeenEyes.Persistence;
 
 /// <summary>
@@ -19,9 +16,9 @@ namespace KeenEyes.Persistence;
 /// provides encrypted save/load operations.
 /// </para>
 /// <para>
-/// <b>Note:</b> This plugin currently requires a concrete World instance because
-/// the snapshot serialization APIs are deeply integrated with World internals.
-/// Future versions may support custom IWorld implementations.
+/// <b>Note:</b> When using a custom IWorld implementation (not the standard World class),
+/// the <see cref="PersistenceConfig.SaveDirectory"/> must be explicitly set since
+/// custom implementations may not provide a default save directory.
 /// </para>
 /// </remarks>
 /// <example>
@@ -57,17 +54,8 @@ public sealed class PersistencePlugin(PersistenceConfig? config = null) : IWorld
             persistenceCapability.SaveDirectory = config.SaveDirectory;
         }
 
-        // EncryptedPersistenceApi requires concrete World for snapshot operations
-        // TODO: Abstract snapshot functionality to support custom IWorld implementations
-        if (context.World is not World world)
-        {
-            throw new InvalidOperationException(
-                "PersistencePlugin currently requires a concrete World instance. " +
-                "Custom IWorld implementations are not yet supported for persistence.");
-        }
-
         // Create and register the encrypted persistence API
-        var api = new EncryptedPersistenceApi(world, config);
+        var api = new EncryptedPersistenceApi(context.World, config);
         context.SetExtension(api);
     }
 

--- a/tests/KeenEyes.Core.Tests/MigrationTests.cs
+++ b/tests/KeenEyes.Core.Tests/MigrationTests.cs
@@ -547,7 +547,7 @@ internal sealed class VersionedSerializer(int currentVersion) : IComponentSerial
     {
         if (typeName.Contains("SerializablePosition"))
         {
-            return serialization.Components.Register<SerializablePosition>(isTag);
+            return (KeenEyes.ComponentInfo)serialization.Components.Register<SerializablePosition>(isTag);
         }
         return null;
     }

--- a/tests/KeenEyes.Core.Tests/PluginLifecycleTests.cs
+++ b/tests/KeenEyes.Core.Tests/PluginLifecycleTests.cs
@@ -1,6 +1,3 @@
-// TODO: Remove this suppression after refactoring to use IWorld interface
-#pragma warning disable KEEN050 // IWorld to World cast - test code pending refactoring
-
 namespace KeenEyes.Tests;
 
 /// <summary>

--- a/tests/KeenEyes.Core.Tests/PluginTestHelpers.cs
+++ b/tests/KeenEyes.Core.Tests/PluginTestHelpers.cs
@@ -1,6 +1,3 @@
-// TODO: Remove this suppression after refactoring to use IWorld interface
-#pragma warning disable KEEN050 // IWorld to World cast - test code pending refactoring
-
 namespace KeenEyes.Tests;
 
 /// <summary>
@@ -241,8 +238,7 @@ public class TestWorldAccessPlugin : IWorldPlugin
 
     public void Install(IPluginContext context)
     {
-        var world = (World)context.World;
-        world.SetSingleton(new TestGameConfig { Difficulty = 5 });
+        context.World.SetSingleton(new TestGameConfig { Difficulty = 5 });
     }
 
     public void Uninstall(IPluginContext context)

--- a/tests/KeenEyes.Core.Tests/Serialization/TestJsonSerializer.cs
+++ b/tests/KeenEyes.Core.Tests/Serialization/TestJsonSerializer.cs
@@ -45,7 +45,7 @@ internal sealed class TestJsonSerializer : IComponentSerializer
             using var doc = JsonDocument.Parse(jsonStr);
             return doc.RootElement.Clone();
         };
-        registrars[type] = (serialization, isTag) => serialization.Components.Register<T>(isTag);
+        registrars[type] = (serialization, isTag) => (ComponentInfo)serialization.Components.Register<T>(isTag);
         singletonSetters[type] = (serialization, value) => serialization.SetSingleton((T)value);
 
         return this;

--- a/tests/KeenEyes.Core.Tests/SerializationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SerializationTests.cs
@@ -1566,7 +1566,7 @@ internal sealed class WorkingAotSerializer : IComponentSerializer
     {
         if (typeName.Contains("SerializablePosition"))
         {
-            return serialization.Components.Register<SerializablePosition>(isTag);
+            return (ComponentInfo)serialization.Components.Register<SerializablePosition>(isTag);
         }
         return null;
     }
@@ -1626,7 +1626,7 @@ internal sealed class DeserializingAotSerializer : IComponentSerializer
     {
         if (typeName.Contains("SerializablePosition"))
         {
-            return serialization.Components.Register<SerializablePosition>(isTag);
+            return (ComponentInfo)serialization.Components.Register<SerializablePosition>(isTag);
         }
         return null;
     }

--- a/tests/KeenEyes.Core.Tests/SystemHookPluginIntegrationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SystemHookPluginIntegrationTests.cs
@@ -1,5 +1,5 @@
-// TODO: Remove this suppression after refactoring to use IWorld interface
-#pragma warning disable KEEN050 // IWorld to World cast - test code pending refactoring
+// Suppression required: AddSystemHook is a World-specific feature not exposed on IWorld
+#pragma warning disable KEEN050 // IWorld to World cast - intentional for testing World-specific features
 
 namespace KeenEyes.Tests;
 

--- a/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
+++ b/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
@@ -747,7 +747,7 @@ internal sealed class TestPersistenceSerializer : IComponentSerializer, IBinaryC
             using var doc = JsonDocument.Parse(jsonStr);
             return doc.RootElement.Clone();
         };
-        registrars[type] = (serialization, isTag) => serialization.Components.Register<T>(isTag);
+        registrars[type] = (serialization, isTag) => (ComponentInfo)serialization.Components.Register<T>(isTag);
         singletonSetters[type] = (serialization, value) => serialization.SetSingleton((T)value);
 
         binaryDeserializers[name] = reader =>


### PR DESCRIPTION
## Summary
- Create `IComponentInfo` interface in Abstractions for component metadata abstraction
- Move `ISerializationCapability` from Core to Abstractions following capability pattern
- Add `IComponentRegistry` interface for component registration abstraction
- Add singleton operations (`SetSingleton`, `GetSingleton`, `TryGetSingleton`, `HasSingleton`, `RemoveSingleton`) directly to `IWorld`
- Update all consumers to use `ISnapshotCapability` pattern for `GetComponents`

This follows the architectural principle that capabilities should be offered/exposed through the World's API, not inherited directly on `IWorld`.

## Test plan
- [x] All 2310 Core tests pass
- [x] All 79 Persistence tests pass  
- [x] All 241 Network tests pass
- [x] Full test suite passes (13086 tests, 0 failures)
- [x] Build passes with zero warnings
- [x] Code formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)