### PR TITLE
feat(testbridge): Add IWindowController for window state queries

### DIFF
--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -5,6 +5,7 @@ using KeenEyes.TestBridge.Input;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge;
 
@@ -70,6 +71,11 @@ public interface ITestBridge : IDisposable
     /// Gets the log controller for querying application logs.
     /// </summary>
     ILogController Logs { get; }
+
+    /// <summary>
+    /// Gets the window controller for querying window state.
+    /// </summary>
+    IWindowController Window { get; }
 
     /// <summary>
     /// Gets the input context used by this bridge.

--- a/src/KeenEyes.TestBridge.Abstractions/Window/IWindowController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Window/IWindowController.cs
@@ -1,0 +1,66 @@
+namespace KeenEyes.TestBridge.Window;
+
+/// <summary>
+/// Controller for querying window state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The window controller provides methods for querying the state of the application
+/// window, including dimensions, title, focus state, and more.
+/// </para>
+/// <para>
+/// Window queries may be unavailable in headless mode or when no window provider
+/// is registered. Check <see cref="IsAvailable"/> before making queries.
+/// </para>
+/// </remarks>
+public interface IWindowController
+{
+    /// <summary>
+    /// Gets whether window queries are available.
+    /// </summary>
+    /// <remarks>
+    /// Window queries may be unavailable in headless mode or when
+    /// no window provider is registered.
+    /// </remarks>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets all window state as a snapshot.
+    /// </summary>
+    /// <returns>A snapshot containing all window state.</returns>
+    /// <remarks>
+    /// Use this method when you need multiple properties at once to minimize
+    /// IPC round-trips.
+    /// </remarks>
+    Task<WindowStateSnapshot> GetStateAsync();
+
+    /// <summary>
+    /// Gets the window dimensions in pixels.
+    /// </summary>
+    /// <returns>The window dimensions as (Width, Height).</returns>
+    Task<(int Width, int Height)> GetSizeAsync();
+
+    /// <summary>
+    /// Gets the window title.
+    /// </summary>
+    /// <returns>The window title string.</returns>
+    Task<string> GetTitleAsync();
+
+    /// <summary>
+    /// Gets whether the window is closing or has been closed.
+    /// </summary>
+    /// <returns>True if the window is closing; otherwise false.</returns>
+    Task<bool> IsClosingAsync();
+
+    /// <summary>
+    /// Gets whether the window currently has input focus.
+    /// </summary>
+    /// <returns>True if the window has focus; otherwise false.</returns>
+    Task<bool> IsFocusedAsync();
+
+    /// <summary>
+    /// Gets the aspect ratio (width / height) of the window.
+    /// </summary>
+    /// <returns>The aspect ratio as a floating-point value.</returns>
+    Task<float> GetAspectRatioAsync();
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Window/WindowStateSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Window/WindowStateSnapshot.cs
@@ -1,0 +1,41 @@
+namespace KeenEyes.TestBridge.Window;
+
+/// <summary>
+/// Immutable snapshot of window state.
+/// </summary>
+/// <remarks>
+/// This record captures all window state in a single object, enabling efficient
+/// transfer over IPC with a single round-trip.
+/// </remarks>
+public sealed record WindowStateSnapshot
+{
+    /// <summary>
+    /// Gets the window width in pixels.
+    /// </summary>
+    public required int Width { get; init; }
+
+    /// <summary>
+    /// Gets the window height in pixels.
+    /// </summary>
+    public required int Height { get; init; }
+
+    /// <summary>
+    /// Gets the window title.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets whether the window is closing or has been closed.
+    /// </summary>
+    public required bool IsClosing { get; init; }
+
+    /// <summary>
+    /// Gets whether the window currently has input focus.
+    /// </summary>
+    public required bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Gets the aspect ratio (width / height) of the window.
+    /// </summary>
+    public required float AspectRatio { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteWindowController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteWindowController.cs
@@ -1,0 +1,58 @@
+using KeenEyes.TestBridge.Ipc.Protocol;
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IWindowController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteWindowController(TestBridgeClient client) : IWindowController
+{
+    /// <inheritdoc />
+    public bool IsAvailable => client.SendRequestAsync<bool>("window.isAvailable", null, CancellationToken.None)
+        .GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public async Task<WindowStateSnapshot> GetStateAsync()
+    {
+        var result = await client.SendRequestAsync<WindowStateSnapshot>("window.getState", null, CancellationToken.None);
+        return result ?? throw new InvalidOperationException("Failed to get window state");
+    }
+
+    /// <inheritdoc />
+    public async Task<(int Width, int Height)> GetSizeAsync()
+    {
+        var result = await client.SendRequestAsync<WindowSizeResult>("window.getSize", null, CancellationToken.None);
+        if (result == null)
+        {
+            return (0, 0);
+        }
+
+        return (result.Width, result.Height);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetTitleAsync()
+    {
+        var result = await client.SendRequestAsync<string>("window.getTitle", null, CancellationToken.None);
+        return result ?? string.Empty;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsClosingAsync()
+    {
+        return await client.SendRequestAsync<bool>("window.isClosing", null, CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsFocusedAsync()
+    {
+        return await client.SendRequestAsync<bool>("window.isFocused", null, CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<float> GetAspectRatioAsync()
+    {
+        return await client.SendRequestAsync<float>("window.getAspectRatio", null, CancellationToken.None);
+    }
+}

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -10,6 +10,7 @@ using KeenEyes.TestBridge.Ipc.Transport;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Client;
 
@@ -67,6 +68,7 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         State = new RemoteStateController(this);
         Capture = new RemoteCaptureController(this);
         Logs = new RemoteLogController(this);
+        Window = new RemoteWindowController(this);
 
         transport.MessageReceived += OnMessageReceived;
         transport.ConnectionChanged += OnConnectionChanged;
@@ -94,6 +96,9 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public ILogController Logs { get; }
+
+    /// <inheritdoc />
+    public IWindowController Window { get; }
 
     /// <inheritdoc />
     /// <remarks>
@@ -381,6 +386,17 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         if (type == typeof(LogStatsSnapshot))
         {
             return (T?)(object?)element.Deserialize(IpcJsonContext.Default.LogStatsSnapshot);
+        }
+
+        // Window types
+        if (type == typeof(WindowStateSnapshot))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.WindowStateSnapshot);
+        }
+
+        if (type == typeof(WindowSizeResult))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.WindowSizeResult);
         }
 
         // Fallback for unknown types - let the exception surface during development

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/WindowCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/WindowCommandHandler.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Ipc.Protocol;
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles window state query commands.
+/// </summary>
+internal sealed class WindowCommandHandler(IWindowController windowController) : ICommandHandler
+{
+    public string Prefix => "window";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            "isAvailable" => windowController.IsAvailable,
+            "getState" => await windowController.GetStateAsync(),
+            "getSize" => await HandleGetSizeAsync(),
+            "getTitle" => await windowController.GetTitleAsync(),
+            "isClosing" => await windowController.IsClosingAsync(),
+            "isFocused" => await windowController.IsFocusedAsync(),
+            "getAspectRatio" => await windowController.GetAspectRatioAsync(),
+            _ => throw new InvalidOperationException($"Unknown window command: {command}")
+        };
+    }
+
+    private async Task<WindowSizeResult> HandleGetSizeAsync()
+    {
+        var (width, height) = await windowController.GetSizeAsync();
+        return new WindowSizeResult { Width = width, Height = height };
+    }
+}

--- a/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
+++ b/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
@@ -66,7 +66,8 @@ public sealed class IpcBridgeServer : IDisposable
             ["input"] = new InputCommandHandler(bridge.Input),
             ["state"] = new StateCommandHandler(bridge.State),
             ["capture"] = new CaptureCommandHandler(bridge.Capture),
-            ["log"] = new LogCommandHandler(bridge.Logs)
+            ["log"] = new LogCommandHandler(bridge.Logs),
+            ["window"] = new WindowCommandHandler(bridge.Window)
         };
 
         transport.MessageReceived += OnMessageReceived;

--- a/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
@@ -4,6 +4,7 @@ using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Ipc.Protocol;
 
@@ -89,6 +90,9 @@ namespace KeenEyes.TestBridge.Ipc.Protocol;
 // Result types (serializable alternatives to tuples)
 [JsonSerializable(typeof(FrameSizeResult))]
 [JsonSerializable(typeof(MousePositionResult))]
+[JsonSerializable(typeof(WindowSizeResult))]
+// Window types
+[JsonSerializable(typeof(WindowStateSnapshot))]
 // Input command arguments
 [JsonSerializable(typeof(KeyActionArgs))]
 [JsonSerializable(typeof(KeyPressArgs))]
@@ -156,4 +160,20 @@ public sealed record MousePositionResult
     /// Gets the Y coordinate.
     /// </summary>
     public float Y { get; init; }
+}
+
+/// <summary>
+/// Result type for window size queries (serializable alternative to tuple).
+/// </summary>
+public sealed record WindowSizeResult
+{
+    /// <summary>
+    /// Gets the window width in pixels.
+    /// </summary>
+    public required int Width { get; init; }
+
+    /// <summary>
+    /// Gets the window height in pixels.
+    /// </summary>
+    public required int Height { get; init; }
 }

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -9,6 +9,8 @@ using KeenEyes.TestBridge.LoggingImpl;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.ProcessImpl;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Window;
+using KeenEyes.TestBridge.WindowImpl;
 using KeenEyes.Testing.Input;
 
 namespace KeenEyes.TestBridge;
@@ -36,6 +38,7 @@ public sealed class InProcessBridge : ITestBridge
     private readonly CaptureControllerImpl captureController;
     private readonly ProcessControllerImpl processController;
     private readonly LogControllerImpl logController;
+    private readonly WindowControllerImpl windowController;
     private readonly TestBridgeOptions options;
     private bool disposed;
 
@@ -46,7 +49,8 @@ public sealed class InProcessBridge : ITestBridge
     /// <param name="options">Configuration options.</param>
     /// <param name="graphicsContext">Optional graphics context for screenshot capture.</param>
     /// <param name="loopProvider">Optional loop provider for render thread marshalling.</param>
-    public InProcessBridge(World world, TestBridgeOptions? options = null, IGraphicsContext? graphicsContext = null, ILoopProvider? loopProvider = null)
+    /// <param name="window">Optional window for window state queries.</param>
+    public InProcessBridge(World world, TestBridgeOptions? options = null, IGraphicsContext? graphicsContext = null, ILoopProvider? loopProvider = null, IWindow? window = null)
     {
         this.world = world;
         this.options = options ?? new TestBridgeOptions();
@@ -66,6 +70,7 @@ public sealed class InProcessBridge : ITestBridge
         captureController = new CaptureControllerImpl(graphicsContext, loopProvider);
         processController = new ProcessControllerImpl();
         logController = new LogControllerImpl(this.options.LogQueryable);
+        windowController = new WindowControllerImpl(window);
 
         // Wire up log controller to state controller for WorldStats
         stateController.SetLogController(logController);
@@ -88,6 +93,9 @@ public sealed class InProcessBridge : ITestBridge
 
     /// <inheritdoc />
     public ILogController Logs => logController;
+
+    /// <inheritdoc />
+    public IWindowController Window => windowController;
 
     /// <inheritdoc />
     public IInputContext InputContext => compositeInputContext is not null

--- a/src/KeenEyes.TestBridge/Window/WindowControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/Window/WindowControllerImpl.cs
@@ -1,0 +1,85 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.TestBridge.WindowImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="IWindowController"/>.
+/// </summary>
+/// <remarks>
+/// This implementation accesses the <see cref="IWindow"/> directly for
+/// in-process testing scenarios.
+/// </remarks>
+/// <param name="window">The window to query, or null if unavailable.</param>
+internal sealed class WindowControllerImpl(IWindow? window) : IWindowController
+{
+    /// <inheritdoc />
+    public bool IsAvailable => window != null;
+
+    /// <inheritdoc />
+    public Task<WindowStateSnapshot> GetStateAsync()
+    {
+        if (window == null)
+        {
+            return Task.FromResult(CreateUnavailableSnapshot());
+        }
+
+        return Task.FromResult(new WindowStateSnapshot
+        {
+            Width = window.Width,
+            Height = window.Height,
+            Title = window.Title,
+            IsClosing = window.IsClosing,
+            IsFocused = window.IsFocused,
+            AspectRatio = window.AspectRatio
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<(int Width, int Height)> GetSizeAsync()
+    {
+        if (window == null)
+        {
+            return Task.FromResult((0, 0));
+        }
+
+        return Task.FromResult((window.Width, window.Height));
+    }
+
+    /// <inheritdoc />
+    public Task<string> GetTitleAsync()
+    {
+        return Task.FromResult(window?.Title ?? string.Empty);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsClosingAsync()
+    {
+        return Task.FromResult(window?.IsClosing ?? false);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsFocusedAsync()
+    {
+        return Task.FromResult(window?.IsFocused ?? false);
+    }
+
+    /// <inheritdoc />
+    public Task<float> GetAspectRatioAsync()
+    {
+        return Task.FromResult(window?.AspectRatio ?? 0f);
+    }
+
+    private static WindowStateSnapshot CreateUnavailableSnapshot()
+    {
+        return new WindowStateSnapshot
+        {
+            Width = 0,
+            Height = 0,
+            Title = string.Empty,
+            IsClosing = false,
+            IsFocused = false,
+            AspectRatio = 0f
+        };
+    }
+}

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/CommandHandlerTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/CommandHandlerTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using KeenEyes.TestBridge.Ipc.Handlers;
+using KeenEyes.TestBridge.Ipc.Protocol;
+using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Tests.Ipc;
 
@@ -241,5 +243,102 @@ public class CaptureCommandHandlerTests : IDisposable
 
         result.ShouldNotBeNull();
         ((int)result!).ShouldBe(0);
+    }
+}
+
+public class WindowCommandHandlerTests : IDisposable
+{
+    private readonly World world;
+    private readonly InProcessBridge bridge;
+    private readonly WindowCommandHandler handler;
+
+    public WindowCommandHandlerTests()
+    {
+        world = new World();
+        bridge = new InProcessBridge(world);
+        handler = new WindowCommandHandler(bridge.Window);
+    }
+
+    public void Dispose()
+    {
+        bridge.Dispose();
+        world.Dispose();
+    }
+
+    [Fact]
+    public void Prefix_ReturnsWindow()
+    {
+        handler.Prefix.ShouldBe("window");
+    }
+
+    [Fact]
+    public async Task HandleAsync_IsAvailable_ReturnsBool()
+    {
+        var result = await handler.HandleAsync("isAvailable", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        // Without window, should be false
+        ((bool)result!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_GetState_ReturnsSnapshot()
+    {
+        var result = await handler.HandleAsync("getState", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<WindowStateSnapshot>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_GetSize_ReturnsSizeResult()
+    {
+        var result = await handler.HandleAsync("getSize", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<WindowSizeResult>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_GetTitle_ReturnsString()
+    {
+        var result = await handler.HandleAsync("getTitle", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeOfType<string>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_IsClosing_ReturnsBool()
+    {
+        var result = await handler.HandleAsync("isClosing", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        ((bool)result!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_IsFocused_ReturnsBool()
+    {
+        var result = await handler.HandleAsync("isFocused", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        ((bool)result!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_GetAspectRatio_ReturnsFloat()
+    {
+        var result = await handler.HandleAsync("getAspectRatio", null, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        ((float)result!).ShouldBe(0f);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UnknownCommand_Throws()
+    {
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await handler.HandleAsync("unknownCommand", null, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/KeenEyes.TestBridge.Tests/Window/WindowControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Window/WindowControllerImplTests.cs
@@ -1,0 +1,287 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.TestBridge.Tests.Window;
+
+public class WindowControllerImplTests
+{
+    #region IsAvailable
+
+    [Fact]
+    public void IsAvailable_WithWindow_ReturnsTrue()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow();
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        bridge.Window.IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_WithoutWindow_ReturnsFalse()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        bridge.Window.IsAvailable.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region GetStateAsync
+
+    [Fact]
+    public async Task GetStateAsync_WithWindow_ReturnsState()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow
+        {
+            Width = 1920,
+            Height = 1080,
+            Title = "Test Window",
+            IsClosing = false,
+            IsFocused = true
+        };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var state = await bridge.Window.GetStateAsync();
+
+        state.Width.ShouldBe(1920);
+        state.Height.ShouldBe(1080);
+        state.Title.ShouldBe("Test Window");
+        state.IsClosing.ShouldBeFalse();
+        state.IsFocused.ShouldBeTrue();
+        state.AspectRatio.ShouldBe(1920f / 1080f, 0.01f);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_WithoutWindow_ReturnsDefaults()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var state = await bridge.Window.GetStateAsync();
+
+        state.Width.ShouldBe(0);
+        state.Height.ShouldBe(0);
+        state.Title.ShouldBe(string.Empty);
+        state.IsClosing.ShouldBeFalse();
+        state.IsFocused.ShouldBeFalse();
+        state.AspectRatio.ShouldBe(0f);
+    }
+
+    #endregion
+
+    #region GetSizeAsync
+
+    [Fact]
+    public async Task GetSizeAsync_WithWindow_ReturnsSize()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow
+        {
+            Width = 1280,
+            Height = 720
+        };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var (width, height) = await bridge.Window.GetSizeAsync();
+
+        width.ShouldBe(1280);
+        height.ShouldBe(720);
+    }
+
+    [Fact]
+    public async Task GetSizeAsync_WithoutWindow_ReturnsZero()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var (width, height) = await bridge.Window.GetSizeAsync();
+
+        width.ShouldBe(0);
+        height.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region GetTitleAsync
+
+    [Fact]
+    public async Task GetTitleAsync_WithWindow_ReturnsTitle()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow { Title = "My Game Title" };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var title = await bridge.Window.GetTitleAsync();
+
+        title.ShouldBe("My Game Title");
+    }
+
+    [Fact]
+    public async Task GetTitleAsync_WithoutWindow_ReturnsEmpty()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var title = await bridge.Window.GetTitleAsync();
+
+        title.ShouldBe(string.Empty);
+    }
+
+    #endregion
+
+    #region IsClosingAsync
+
+    [Fact]
+    public async Task IsClosingAsync_WithWindow_NotClosing_ReturnsFalse()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow { IsClosing = false };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var isClosing = await bridge.Window.IsClosingAsync();
+
+        isClosing.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsClosingAsync_WithWindow_Closing_ReturnsTrue()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow { IsClosing = true };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var isClosing = await bridge.Window.IsClosingAsync();
+
+        isClosing.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsClosingAsync_WithoutWindow_ReturnsFalse()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var isClosing = await bridge.Window.IsClosingAsync();
+
+        isClosing.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region IsFocusedAsync
+
+    [Fact]
+    public async Task IsFocusedAsync_WithWindow_Focused_ReturnsTrue()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow { IsFocused = true };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var isFocused = await bridge.Window.IsFocusedAsync();
+
+        isFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsFocusedAsync_WithWindow_NotFocused_ReturnsFalse()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow { IsFocused = false };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var isFocused = await bridge.Window.IsFocusedAsync();
+
+        isFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsFocusedAsync_WithoutWindow_ReturnsFalse()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var isFocused = await bridge.Window.IsFocusedAsync();
+
+        isFocused.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region GetAspectRatioAsync
+
+    [Fact]
+    public async Task GetAspectRatioAsync_WithWindow_ReturnsRatio()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow
+        {
+            Width = 1600,
+            Height = 900
+        };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var ratio = await bridge.Window.GetAspectRatioAsync();
+
+        ratio.ShouldBe(1600f / 900f, 0.01f);
+    }
+
+    [Fact]
+    public async Task GetAspectRatioAsync_WithWindow_ZeroHeight_ReturnsZero()
+    {
+        using var world = new World();
+        var mockWindow = new TestWindow
+        {
+            Width = 1920,
+            Height = 0
+        };
+        using var bridge = new InProcessBridge(world, window: mockWindow);
+
+        var ratio = await bridge.Window.GetAspectRatioAsync();
+
+        ratio.ShouldBe(0f);
+    }
+
+    [Fact]
+    public async Task GetAspectRatioAsync_WithoutWindow_ReturnsZero()
+    {
+        using var world = new World();
+        using var bridge = new InProcessBridge(world);
+
+        var ratio = await bridge.Window.GetAspectRatioAsync();
+
+        ratio.ShouldBe(0f);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Test implementation of IWindow for unit testing.
+    /// </summary>
+#pragma warning disable CS0067 // Events are never used - required by interface
+    private sealed class TestWindow : IWindow
+    {
+        public int Width { get; set; } = 800;
+        public int Height { get; set; } = 600;
+        public string Title { get; set; } = "Test Window";
+        public bool IsClosing { get; set; }
+        public bool IsFocused { get; set; } = true;
+        public float AspectRatio => Height > 0 ? (float)Width / Height : 0f;
+
+        public event Action? OnLoad;
+        public event Action<int, int>? OnResize;
+        public event Action? OnClosing;
+        public event Action<double>? OnUpdate;
+        public event Action<double>? OnRender;
+
+        public IGraphicsDevice CreateDevice() => throw new NotSupportedException();
+        public void Run() { }
+        public void DoEvents() { }
+        public void SwapBuffers() { }
+        public void Close() => IsClosing = true;
+        public void Dispose() { }
+    }
+#pragma warning restore CS0067
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/WindowTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/WindowTools.cs
@@ -1,0 +1,242 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Window;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for window state queries.
+/// </summary>
+[McpServerToolType]
+public sealed class WindowTools(BridgeConnectionManager connection)
+{
+    [McpServerTool(Name = "window_is_available")]
+    [Description("Check if window state queries are available. Returns false if the game is running headless.")]
+    public WindowAvailableResult WindowIsAvailable()
+    {
+        var bridge = connection.GetBridge();
+        return new WindowAvailableResult
+        {
+            Available = bridge.Window.IsAvailable
+        };
+    }
+
+    [McpServerTool(Name = "window_get_state")]
+    [Description("Get complete window state including size, title, focus state, and closing status.")]
+    public async Task<WindowStateResult> WindowGetState()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowStateResult
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var state = await bridge.Window.GetStateAsync();
+        return new WindowStateResult
+        {
+            Success = true,
+            Width = state.Width,
+            Height = state.Height,
+            Title = state.Title,
+            IsClosing = state.IsClosing,
+            IsFocused = state.IsFocused,
+            AspectRatio = state.AspectRatio
+        };
+    }
+
+    [McpServerTool(Name = "window_get_size")]
+    [Description("Get the current window dimensions in pixels.")]
+    public async Task<WindowSizeResultMcp> WindowGetSize()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowSizeResultMcp
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var (width, height) = await bridge.Window.GetSizeAsync();
+        return new WindowSizeResultMcp
+        {
+            Success = true,
+            Width = width,
+            Height = height
+        };
+    }
+
+    [McpServerTool(Name = "window_get_title")]
+    [Description("Get the current window title.")]
+    public async Task<WindowTitleResult> WindowGetTitle()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowTitleResult
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var title = await bridge.Window.GetTitleAsync();
+        return new WindowTitleResult
+        {
+            Success = true,
+            Title = title
+        };
+    }
+
+    [McpServerTool(Name = "window_is_closing")]
+    [Description("Check if the window is in the process of closing.")]
+    public async Task<WindowClosingResult> WindowIsClosing()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowClosingResult
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var isClosing = await bridge.Window.IsClosingAsync();
+        return new WindowClosingResult
+        {
+            Success = true,
+            IsClosing = isClosing
+        };
+    }
+
+    [McpServerTool(Name = "window_is_focused")]
+    [Description("Check if the window currently has focus.")]
+    public async Task<WindowFocusedResult> WindowIsFocused()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowFocusedResult
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var isFocused = await bridge.Window.IsFocusedAsync();
+        return new WindowFocusedResult
+        {
+            Success = true,
+            IsFocused = isFocused
+        };
+    }
+
+    [McpServerTool(Name = "window_get_aspect_ratio")]
+    [Description("Get the current window aspect ratio (width / height).")]
+    public async Task<WindowAspectRatioResult> WindowGetAspectRatio()
+    {
+        var bridge = connection.GetBridge();
+
+        if (!bridge.Window.IsAvailable)
+        {
+            return new WindowAspectRatioResult
+            {
+                Success = false,
+                Error = "Window state queries are not available (game may be running headless)"
+            };
+        }
+
+        var aspectRatio = await bridge.Window.GetAspectRatioAsync();
+        return new WindowAspectRatioResult
+        {
+            Success = true,
+            AspectRatio = aspectRatio
+        };
+    }
+}
+
+/// <summary>
+/// Result indicating if window queries are available.
+/// </summary>
+public sealed record WindowAvailableResult
+{
+    public required bool Available { get; init; }
+}
+
+/// <summary>
+/// Result containing complete window state.
+/// </summary>
+public sealed record WindowStateResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public string? Title { get; init; }
+    public bool IsClosing { get; init; }
+    public bool IsFocused { get; init; }
+    public float AspectRatio { get; init; }
+}
+
+/// <summary>
+/// Result containing window size.
+/// </summary>
+public sealed record WindowSizeResultMcp
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+}
+
+/// <summary>
+/// Result containing window title.
+/// </summary>
+public sealed record WindowTitleResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public string? Title { get; init; }
+}
+
+/// <summary>
+/// Result indicating if window is closing.
+/// </summary>
+public sealed record WindowClosingResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public bool IsClosing { get; init; }
+}
+
+/// <summary>
+/// Result indicating if window is focused.
+/// </summary>
+public sealed record WindowFocusedResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public bool IsFocused { get; init; }
+}
+
+/// <summary>
+/// Result containing window aspect ratio.
+/// </summary>
+public sealed record WindowAspectRatioResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public float AspectRatio { get; init; }
+}


### PR DESCRIPTION
## Summary
- Add `IWindowController` interface to TestBridge API for querying window state (size, title, focus, closing status)
- Implement in-process, IPC, and MCP layers for full stack support
- Add comprehensive unit tests (25 new tests)

## Changes
### New Files
- `src/KeenEyes.TestBridge.Abstractions/Window/IWindowController.cs` - Interface definition
- `src/KeenEyes.TestBridge.Abstractions/Window/WindowStateSnapshot.cs` - Immutable state record
- `src/KeenEyes.TestBridge/Window/WindowControllerImpl.cs` - In-process implementation
- `src/KeenEyes.TestBridge.Ipc/Handlers/WindowCommandHandler.cs` - IPC handler
- `src/KeenEyes.TestBridge.Client/RemoteWindowController.cs` - IPC client
- `tools/KeenEyes.Mcp.TestBridge/Tools/WindowTools.cs` - MCP tools
- `tests/KeenEyes.TestBridge.Tests/Window/WindowControllerImplTests.cs` - Unit tests

### Modified Files
- `ITestBridge.cs` - Added `Window` property
- `InProcessBridge.cs` - Added window support
- `IpcBridgeServer.cs` - Registered window handler
- `IpcJsonContext.cs` - Added AOT serialization types
- `TestBridgeClient.cs` - Added Window property and deserialization

## MCP Tools Added
| Tool | Description |
|------|-------------|
| `window_is_available` | Check if window queries are available |
| `window_get_state` | Get complete window state |
| `window_get_size` | Get window dimensions |
| `window_get_title` | Get window title |
| `window_is_closing` | Check if window is closing |
| `window_is_focused` | Check if window has focus |
| `window_get_aspect_ratio` | Get aspect ratio |

## Test plan
- [x] Unit tests added for WindowControllerImpl (17 tests)
- [x] Unit tests added for WindowCommandHandler (8 tests)
- [x] All 248 TestBridge tests pass
- [x] Build passes with zero warnings

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)