### PR TITLE
feat(graphics): Add render target abstraction for off-screen rendering

### DIFF
--- a/src/KeenEyes.Graphics.Abstractions/Enums/FramebufferEnums.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Enums/FramebufferEnums.cs
@@ -1,0 +1,268 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Framebuffer binding targets.
+/// </summary>
+public enum FramebufferTarget
+{
+    /// <summary>
+    /// Both read and draw framebuffer.
+    /// </summary>
+    Framebuffer,
+
+    /// <summary>
+    /// Draw framebuffer only.
+    /// </summary>
+    DrawFramebuffer,
+
+    /// <summary>
+    /// Read framebuffer only.
+    /// </summary>
+    ReadFramebuffer
+}
+
+/// <summary>
+/// Framebuffer attachment points.
+/// </summary>
+public enum FramebufferAttachment
+{
+    /// <summary>
+    /// Color attachment 0.
+    /// </summary>
+    ColorAttachment0,
+
+    /// <summary>
+    /// Color attachment 1.
+    /// </summary>
+    ColorAttachment1,
+
+    /// <summary>
+    /// Color attachment 2.
+    /// </summary>
+    ColorAttachment2,
+
+    /// <summary>
+    /// Color attachment 3.
+    /// </summary>
+    ColorAttachment3,
+
+    /// <summary>
+    /// Depth attachment.
+    /// </summary>
+    DepthAttachment,
+
+    /// <summary>
+    /// Stencil attachment.
+    /// </summary>
+    StencilAttachment,
+
+    /// <summary>
+    /// Combined depth and stencil attachment.
+    /// </summary>
+    DepthStencilAttachment
+}
+
+/// <summary>
+/// Framebuffer completeness status.
+/// </summary>
+public enum FramebufferStatus
+{
+    /// <summary>
+    /// Framebuffer is complete and ready for use.
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    /// Attachment is incomplete.
+    /// </summary>
+    IncompleteAttachment,
+
+    /// <summary>
+    /// Required attachment is missing.
+    /// </summary>
+    IncompleteMissingAttachment,
+
+    /// <summary>
+    /// Draw buffer has no attachment.
+    /// </summary>
+    IncompleteDrawBuffer,
+
+    /// <summary>
+    /// Read buffer has no attachment.
+    /// </summary>
+    IncompleteReadBuffer,
+
+    /// <summary>
+    /// Framebuffer configuration is unsupported.
+    /// </summary>
+    Unsupported,
+
+    /// <summary>
+    /// Attachments have different dimensions.
+    /// </summary>
+    IncompleteMultisample,
+
+    /// <summary>
+    /// Layer attachment is incomplete.
+    /// </summary>
+    IncompleteLayerTargets,
+
+    /// <summary>
+    /// Unknown error.
+    /// </summary>
+    Unknown
+}
+
+/// <summary>
+/// Renderbuffer storage formats.
+/// </summary>
+public enum RenderbufferFormat
+{
+    /// <summary>
+    /// 16-bit depth buffer.
+    /// </summary>
+    DepthComponent16,
+
+    /// <summary>
+    /// 24-bit depth buffer.
+    /// </summary>
+    DepthComponent24,
+
+    /// <summary>
+    /// 32-bit floating point depth buffer.
+    /// </summary>
+    DepthComponent32F,
+
+    /// <summary>
+    /// Combined 24-bit depth and 8-bit stencil.
+    /// </summary>
+    Depth24Stencil8,
+
+    /// <summary>
+    /// 8-bit stencil buffer.
+    /// </summary>
+    StencilIndex8,
+
+    /// <summary>
+    /// 4-channel 8-bit color buffer.
+    /// </summary>
+    RGBA8,
+
+    /// <summary>
+    /// 4-channel 16-bit floating point color buffer.
+    /// </summary>
+    RGBA16F,
+
+    /// <summary>
+    /// 4-channel 32-bit floating point color buffer.
+    /// </summary>
+    RGBA32F
+}
+
+/// <summary>
+/// Draw buffer selection modes.
+/// </summary>
+public enum DrawBufferMode
+{
+    /// <summary>
+    /// No draw buffer.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Front buffer (for default framebuffer).
+    /// </summary>
+    Front,
+
+    /// <summary>
+    /// Back buffer (for default framebuffer).
+    /// </summary>
+    Back,
+
+    /// <summary>
+    /// Color attachment 0.
+    /// </summary>
+    ColorAttachment0,
+
+    /// <summary>
+    /// Color attachment 1.
+    /// </summary>
+    ColorAttachment1,
+
+    /// <summary>
+    /// Color attachment 2.
+    /// </summary>
+    ColorAttachment2,
+
+    /// <summary>
+    /// Color attachment 3.
+    /// </summary>
+    ColorAttachment3
+}
+
+/// <summary>
+/// Render target format for creating render targets.
+/// </summary>
+public enum RenderTargetFormat
+{
+    /// <summary>
+    /// RGBA 8-bit per channel color with 24-bit depth.
+    /// </summary>
+    RGBA8Depth24,
+
+    /// <summary>
+    /// RGBA 16-bit floating point per channel color with 24-bit depth.
+    /// </summary>
+    RGBA16FDepth24,
+
+    /// <summary>
+    /// RGBA 32-bit floating point per channel color with 32-bit depth.
+    /// </summary>
+    RGBA32FDepth32F,
+
+    /// <summary>
+    /// Depth-only 24-bit.
+    /// </summary>
+    Depth24,
+
+    /// <summary>
+    /// Depth-only 32-bit floating point.
+    /// </summary>
+    Depth32F
+}
+
+/// <summary>
+/// Cubemap face targets for texture operations.
+/// </summary>
+public enum CubemapFace
+{
+    /// <summary>
+    /// Positive X face (+X).
+    /// </summary>
+    PositiveX,
+
+    /// <summary>
+    /// Negative X face (-X).
+    /// </summary>
+    NegativeX,
+
+    /// <summary>
+    /// Positive Y face (+Y).
+    /// </summary>
+    PositiveY,
+
+    /// <summary>
+    /// Negative Y face (-Y).
+    /// </summary>
+    NegativeY,
+
+    /// <summary>
+    /// Positive Z face (+Z).
+    /// </summary>
+    PositiveZ,
+
+    /// <summary>
+    /// Negative Z face (-Z).
+    /// </summary>
+    NegativeZ
+}

