### PR TITLE
feat(samples): Add PBR rendering demo with interactive camera

### DIFF
--- a/samples/KeenEyes.Sample.PBR/Components.cs
+++ b/samples/KeenEyes.Sample.PBR/Components.cs
@@ -1,0 +1,133 @@
+using System.Numerics;
+
+namespace KeenEyes.Sample.PBR;
+
+/// <summary>
+/// Component for an orbit camera that rotates around a target point.
+/// </summary>
+[Component]
+public partial struct OrbitCamera
+{
+    /// <summary>
+    /// The point to orbit around.
+    /// </summary>
+    public Vector3 Target;
+
+    /// <summary>
+    /// Distance from the target.
+    /// </summary>
+    public float Distance;
+
+    /// <summary>
+    /// Horizontal angle in radians (yaw).
+    /// </summary>
+    public float Yaw;
+
+    /// <summary>
+    /// Vertical angle in radians (pitch).
+    /// </summary>
+    public float Pitch;
+
+    /// <summary>
+    /// Minimum distance from target.
+    /// </summary>
+    public float MinDistance;
+
+    /// <summary>
+    /// Maximum distance from target.
+    /// </summary>
+    public float MaxDistance;
+
+    /// <summary>
+    /// Minimum pitch angle in radians.
+    /// </summary>
+    public float MinPitch;
+
+    /// <summary>
+    /// Maximum pitch angle in radians.
+    /// </summary>
+    public float MaxPitch;
+
+    /// <summary>
+    /// Rotation sensitivity for mouse movement.
+    /// </summary>
+    public float RotationSensitivity;
+
+    /// <summary>
+    /// Zoom sensitivity for mouse scroll.
+    /// </summary>
+    public float ZoomSensitivity;
+
+    /// <summary>
+    /// Creates a default orbit camera configuration.
+    /// </summary>
+    public static OrbitCamera Default => new()
+    {
+        Target = Vector3.Zero,
+        Distance = 5f,
+        Yaw = 0f,
+        Pitch = 0.3f,
+        MinDistance = 1f,
+        MaxDistance = 20f,
+        MinPitch = -MathF.PI / 2f + 0.1f,
+        MaxPitch = MathF.PI / 2f - 0.1f,
+        RotationSensitivity = 0.005f,
+        ZoomSensitivity = 0.5f
+    };
+}
+
+/// <summary>
+/// Component that makes an entity slowly rotate for demonstration.
+/// </summary>
+[Component]
+public partial struct AutoRotate
+{
+    /// <summary>
+    /// Rotation speed in radians per second around the Y axis.
+    /// </summary>
+    public float Speed;
+}
+
+/// <summary>
+/// Tag component to identify the main model entity.
+/// </summary>
+[TagComponent]
+public partial struct MainModelTag;
+
+/// <summary>
+/// Tag component to identify the ground plane.
+/// </summary>
+[TagComponent]
+public partial struct GroundTag;
+
+/// <summary>
+/// Component that makes a point light orbit around a center point.
+/// </summary>
+[Component]
+public partial struct OrbitingLight
+{
+    /// <summary>
+    /// The center point to orbit around.
+    /// </summary>
+    public Vector3 Center;
+
+    /// <summary>
+    /// Radius of the orbit.
+    /// </summary>
+    public float Radius;
+
+    /// <summary>
+    /// Height above the center point.
+    /// </summary>
+    public float Height;
+
+    /// <summary>
+    /// Current angle in radians.
+    /// </summary>
+    public float Angle;
+
+    /// <summary>
+    /// Rotation speed in radians per second.
+    /// </summary>
+    public float Speed;
+}

