### PR TITLE
fix(ci): Use --max-parallel-test-modules 1 in pre-push hook

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -17,7 +17,7 @@
          "name": "dotnet-test",
          "group": "pre-push",
          "command": "dotnet",
-         "args": ["test", "--no-build", "-c", "Release", "--", "--max-threads=4"]
+         "args": ["test", "--no-build", "-c", "Release", "--max-parallel-test-modules", "1"]
       }
    ]
 }


### PR DESCRIPTION
## Summary
- Fix pre-push hook hanging on Parallelism, Network, and Debugging test suites
- Replace `--max-threads=4` with `--max-parallel-test-modules 1` to prevent ThreadPool contention

## Problem
The pre-push hook was using `--max-threads=4` which causes intermittent hangs due to ThreadPool contention when running parallel test assemblies. This is documented in CLAUDE.md:

> Always use `--max-parallel-test-modules 1` when running tests. This prevents test assemblies from running in parallel, which causes ThreadPool contention and intermittent hangs in the Parallelism, Network, and Debugging test suites.

## Solution
Update `.husky/task-runner.json` to use `--max-parallel-test-modules 1` instead of `--max-threads=4`.

## Test plan
- [x] Pre-push hook no longer hangs on test execution
- [x] All tests still run and pass

🤖 Generated with [Claude Code](https://claude.ai/code)