--- a/src/KeenEyes.Graphics.Abstractions/Enums/GraphicsEnums.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Enums/GraphicsEnums.cs
@@ -121,14 +121,29 @@ public enum TextureParam
     MagFilter,
 
     /// <summary>
-    /// Horizontal wrapping mode.
+    /// Horizontal wrapping mode (S coordinate).
     /// </summary>
     WrapS,
 
     /// <summary>
-    /// Vertical wrapping mode.
+    /// Vertical wrapping mode (T coordinate).
     /// </summary>
-    WrapT
+    WrapT,
+
+    /// <summary>
+    /// Depth wrapping mode (R coordinate) for 3D textures and cubemaps.
+    /// </summary>
+    WrapR,
+
+    /// <summary>
+    /// Texture comparison mode for depth textures.
+    /// </summary>
+    CompareMode,
+
+    /// <summary>
+    /// Texture comparison function for depth textures.
+    /// </summary>
+    CompareFunc
 }
 
 /// <summary>
@@ -232,7 +247,23 @@ public enum TextureUnit
     /// <summary>Texture unit 6.</summary>
     Texture6,
     /// <summary>Texture unit 7.</summary>
-    Texture7
+    Texture7,
+    /// <summary>Texture unit 8.</summary>
+    Texture8,
+    /// <summary>Texture unit 9.</summary>
+    Texture9,
+    /// <summary>Texture unit 10.</summary>
+    Texture10,
+    /// <summary>Texture unit 11.</summary>
+    Texture11,
+    /// <summary>Texture unit 12.</summary>
+    Texture12,
+    /// <summary>Texture unit 13.</summary>
+    Texture13,
+    /// <summary>Texture unit 14.</summary>
+    Texture14,
+    /// <summary>Texture unit 15.</summary>
+    Texture15
 }
 
 /// <summary>
@@ -457,7 +488,31 @@ public enum PixelFormat
     RGB,
 
     /// <summary>Red, green, blue, and alpha channels.</summary>
-    RGBA
+    RGBA,
+
+    /// <summary>16-bit depth buffer.</summary>
+    Depth16,
+
+    /// <summary>24-bit depth buffer.</summary>
+    Depth24,
+
+    /// <summary>32-bit floating point depth buffer.</summary>
+    Depth32F,
+
+    /// <summary>Combined 24-bit depth and 8-bit stencil.</summary>
+    Depth24Stencil8,
+
+    /// <summary>16-bit floating point per channel RGB.</summary>
+    RGB16F,
+
+    /// <summary>32-bit floating point per channel RGB.</summary>
+    RGB32F,
+
+    /// <summary>16-bit floating point per channel RGBA.</summary>
+    RGBA16F,
+
+    /// <summary>32-bit floating point per channel RGBA.</summary>
+    RGBA32F
 }
 
 /// <summary>

--- a/src/KeenEyes.Graphics.Abstractions/Handles/CubemapRenderTargetHandle.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Handles/CubemapRenderTargetHandle.cs
@@ -1,0 +1,45 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// An opaque handle to a cubemap render target resource.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cubemap render target handles represent off-screen framebuffers that render to all six
+/// faces of a cubemap texture. These are used for:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Point light omnidirectional shadow maps</description></item>
+/// <item><description>Environment map generation</description></item>
+/// <item><description>IBL irradiance and specular convolution</description></item>
+/// </list>
+/// <para>
+/// The handle includes the face size and depth information to support queries without
+/// requiring backend access.
+/// </para>
+/// </remarks>
+/// <param name="Id">The internal identifier for this cubemap render target resource.</param>
+/// <param name="Size">The size of each cubemap face in pixels (faces are square).</param>
+/// <param name="HasDepth">Whether the cubemap render target has a depth buffer.</param>
+/// <param name="MipLevels">The number of mip levels (1 for shadow maps, more for IBL pre-filtering).</param>
+public readonly record struct CubemapRenderTargetHandle(int Id, int Size = 0, bool HasDepth = true, int MipLevels = 1)
+{
+    /// <summary>
+    /// An invalid cubemap render target handle representing no render target.
+    /// </summary>
+    public static readonly CubemapRenderTargetHandle Invalid = new(-1, 0);
+
+    /// <summary>
+    /// Gets whether this handle refers to a valid cubemap render target resource.
+    /// </summary>
+    /// <remarks>
+    /// A valid handle has a non-negative ID. Note that a valid handle does not guarantee
+    /// the resource still exists - it may have been disposed.
+    /// </remarks>
+    public bool IsValid => Id >= 0;
+
+    /// <inheritdoc />
+    public override string ToString() => IsValid
+        ? $"CubemapRenderTarget({Id}, {Size}x{Size}x6, depth={HasDepth}, mips={MipLevels})"
+        : "CubemapRenderTarget(Invalid)";
+}