--- a/samples/KeenEyes.Sample.PBR/KeenEyes.Sample.PBR.csproj
+++ b/samples/KeenEyes.Sample.PBR/KeenEyes.Sample.PBR.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\KeenEyes.Assets\KeenEyes.Assets.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Silk\KeenEyes.Graphics.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics\KeenEyes.Graphics.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Abstractions\KeenEyes.Input.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Silk\KeenEyes.Input.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk\KeenEyes.Platform.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Runtime\KeenEyes.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Spatial\KeenEyes.Spatial.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Assets\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/KeenEyes.Sample.PBR/Program.cs
+++ b/samples/KeenEyes.Sample.PBR/Program.cs
@@ -1,0 +1,338 @@
+// KeenEyes PBR Sample
+// Demonstrates Physically Based Rendering with the Cook-Torrance BRDF shader.
+//
+// This sample demonstrates:
+// - PBR metallic-roughness workflow
+// - Multiple light sources (directional, point, spot)
+// - Interactive orbit camera controls
+// - Material variations showing different metallic/roughness combinations
+//
+// Controls:
+//   Left Mouse Drag  - Rotate camera around target
+//   Right Mouse Drag - Rotate camera around target
+//   Scroll Wheel     - Zoom in/out
+//   Escape           - Exit
+//
+// NOTE: This sample requires a display to run. It will not work in headless environments.
+
+using System.Numerics;
+using KeenEyes;
+using KeenEyes.Common;
+using KeenEyes.Graphics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Input.Silk;
+using KeenEyes.Platform.Silk;
+using KeenEyes.Runtime;
+using KeenEyes.Sample.PBR;
+
+Console.WriteLine("KeenEyes PBR Sample");
+Console.WriteLine("===================");
+Console.WriteLine();
+Console.WriteLine("This sample demonstrates Physically Based Rendering (PBR):");
+Console.WriteLine("- Cook-Torrance BRDF with GGX distribution");
+Console.WriteLine("- Metallic-roughness workflow");
+Console.WriteLine("- Multiple light types (directional, point, spot)");
+Console.WriteLine("- Interactive orbit camera");
+Console.WriteLine();
+Console.WriteLine("Controls:");
+Console.WriteLine("  Left/Right Mouse Drag - Rotate camera");
+Console.WriteLine("  Scroll Wheel          - Zoom in/out");
+Console.WriteLine("  Escape                - Exit");
+Console.WriteLine();
+
+// Configure window
+var windowConfig = new WindowConfig
+{
+    Title = "KeenEyes PBR Sample - Drag to rotate, scroll to zoom",
+    Width = 1280,
+    Height = 720,
+    VSync = true
+};
+
+// Configure graphics
+var graphicsConfig = new SilkGraphicsConfig
+{
+    ClearColor = new Vector4(0.05f, 0.05f, 0.1f, 1f), // Dark blue-ish background
+    EnableDepthTest = true,
+    EnableCulling = true
+};
+
+// Configure input
+var inputConfig = new SilkInputConfig
+{
+    EnableGamepads = false,
+    CaptureMouseOnClick = false
+};
+
+using var world = new World();
+
+// Install plugins
+world.InstallPlugin(new SilkWindowPlugin(windowConfig));
+world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
+world.InstallPlugin(new SilkInputPlugin(inputConfig));
+
+// Register graphics systems
+world.AddSystem<CameraSystem>(SystemPhase.EarlyUpdate, order: 0);
+world.AddSystem<RenderSystem>(SystemPhase.Render, order: 0);
+
+// Register custom systems
+world.AddSystem<OrbitCameraSystem>(SystemPhase.Update, order: 0);
+world.AddSystem<CameraZoomSystem>(SystemPhase.Update, order: 1);
+world.AddSystem<AutoRotateSystem>(SystemPhase.Update, order: 2);
+world.AddSystem<OrbitingLightSystem>(SystemPhase.Update, order: 3);
+
+Console.WriteLine("Starting graphics...");
+
+try
+{
+    world.CreateRunner()
+        .OnReady(() =>
+        {
+            Console.WriteLine("Graphics initialized, creating PBR scene...");
+
+            var input = world.GetExtension<IInputContext>();
+            var graphics = world.GetExtension<IGraphicsContext>();
+
+            // Set up exit handler
+            input.Keyboard.OnKeyDown += args =>
+            {
+                if (args.Key == Key.Escape)
+                {
+                    Environment.Exit(0);
+                }
+            };
+
+            // Create the PBR demo scene
+            CreatePbrScene(world, graphics);
+
+            Console.WriteLine("Scene created!");
+            Console.WriteLine();
+            Console.WriteLine("Material Grid:");
+            Console.WriteLine("  Rows: Metallic (0.0 bottom to 1.0 top)");
+            Console.WriteLine("  Columns: Roughness (0.0 left to 1.0 right)");
+        })
+        .OnResize((width, height) =>
+        {
+            Console.WriteLine($"Window resized to {width}x{height}");
+        })
+        .Run();
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Error: {ex.Message}");
+    Console.WriteLine("This sample requires a display.");
+}
+
+Console.WriteLine("Sample complete!");
+
+// Create the PBR demonstration scene
+static void CreatePbrScene(World world, IGraphicsContext graphics)
+{
+    // Create mesh resources
+    var cubeMesh = graphics.CreateCube(1f);
+    var groundMesh = graphics.CreateQuad(30f, 30f);
+
+    // Create orbit camera
+    var orbitCamera = OrbitCamera.Default with
+    {
+        Distance = 12f,
+        Yaw = MathF.PI / 4f,
+        Pitch = 0.4f,
+        Target = new Vector3(0, 1.5f, 0),
+        MinDistance = 3f,
+        MaxDistance = 30f
+    };
+
+    // Calculate initial camera position for orbit camera
+    var cosP = MathF.Cos(orbitCamera.Pitch);
+    var sinP = MathF.Sin(orbitCamera.Pitch);
+    var cosY = MathF.Cos(orbitCamera.Yaw);
+    var sinY = MathF.Sin(orbitCamera.Yaw);
+    var offset = new Vector3(cosP * sinY * orbitCamera.Distance, sinP * orbitCamera.Distance, cosP * cosY * orbitCamera.Distance);
+    var cameraPos = orbitCamera.Target + offset;
+    var forward = Vector3.Normalize(orbitCamera.Target - cameraPos);
+    var right = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, forward));
+    var up = Vector3.Cross(forward, right);
+
+    world.Spawn()
+        .With(new Transform3D(
+            cameraPos,
+            Quaternion.CreateFromRotationMatrix(new Matrix4x4(
+                right.X, right.Y, right.Z, 0,
+                up.X, up.Y, up.Z, 0,
+                -forward.X, -forward.Y, -forward.Z, 0,
+                0, 0, 0, 1)),
+            Vector3.One))
+        .With(Camera.CreatePerspective(60f, 16f / 9f, 0.1f, 1000f))
+        .With(orbitCamera)
+        .WithTag<MainCameraTag>()
+        .Build();
+
+    // Create directional light (sun)
+    world.Spawn()
+        .With(new Transform3D(
+            Vector3.Zero,
+            Quaternion.CreateFromYawPitchRoll(0.8f, -0.6f, 0),
+            Vector3.One))
+        .With(Light.Directional(new Vector3(1f, 0.95f, 0.9f), 0.8f))
+        .Build();
+
+    // Create orbiting point light (warm)
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(5f, 3f, 0),
+            Quaternion.Identity,
+            Vector3.One))
+        .With(Light.Point(new Vector3(1f, 0.6f, 0.2f), 1.5f, 15f))
+        .With(new OrbitingLight
+        {
+            Center = new Vector3(0, 0, 0),
+            Radius = 5f,
+            Height = 3f,
+            Angle = 0f,
+            Speed = 0.5f
+        })
+        .Build();
+
+    // Create second orbiting point light (cool, opposite direction)
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(-5f, 3f, 0),
+            Quaternion.Identity,
+            Vector3.One))
+        .With(Light.Point(new Vector3(0.2f, 0.5f, 1f), 1.2f, 15f))
+        .With(new OrbitingLight
+        {
+            Center = new Vector3(0, 0, 0),
+            Radius = 5f,
+            Height = 4f,
+            Angle = MathF.PI,
+            Speed = -0.3f
+        })
+        .Build();
+
+    // Create spot light pointing down at center
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(0, 8f, 0),
+            Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI / 2f), // Point down
+            Vector3.One))
+        .With(Light.Spot(new Vector3(1f, 1f, 1f), 0.6f, 20f, 15f, 30f))
+        .Build();
+
+    // Create ground plane
+    var groundMaterial = new Material
+    {
+        ShaderId = graphics.PbrShader.Id,
+        BaseColorTextureId = graphics.WhiteTexture.Id,
+        BaseColorFactor = new Vector4(0.15f, 0.15f, 0.17f, 1f), // Dark gray
+        MetallicFactor = 0f,
+        RoughnessFactor = 0.9f,
+        NormalScale = 1f,
+        OcclusionStrength = 1f,
+        AlphaCutoff = 0.5f,
+        AlphaMode = AlphaMode.Opaque
+    };
+
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(0, 0, 0),
+            Quaternion.CreateFromAxisAngle(Vector3.UnitX, -MathF.PI / 2f),
+            Vector3.One))
+        .With(new Renderable(groundMesh.Id, 0))
+        .With(groundMaterial)
+        .WithTag<GroundTag>()
+        .Build();
+
+    // Create material variation grid (5x5)
+    // X axis: Roughness from 0 to 1
+    // Z axis: Metallic from 0 to 1
+    var gridSize = 5;
+    var spacing = 1.8f;
+    var startX = -(gridSize - 1) * spacing / 2f;
+    var startZ = -(gridSize - 1) * spacing / 2f;
+
+    // Base colors for the spheres
+    var baseColors = new[]
+    {
+        new Vector4(0.9f, 0.2f, 0.2f, 1f),  // Red
+        new Vector4(0.2f, 0.8f, 0.3f, 1f),  // Green
+        new Vector4(0.2f, 0.4f, 0.9f, 1f),  // Blue
+        new Vector4(0.95f, 0.8f, 0.1f, 1f), // Gold
+        new Vector4(0.85f, 0.85f, 0.9f, 1f) // Silver/White
+    };
+
+    for (var row = 0; row < gridSize; row++)
+    {
+        for (var col = 0; col < gridSize; col++)
+        {
+            var x = startX + col * spacing;
+            var z = startZ + row * spacing;
+            var metallic = row / (float)(gridSize - 1);
+            var roughness = col / (float)(gridSize - 1);
+
+            // Use different base color per row
+            var baseColor = baseColors[row];
+
+            // For metallic materials (metallic > 0.5), use a more neutral base
+            // as the F0 reflectance will dominate
+            if (metallic > 0.5f)
+            {
+                baseColor = Vector4.Lerp(baseColor, new Vector4(0.95f, 0.93f, 0.88f, 1f), (metallic - 0.5f) * 2f);
+            }
+
+            var material = new Material
+            {
+                ShaderId = graphics.PbrShader.Id,
+                BaseColorTextureId = graphics.WhiteTexture.Id,
+                BaseColorFactor = baseColor,
+                MetallicFactor = metallic,
+                RoughnessFactor = Math.Max(0.05f, roughness), // Clamp to avoid perfectly smooth (artifacts)
+                NormalScale = 1f,
+                OcclusionStrength = 1f,
+                AlphaCutoff = 0.5f,
+                AlphaMode = AlphaMode.Opaque
+            };
+
+            world.Spawn()
+                .With(new Transform3D(
+                    new Vector3(x, 0.7f, z),
+                    Quaternion.Identity,
+                    Vector3.One * 0.8f))
+                .With(new Renderable(cubeMesh.Id, 0))
+                .With(material)
+                .Build();
+        }
+    }
+
+    // Create a larger center piece with auto-rotate
+    var centerMaterial = new Material
+    {
+        ShaderId = graphics.PbrShader.Id,
+        BaseColorTextureId = graphics.WhiteTexture.Id,
+        BaseColorFactor = new Vector4(1f, 0.85f, 0.6f, 1f), // Gold-ish
+        MetallicFactor = 0.9f,
+        RoughnessFactor = 0.1f,
+        NormalScale = 1f,
+        OcclusionStrength = 1f,
+        EmissiveFactor = new Vector3(0.1f, 0.05f, 0f), // Slight emissive glow
+        AlphaCutoff = 0.5f,
+        AlphaMode = AlphaMode.Opaque
+    };
+
+    world.Spawn()
+        .With(new Transform3D(
+            new Vector3(0, 3f, 0),
+            Quaternion.Identity,
+            new Vector3(1.5f, 1.5f, 1.5f)))
+        .With(new Renderable(cubeMesh.Id, 0))
+        .With(centerMaterial)
+        .With(new AutoRotate { Speed = 0.3f })
+        .WithTag<MainModelTag>()
+        .Build();
+
+    Console.WriteLine($"Created {gridSize * gridSize} material samples + 1 center piece");
+    Console.WriteLine($"Lights: 1 directional + 2 orbiting point + 1 spot = 4 total");
+}

