### PR TITLE
feat(graphics): Enhance RenderSystem for multi-light PBR rendering

### DIFF
--- a/src/KeenEyes.Graphics.Silk/Shaders/DefaultShaders.cs
+++ b/src/KeenEyes.Graphics.Silk/Shaders/DefaultShaders.cs
@@ -189,7 +189,6 @@ internal static class DefaultShaders
         uniform mat4 uModel;
         uniform mat4 uView;
         uniform mat4 uProjection;
-        uniform mat3 uNormalMatrix;
 
         out vec3 vWorldPos;
         out vec3 vNormal;
@@ -202,12 +201,15 @@ internal static class DefaultShaders
             vec4 worldPos = uModel * vec4(aPosition, 1.0);
             vWorldPos = worldPos.xyz;
 
+            // Calculate normal matrix (inverse transpose of model matrix upper 3x3)
+            mat3 normalMatrix = mat3(transpose(inverse(uModel)));
+
             // Transform normal to world space
-            vec3 N = normalize(uNormalMatrix * aNormal);
+            vec3 N = normalize(normalMatrix * aNormal);
             vNormal = N;
 
             // Transform tangent to world space and compute TBN matrix
-            vec3 T = normalize(uNormalMatrix * aTangent.xyz);
+            vec3 T = normalize(normalMatrix * aTangent.xyz);
             // Re-orthogonalize T with respect to N
             T = normalize(T - dot(T, N) * N);
             // Compute bitangent using tangent handedness

--- a/src/KeenEyes.Graphics/Systems/RenderSystem.cs
+++ b/src/KeenEyes.Graphics/Systems/RenderSystem.cs
@@ -15,15 +15,31 @@ namespace KeenEyes.Graphics;
 /// camera's view and projection matrices for rendering.
 /// </para>
 /// <para>
+/// This system supports both simple lit shaders and full PBR rendering with Cook-Torrance BRDF.
+/// When using the PBR shader, it binds all PBR texture slots and sets appropriate uniforms.
+/// </para>
+/// <para>
 /// This system runs in the Render phase and requires an <see cref="IGraphicsContext"/>
 /// extension to be present on the world.
 /// </para>
 /// </remarks>
 public sealed class RenderSystem : ISystem
 {
+    private const int MaxLights = 8;
+
     private IWorld? world;
     private IGraphicsContext? graphics;
     private readonly List<(Entity Entity, int Layer)> renderQueue = [];
+
+    // Light data arrays for uniform upload
+    private readonly Vector3[] lightPositions = new Vector3[MaxLights];
+    private readonly Vector3[] lightDirections = new Vector3[MaxLights];
+    private readonly Vector3[] lightColors = new Vector3[MaxLights];
+    private readonly float[] lightIntensities = new float[MaxLights];
+    private readonly int[] lightTypes = new int[MaxLights];
+    private readonly float[] lightRanges = new float[MaxLights];
+    private readonly float[] lightInnerCones = new float[MaxLights];
+    private readonly float[] lightOuterCones = new float[MaxLights];
 
     /// <inheritdoc />
     public bool Enabled { get; set; } = true;
@@ -99,28 +115,11 @@ public sealed class RenderSystem : ISystem
             graphics.Clear(clearMask);
         }
 
-        // Enable depth testing and culling
+        // Enable depth testing
         graphics.SetDepthTest(true);
-        graphics.SetCulling(true, CullFaceMode.Back);
 
-        // Collect light data
-        Vector3 lightDirection = -Vector3.UnitY;
-        Vector3 lightColor = Vector3.One;
-        float lightIntensity = 1f;
-
-        foreach (var entity in world.Query<Light, Transform3D>())
-        {
-            ref readonly var light = ref world.Get<Light>(entity);
-            ref readonly var lightTransform = ref world.Get<Transform3D>(entity);
-
-            if (light.Type == LightType.Directional)
-            {
-                lightDirection = lightTransform.Forward();
-                lightColor = light.Color;
-                lightIntensity = light.Intensity;
-                break; // Use first directional light
-            }
-        }
+        // Collect all lights (up to MaxLights)
+        int lightCount = CollectLights();
 
         // Build render queue
         renderQueue.Clear();