--- a/src/KeenEyes.Graphics.Abstractions/Handles/RenderTargetHandle.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Handles/RenderTargetHandle.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// An opaque handle to a render target (framebuffer) resource.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Render target handles represent off-screen framebuffers used for multi-pass rendering
+/// such as shadow maps, post-processing effects, and image-based lighting pre-computation.
+/// </para>
+/// <para>
+/// Handles are opaque identifiers that avoid exposing backend-specific resource types,
+/// enabling portability across different graphics APIs (OpenGL, Vulkan, DirectX, etc.).
+/// </para>
+/// <para>
+/// The handle includes dimensions and format information to support queries without
+/// requiring backend access.
+/// </para>
+/// </remarks>
+/// <param name="Id">The internal identifier for this render target resource.</param>
+/// <param name="Width">The render target width in pixels.</param>
+/// <param name="Height">The render target height in pixels.</param>
+/// <param name="Format">The render target format.</param>
+public readonly record struct RenderTargetHandle(int Id, int Width = 0, int Height = 0, RenderTargetFormat Format = RenderTargetFormat.RGBA8Depth24)
+{
+    /// <summary>
+    /// An invalid render target handle representing no render target.
+    /// </summary>
+    public static readonly RenderTargetHandle Invalid = new(-1, 0, 0);
+
+    /// <summary>
+    /// Gets whether this handle refers to a valid render target resource.
+    /// </summary>
+    /// <remarks>
+    /// A valid handle has a non-negative ID. Note that a valid handle does not guarantee
+    /// the resource still exists - it may have been disposed.
+    /// </remarks>
+    public bool IsValid => Id >= 0;
+
+    /// <summary>
+    /// Gets the render target size as a vector.
+    /// </summary>
+    public Vector2 Size => new(Width, Height);
+
+    /// <summary>
+    /// Gets whether this render target has a color attachment.
+    /// </summary>
+    public bool HasColorAttachment => Format is not (RenderTargetFormat.Depth24 or RenderTargetFormat.Depth32F);
+
+    /// <summary>
+    /// Gets whether this render target has a depth attachment.
+    /// </summary>
+    /// <remarks>
+    /// All supported render target formats include a depth buffer.
+    /// </remarks>
+    public static bool HasDepthAttachment => true;
+
+    /// <inheritdoc />
+    public override string ToString() => IsValid ? $"RenderTarget({Id}, {Width}x{Height}, {Format})" : "RenderTarget(Invalid)";
+}

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
@@ -432,4 +432,122 @@ public interface IGraphicsContext : IDisposable
     void SetCulling(bool enabled, CullFaceMode mode = CullFaceMode.Back);
 
     #endregion
+
+    #region Render Target Operations
+
+    /// <summary>
+    /// Creates a render target (off-screen framebuffer) for rendering.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Render targets allow rendering to off-screen textures for effects like:
+    /// shadow mapping, post-processing, environment map generation, and more.
+    /// </para>
+    /// <para>
+    /// The returned handle can be used to bind the render target for rendering
+    /// and to retrieve the color/depth textures for use in subsequent passes.
+    /// </para>
+    /// </remarks>
+    /// <param name="width">The render target width in pixels.</param>
+    /// <param name="height">The render target height in pixels.</param>
+    /// <param name="format">The render target format.</param>
+    /// <returns>A handle to the created render target.</returns>
+    RenderTargetHandle CreateRenderTarget(int width, int height, RenderTargetFormat format);
+
+    /// <summary>
+    /// Creates a depth-only render target for shadow mapping.
+    /// </summary>
+    /// <remarks>
+    /// Depth-only render targets have no color attachment, making them optimal
+    /// for shadow map generation where only depth values are needed.
+    /// </remarks>
+    /// <param name="width">The render target width in pixels.</param>
+    /// <param name="height">The render target height in pixels.</param>
+    /// <returns>A handle to the created depth-only render target.</returns>
+    RenderTargetHandle CreateDepthOnlyRenderTarget(int width, int height);
+
+    /// <summary>
+    /// Creates a cubemap render target for omnidirectional rendering.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Cubemap render targets are used for:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Point light shadow maps (omnidirectional shadows)</description></item>
+    /// <item><description>Environment map generation</description></item>
+    /// <item><description>IBL irradiance and specular convolution</description></item>
+    /// </list>
+    /// </remarks>
+    /// <param name="size">The size of each cubemap face in pixels (faces are square).</param>
+    /// <param name="withDepth">Whether to include a depth buffer.</param>
+    /// <param name="mipLevels">The number of mip levels (1 for shadow maps, more for IBL).</param>
+    /// <returns>A handle to the created cubemap render target.</returns>
+    CubemapRenderTargetHandle CreateCubemapRenderTarget(int size, bool withDepth, int mipLevels = 1);
+
+    /// <summary>
+    /// Binds a render target for rendering.
+    /// </summary>
+    /// <remarks>
+    /// All subsequent draw calls will render to this target until
+    /// <see cref="UnbindRenderTarget"/> is called or another target is bound.
+    /// </remarks>
+    /// <param name="target">The render target to bind.</param>
+    void BindRenderTarget(RenderTargetHandle target);
+
+    /// <summary>
+    /// Binds a specific face of a cubemap render target for rendering.
+    /// </summary>
+    /// <param name="target">The cubemap render target to bind.</param>
+    /// <param name="face">The cubemap face to render to.</param>
+    /// <param name="mipLevel">The mip level to render to (default: 0).</param>
+    void BindCubemapRenderTarget(CubemapRenderTargetHandle target, CubemapFace face, int mipLevel = 0);
+
+    /// <summary>
+    /// Unbinds the current render target and restores rendering to the default framebuffer.
+    /// </summary>
+    void UnbindRenderTarget();
+
+    /// <summary>
+    /// Gets the color texture from a render target.
+    /// </summary>
+    /// <remarks>
+    /// The returned texture handle can be bound to a shader for sampling
+    /// the render target's color output in subsequent passes.
+    /// </remarks>
+    /// <param name="target">The render target.</param>
+    /// <returns>A texture handle for the color attachment, or Invalid if depth-only.</returns>
+    TextureHandle GetRenderTargetColorTexture(RenderTargetHandle target);
+
+    /// <summary>
+    /// Gets the depth texture from a render target.
+    /// </summary>
+    /// <remarks>
+    /// The returned texture handle can be bound to a shader for sampling
+    /// the render target's depth output in subsequent passes (e.g., shadow mapping).
+    /// </remarks>
+    /// <param name="target">The render target.</param>
+    /// <returns>A texture handle for the depth attachment.</returns>
+    TextureHandle GetRenderTargetDepthTexture(RenderTargetHandle target);
+
+    /// <summary>
+    /// Gets the cubemap texture from a cubemap render target.
+    /// </summary>
+    /// <param name="target">The cubemap render target.</param>
+    /// <returns>A texture handle for the cubemap.</returns>
+    TextureHandle GetCubemapRenderTargetTexture(CubemapRenderTargetHandle target);
+
+    /// <summary>
+    /// Deletes a render target and its associated resources.
+    /// </summary>
+    /// <param name="target">The render target to delete.</param>
+    void DeleteRenderTarget(RenderTargetHandle target);
+
+    /// <summary>
+    /// Deletes a cubemap render target and its associated resources.
+    /// </summary>
+    /// <param name="target">The cubemap render target to delete.</param>
+    void DeleteCubemapRenderTarget(CubemapRenderTargetHandle target);
+
+    #endregion
 }

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
@@ -469,6 +469,109 @@ public interface IGraphicsDevice : IDisposable
 
     #endregion
 