--- a/samples/KeenEyes.Sample.PBR/Systems.cs
+++ b/samples/KeenEyes.Sample.PBR/Systems.cs
@@ -1,0 +1,194 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graphics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.Sample.PBR;
+
+/// <summary>
+/// System that updates orbit cameras based on mouse input.
+/// </summary>
+public class OrbitCameraSystem : SystemBase
+{
+    private IInputContext? input;
+    private Vector2 lastMousePosition;
+    private bool initialized;
+
+    /// <summary>
+    /// Updates the orbit camera based on mouse input.
+    /// </summary>
+    public override void Update(float deltaTime)
+    {
+        input ??= World.TryGetExtension<IInputContext>(out var ctx) ? ctx : null;
+        if (input is null)
+        {
+            return;
+        }
+
+        var mouse = input.Mouse;
+        var currentPos = mouse.Position;
+
+        // Initialize last position on first frame
+        if (!initialized)
+        {
+            lastMousePosition = currentPos;
+            initialized = true;
+            return;
+        }
+
+        // Calculate mouse delta
+        var mouseDelta = currentPos - lastMousePosition;
+        lastMousePosition = currentPos;
+
+        foreach (var entity in World.Query<Transform3D, OrbitCamera, MainCameraTag>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            ref var orbit = ref World.Get<OrbitCamera>(entity);
+
+            // Rotate when right mouse button is held (or left click drag)
+            if (mouse.IsButtonDown(MouseButton.Right) || mouse.IsButtonDown(MouseButton.Left))
+            {
+                orbit.Yaw -= mouseDelta.X * orbit.RotationSensitivity;
+                orbit.Pitch -= mouseDelta.Y * orbit.RotationSensitivity;
+
+                // Clamp pitch
+                orbit.Pitch = Math.Clamp(orbit.Pitch, orbit.MinPitch, orbit.MaxPitch);
+            }
+
+            // Calculate camera position from spherical coordinates
+            var cosP = MathF.Cos(orbit.Pitch);
+            var sinP = MathF.Sin(orbit.Pitch);
+            var cosY = MathF.Cos(orbit.Yaw);
+            var sinY = MathF.Sin(orbit.Yaw);
+
+            var offset = new Vector3(
+                cosP * sinY * orbit.Distance,
+                sinP * orbit.Distance,
+                cosP * cosY * orbit.Distance);
+
+            var cameraPos = orbit.Target + offset;
+
+            // Calculate look-at rotation
+            var forward = Vector3.Normalize(orbit.Target - cameraPos);
+            var right = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, forward));
+            var up = Vector3.Cross(forward, right);
+
+            // Handle edge case when looking straight up/down
+            if (float.IsNaN(right.X))
+            {
+                right = new Vector3(1, 0, 0);
+                up = Vector3.Cross(forward, right);
+            }
+
+            transform.Position = cameraPos;
+            transform.Rotation = Quaternion.CreateFromRotationMatrix(new Matrix4x4(
+                right.X, right.Y, right.Z, 0,
+                up.X, up.Y, up.Z, 0,
+                -forward.X, -forward.Y, -forward.Z, 0,
+                0, 0, 0, 1));
+        }
+    }
+}
+
+/// <summary>
+/// System that handles camera zoom via mouse scroll.
+/// </summary>
+public class CameraZoomSystem : SystemBase
+{
+    private IInputContext? input;
+    private float accumulatedScroll;
+    private Action<MouseScrollEventArgs>? scrollHandler;
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        if (World.TryGetExtension<IInputContext>(out var ctx))
+        {
+            input = ctx;
+            scrollHandler = args =>
+            {
+                accumulatedScroll += args.DeltaY;
+            };
+            ctx!.Mouse.OnScroll += scrollHandler;
+        }
+    }
+
+    /// <summary>
+    /// Updates camera zoom based on scroll input.
+    /// </summary>
+    public override void Update(float deltaTime)
+    {
+        if (input is null || accumulatedScroll.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        foreach (var entity in World.Query<OrbitCamera, MainCameraTag>())
+        {
+            ref var orbit = ref World.Get<OrbitCamera>(entity);
+
+            // Zoom in/out
+            orbit.Distance -= accumulatedScroll * orbit.ZoomSensitivity;
+            orbit.Distance = Math.Clamp(orbit.Distance, orbit.MinDistance, orbit.MaxDistance);
+        }
+
+        accumulatedScroll = 0;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && input is not null && scrollHandler is not null)
+        {
+            input.Mouse.OnScroll -= scrollHandler;
+        }
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>
+/// System that slowly rotates entities with the AutoRotate component.
+/// </summary>
+public class AutoRotateSystem : SystemBase
+{
+    /// <summary>
+    /// Updates the rotation of auto-rotating entities.
+    /// </summary>
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Transform3D, AutoRotate>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            ref readonly var autoRotate = ref World.Get<AutoRotate>(entity);
+
+            var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitY, autoRotate.Speed * deltaTime);
+            transform.Rotation = Quaternion.Normalize(transform.Rotation * rotation);
+        }
+    }
+}
+
+/// <summary>
+/// System that animates orbiting lights.
+/// </summary>
+public class OrbitingLightSystem : SystemBase
+{
+    /// <summary>
+    /// Updates the position of orbiting lights.
+    /// </summary>
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Transform3D, OrbitingLight>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            ref var orbitingLight = ref World.Get<OrbitingLight>(entity);
+
+            orbitingLight.Angle += orbitingLight.Speed * deltaTime;
+
+            transform.Position = new Vector3(
+                orbitingLight.Center.X + MathF.Cos(orbitingLight.Angle) * orbitingLight.Radius,
+                orbitingLight.Center.Y + orbitingLight.Height,
+                orbitingLight.Center.Z + MathF.Sin(orbitingLight.Angle) * orbitingLight.Radius);
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.PBR/packages.lock.json
+++ b/samples/KeenEyes.Sample.PBR/packages.lock.json
@@ -1,0 +1,304 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.17.0.131074, )",
+        "resolved": "10.17.0.131074",
+        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+      },
+      "Cyotek.Drawing.BitmapFont": {
+        "type": "Transitive",
+        "resolved": "2.0.4",
+        "contentHash": "iA6WehGVdMUuNbfsQQDq/Bt+mMd/OqHjiMUtKFLIQd/0pyYh4ehT7FEjTxN9/4OXNKQZsp9bAJgltP2nnswUJg=="
+      },
+      "FontStashSharp.Base": {
+        "type": "Transitive",
+        "resolved": "1.2.2",
+        "contentHash": "t2PT+/Sat9WPLm4AVYU1Aa/PrOgNQ4npSUGDHTYufXzLUHxrN3+BaRhAU0DZXkJNfuGCS5iKaQNopNXe9ES24g=="
+      },
+      "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.2.2",
+        "contentHash": "OoXoGkxNMhyQeYR/wjeN6Bs8Guea7FisKXLcVJdeNtSYT+5iKxIh4ETi9x9OIk7GEQtNbE0yVhG3rb8RS04Kmg==",
+        "dependencies": {
+          "FontStashSharp.Base": "1.2.2",
+          "StbTrueTypeSharp": "1.26.12"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "NSmDw3K0ozNDgShSIpsZcbFIzBX4w28nDag+TfaQujkXGazBm+lid5onlWoCBy4VsLxqnnKjEBbGSJVWJMf43g=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "XbDilPmvsQIrvxZkeVCNNX3LyRtA3hN6UykAiyZjlu/JkYh68U3WQummpP+j7jsxlX8s/pOrrU3vbN8LnMl0VA==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "8.0.0"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "I1u6CmwwtD+5OIHditbMBVHRQUHZWhfW3Z38mvydxwkZpAvjs5BCxyen6ecOVpbYD6I0EOjZ42M3IsaZbwiYUg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "DZy30akJABBmTnn8OICik0TFEuXrkd7YCQvoq+oh50eJzXt8JgEYYa+sJYBib/Phs5WULZg/QR7fM8Gi1G3tXg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "LZPZT1e/RxnjKfkqlp2Wp8KJFP1Av/ErTCZ00EzZpFR1lhUSBgSmgJwXg6XlWoEJHyeJcsXV688zjoEe6YW0BA==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "ynasHSQ4jGrmpn/07UagE3qVNRLzWvg+fbM8uHI0d5LF95y++Kuno42QLkP/UEruC1YovI+NRhMfGJy0gDQaZg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Maths": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.22.0",
+        "contentHash": "hBNxNSLvx/jdfvbU6oCsXcgLfqf9hMlEc6Mq/rllJ0eUTLloacuOZHTM8V702QGf7hOR+Mo4bTFqTqBnC0CM7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.22.0",
+          "Silk.NET.Windowing.Common": "2.22.0"
+        }
+      },
+      "StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.26.12",
+        "contentHash": "hCc6/OsfcPa5VsLECcEU2m78WOshBrKwK42nAodSm9Z5wH68f7n66SoiRLCdGCkDaqbWz2TlX4zYHIjogj1HJA=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[1.16.0, )",
+          "NVorbis": "[0.10.5, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.silk": {
+        "type": "Project",
+        "dependencies": {
+          "FontStashSharp.PlatformAgnostic": "[1.5.2, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Maths": "[2.22.0, )",
+          "Silk.NET.OpenGL": "[2.22.0, )"
+        }
+      },
+      "keeneyes.input": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.22.0, )"
+        }
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.22.0, )",
+          "Silk.NET.Windowing": "[2.22.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.22.0, )",
+          "Silk.NET.Windowing": "[2.22.0, )"
+        }
+      },
+      "keeneyes.runtime": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.spatial": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "FontStashSharp.PlatformAgnostic": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "/Srtf2DyIBBTbaZ4jpOQZnGFoEcbiXPMZnPuSft8MkMdbMYgCXPD5S123a992qTGVFKQjD9IGapd7Kyg2GD6sw==",
+        "dependencies": {
+          "Cyotek.Drawing.BitmapFont": "2.0.4",
+          "FontStashSharp.Base": "1.2.2",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.2",
+          "StbImageSharp": "2.30.15"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "1gqbKHrKpBv2Vk983kVpMqXL4Uj36NaUIQ2YbQosFVa3pXJE8UMGiWqKtaeoMqnzItusZ1WYgDHKge37EvNm/w==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.22.0",
+          "Silk.NET.Input.Glfw": "2.22.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "W9b5UlUGCu5Ywb5f8ZyIWJ475ucY+mT/nEiSTo3JH098VxHaZS/02bYr9f29VWBaJhh3DwMkfxQvgTyXzTrHyw=="
+      },
+      "Silk.NET.OpenGL": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "AmbtflPvaGWw7fHEHrcFTd54OTAj0bemzx4WV2ELJdW2NBPSvtyz31nhyuBVTml20+NtW4Z3yhDGUpM6uouVDQ==",
+        "dependencies": {
+          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Maths": "2.22.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.22.0, )",
+        "resolved": "2.22.0",
+        "contentHash": "yKGe/8REdm+T43LdtfUpFUx9eQARwx6wTmEoJ2bANVGQPCvWYC2Qi1+haT6n63dyNIX+iJWKg4++F4TFjg0/Fw==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.22.0",
+          "Silk.NET.Windowing.Glfw": "2.22.0"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Assets.Tests/KeenEyes.Assets.Tests.csproj
+++ b/tests/KeenEyes.Assets.Tests/KeenEyes.Assets.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Animation\KeenEyes.Animation.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Assets\KeenEyes.Assets.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />


### PR DESCRIPTION
## Summary
- Adds Sample.PBR demonstrating Physically Based Rendering with Cook-Torrance BRDF
- Creates 5x5 material grid showing metallic/roughness variations (0-1 range each axis)
- Implements multiple light types: 1 directional, 2 orbiting point lights, 1 spot light
- Adds interactive orbit camera with mouse drag rotation and scroll zoom

## Features
- **OrbitCameraSystem**: Spherical coordinate camera control with mouse input
- **CameraZoomSystem**: Mouse scroll wheel zoom with distance clamping
- **OrbitingLightSystem**: Animated point lights orbiting the scene
- **AutoRotateSystem**: Slowly rotating center piece demonstration

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 13,086 unit tests pass
- [x] Pre-commit hooks pass (dotnet-format)
- [x] Pre-push hooks pass (dotnet-build, dotnet-test)
- [ ] Manual testing: Run sample to verify rendering

## Related Issues
Closes #890 (Phase 6: Sample.PBR Demo)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)