@@ -135,7 +134,7 @@ public sealed class RenderSystem : ISystem
 
         // Render each entity
         ShaderHandle currentShader = default;
-        TextureHandle currentTexture = default;
+        bool isPbrShader = false;
 
         foreach (var (entity, _) in renderQueue)
         {
@@ -149,54 +148,241 @@ public sealed class RenderSystem : ISystem
             }
 
             // Get material (use solid shader if no material component)
+            Material material = Material.Default;
             ShaderHandle shader = graphics.SolidShader;
-            TextureHandle texture = graphics.WhiteTexture;
-            Vector4 color = Vector4.One;
-            Vector3 emissive = Vector3.Zero;
 
             if (world.Has<Material>(entity))
             {
-                ref readonly var material = ref world.Get<Material>(entity);
+                material = world.Get<Material>(entity);
                 shader = material.ShaderId > 0 ? new ShaderHandle(material.ShaderId) : graphics.LitShader;
-                texture = material.BaseColorTextureId > 0 ? new TextureHandle(material.BaseColorTextureId) : graphics.WhiteTexture;
-                color = material.BaseColorFactor;
-                emissive = material.EmissiveFactor;
             }
 
-            // Bind shader
+            // Handle culling based on material double-sided flag
+            if (material.DoubleSided)
+            {
+                graphics.SetCulling(false);
+            }
+            else
+            {
+                graphics.SetCulling(true, CullFaceMode.Back);
+            }
+
+            // Handle alpha blending
+            if (material.AlphaMode == AlphaMode.Blend)
+            {
+                graphics.SetBlending(true);
+            }
+            else
+            {
+                graphics.SetBlending(false);
+            }
+
+            // Bind shader if changed
             if (currentShader.Id != shader.Id)
             {
                 graphics.BindShader(shader);
                 currentShader = shader;
+                isPbrShader = shader.Id == graphics.PbrShader.Id;
 
                 // Set per-frame uniforms
                 graphics.SetUniform("uView", viewMatrix);
                 graphics.SetUniform("uProjection", projectionMatrix);
                 graphics.SetUniform("uCameraPosition", cameraTransform.Position);
-                graphics.SetUniform("uLightDirection", lightDirection);
-                graphics.SetUniform("uLightColor", lightColor);
-                graphics.SetUniform("uLightIntensity", lightIntensity);
+
+                if (isPbrShader)
+                {
+                    // Set PBR light uniforms
+                    SetPbrLightUniforms(lightCount);
+                }
+                else
+                {
+                    // Legacy single light uniform (for LitShader compatibility)
+                    SetLegacyLightUniforms(lightCount);
+                }
             }
 
-            // Bind texture
-            if (currentTexture.Id != texture.Id)
-            {
-                graphics.BindTexture(texture, 0);
-                graphics.SetUniform("uTexture", 0);
-                currentTexture = texture;
-            }
+            // Calculate model and normal matrices
+            Matrix4x4 modelMatrix = transform.Matrix();
 
             // Set per-object uniforms
-            Matrix4x4 modelMatrix = transform.Matrix();
             graphics.SetUniform("uModel", modelMatrix);
-            graphics.SetUniform("uColor", color);
-            graphics.SetUniform("uEmissive", emissive);
+
+            if (isPbrShader)
+            {
+                // Bind PBR textures and set material uniforms
+                BindPbrMaterial(material);
+            }
+            else
+            {
+                // Legacy material binding (for LitShader compatibility)
+                BindLegacyMaterial(material);
+            }
 
             // Draw mesh
             var meshHandle = new MeshHandle(renderable.MeshId);
             graphics.BindMesh(meshHandle);
             graphics.DrawMesh(meshHandle);
         }