+    #region Framebuffer Operations
+
+    /// <summary>
+    /// Generates a new framebuffer object.
+    /// </summary>
+    /// <returns>The framebuffer handle.</returns>
+    uint GenFramebuffer();
+
+    /// <summary>
+    /// Binds a framebuffer object.
+    /// </summary>
+    /// <param name="target">The framebuffer target.</param>
+    /// <param name="framebuffer">The framebuffer handle (0 to bind the default framebuffer).</param>
+    void BindFramebuffer(FramebufferTarget target, uint framebuffer);
+
+    /// <summary>
+    /// Deletes a framebuffer object.
+    /// </summary>
+    /// <param name="framebuffer">The framebuffer handle.</param>
+    void DeleteFramebuffer(uint framebuffer);
+
+    /// <summary>
+    /// Attaches a 2D texture to a framebuffer.
+    /// </summary>
+    /// <param name="target">The framebuffer target.</param>
+    /// <param name="attachment">The attachment point.</param>
+    /// <param name="texTarget">The texture target.</param>
+    /// <param name="texture">The texture handle.</param>
+    /// <param name="level">The mipmap level to attach.</param>
+    void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment,
+                              TextureTarget texTarget, uint texture, int level);
+
+    /// <summary>
+    /// Checks the completeness status of a framebuffer.
+    /// </summary>
+    /// <param name="target">The framebuffer target.</param>
+    /// <returns>The framebuffer status.</returns>
+    FramebufferStatus CheckFramebufferStatus(FramebufferTarget target);
+
+    /// <summary>
+    /// Generates a new renderbuffer object.
+    /// </summary>
+    /// <returns>The renderbuffer handle.</returns>
+    uint GenRenderbuffer();
+
+    /// <summary>
+    /// Binds a renderbuffer object.
+    /// </summary>
+    /// <param name="renderbuffer">The renderbuffer handle (0 to unbind).</param>
+    void BindRenderbuffer(uint renderbuffer);
+
+    /// <summary>
+    /// Deletes a renderbuffer object.
+    /// </summary>
+    /// <param name="renderbuffer">The renderbuffer handle.</param>
+    void DeleteRenderbuffer(uint renderbuffer);
+
+    /// <summary>
+    /// Allocates storage for a renderbuffer.
+    /// </summary>
+    /// <param name="format">The internal format.</param>
+    /// <param name="width">The width in pixels.</param>
+    /// <param name="height">The height in pixels.</param>
+    void RenderbufferStorage(RenderbufferFormat format, uint width, uint height);
+
+    /// <summary>
+    /// Attaches a renderbuffer to a framebuffer.
+    /// </summary>
+    /// <param name="target">The framebuffer target.</param>
+    /// <param name="attachment">The attachment point.</param>
+    /// <param name="renderbuffer">The renderbuffer handle.</param>
+    void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment,
+                                 uint renderbuffer);
+
+    /// <summary>
+    /// Specifies the color buffer to draw to.
+    /// </summary>
+    /// <param name="mode">The draw buffer mode.</param>
+    void DrawBuffer(DrawBufferMode mode);
+
+    /// <summary>
+    /// Specifies the color buffer to read from.
+    /// </summary>
+    /// <param name="mode">The read buffer mode.</param>
+    void ReadBuffer(DrawBufferMode mode);
+
+    /// <summary>
+    /// Enables or disables writing to the depth buffer.
+    /// </summary>
+    /// <param name="flag">True to enable writing, false to disable.</param>
+    void DepthMask(bool flag);
+
+    /// <summary>
+    /// Enables or disables writing to color buffer components.
+    /// </summary>
+    /// <param name="red">Enable writing to red channel.</param>
+    /// <param name="green">Enable writing to green channel.</param>
+    /// <param name="blue">Enable writing to blue channel.</param>
+    /// <param name="alpha">Enable writing to alpha channel.</param>
+    void ColorMask(bool red, bool green, bool blue, bool alpha);
+
+    #endregion
+
     #region Debug
 
     /// <summary>

--- a/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
+++ b/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
@@ -1,0 +1,466 @@
+using System.Diagnostics.CodeAnalysis;
+
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graphics.Silk;
+
+/// <summary>
+/// Internal data for a standard render target.
+/// </summary>
+internal sealed class RenderTargetData
+{
+    public required uint FramebufferId { get; init; }
+    public required uint ColorTextureId { get; init; }
+    public required uint DepthTextureId { get; init; }
+    public required int Width { get; init; }
+    public required int Height { get; init; }
+    public required RenderTargetFormat Format { get; init; }
+    public bool IsDepthOnly => Format is RenderTargetFormat.Depth24 or RenderTargetFormat.Depth32F;
+}
+
+/// <summary>
+/// Internal data for a cubemap render target.
+/// </summary>
+internal sealed class CubemapRenderTargetData
+{
+    public required uint FramebufferId { get; init; }
+    public required uint CubemapTextureId { get; init; }
+    public required uint DepthRenderbufferId { get; init; }
+    public required int Size { get; init; }
+    public required bool HasDepth { get; init; }
+    public required int MipLevels { get; init; }
+}
+
+/// <summary>
+/// Manages render target (framebuffer) lifecycle and state tracking.
+/// </summary>
+/// <remarks>
+/// This internal manager handles:
+/// <list type="bullet">
+/// <item><description>Creation and deletion of framebuffer objects</description></item>
+/// <item><description>Attachment of color and depth textures</description></item>
+/// <item><description>Binding and unbinding of render targets</description></item>
+/// <item><description>Handle-to-resource mapping</description></item>
+/// </list>
+/// </remarks>
+/// <param name="device">The graphics device for GPU operations.</param>
+[ExcludeFromCodeCoverage(Justification = "Requires real GPU context")]
+internal sealed class RenderTargetManager(IGraphicsDevice device) : IDisposable
+{
+    private readonly IGraphicsDevice device = device ?? throw new ArgumentNullException(nameof(device));
+    private readonly Dictionary<int, RenderTargetData> renderTargets = [];
+    private readonly Dictionary<int, CubemapRenderTargetData> cubemapRenderTargets = [];
+    private int nextRenderTargetId;
+    private int nextCubemapRenderTargetId;
+    private bool disposed;
+
+    /// <summary>
+    /// Creates a render target with the specified format.
+    /// </summary>
+    public RenderTargetHandle CreateRenderTarget(int width, int height, RenderTargetFormat format)
+    {
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width));
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height));
+        }
+
+        // Generate framebuffer
+        var fbo = device.GenFramebuffer();
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, fbo);
+
+        uint colorTexture = 0;
+        var isDepthOnly = format is RenderTargetFormat.Depth24 or RenderTargetFormat.Depth32F;
+
+        if (!isDepthOnly)
+        {
+            // Create color texture
+            colorTexture = CreateColorTexture(width, height, format);
+            device.FramebufferTexture2D(
+                FramebufferTarget.Framebuffer,
+                FramebufferAttachment.ColorAttachment0,
+                TextureTarget.Texture2D,
+                colorTexture,
+                0);
+        }
+        else
+        {
+            // For depth-only render targets, disable color writes
+            device.DrawBuffer(DrawBufferMode.None);
+            device.ReadBuffer(DrawBufferMode.None);
+        }
+
+        // Create depth texture (all formats use depth attachment)
+        var depthTexture = CreateDepthTexture(width, height, format);
+        device.FramebufferTexture2D(
+            FramebufferTarget.Framebuffer,
+            FramebufferAttachment.DepthAttachment,
+            TextureTarget.Texture2D,
+            depthTexture,
+            0);
+
+        // Check completeness
+        var status = device.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+        if (status != FramebufferStatus.Complete)
+        {
+            // Clean up on failure
+            device.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+            device.DeleteFramebuffer(fbo);
+            if (colorTexture != 0)
+            {
+                device.DeleteTexture(colorTexture);
+            }
+
+            device.DeleteTexture(depthTexture);
+            throw new InvalidOperationException($"Failed to create render target: {status}");
+        }
+
+        // Unbind
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
+        // Store data
+        var id = nextRenderTargetId++;
+        renderTargets[id] = new RenderTargetData
+        {
+            FramebufferId = fbo,
+            ColorTextureId = colorTexture,
+            DepthTextureId = depthTexture,
+            Width = width,
+            Height = height,
+            Format = format
+        };
+
+        return new RenderTargetHandle(id, width, height, format);
+    }
+
+    /// <summary>
+    /// Creates a depth-only render target for shadow mapping.
+    /// </summary>
+    public RenderTargetHandle CreateDepthOnlyRenderTarget(int width, int height)
+    {
+        return CreateRenderTarget(width, height, RenderTargetFormat.Depth24);
+    }
+
+    /// <summary>
+    /// Creates a cubemap render target for omnidirectional rendering.
+    /// </summary>
+    public CubemapRenderTargetHandle CreateCubemapRenderTarget(int size, bool withDepth, int mipLevels = 1)
+    {
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size));
+        }
+
+        if (mipLevels < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(mipLevels));
+        }
+
+        // Generate framebuffer
+        var fbo = device.GenFramebuffer();
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, fbo);
+
+        // Create cubemap texture
+        var cubemapTexture = device.GenTexture();
+        device.BindTexture(TextureTarget.TextureCubeMap, cubemapTexture);
+
+        // Allocate storage for each face
+        for (int face = 0; face < 6; face++)
+        {
+            var currentSize = size;
+            for (int mip = 0; mip < mipLevels; mip++)
+            {
+                // TextureCubeMapPositiveX = 0x8515, each face is consecutive
+                var faceTarget = (TextureTarget)(0x8515 + face);
+                device.TexImage2D(faceTarget, mip, currentSize, currentSize, PixelFormat.RGBA, ReadOnlySpan<byte>.Empty);
+                currentSize = Math.Max(1, currentSize / 2);
+            }
+        }
+
+        // Set texture parameters
+        device.TexParameter(TextureTarget.TextureCubeMap, TextureParam.MinFilter,
+            mipLevels > 1 ? (int)TextureMinFilter.LinearMipmapLinear : (int)TextureMinFilter.Linear);
+        device.TexParameter(TextureTarget.TextureCubeMap, TextureParam.MagFilter, (int)TextureMagFilter.Linear);
+        device.TexParameter(TextureTarget.TextureCubeMap, TextureParam.WrapS, (int)TextureWrapMode.ClampToEdge);
+        device.TexParameter(TextureTarget.TextureCubeMap, TextureParam.WrapT, (int)TextureWrapMode.ClampToEdge);
+        device.TexParameter(TextureTarget.TextureCubeMap, TextureParam.WrapR, (int)TextureWrapMode.ClampToEdge);
+
+        // Create depth renderbuffer if needed
+        uint depthRenderbuffer = 0;
+        if (withDepth)
+        {
+            depthRenderbuffer = device.GenRenderbuffer();
+            device.BindRenderbuffer(depthRenderbuffer);
+            device.RenderbufferStorage(RenderbufferFormat.DepthComponent24, (uint)size, (uint)size);
+            device.FramebufferRenderbuffer(
+                FramebufferTarget.Framebuffer,
+                FramebufferAttachment.DepthAttachment,
+                depthRenderbuffer);
+        }
+
+        // Attach first face for initial completeness check
+        device.FramebufferTexture2D(
+            FramebufferTarget.Framebuffer,
+            FramebufferAttachment.ColorAttachment0,
+            (TextureTarget)0x8515, // TextureCubeMapPositiveX
+            cubemapTexture,
+            0);
+
+        // Check completeness
+        var status = device.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+        if (status != FramebufferStatus.Complete)
+        {
+            // Clean up on failure
+            device.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+            device.DeleteFramebuffer(fbo);
+            device.DeleteTexture(cubemapTexture);
+            if (depthRenderbuffer != 0)
+            {
+                device.DeleteRenderbuffer(depthRenderbuffer);
+            }
+
+            throw new InvalidOperationException($"Failed to create cubemap render target: {status}");
+        }
+
+        // Unbind
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
+        // Store data
+        var id = nextCubemapRenderTargetId++;
+        cubemapRenderTargets[id] = new CubemapRenderTargetData
+        {
+            FramebufferId = fbo,
+            CubemapTextureId = cubemapTexture,
+            DepthRenderbufferId = depthRenderbuffer,
+            Size = size,
+            HasDepth = withDepth,
+            MipLevels = mipLevels
+        };
+
+        return new CubemapRenderTargetHandle(id, size, withDepth, mipLevels);
+    }
+
+    /// <summary>
+    /// Binds a render target for rendering.
+    /// </summary>
+    public void BindRenderTarget(RenderTargetHandle target)
+    {
+        if (!target.IsValid || !renderTargets.TryGetValue(target.Id, out var data))
+        {
+            throw new ArgumentException("Invalid render target handle", nameof(target));
+        }
+
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, data.FramebufferId);
+        device.Viewport(0, 0, (uint)data.Width, (uint)data.Height);
+    }
+
+    /// <summary>
+    /// Binds a specific face of a cubemap render target for rendering.
+    /// </summary>
+    public void BindCubemapRenderTarget(CubemapRenderTargetHandle target, CubemapFace face, int mipLevel = 0)
+    {
+        if (!target.IsValid || !cubemapRenderTargets.TryGetValue(target.Id, out var data))
+        {
+            throw new ArgumentException("Invalid cubemap render target handle", nameof(target));
+        }
+
+        if (mipLevel < 0 || mipLevel >= data.MipLevels)
+        {
+            throw new ArgumentOutOfRangeException(nameof(mipLevel));
+        }
+
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, data.FramebufferId);
+
+        // Attach the specified face at the specified mip level
+        var faceTarget = (TextureTarget)(0x8515 + (int)face); // TextureCubeMapPositiveX + face
+        device.FramebufferTexture2D(
+            FramebufferTarget.Framebuffer,
+            FramebufferAttachment.ColorAttachment0,
+            faceTarget,
+            data.CubemapTextureId,
+            mipLevel);
+
+        // Calculate viewport size for this mip level
+        var mipSize = Math.Max(1, data.Size >> mipLevel);
+        device.Viewport(0, 0, (uint)mipSize, (uint)mipSize);
+    }
+
+    /// <summary>
+    /// Unbinds the current render target.
+    /// </summary>
+    public void UnbindRenderTarget()
+    {
+        device.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+    }
+
+    /// <summary>
+    /// Gets the color texture ID for a render target.
+    /// </summary>
+    public uint GetColorTextureId(RenderTargetHandle target)
+    {
+        if (!target.IsValid || !renderTargets.TryGetValue(target.Id, out var data))
+        {
+            return 0;
+        }
+
+        return data.ColorTextureId;
+    }
+
+    /// <summary>
+    /// Gets the depth texture ID for a render target.
+    /// </summary>
+    public uint GetDepthTextureId(RenderTargetHandle target)
+    {
+        if (!target.IsValid || !renderTargets.TryGetValue(target.Id, out var data))
+        {
+            return 0;
+        }
+
+        return data.DepthTextureId;
+    }
+
+    /// <summary>
+    /// Gets the cubemap texture ID for a cubemap render target.
+    /// </summary>
+    public uint GetCubemapTextureId(CubemapRenderTargetHandle target)
+    {
+        if (!target.IsValid || !cubemapRenderTargets.TryGetValue(target.Id, out var data))
+        {
+            return 0;
+        }
+
+        return data.CubemapTextureId;
+    }
+
+    /// <summary>
+    /// Deletes a render target and its associated resources.
+    /// </summary>
+    public void DeleteRenderTarget(RenderTargetHandle target)
+    {
+        if (!target.IsValid || !renderTargets.TryGetValue(target.Id, out var data))
+        {
+            return;
+        }
+
+        device.DeleteFramebuffer(data.FramebufferId);
+        if (data.ColorTextureId != 0)
+        {
+            device.DeleteTexture(data.ColorTextureId);
+        }
+
+        device.DeleteTexture(data.DepthTextureId);
+        renderTargets.Remove(target.Id);
+    }
+
+    /// <summary>
+    /// Deletes a cubemap render target and its associated resources.
+    /// </summary>
+    public void DeleteCubemapRenderTarget(CubemapRenderTargetHandle target)
+    {
+        if (!target.IsValid || !cubemapRenderTargets.TryGetValue(target.Id, out var data))
+        {
+            return;
+        }
+
+        device.DeleteFramebuffer(data.FramebufferId);
+        device.DeleteTexture(data.CubemapTextureId);
+        if (data.DepthRenderbufferId != 0)
+        {
+            device.DeleteRenderbuffer(data.DepthRenderbufferId);
+        }
+
+        cubemapRenderTargets.Remove(target.Id);
+    }
+
+    private uint CreateColorTexture(int width, int height, RenderTargetFormat format)
+    {
+        var texture = device.GenTexture();
+        device.BindTexture(TextureTarget.Texture2D, texture);
+
+        var pixelFormat = format switch
+        {
+            RenderTargetFormat.RGBA8Depth24 => PixelFormat.RGBA,
+            RenderTargetFormat.RGBA16FDepth24 => PixelFormat.RGBA16F,
+            RenderTargetFormat.RGBA32FDepth32F => PixelFormat.RGBA32F,
+            _ => PixelFormat.RGBA
+        };
+
+        device.TexImage2D(TextureTarget.Texture2D, 0, width, height, pixelFormat, ReadOnlySpan<byte>.Empty);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.MinFilter, (int)TextureMinFilter.Linear);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.MagFilter, (int)TextureMagFilter.Linear);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapS, (int)TextureWrapMode.ClampToEdge);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapT, (int)TextureWrapMode.ClampToEdge);
+
+        return texture;
+    }
+
+    private uint CreateDepthTexture(int width, int height, RenderTargetFormat format)
+    {
+        var texture = device.GenTexture();
+        device.BindTexture(TextureTarget.Texture2D, texture);
+
+        var pixelFormat = format switch
+        {
+            RenderTargetFormat.RGBA8Depth24 or RenderTargetFormat.RGBA16FDepth24 or RenderTargetFormat.Depth24
+                => PixelFormat.Depth24,
+            RenderTargetFormat.RGBA32FDepth32F or RenderTargetFormat.Depth32F
+                => PixelFormat.Depth32F,
+            _ => PixelFormat.Depth24
+        };
+
+        device.TexImage2D(TextureTarget.Texture2D, 0, width, height, pixelFormat, ReadOnlySpan<byte>.Empty);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.MinFilter, (int)TextureMinFilter.Nearest);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.MagFilter, (int)TextureMagFilter.Nearest);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapS, (int)TextureWrapMode.ClampToEdge);
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapT, (int)TextureWrapMode.ClampToEdge);
+
+        // For shadow mapping: enable depth comparison
+        // GL_TEXTURE_COMPARE_MODE = 0x884C, GL_COMPARE_REF_TO_TEXTURE = 0x884E
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.CompareMode, 0x884E);
+        // GL_TEXTURE_COMPARE_FUNC with GL_LEQUAL = 0x0203
+        device.TexParameter(TextureTarget.Texture2D, TextureParam.CompareFunc, 0x0203);
+
+        return texture;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // Delete all render targets
+        foreach (var data in renderTargets.Values)
+        {
+            device.DeleteFramebuffer(data.FramebufferId);
+            if (data.ColorTextureId != 0)
+            {
+                device.DeleteTexture(data.ColorTextureId);
+            }
+
+            device.DeleteTexture(data.DepthTextureId);
+        }
+
+        renderTargets.Clear();
+
+        // Delete all cubemap render targets
+        foreach (var data in cubemapRenderTargets.Values)
+        {
+            device.DeleteFramebuffer(data.FramebufferId);
+            device.DeleteTexture(data.CubemapTextureId);
+            if (data.DepthRenderbufferId != 0)
+            {
+                device.DeleteRenderbuffer(data.DepthRenderbufferId);
+            }
+        }
+
+        cubemapRenderTargets.Clear();
+    }
+}