+    }
+
+    /// <summary>
+    /// Collects all lights in the scene into arrays for uniform upload.
+    /// </summary>
+    /// <returns>The number of lights collected (capped at MaxLights).</returns>
+    private int CollectLights()
+    {
+        int lightCount = 0;
+
+        foreach (var entity in world!.Query<Light, Transform3D>())
+        {
+            if (lightCount >= MaxLights)
+            {
+                break;
+            }
+
+            ref readonly var light = ref world.Get<Light>(entity);
+            ref readonly var lightTransform = ref world.Get<Transform3D>(entity);
+
+            lightPositions[lightCount] = lightTransform.Position;
+            lightDirections[lightCount] = lightTransform.Forward();
+            lightColors[lightCount] = light.Color;
+            lightIntensities[lightCount] = light.Intensity;
+            lightTypes[lightCount] = (int)light.Type;
+            lightRanges[lightCount] = light.Range;
+            // Convert cone angles from degrees to cosine values for efficient shader comparison
+            lightInnerCones[lightCount] = MathF.Cos(light.InnerConeAngle * MathF.PI / 180f);
+            lightOuterCones[lightCount] = MathF.Cos(light.OuterConeAngle * MathF.PI / 180f);
+
+            lightCount++;
+        }
+
+        return lightCount;
+    }
+
+    /// <summary>
+    /// Sets PBR light uniforms for all collected lights.
+    /// </summary>
+    private void SetPbrLightUniforms(int lightCount)
+    {
+        graphics!.SetUniform("uLightCount", lightCount);
+
+        for (int i = 0; i < lightCount; i++)
+        {
+            graphics.SetUniform($"uLightPositions[{i}]", lightPositions[i]);
+            graphics.SetUniform($"uLightDirections[{i}]", lightDirections[i]);
+            graphics.SetUniform($"uLightColors[{i}]", lightColors[i]);
+            graphics.SetUniform($"uLightIntensities[{i}]", lightIntensities[i]);
+            graphics.SetUniform($"uLightTypes[{i}]", lightTypes[i]);
+            graphics.SetUniform($"uLightRanges[{i}]", lightRanges[i]);
+            graphics.SetUniform($"uLightInnerCones[{i}]", lightInnerCones[i]);
+            graphics.SetUniform($"uLightOuterCones[{i}]", lightOuterCones[i]);
+        }
+    }
+
+    /// <summary>
+    /// Sets legacy single-light uniforms for backward compatibility with LitShader.
+    /// </summary>
+    private void SetLegacyLightUniforms(int lightCount)
+    {
+        if (lightCount > 0)
+        {
+            // Find first directional light for legacy shader
+            for (int i = 0; i < lightCount; i++)
+            {
+                if (lightTypes[i] == (int)LightType.Directional)
+                {
+                    graphics!.SetUniform("uLightDirection", lightDirections[i]);
+                    graphics.SetUniform("uLightColor", lightColors[i]);
+                    graphics.SetUniform("uLightIntensity", lightIntensities[i]);
+                    return;
+                }
+            }
+
+            // No directional light, use first light
+            graphics!.SetUniform("uLightDirection", lightDirections[0]);
+            graphics!.SetUniform("uLightColor", lightColors[0]);
+            graphics!.SetUniform("uLightIntensity", lightIntensities[0]);
+        }
+        else
+        {
+            // Default light
+            graphics!.SetUniform("uLightDirection", -Vector3.UnitY);
+            graphics.SetUniform("uLightColor", Vector3.One);
+            graphics.SetUniform("uLightIntensity", 1f);
+        }
+    }
+
+    /// <summary>
+    /// Binds all PBR textures and sets material uniforms.
+    /// </summary>
+    private void BindPbrMaterial(in Material material)
+    {
+        // Bind textures to their respective slots
+        // Slot 0: Base Color
+        var baseColorTexture = material.BaseColorTextureId > 0
+            ? new TextureHandle(material.BaseColorTextureId)
+            : graphics!.WhiteTexture;
+        graphics!.BindTexture(baseColorTexture, 0);
+        graphics.SetUniform("uBaseColorMap", 0);
+        graphics.SetUniform("uHasBaseColorMap", material.BaseColorTextureId > 0 ? 1 : 0);
+
+        // Slot 1: Normal Map
+        var normalTexture = material.NormalMapId > 0
+            ? new TextureHandle(material.NormalMapId)
+            : graphics.WhiteTexture;
+        graphics.BindTexture(normalTexture, 1);
+        graphics.SetUniform("uNormalMap", 1);
+        graphics.SetUniform("uHasNormalMap", material.NormalMapId > 0 ? 1 : 0);
+
+        // Slot 2: Metallic-Roughness
+        var mrTexture = material.MetallicRoughnessTextureId > 0
+            ? new TextureHandle(material.MetallicRoughnessTextureId)
+            : graphics.WhiteTexture;
+        graphics.BindTexture(mrTexture, 2);
+        graphics.SetUniform("uMetallicRoughnessMap", 2);
+        graphics.SetUniform("uHasMetallicRoughnessMap", material.MetallicRoughnessTextureId > 0 ? 1 : 0);
+
+        // Slot 3: Occlusion
+        var occlusionTexture = material.OcclusionTextureId > 0
+            ? new TextureHandle(material.OcclusionTextureId)
+            : graphics.WhiteTexture;
+        graphics.BindTexture(occlusionTexture, 3);
+        graphics.SetUniform("uOcclusionMap", 3);
+        graphics.SetUniform("uHasOcclusionMap", material.OcclusionTextureId > 0 ? 1 : 0);
+
+        // Slot 4: Emissive
+        var emissiveTexture = material.EmissiveTextureId > 0
+            ? new TextureHandle(material.EmissiveTextureId)
+            : graphics.WhiteTexture;
+        graphics.BindTexture(emissiveTexture, 4);
+        graphics.SetUniform("uEmissiveMap", 4);
+        graphics.SetUniform("uHasEmissiveMap", material.EmissiveTextureId > 0 ? 1 : 0);
+
+        // Set material factor uniforms
+        graphics.SetUniform("uBaseColorFactor", material.BaseColorFactor);
+        graphics.SetUniform("uMetallicFactor", material.MetallicFactor);
+        graphics.SetUniform("uRoughnessFactor", material.RoughnessFactor);
+        graphics.SetUniform("uEmissiveFactor", material.EmissiveFactor);
+        graphics.SetUniform("uNormalScale", material.NormalScale);
+        graphics.SetUniform("uOcclusionStrength", material.OcclusionStrength);
+        graphics.SetUniform("uAlphaCutoff", material.AlphaCutoff);
+    }
+
+    /// <summary>
+    /// Binds legacy material for LitShader and other non-PBR shaders.
+    /// </summary>
+    private void BindLegacyMaterial(in Material material)
+    {
+        // Bind base color texture
+        var texture = material.BaseColorTextureId > 0
+            ? new TextureHandle(material.BaseColorTextureId)
+            : graphics!.WhiteTexture;
+        graphics!.BindTexture(texture, 0);
+        graphics.SetUniform("uTexture", 0);
+
+        // Set legacy uniforms
+        graphics.SetUniform("uColor", material.BaseColorFactor);
+        graphics.SetUniform("uEmissive", material.EmissiveFactor);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Update RenderSystem to fully support PBR shader with multi-light rendering
- Collect up to 8 lights (directional, point, spot) into uniform arrays
- Bind all 5 PBR texture slots and set material factor uniforms
- Handle alpha blending and double-sided materials
- Maintain backward compatibility with legacy LitShader

## Implementation Details

### Light Collection
- Collects all Light components into pre-allocated arrays
- Supports directional, point, and spot lights
- Converts cone angles to cosine values for efficient shader comparison

### PBR Material Binding
| Texture Slot | Uniform | Usage |
|--------------|---------|-------|
| 0 | uBaseColorMap | RGB = albedo, A = opacity |
| 1 | uNormalMap | Tangent-space normal |
| 2 | uMetallicRoughnessMap | G=roughness, B=metallic |
| 3 | uOcclusionMap | R=ambient occlusion |
| 4 | uEmissiveMap | RGB=emissive color |

### Material Uniforms Set
- uBaseColorFactor, uMetallicFactor, uRoughnessFactor
- uEmissiveFactor, uNormalScale, uOcclusionStrength
- uAlphaCutoff, uHasXxxMap flags

### Alpha & Culling
- AlphaMode.Blend enables GPU blending
- DoubleSided materials disable backface culling

## Test plan
- [x] Build passes with zero warnings
- [x] All 13,147 tests pass
- [x] Backward compatible with existing samples using LitShader

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)