--- a/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
@@ -343,5 +343,18 @@ file sealed class MockGraphicsContext : IGraphicsContext
     public void SetBlending(bool enabled) { }
     public void SetCulling(bool enabled, CullFaceMode mode = CullFaceMode.Back) { }
 
+    // Render target operations
+    public RenderTargetHandle CreateRenderTarget(int width, int height, RenderTargetFormat format) => new(1, width, height, format);
+    public RenderTargetHandle CreateDepthOnlyRenderTarget(int width, int height) => new(1, width, height, RenderTargetFormat.Depth32F);
+    public CubemapRenderTargetHandle CreateCubemapRenderTarget(int size, bool withDepth, int mipLevels = 1) => new(1, size, withDepth, mipLevels);
+    public void BindRenderTarget(RenderTargetHandle target) { }
+    public void BindCubemapRenderTarget(CubemapRenderTargetHandle target, CubemapFace face, int mipLevel = 0) { }
+    public void UnbindRenderTarget() { }
+    public TextureHandle GetRenderTargetColorTexture(RenderTargetHandle target) => new(100, target.Width, target.Height);
+    public TextureHandle GetRenderTargetDepthTexture(RenderTargetHandle target) => new(101, target.Width, target.Height);
+    public TextureHandle GetCubemapRenderTargetTexture(CubemapRenderTargetHandle target) => new(102, target.Size, target.Size);
+    public void DeleteRenderTarget(RenderTargetHandle target) { }
+    public void DeleteCubemapRenderTarget(CubemapRenderTargetHandle target) { }
+
     public void Dispose() { }
 }

--- a/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
+++ b/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
@@ -460,6 +460,85 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
 
     #endregion
 
+    #region Framebuffer Operations
+
+    public uint GenFramebuffer()
+    {
+        uint handle = nextHandle++;
+        Calls.Add($"GenFramebuffer() => {handle}");
+        return handle;
+    }
+
+    public void BindFramebuffer(FramebufferTarget target, uint framebuffer)
+    {
+        Calls.Add($"BindFramebuffer({target}, {framebuffer})");
+    }
+
+    public void DeleteFramebuffer(uint framebuffer)
+    {
+        Calls.Add($"DeleteFramebuffer({framebuffer})");
+    }
+
+    public void FramebufferTexture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget texTarget, uint texture, int level)
+    {
+        Calls.Add($"FramebufferTexture2D({target}, {attachment}, {texTarget}, {texture}, {level})");
+    }
+
+    public FramebufferStatus CheckFramebufferStatus(FramebufferTarget target)
+    {
+        Calls.Add($"CheckFramebufferStatus({target})");
+        return FramebufferStatus.Complete;
+    }
+
+    public uint GenRenderbuffer()
+    {
+        uint handle = nextHandle++;
+        Calls.Add($"GenRenderbuffer() => {handle}");
+        return handle;
+    }
+
+    public void BindRenderbuffer(uint renderbuffer)
+    {
+        Calls.Add($"BindRenderbuffer({renderbuffer})");
+    }
+
+    public void DeleteRenderbuffer(uint renderbuffer)
+    {
+        Calls.Add($"DeleteRenderbuffer({renderbuffer})");
+    }
+
+    public void RenderbufferStorage(RenderbufferFormat format, uint width, uint height)
+    {
+        Calls.Add($"RenderbufferStorage({format}, {width}, {height})");
+    }
+
+    public void FramebufferRenderbuffer(FramebufferTarget target, FramebufferAttachment attachment, uint renderbuffer)
+    {
+        Calls.Add($"FramebufferRenderbuffer({target}, {attachment}, {renderbuffer})");
+    }
+
+    public void DrawBuffer(DrawBufferMode mode)
+    {
+        Calls.Add($"DrawBuffer({mode})");
+    }
+
+    public void ReadBuffer(DrawBufferMode mode)
+    {
+        Calls.Add($"ReadBuffer({mode})");
+    }
+
+    public void DepthMask(bool flag)
+    {
+        Calls.Add($"DepthMask({flag})");
+    }
+
+    public void ColorMask(bool red, bool green, bool blue, bool alpha)
+    {
+        Calls.Add($"ColorMask({red}, {green}, {blue}, {alpha})");
+    }
+
+    #endregion
+
     /// <summary>
     /// Clears all recorded calls and resets state.
     /// </summary>


### PR DESCRIPTION
## Summary
- Add framebuffer/render target abstraction as foundation for Shadow Mapping (#897) and IBL (#896)
- Implement 14 IGraphicsDevice methods for framebuffer/renderbuffer operations
- Add 11 IGraphicsContext methods for render target lifecycle management
- Create RenderTargetManager for FBO state and resource tracking
- Support both 2D render targets and cubemap render targets for shadow mapping and IBL

## Details
This PR implements Phase 1 of the Shadow Mapping & IBL feature plan:

### New Types
- `RenderTargetHandle` - Handle for 2D render targets
- `CubemapRenderTargetHandle` - Handle for cubemap render targets
- `FramebufferEnums.cs` - Framebuffer target, attachment, status enums
- `RenderTargetFormat` - Color/depth/stencil format options

### IGraphicsDevice Extensions
- `GenFramebuffer`, `BindFramebuffer`, `DeleteFramebuffer`
- `FramebufferTexture2D`, `CheckFramebufferStatus`
- `GenRenderbuffer`, `BindRenderbuffer`, `DeleteRenderbuffer`
- `RenderbufferStorage`, `FramebufferRenderbuffer`
- `DrawBuffer`, `ReadBuffer`, `DepthMask`, `ColorMask`

### IGraphicsContext Extensions
- `CreateRenderTarget`, `CreateDepthOnlyRenderTarget`, `CreateCubemapRenderTarget`
- `BindRenderTarget`, `BindCubemapRenderTarget`, `UnbindRenderTarget`
- `GetRenderTargetColorTexture`, `GetRenderTargetDepthTexture`, `GetCubemapRenderTargetTexture`
- `DeleteRenderTarget`, `DeleteCubemapRenderTarget`

### Testing
- Updated MockGraphicsDevice with full framebuffer operation tracking
- Updated MockGraphicsContext with render target test support
- All 13,419 tests pass

## Test plan
- [x] Unit tests pass locally
- [x] Build succeeds with 0 warnings
- [x] All mocks updated for new interfaces

## Related Issues
Foundation for #897 and #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)