### PR TITLE
feat(graphics): Add Shadow Mapping with CSM and Image-Based Lighting

### DIFF
--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -143,7 +143,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
         _clipboard = new EntityClipboard();
         _layoutManager = LayoutManager.Instance;
         _logProvider = new EditorLogProvider();
-        _assetDatabase = new AssetDatabase(Environment.CurrentDirectory);
+        _assetDatabase = new AssetDatabase(System.Environment.CurrentDirectory);
         _serializer = new EditorComponentSerializer();
 
         // Scan for known asset types
@@ -1658,7 +1658,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
     {
         // Save layout before exiting
         _layoutManager.Save();
-        Environment.Exit(0);
+        System.Environment.Exit(0);
     }
 
     private void SetupInputHandling()
@@ -1677,7 +1677,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
             if (args.Key == Key.Escape)
             {
                 Console.WriteLine("Escape pressed - closing editor...");
-                Environment.Exit(0);
+                System.Environment.Exit(0);
             }
         };
 

--- a/samples/KeenEyes.Sample.Input/Program.cs
+++ b/samples/KeenEyes.Sample.Input/Program.cs
@@ -138,7 +138,7 @@ static void SetupInputEvents(IInputContext input)
             Console.WriteLine("Escape pressed - closing...");
             // Note: Calling Environment.Exit() bypasses proper cleanup.
             // In a real application, use window.Close() instead.
-            Environment.Exit(0);
+            System.Environment.Exit(0);
         }
 
         if (!args.IsRepeat)

--- a/samples/KeenEyes.Sample.Showcase/Program.cs
+++ b/samples/KeenEyes.Sample.Showcase/Program.cs
@@ -711,7 +711,7 @@ static void SetupInputEvents(IInputContext input, World world)
             else
             {
                 Console.WriteLine("Exiting...");
-                Environment.Exit(0);
+                System.Environment.Exit(0);
             }
         }
         else if (args.Key == Key.F1)

--- a/samples/KeenEyes.Sample.UI/Program.cs
+++ b/samples/KeenEyes.Sample.UI/Program.cs
@@ -202,7 +202,7 @@ try
                 if (args.Key == Key.Escape)
                 {
                     Console.WriteLine("Escape pressed - closing...");
-                    Environment.Exit(0);
+                    System.Environment.Exit(0);
                 }
             };
 

--- a/src/KeenEyes.Graphics.Abstractions/Components/Environment.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Components/Environment.cs
@@ -1,0 +1,125 @@
+using KeenEyes.Common;
+
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Component that provides environmental lighting and skybox rendering.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Environment component enables Image-Based Lighting (IBL) from HDR environment maps.
+/// When attached to an entity, it provides:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Diffuse ambient lighting from the irradiance map</description></item>
+/// <item><description>Specular reflections from the pre-filtered environment map</description></item>
+/// <item><description>Optional skybox rendering using the environment cubemap</description></item>
+/// </list>
+/// <para>
+/// Only one active Environment should be present in a scene at a time.
+/// Use the <see cref="ActiveEnvironmentTag"/> to mark which environment is active.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Create an environment entity with IBL
+/// var env = world.Spawn()
+///     .With(new Environment
+///     {
+///         IBLDataId = loadedIblData.Id,
+///         Intensity = 1.0f,
+///         Rotation = 0f,
+///         AffectsLighting = true,
+///         RenderSkybox = true
+///     })
+///     .WithTag&lt;ActiveEnvironmentTag&gt;()
+///     .Build();
+/// </code>
+/// </example>
+public struct Environment : IComponent
+{
+    /// <summary>
+    /// Gets or sets the ID of the IBL data to use.
+    /// </summary>
+    /// <remarks>
+    /// This references pre-processed IBL data containing irradiance,
+    /// specular, and BRDF lookup textures.
+    /// </remarks>
+    public int IBLDataId;
+
+    /// <summary>
+    /// Gets or sets the intensity multiplier for IBL lighting.
+    /// </summary>
+    /// <remarks>
+    /// Values greater than 1.0 increase the brightness of environment lighting.
+    /// Default is 1.0.
+    /// </remarks>
+    public float Intensity;
+
+    /// <summary>
+    /// Gets or sets the Y-axis rotation of the environment in degrees.
+    /// </summary>
+    /// <remarks>
+    /// Rotates the environment map around the vertical axis.
+    /// Useful for aligning the environment with the scene.
+    /// </remarks>
+    public float Rotation;
+
+    /// <summary>
+    /// Gets or sets whether this environment affects scene lighting.
+    /// </summary>
+    /// <remarks>
+    /// When true, the IBL irradiance and specular maps contribute
+    /// to the lighting of PBR materials.
+    /// </remarks>
+    public bool AffectsLighting;
+
+    /// <summary>
+    /// Gets or sets whether to render the environment as a skybox.
+    /// </summary>
+    /// <remarks>
+    /// When true, the environment cubemap is rendered as a background skybox.
+    /// </remarks>
+    public bool RenderSkybox;
+
+    /// <summary>
+    /// Gets or sets the exposure adjustment for the skybox.
+    /// </summary>
+    /// <remarks>
+    /// Adjusts the brightness of the skybox independently of IBL lighting.
+    /// Default is 1.0.
+    /// </remarks>
+    public float SkyboxExposure;
+
+    /// <summary>
+    /// Gets or sets the blur level for the skybox (0 = sharp, 1 = fully blurred).
+    /// </summary>
+    /// <remarks>
+    /// Uses the specular map mip levels to blur the skybox.
+    /// Useful for stylized or fog-like effects.
+    /// </remarks>
+    public float SkyboxBlur;
+
+    /// <summary>
+    /// Creates a default environment configuration.
+    /// </summary>
+    public static Environment Default => new()
+    {
+        IBLDataId = 0,
+        Intensity = 1.0f,
+        Rotation = 0f,
+        AffectsLighting = true,
+        RenderSkybox = true,
+        SkyboxExposure = 1.0f,
+        SkyboxBlur = 0f
+    };
+}
+
+/// <summary>
+/// Tag component marking the active environment for the scene.
+/// </summary>
+/// <remarks>
+/// Only one entity should have this tag at a time. The render system
+/// uses this to find which environment to apply for IBL and skybox rendering.
+/// </remarks>
+public struct ActiveEnvironmentTag : IComponent;

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
@@ -128,6 +128,25 @@ public interface IGraphicsContext : IDisposable
     ShaderHandle PbrShadowShader { get; }
 
     /// <summary>
+    /// Gets the PBR shader with Image-Based Lighting (IBL) support.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This shader extends the standard PBR shader with IBL ambient lighting:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Diffuse IBL from irradiance cubemap</description></item>
+    /// <item><description>Specular IBL from pre-filtered environment map</description></item>
+    /// <item><description>Environment rotation and intensity controls</description></item>
+    /// </list>
+    /// <para>
+    /// Additional texture slots for IBL:
+    /// 5 = Irradiance map (cubemap), 6 = Specular map (cubemap), 7 = BRDF LUT (2D)
+    /// </para>
+    /// </remarks>
+    ShaderHandle PbrIblShader { get; }
+
+    /// <summary>
     /// Gets a 1x1 white texture for solid color rendering.
     /// </summary>
     TextureHandle WhiteTexture { get; }
@@ -276,6 +295,32 @@ public interface IGraphicsContext : IDisposable
     /// <param name="handle">The texture handle.</param>
     /// <param name="unit">The texture unit (default: 0).</param>
     void BindTexture(TextureHandle handle, int unit = 0);
+
+    /// <summary>
+    /// Creates an HDR texture from floating-point pixel data.
+    /// </summary>
+    /// <remarks>
+    /// HDR textures store high dynamic range values and are used for
+    /// environment maps, IBL processing, and post-processing effects.
+    /// </remarks>
+    /// <param name="width">The texture width in pixels.</param>
+    /// <param name="height">The texture height in pixels.</param>
+    /// <param name="pixels">The floating-point pixel data (RGB format, 3 floats per pixel).</param>
+    /// <returns>The texture handle.</returns>
+    TextureHandle CreateHdrTexture(int width, int height, ReadOnlySpan<float> pixels);
+
+    /// <summary>
+    /// Binds a cubemap texture to a texture unit.
+    /// </summary>
+    /// <param name="handle">The cubemap texture handle.</param>
+    /// <param name="unit">The texture unit (default: 0).</param>
+    void BindCubemapTexture(TextureHandle handle, int unit = 0);
+
+    /// <summary>
+    /// Deletes a cubemap texture resource.
+    /// </summary>
+    /// <param name="handle">The cubemap texture handle.</param>
+    void DeleteCubemapTexture(TextureHandle handle);
 
     #endregion
 
@@ -563,10 +608,32 @@ public interface IGraphicsContext : IDisposable
     void DeleteRenderTarget(RenderTargetHandle target);
 
     /// <summary>
+    /// Deletes a render target but keeps the color texture for continued use.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you need to use the render target's output as a texture
+    /// but no longer need the framebuffer for rendering. The caller is
+    /// responsible for deleting the texture when done.
+    /// </remarks>
+    /// <param name="target">The render target to delete.</param>
+    void DeleteRenderTargetKeepTexture(RenderTargetHandle target);
+
+    /// <summary>
     /// Deletes a cubemap render target and its associated resources.
     /// </summary>
     /// <param name="target">The cubemap render target to delete.</param>
     void DeleteCubemapRenderTarget(CubemapRenderTargetHandle target);
+
+    /// <summary>
+    /// Deletes a cubemap render target but keeps the cubemap texture for continued use.
+    /// </summary>
+    /// <remarks>
+    /// Use this when you need to use the render target's cubemap as a texture
+    /// but no longer need the framebuffer for rendering. The caller is
+    /// responsible for deleting the texture when done.
+    /// </remarks>
+    /// <param name="target">The cubemap render target to delete.</param>
+    void DeleteCubemapRenderTargetKeepTexture(CubemapRenderTargetHandle target);
 
     #endregion
 }

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
@@ -57,6 +57,14 @@ public interface IGraphicsDevice : IDisposable
     void BufferData(BufferTarget target, ReadOnlySpan<byte> data, BufferUsage usage);
 
     /// <summary>
+    /// Uploads floating-point data to a buffer.
+    /// </summary>
+    /// <param name="target">The buffer target.</param>
+    /// <param name="data">The floating-point data to upload.</param>
+    /// <param name="usage">The usage hint.</param>
+    void BufferData(BufferTarget target, ReadOnlySpan<float> data, BufferUsage usage);
+
+    /// <summary>
     /// Deletes a vertex array object.
     /// </summary>
     /// <param name="vao">The VAO handle.</param>
@@ -127,6 +135,17 @@ public interface IGraphicsDevice : IDisposable
     /// <param name="format">The pixel format.</param>
     /// <param name="data">The pixel data.</param>
     void TexImage2D(TextureTarget target, int level, int width, int height, PixelFormat format, ReadOnlySpan<byte> data);
+
+    /// <summary>
+    /// Uploads 2D HDR texture data (floating-point).
+    /// </summary>
+    /// <param name="target">The texture target.</param>
+    /// <param name="level">The mipmap level.</param>
+    /// <param name="width">The texture width.</param>
+    /// <param name="height">The texture height.</param>
+    /// <param name="format">The pixel format (should be RGB32F or RGBA32F).</param>
+    /// <param name="data">The floating-point pixel data.</param>
+    void TexImage2D(TextureTarget target, int level, int width, int height, PixelFormat format, ReadOnlySpan<float> data);
 
     /// <summary>
     /// Sets a texture parameter (integer value).

--- a/src/KeenEyes.Graphics.Abstractions/Ibl/IblData.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Ibl/IblData.cs
@@ -1,0 +1,130 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Contains the processed IBL textures for a single environment.
+/// </summary>
+/// <remarks>
+/// <para>
+/// IBL data consists of three pre-computed textures derived from an HDR environment map:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Irradiance Map</b> - A low-resolution cubemap containing the integral of incoming
+/// light over the hemisphere for each direction. Used for diffuse ambient lighting.
+/// </description></item>
+/// <item><description>
+/// <b>Pre-filtered Specular Map</b> - A cubemap with mip levels, where each level
+/// represents increasing roughness. Used for specular reflections.
+/// </description></item>
+/// <item><description>
+/// <b>BRDF LUT</b> - A 2D lookup table storing the split-sum approximation of the
+/// specular BRDF. Indexed by (NdotV, roughness).
+/// </description></item>
+/// </list>
+/// </remarks>
+public struct IblData
+{
+    /// <summary>
+    /// Gets or sets the original environment cubemap texture.
+    /// </summary>
+    /// <remarks>
+    /// This is the source HDR environment map converted to a cubemap.
+    /// Can be used for skybox rendering.
+    /// </remarks>
+    public TextureHandle EnvironmentMap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the irradiance cubemap for diffuse IBL.
+    /// </summary>
+    /// <remarks>
+    /// A low-resolution cubemap where each texel contains the average
+    /// irradiance from the hemisphere oriented in that direction.
+    /// </remarks>
+    public TextureHandle IrradianceMap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pre-filtered specular cubemap for specular IBL.
+    /// </summary>
+    /// <remarks>
+    /// A cubemap with mip levels where:
+    /// - Level 0 = mirror reflection (roughness 0)
+    /// - Higher levels = increasingly blurred (higher roughness)
+    /// </remarks>
+    public TextureHandle SpecularMap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BRDF lookup texture.
+    /// </summary>
+    /// <remarks>
+    /// A 2D texture storing precomputed BRDF integration values.
+    /// R channel = scale, G channel = bias for the Fresnel term.
+    /// </remarks>
+    public TextureHandle BrdfLut { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings used to generate this IBL data.
+    /// </summary>
+    public IblSettings Settings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of mip levels in the specular map.
+    /// </summary>
+    public int SpecularMipLevels { get; set; }
+
+    /// <summary>
+    /// Gets whether this IBL data is valid and ready for use.
+    /// </summary>
+    public readonly bool IsValid =>
+        IrradianceMap.IsValid &&
+        SpecularMap.IsValid &&
+        BrdfLut.IsValid;
+
+    /// <summary>
+    /// Gets whether this IBL data includes the original environment map.
+    /// </summary>
+    public readonly bool HasEnvironmentMap => EnvironmentMap.IsValid;
+
+    /// <summary>
+    /// Creates an invalid/empty IBL data instance.
+    /// </summary>
+    public static IblData Invalid => new()
+    {
+        EnvironmentMap = TextureHandle.Invalid,
+        IrradianceMap = TextureHandle.Invalid,
+        SpecularMap = TextureHandle.Invalid,
+        BrdfLut = TextureHandle.Invalid,
+        Settings = IblSettings.Default,
+        SpecularMipLevels = 0
+    };
+}
+
+/// <summary>
+/// Represents a loaded HDR environment for IBL processing.
+/// </summary>
+public struct EnvironmentMapData
+{
+    /// <summary>
+    /// Gets or sets the HDR pixel data (RGB float values).
+    /// </summary>
+    public float[] Pixels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the equirectangular map.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the equirectangular map.
+    /// </summary>
+    public int Height { get; set; }
+
+    /// <summary>
+    /// Gets whether this environment map data is valid.
+    /// </summary>
+    public readonly bool IsValid => Pixels != null && Pixels.Length > 0 && Width > 0 && Height > 0;
+
+    /// <summary>
+    /// Gets the number of color channels (always 3 for RGB).
+    /// </summary>
+    public static int Channels => 3;
+}

--- a/src/KeenEyes.Graphics.Abstractions/Ibl/IblSettings.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Ibl/IblSettings.cs
@@ -1,0 +1,145 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Resolution presets for IBL cubemap processing.
+/// </summary>
+public enum IBLResolution
+{
+    /// <summary>
+    /// Low quality (64x64 irradiance, 128x128 specular).
+    /// </summary>
+    Low = 64,
+
+    /// <summary>
+    /// Medium quality (128x128 irradiance, 256x256 specular).
+    /// </summary>
+    Medium = 128,
+
+    /// <summary>
+    /// High quality (256x256 irradiance, 512x512 specular).
+    /// </summary>
+    High = 256,
+
+    /// <summary>
+    /// Very high quality (512x512 irradiance, 1024x1024 specular).
+    /// </summary>
+    VeryHigh = 512
+}
+
+/// <summary>
+/// Configuration settings for Image-Based Lighting (IBL).
+/// </summary>
+/// <remarks>
+/// <para>
+/// IBL uses HDR environment maps to provide realistic ambient lighting
+/// and reflections. The environment map is processed into:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Irradiance map - diffuse ambient lighting (low resolution)</description></item>
+/// <item><description>Pre-filtered specular map - blurred reflections per roughness level</description></item>
+/// <item><description>BRDF LUT - precomputed BRDF integration lookup table</description></item>
+/// </list>
+/// </remarks>
+public struct IblSettings
+{
+    /// <summary>
+    /// Gets or sets the resolution for the irradiance map.
+    /// </summary>
+    /// <remarks>
+    /// The irradiance map stores diffuse ambient lighting and can be low resolution
+    /// since it represents slowly varying lighting across the hemisphere.
+    /// </remarks>
+    public IBLResolution IrradianceResolution { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolution for the pre-filtered specular map.
+    /// </summary>
+    /// <remarks>
+    /// Higher resolutions provide sharper reflections on smooth surfaces.
+    /// The specular map includes multiple mip levels for different roughness values.
+    /// </remarks>
+    public IBLResolution SpecularResolution { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of mip levels for the specular map.
+    /// </summary>
+    /// <remarks>
+    /// Each mip level represents a different roughness value, from sharp (level 0)
+    /// to fully rough (max level). Typically 5-9 levels are used.
+    /// </remarks>
+    public int SpecularMipLevels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolution for the BRDF lookup table.
+    /// </summary>
+    /// <remarks>
+    /// The BRDF LUT is a 2D texture indexed by (NdotV, roughness).
+    /// 512x512 is typically sufficient for high quality.
+    /// </remarks>
+    public int BrdfLutResolution { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of samples for irradiance convolution.
+    /// </summary>
+    /// <remarks>
+    /// Higher sample counts produce smoother irradiance maps but take longer to compute.
+    /// </remarks>
+    public int IrradianceSampleCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of samples for specular pre-filtering.
+    /// </summary>
+    /// <remarks>
+    /// Higher sample counts reduce noise in the pre-filtered specular map.
+    /// </remarks>
+    public int SpecularSampleCount { get; set; }
+
+    /// <summary>
+    /// Gets the irradiance map resolution in pixels.
+    /// </summary>
+    public readonly int IrradianceResolutionPixels => (int)IrradianceResolution;
+
+    /// <summary>
+    /// Gets the specular map resolution in pixels.
+    /// </summary>
+    public readonly int SpecularResolutionPixels => (int)SpecularResolution * 2;
+
+    /// <summary>
+    /// Gets the default IBL settings optimized for quality and performance.
+    /// </summary>
+    public static IblSettings Default => new()
+    {
+        IrradianceResolution = IBLResolution.Medium,
+        SpecularResolution = IBLResolution.High,
+        SpecularMipLevels = 5,
+        BrdfLutResolution = 512,
+        IrradianceSampleCount = 2048,
+        SpecularSampleCount = 1024
+    };
+
+    /// <summary>
+    /// Gets low quality IBL settings for faster processing.
+    /// </summary>
+    public static IblSettings Low => new()
+    {
+        IrradianceResolution = IBLResolution.Low,
+        SpecularResolution = IBLResolution.Low,
+        SpecularMipLevels = 4,
+        BrdfLutResolution = 256,
+        IrradianceSampleCount = 512,
+        SpecularSampleCount = 256
+    };
+
+    /// <summary>
+    /// Gets high quality IBL settings for best visual quality.
+    /// </summary>
+    public static IblSettings High => new()
+    {
+        IrradianceResolution = IBLResolution.High,
+        SpecularResolution = IBLResolution.VeryHigh,
+        SpecularMipLevels = 7,
+        BrdfLutResolution = 512,
+        IrradianceSampleCount = 4096,
+        SpecularSampleCount = 2048
+    };
+}

--- a/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
@@ -45,6 +45,18 @@ public sealed class OpenGLDevice(GL gl) : IGraphicsDevice
     }
 
     /// <inheritdoc />
+    public void BufferData(BufferTarget target, ReadOnlySpan<float> data, BufferUsage usage)
+    {
+        unsafe
+        {
+            fixed (float* ptr = data)
+            {
+                gl.BufferData(ToGL(target), (nuint)(data.Length * sizeof(float)), ptr, ToGL(usage));
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public void DeleteVertexArray(uint vao) => gl.DeleteVertexArray(vao);
 
     /// <inheritdoc />
@@ -123,6 +135,44 @@ public sealed class OpenGLDevice(GL gl) : IGraphicsDevice
                         0,
                         ToGL(format),
                         pixelType,
+                        ptr);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void TexImage2D(Abstractions.TextureTarget target, int level, int width, int height, Abstractions.PixelFormat format, ReadOnlySpan<float> data)
+    {
+        unsafe
+        {
+            if (data.IsEmpty)
+            {
+                // Allocate GPU memory without initializing (null pointer)
+                gl.TexImage2D(
+                    ToGL(target),
+                    level,
+                    ToGLInternalFormat(format),
+                    (uint)width,
+                    (uint)height,
+                    0,
+                    ToGL(format),
+                    PixelType.Float,
+                    null);
+            }
+            else
+            {
+                fixed (float* ptr = data)
+                {
+                    gl.TexImage2D(
+                        ToGL(target),
+                        level,
+                        ToGLInternalFormat(format),
+                        (uint)width,
+                        (uint)height,
+                        0,
+                        ToGL(format),
+                        PixelType.Float,
                         ptr);
                 }
             }

--- a/src/KeenEyes.Graphics.Silk/Ibl/IblManager.cs
+++ b/src/KeenEyes.Graphics.Silk/Ibl/IblManager.cs
@@ -1,0 +1,586 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Shaders;
+
+namespace KeenEyes.Graphics.Silk.Ibl;
+
+/// <summary>
+/// Manages Image-Based Lighting (IBL) processing and resources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This manager handles the complete IBL pipeline:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Loading HDR environment maps (equirectangular format)</description></item>
+/// <item><description>Converting equirectangular maps to cubemaps</description></item>
+/// <item><description>Generating irradiance maps for diffuse IBL</description></item>
+/// <item><description>Generating pre-filtered specular maps for specular IBL</description></item>
+/// <item><description>Generating BRDF lookup tables</description></item>
+/// </list>
+/// </remarks>
+/// <param name="graphics">The graphics context for creating textures and render targets.</param>
+/// <param name="device">The graphics device for low-level GPU operations.</param>
+[ExcludeFromCodeCoverage(Justification = "Requires real GPU context")]
+public sealed class IblManager(IGraphicsContext graphics, IGraphicsDevice device) : IDisposable
+{
+    private readonly Dictionary<int, IblData> iblDataStore = [];
+    private int nextIblDataId = 1;
+    private bool disposed;
+
+    // Shared resources
+    private TextureHandle sharedBrdfLut = TextureHandle.Invalid;
+    private uint cubeVao;
+    private uint cubeVbo;
+    private uint quadVao;
+    private uint quadVbo;
+    private bool meshesInitialized;
+
+    // Shader programs (created on demand)
+    private uint equirectToCubemapProgram;
+    private uint irradianceProgram;
+    private uint specularPrefilterProgram;
+    private uint brdfLutProgram;
+
+    /// <summary>
+    /// Gets the graphics context used by this manager.
+    /// </summary>
+    public IGraphicsContext Graphics => graphics;
+
+    /// <summary>
+    /// Gets the shared BRDF lookup table.
+    /// </summary>
+    /// <remarks>
+    /// The BRDF LUT is the same for all environments and only needs to be generated once.
+    /// </remarks>
+    public TextureHandle SharedBrdfLut => sharedBrdfLut;
+
+    /// <summary>
+    /// Processes an HDR environment map and generates all IBL textures.
+    /// </summary>
+    /// <param name="environmentData">The HDR environment map data.</param>
+    /// <param name="settings">The IBL processing settings.</param>
+    /// <returns>The ID of the generated IBL data.</returns>
+    public int ProcessEnvironmentMap(EnvironmentMapData environmentData, IblSettings? settings = null)
+    {
+        if (!environmentData.IsValid)
+        {
+            throw new ArgumentException("Invalid environment map data", nameof(environmentData));
+        }
+
+        var iblSettings = settings ?? IblSettings.Default;
+
+        EnsureInitialized();
+
+        // Create equirectangular texture from HDR data
+        var equirectTexture = CreateHdrTexture(environmentData);
+
+        try
+        {
+            // Convert to cubemap
+            int envSize = iblSettings.SpecularResolutionPixels;
+            var environmentMap = ConvertEquirectangularToCubemap(equirectTexture, envSize);
+
+            // Generate irradiance map
+            var irradianceMap = GenerateIrradianceMap(
+                environmentMap,
+                iblSettings.IrradianceResolutionPixels);
+
+            // Generate specular map with mip levels
+            var specularMap = GenerateSpecularMap(
+                environmentMap,
+                iblSettings.SpecularResolutionPixels,
+                iblSettings.SpecularMipLevels,
+                iblSettings.SpecularSampleCount);
+
+            // Get or generate shared BRDF LUT
+            if (!sharedBrdfLut.IsValid)
+            {
+                sharedBrdfLut = GenerateBrdfLut(iblSettings.BrdfLutResolution);
+            }
+
+            var iblData = new IblData
+            {
+                EnvironmentMap = environmentMap,
+                IrradianceMap = irradianceMap,
+                SpecularMap = specularMap,
+                BrdfLut = sharedBrdfLut,
+                Settings = iblSettings,
+                SpecularMipLevels = iblSettings.SpecularMipLevels
+            };
+
+            int id = nextIblDataId++;
+            iblDataStore[id] = iblData;
+            return id;
+        }
+        finally
+        {
+            // Clean up temporary equirectangular texture
+            graphics.DeleteTexture(equirectTexture);
+        }
+    }
+
+    /// <summary>
+    /// Gets the IBL data for the specified ID.
+    /// </summary>
+    /// <param name="id">The IBL data ID.</param>
+    /// <returns>The IBL data, or <see cref="IblData.Invalid"/> if not found.</returns>
+    public IblData GetIblData(int id)
+    {
+        return iblDataStore.TryGetValue(id, out var data) ? data : IblData.Invalid;
+    }
+
+    /// <summary>
+    /// Deletes the IBL data for the specified ID.
+    /// </summary>
+    /// <param name="id">The IBL data ID.</param>
+    /// <returns>True if deleted, false if not found.</returns>
+    public bool DeleteIblData(int id)
+    {
+        if (!iblDataStore.TryGetValue(id, out var data))
+        {
+            return false;
+        }
+
+        // Delete textures (except shared BRDF LUT)
+        if (data.EnvironmentMap.IsValid)
+        {
+            graphics.DeleteCubemapTexture(data.EnvironmentMap);
+        }
+
+        if (data.IrradianceMap.IsValid)
+        {
+            graphics.DeleteCubemapTexture(data.IrradianceMap);
+        }
+
+        if (data.SpecularMap.IsValid)
+        {
+            graphics.DeleteCubemapTexture(data.SpecularMap);
+        }
+
+        iblDataStore.Remove(id);
+        return true;
+    }
+
+    /// <summary>
+    /// Gets all loaded IBL data IDs.
+    /// </summary>
+    public IEnumerable<int> LoadedIblDataIds => iblDataStore.Keys;
+
+    private void EnsureInitialized()
+    {
+        if (!meshesInitialized)
+        {
+            InitializeMeshes();
+            InitializeShaders();
+            meshesInitialized = true;
+        }
+    }
+
+    private void InitializeMeshes()
+    {
+        // Create unit cube for cubemap rendering
+        float[] cubeVertices =
+        [
+            // Back face
+            -1.0f, -1.0f, -1.0f,
+            1.0f, 1.0f, -1.0f,
+            1.0f, -1.0f, -1.0f,
+            1.0f, 1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f,
+            -1.0f, 1.0f, -1.0f,
+            // Front face
+            -1.0f, -1.0f, 1.0f,
+            1.0f, -1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f,
+            -1.0f, 1.0f, 1.0f,
+            -1.0f, -1.0f, 1.0f,
+            // Left face
+            -1.0f, 1.0f, 1.0f,
+            -1.0f, 1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, 1.0f,
+            -1.0f, 1.0f, 1.0f,
+            // Right face
+            1.0f, 1.0f, 1.0f,
+            1.0f, -1.0f, -1.0f,
+            1.0f, 1.0f, -1.0f,
+            1.0f, -1.0f, -1.0f,
+            1.0f, 1.0f, 1.0f,
+            1.0f, -1.0f, 1.0f,
+            // Bottom face
+            -1.0f, -1.0f, -1.0f,
+            1.0f, -1.0f, -1.0f,
+            1.0f, -1.0f, 1.0f,
+            1.0f, -1.0f, 1.0f,
+            -1.0f, -1.0f, 1.0f,
+            -1.0f, -1.0f, -1.0f,
+            // Top face
+            -1.0f, 1.0f, -1.0f,
+            1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, -1.0f,
+            1.0f, 1.0f, 1.0f,
+            -1.0f, 1.0f, -1.0f,
+            -1.0f, 1.0f, 1.0f
+        ];
+
+        cubeVao = device.GenVertexArray();
+        cubeVbo = device.GenBuffer();
+
+        device.BindVertexArray(cubeVao);
+        device.BindBuffer(BufferTarget.ArrayBuffer, cubeVbo);
+        device.BufferData(BufferTarget.ArrayBuffer, cubeVertices.AsSpan(), BufferUsage.StaticDraw);
+
+        // Position attribute
+        device.EnableVertexAttribArray(0);
+        device.VertexAttribPointer(0, 3, VertexAttribType.Float, false, 3 * sizeof(float), 0);
+
+        // Create fullscreen quad for BRDF LUT
+        float[] quadVertices =
+        [
+            // Position (XY)   TexCoord (UV)
+            0.0f, 0.0f,       0.0f, 0.0f,
+            1.0f, 0.0f,       1.0f, 0.0f,
+            1.0f, 1.0f,       1.0f, 1.0f,
+
+            0.0f, 0.0f,       0.0f, 0.0f,
+            1.0f, 1.0f,       1.0f, 1.0f,
+            0.0f, 1.0f,       0.0f, 1.0f
+        ];
+
+        quadVao = device.GenVertexArray();
+        quadVbo = device.GenBuffer();
+
+        device.BindVertexArray(quadVao);
+        device.BindBuffer(BufferTarget.ArrayBuffer, quadVbo);
+        device.BufferData(BufferTarget.ArrayBuffer, quadVertices.AsSpan(), BufferUsage.StaticDraw);
+
+        // Position attribute (location 0)
+        device.EnableVertexAttribArray(0);
+        device.VertexAttribPointer(0, 2, VertexAttribType.Float, false, 4 * sizeof(float), 0);
+
+        // TexCoord attribute (location 2, as used in the shader)
+        device.EnableVertexAttribArray(2);
+        device.VertexAttribPointer(2, 2, VertexAttribType.Float, false, 4 * sizeof(float), 2 * sizeof(float));
+
+        device.BindVertexArray(0);
+    }
+
+    private void InitializeShaders()
+    {
+        equirectToCubemapProgram = CompileShaderProgram(
+            IblShaders.CubemapVertexShader,
+            IblShaders.EquirectToCubemapFragmentShader);
+
+        irradianceProgram = CompileShaderProgram(
+            IblShaders.CubemapVertexShader,
+            IblShaders.IrradianceConvolutionFragmentShader);
+
+        specularPrefilterProgram = CompileShaderProgram(
+            IblShaders.CubemapVertexShader,
+            IblShaders.SpecularPrefilterFragmentShader);
+
+        brdfLutProgram = CompileShaderProgram(
+            IblShaders.FullscreenQuadVertexShader,
+            IblShaders.BrdfLutFragmentShader);
+    }
+
+    private uint CompileShaderProgram(string vertexSource, string fragmentSource)
+    {
+        uint vertexShader = device.CreateShader(ShaderType.Vertex);
+        device.ShaderSource(vertexShader, vertexSource);
+        device.CompileShader(vertexShader);
+
+        if (!device.GetShaderCompileStatus(vertexShader))
+        {
+            string log = device.GetShaderInfoLog(vertexShader);
+            device.DeleteShader(vertexShader);
+            throw new InvalidOperationException($"Vertex shader compilation failed: {log}");
+        }
+
+        uint fragmentShader = device.CreateShader(ShaderType.Fragment);
+        device.ShaderSource(fragmentShader, fragmentSource);
+        device.CompileShader(fragmentShader);
+
+        if (!device.GetShaderCompileStatus(fragmentShader))
+        {
+            string log = device.GetShaderInfoLog(fragmentShader);
+            device.DeleteShader(vertexShader);
+            device.DeleteShader(fragmentShader);
+            throw new InvalidOperationException($"Fragment shader compilation failed: {log}");
+        }
+
+        uint program = device.CreateProgram();
+        device.AttachShader(program, vertexShader);
+        device.AttachShader(program, fragmentShader);
+        device.LinkProgram(program);
+
+        if (!device.GetProgramLinkStatus(program))
+        {
+            string log = device.GetProgramInfoLog(program);
+            device.DeleteProgram(program);
+            device.DeleteShader(vertexShader);
+            device.DeleteShader(fragmentShader);
+            throw new InvalidOperationException($"Shader program linking failed: {log}");
+        }
+
+        device.DetachShader(program, vertexShader);
+        device.DetachShader(program, fragmentShader);
+        device.DeleteShader(vertexShader);
+        device.DeleteShader(fragmentShader);
+
+        return program;
+    }
+
+    private TextureHandle CreateHdrTexture(EnvironmentMapData data)
+    {
+        return graphics.CreateHdrTexture(data.Width, data.Height, data.Pixels);
+    }
+
+    private TextureHandle ConvertEquirectangularToCubemap(TextureHandle equirectTexture, int size)
+    {
+        // Create cubemap render target
+        var cubemapTarget = graphics.CreateCubemapRenderTarget(size, withDepth: true);
+
+        // Setup view matrices for each face
+        var captureViews = GetCubemapViewMatrices();
+        var captureProjection = Matrix4x4.CreatePerspectiveFieldOfView(
+            MathF.PI / 2f, 1.0f, 0.1f, 10.0f);
+
+        device.UseProgram(equirectToCubemapProgram);
+
+        // Set projection matrix
+        int projLoc = device.GetUniformLocation(equirectToCubemapProgram, "uProjection");
+        device.UniformMatrix4(projLoc, captureProjection);
+
+        // Bind equirectangular texture
+        device.ActiveTexture(TextureUnit.Texture0);
+        graphics.BindTexture(equirectTexture, 0);
+        int texLoc = device.GetUniformLocation(equirectToCubemapProgram, "uEquirectangularMap");
+        device.Uniform1(texLoc, 0);
+
+        int viewLoc = device.GetUniformLocation(equirectToCubemapProgram, "uView");
+
+        // Render each face
+        for (int face = 0; face < 6; face++)
+        {
+            graphics.BindCubemapRenderTarget(cubemapTarget, (CubemapFace)face);
+            device.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
+
+            device.UniformMatrix4(viewLoc, captureViews[face]);
+
+            device.BindVertexArray(cubeVao);
+            device.DrawArrays(PrimitiveType.Triangles, 0, 36);
+        }
+
+        graphics.UnbindRenderTarget();
+
+        // Get the cubemap texture handle
+        var textureHandle = graphics.GetCubemapRenderTargetTexture(cubemapTarget);
+
+        // Generate mipmaps for the environment cubemap
+        device.BindTexture(TextureTarget.TextureCubeMap, (uint)textureHandle.Id);
+        device.GenerateMipmap(TextureTarget.TextureCubeMap);
+
+        // Clean up render target (keep the texture)
+        graphics.DeleteCubemapRenderTargetKeepTexture(cubemapTarget);
+
+        return textureHandle;
+    }
+
+    private TextureHandle GenerateIrradianceMap(TextureHandle environmentCubemap, int size)
+    {
+        // Create cubemap render target for irradiance
+        var irradianceTarget = graphics.CreateCubemapRenderTarget(size, withDepth: true);
+
+        // Setup matrices
+        var captureViews = GetCubemapViewMatrices();
+        var captureProjection = Matrix4x4.CreatePerspectiveFieldOfView(
+            MathF.PI / 2f, 1.0f, 0.1f, 10.0f);
+
+        device.UseProgram(irradianceProgram);
+
+        // Set uniforms
+        int projLoc = device.GetUniformLocation(irradianceProgram, "uProjection");
+        device.UniformMatrix4(projLoc, captureProjection);
+
+        // Bind environment cubemap
+        device.ActiveTexture(TextureUnit.Texture0);
+        graphics.BindCubemapTexture(environmentCubemap, 0);
+        int envLoc = device.GetUniformLocation(irradianceProgram, "uEnvironmentMap");
+        device.Uniform1(envLoc, 0);
+
+        int viewLoc = device.GetUniformLocation(irradianceProgram, "uView");
+
+        // Render each face
+        for (int face = 0; face < 6; face++)
+        {
+            graphics.BindCubemapRenderTarget(irradianceTarget, (CubemapFace)face);
+            device.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
+
+            device.UniformMatrix4(viewLoc, captureViews[face]);
+
+            device.BindVertexArray(cubeVao);
+            device.DrawArrays(PrimitiveType.Triangles, 0, 36);
+        }
+
+        graphics.UnbindRenderTarget();
+
+        // Get the cubemap texture handle and clean up render target
+        var textureHandle = graphics.GetCubemapRenderTargetTexture(irradianceTarget);
+        graphics.DeleteCubemapRenderTargetKeepTexture(irradianceTarget);
+
+        return textureHandle;
+    }
+
+    private TextureHandle GenerateSpecularMap(TextureHandle environmentCubemap, int size, int mipLevels, int sampleCount)
+    {
+        // Create cubemap render target with mip levels
+        var specularTarget = graphics.CreateCubemapRenderTarget(size, withDepth: true, mipLevels);
+
+        // Setup matrices
+        var captureViews = GetCubemapViewMatrices();
+        var captureProjection = Matrix4x4.CreatePerspectiveFieldOfView(
+            MathF.PI / 2f, 1.0f, 0.1f, 10.0f);
+
+        device.UseProgram(specularPrefilterProgram);
+
+        // Set uniforms
+        int projLoc = device.GetUniformLocation(specularPrefilterProgram, "uProjection");
+        device.UniformMatrix4(projLoc, captureProjection);
+
+        // Bind environment cubemap
+        device.ActiveTexture(TextureUnit.Texture0);
+        graphics.BindCubemapTexture(environmentCubemap, 0);
+        int envLoc = device.GetUniformLocation(specularPrefilterProgram, "uEnvironmentMap");
+        device.Uniform1(envLoc, 0);
+
+        int viewLoc = device.GetUniformLocation(specularPrefilterProgram, "uView");
+        int roughnessLoc = device.GetUniformLocation(specularPrefilterProgram, "uRoughness");
+        int sampleCountLoc = device.GetUniformLocation(specularPrefilterProgram, "uSampleCount");
+
+        device.Uniform1(sampleCountLoc, sampleCount);
+
+        // Render each mip level with increasing roughness
+        for (int mip = 0; mip < mipLevels; mip++)
+        {
+            float roughness = (float)mip / (mipLevels - 1);
+            device.Uniform1(roughnessLoc, roughness);
+
+            // Render each face at this mip level
+            for (int face = 0; face < 6; face++)
+            {
+                graphics.BindCubemapRenderTarget(specularTarget, (CubemapFace)face, mip);
+                device.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
+
+                device.UniformMatrix4(viewLoc, captureViews[face]);
+
+                device.BindVertexArray(cubeVao);
+                device.DrawArrays(PrimitiveType.Triangles, 0, 36);
+            }
+        }
+
+        graphics.UnbindRenderTarget();
+
+        // Get the cubemap texture handle and clean up render target
+        var textureHandle = graphics.GetCubemapRenderTargetTexture(specularTarget);
+        graphics.DeleteCubemapRenderTargetKeepTexture(specularTarget);
+
+        return textureHandle;
+    }
+
+    private TextureHandle GenerateBrdfLut(int size)
+    {
+        // Create 2D render target for BRDF LUT (RG16F format)
+        var brdfTarget = graphics.CreateRenderTarget(size, size, RenderTargetFormat.RGBA16FDepth24);
+
+        graphics.BindRenderTarget(brdfTarget);
+        device.Viewport(0, 0, (uint)size, (uint)size);
+        device.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
+
+        device.UseProgram(brdfLutProgram);
+
+        device.BindVertexArray(quadVao);
+        device.DrawArrays(PrimitiveType.Triangles, 0, 6);
+
+        graphics.UnbindRenderTarget();
+
+        // Get the color texture from the render target
+        var textureHandle = graphics.GetRenderTargetColorTexture(brdfTarget);
+        graphics.DeleteRenderTargetKeepTexture(brdfTarget);
+
+        return textureHandle;
+    }
+
+    private static Matrix4x4[] GetCubemapViewMatrices()
+    {
+        // View matrices for each cubemap face
+        return
+        [
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(1, 0, 0), new Vector3(0, -1, 0)),   // +X
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(-1, 0, 0), new Vector3(0, -1, 0)),  // -X
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(0, 1, 0), new Vector3(0, 0, 1)),    // +Y
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(0, -1, 0), new Vector3(0, 0, -1)),  // -Y
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(0, 0, 1), new Vector3(0, -1, 0)),   // +Z
+            Matrix4x4.CreateLookAt(Vector3.Zero, new Vector3(0, 0, -1), new Vector3(0, -1, 0))   // -Z
+        ];
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // Delete all IBL data
+        foreach (var id in iblDataStore.Keys.ToList())
+        {
+            DeleteIblData(id);
+        }
+
+        // Delete shared BRDF LUT
+        if (sharedBrdfLut.IsValid)
+        {
+            graphics.DeleteTexture(sharedBrdfLut);
+            sharedBrdfLut = TextureHandle.Invalid;
+        }
+
+        // Delete meshes
+        if (meshesInitialized)
+        {
+            device.DeleteVertexArray(cubeVao);
+            device.DeleteBuffer(cubeVbo);
+            device.DeleteVertexArray(quadVao);
+            device.DeleteBuffer(quadVbo);
+        }
+
+        // Delete shaders
+        if (equirectToCubemapProgram != 0)
+        {
+            device.DeleteProgram(equirectToCubemapProgram);
+        }
+
+        if (irradianceProgram != 0)
+        {
+            device.DeleteProgram(irradianceProgram);
+        }
+
+        if (specularPrefilterProgram != 0)
+        {
+            device.DeleteProgram(specularPrefilterProgram);
+        }
+
+        if (brdfLutProgram != 0)
+        {
+            device.DeleteProgram(brdfLutProgram);
+        }
+    }
+}

--- a/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
+++ b/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
@@ -376,6 +376,42 @@ internal sealed class RenderTargetManager(IGraphicsDevice device) : IDisposable
         cubemapRenderTargets.Remove(target.Id);
     }
 
+    /// <summary>
+    /// Deletes a render target but keeps the color texture for continued use.
+    /// </summary>
+    public void DeleteRenderTargetKeepTexture(RenderTargetHandle target)
+    {
+        if (!target.IsValid || !renderTargets.TryGetValue(target.Id, out var data))
+        {
+            return;
+        }
+
+        device.DeleteFramebuffer(data.FramebufferId);
+        // Keep the color texture, but delete the depth texture
+        device.DeleteTexture(data.DepthTextureId);
+        renderTargets.Remove(target.Id);
+    }
+
+    /// <summary>
+    /// Deletes a cubemap render target but keeps the cubemap texture for continued use.
+    /// </summary>
+    public void DeleteCubemapRenderTargetKeepTexture(CubemapRenderTargetHandle target)
+    {
+        if (!target.IsValid || !cubemapRenderTargets.TryGetValue(target.Id, out var data))
+        {
+            return;
+        }
+
+        device.DeleteFramebuffer(data.FramebufferId);
+        // Keep the cubemap texture
+        if (data.DepthRenderbufferId != 0)
+        {
+            device.DeleteRenderbuffer(data.DepthRenderbufferId);
+        }
+
+        cubemapRenderTargets.Remove(target.Id);
+    }
+
     private uint CreateColorTexture(int width, int height, RenderTargetFormat format)
     {
         var texture = device.GenTexture();

--- a/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
+++ b/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
@@ -327,6 +327,34 @@ internal sealed class TextureManager : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Registers an externally created GPU texture for management.
+    /// </summary>
+    /// <remarks>
+    /// Use this to register textures created outside the TextureManager
+    /// (e.g., HDR textures, render target textures) so they can be
+    /// tracked and disposed properly.
+    /// </remarks>
+    /// <param name="gpuHandle">The GPU texture handle.</param>
+    /// <param name="width">The texture width.</param>
+    /// <param name="height">The texture height.</param>
+    /// <returns>The texture resource handle.</returns>
+    public int RegisterExternalTexture(uint gpuHandle, int width, int height)
+    {
+        var textureData = new TextureData
+        {
+            Handle = gpuHandle,
+            Width = width,
+            Height = height,
+            HasAlpha = true,
+            DeleteAction = DeleteTextureData
+        };
+
+        int id = nextTextureId++;
+        textures[id] = textureData;
+        return id;
+    }
+
     private void DeleteTextureData(TextureData data)
     {
         Device?.DeleteTexture(data.Handle);

--- a/src/KeenEyes.Graphics.Silk/Shaders/IblShaders.cs
+++ b/src/KeenEyes.Graphics.Silk/Shaders/IblShaders.cs
@@ -1,0 +1,422 @@
+namespace KeenEyes.Graphics.Silk.Shaders;
+
+/// <summary>
+/// Shaders for Image-Based Lighting (IBL) processing and rendering.
+/// </summary>
+internal static class IblShaders
+{
+    /// <summary>
+    /// Vertex shader for fullscreen quad rendering (used by IBL processing).
+    /// </summary>
+    public const string FullscreenQuadVertexShader = """
+        #version 330 core
+
+        layout (location = 0) in vec3 aPosition;
+        layout (location = 2) in vec2 aTexCoord;
+
+        out vec2 vTexCoord;
+
+        void main()
+        {
+            vTexCoord = aTexCoord;
+            gl_Position = vec4(aPosition.xy * 2.0 - 1.0, 0.0, 1.0);
+        }
+        """;
+
+    /// <summary>
+    /// Vertex shader for cubemap rendering (skybox and IBL processing).
+    /// </summary>
+    public const string CubemapVertexShader = """
+        #version 330 core
+
+        layout (location = 0) in vec3 aPosition;
+
+        uniform mat4 uProjection;
+        uniform mat4 uView;
+
+        out vec3 vLocalPos;
+
+        void main()
+        {
+            vLocalPos = aPosition;
+
+            // Remove translation from view matrix for skybox
+            mat4 rotView = mat4(mat3(uView));
+            vec4 clipPos = uProjection * rotView * vec4(aPosition, 1.0);
+
+            // Set z to w so depth is always 1.0 (far plane)
+            gl_Position = clipPos.xyww;
+        }
+        """;
+
+    /// <summary>
+    /// Fragment shader to convert equirectangular HDR map to cubemap.
+    /// </summary>
+    public const string EquirectToCubemapFragmentShader = """
+        #version 330 core
+
+        in vec3 vLocalPos;
+
+        uniform sampler2D uEquirectangularMap;
+
+        out vec4 FragColor;
+
+        const vec2 invAtan = vec2(0.1591, 0.3183); // 1/(2*PI), 1/PI
+
+        vec2 sampleSphericalMap(vec3 v)
+        {
+            vec2 uv = vec2(atan(v.z, v.x), asin(v.y));
+            uv *= invAtan;
+            uv += 0.5;
+            return uv;
+        }
+
+        void main()
+        {
+            vec2 uv = sampleSphericalMap(normalize(vLocalPos));
+            vec3 color = texture(uEquirectangularMap, uv).rgb;
+            FragColor = vec4(color, 1.0);
+        }
+        """;
+
+    /// <summary>
+    /// Fragment shader for irradiance convolution (diffuse IBL).
+    /// </summary>
+    /// <remarks>
+    /// Convolves the environment map to compute the irradiance for each direction.
+    /// This is used for diffuse ambient lighting.
+    /// </remarks>
+    public const string IrradianceConvolutionFragmentShader = """
+        #version 330 core
+
+        in vec3 vLocalPos;
+
+        uniform samplerCube uEnvironmentMap;
+
+        out vec4 FragColor;
+
+        const float PI = 3.14159265359;
+
+        void main()
+        {
+            // The sample direction equals the hemisphere's orientation
+            vec3 N = normalize(vLocalPos);
+
+            vec3 irradiance = vec3(0.0);
+
+            // Tangent space calculation from normal
+            vec3 up = vec3(0.0, 1.0, 0.0);
+            vec3 right = normalize(cross(up, N));
+            up = normalize(cross(N, right));
+
+            float sampleDelta = 0.025;
+            float nrSamples = 0.0;
+
+            // Hemisphere integration
+            for (float phi = 0.0; phi < 2.0 * PI; phi += sampleDelta)
+            {
+                for (float theta = 0.0; theta < 0.5 * PI; theta += sampleDelta)
+                {
+                    // Spherical to cartesian (in tangent space)
+                    vec3 tangentSample = vec3(
+                        sin(theta) * cos(phi),
+                        sin(theta) * sin(phi),
+                        cos(theta)
+                    );
+
+                    // Tangent space to world
+                    vec3 sampleVec = tangentSample.x * right +
+                                     tangentSample.y * up +
+                                     tangentSample.z * N;
+
+                    irradiance += texture(uEnvironmentMap, sampleVec).rgb *
+                                  cos(theta) * sin(theta);
+                    nrSamples++;
+                }
+            }
+
+            irradiance = PI * irradiance * (1.0 / nrSamples);
+
+            FragColor = vec4(irradiance, 1.0);
+        }
+        """;
+
+    /// <summary>
+    /// Fragment shader for specular pre-filtering (GGX importance sampling).
+    /// </summary>
+    /// <remarks>
+    /// Pre-filters the environment map for different roughness levels using
+    /// importance sampling based on the GGX distribution.
+    /// </remarks>
+    public const string SpecularPrefilterFragmentShader = """
+        #version 330 core
+
+        in vec3 vLocalPos;
+
+        uniform samplerCube uEnvironmentMap;
+        uniform float uRoughness;
+        uniform int uSampleCount;
+
+        out vec4 FragColor;
+
+        const float PI = 3.14159265359;
+
+        // Van der Corput sequence for quasi-random sampling
+        float radicalInverse_VdC(uint bits)
+        {
+            bits = (bits << 16u) | (bits >> 16u);
+            bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+            bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+            bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+            bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+            return float(bits) * 2.3283064365386963e-10; // 1 / 0x100000000
+        }
+
+        vec2 hammersley(uint i, uint N)
+        {
+            return vec2(float(i) / float(N), radicalInverse_VdC(i));
+        }
+
+        // GGX importance sampling
+        vec3 importanceSampleGGX(vec2 Xi, vec3 N, float roughness)
+        {
+            float a = roughness * roughness;
+
+            float phi = 2.0 * PI * Xi.x;
+            float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+            float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+
+            // Spherical to cartesian
+            vec3 H;
+            H.x = cos(phi) * sinTheta;
+            H.y = sin(phi) * sinTheta;
+            H.z = cosTheta;
+
+            // Tangent-space to world-space
+            vec3 up = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+            vec3 tangent = normalize(cross(up, N));
+            vec3 bitangent = cross(N, tangent);
+
+            vec3 sampleVec = tangent * H.x + bitangent * H.y + N * H.z;
+            return normalize(sampleVec);
+        }
+
+        // GGX distribution
+        float distributionGGX(vec3 N, vec3 H, float roughness)
+        {
+            float a = roughness * roughness;
+            float a2 = a * a;
+            float NdotH = max(dot(N, H), 0.0);
+            float NdotH2 = NdotH * NdotH;
+
+            float nom = a2;
+            float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+            denom = PI * denom * denom;
+
+            return nom / max(denom, 0.0001);
+        }
+
+        void main()
+        {
+            vec3 N = normalize(vLocalPos);
+            vec3 R = N;
+            vec3 V = R;
+
+            float totalWeight = 0.0;
+            vec3 prefilteredColor = vec3(0.0);
+
+            uint sampleCount = uint(uSampleCount);
+
+            for (uint i = 0u; i < sampleCount; ++i)
+            {
+                vec2 Xi = hammersley(i, sampleCount);
+                vec3 H = importanceSampleGGX(Xi, N, uRoughness);
+                vec3 L = normalize(2.0 * dot(V, H) * H - V);
+
+                float NdotL = max(dot(N, L), 0.0);
+                if (NdotL > 0.0)
+                {
+                    // Sample from mip level based on roughness/pdf
+                    float D = distributionGGX(N, H, uRoughness);
+                    float NdotH = max(dot(N, H), 0.0);
+                    float HdotV = max(dot(H, V), 0.0);
+                    float pdf = D * NdotH / (4.0 * HdotV) + 0.0001;
+
+                    float resolution = float(textureSize(uEnvironmentMap, 0).x);
+                    float saTexel = 4.0 * PI / (6.0 * resolution * resolution);
+                    float saSample = 1.0 / (float(sampleCount) * pdf + 0.0001);
+                    float mipLevel = uRoughness == 0.0 ? 0.0 : 0.5 * log2(saSample / saTexel);
+
+                    prefilteredColor += textureLod(uEnvironmentMap, L, mipLevel).rgb * NdotL;
+                    totalWeight += NdotL;
+                }
+            }
+
+            prefilteredColor = prefilteredColor / max(totalWeight, 0.0001);
+
+            FragColor = vec4(prefilteredColor, 1.0);
+        }
+        """;
+
+    /// <summary>
+    /// Fragment shader for BRDF lookup table generation.
+    /// </summary>
+    /// <remarks>
+    /// Generates a 2D LUT storing the scale and bias for the Fresnel term
+    /// indexed by (NdotV, roughness).
+    /// </remarks>
+    public const string BrdfLutFragmentShader = """
+        #version 330 core
+
+        in vec2 vTexCoord;
+
+        out vec2 FragColor;
+
+        const float PI = 3.14159265359;
+
+        float radicalInverse_VdC(uint bits)
+        {
+            bits = (bits << 16u) | (bits >> 16u);
+            bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+            bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+            bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+            bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+            return float(bits) * 2.3283064365386963e-10;
+        }
+
+        vec2 hammersley(uint i, uint N)
+        {
+            return vec2(float(i) / float(N), radicalInverse_VdC(i));
+        }
+
+        vec3 importanceSampleGGX(vec2 Xi, vec3 N, float roughness)
+        {
+            float a = roughness * roughness;
+
+            float phi = 2.0 * PI * Xi.x;
+            float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+            float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+
+            vec3 H;
+            H.x = cos(phi) * sinTheta;
+            H.y = sin(phi) * sinTheta;
+            H.z = cosTheta;
+
+            vec3 up = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+            vec3 tangent = normalize(cross(up, N));
+            vec3 bitangent = cross(N, tangent);
+
+            vec3 sampleVec = tangent * H.x + bitangent * H.y + N * H.z;
+            return normalize(sampleVec);
+        }
+
+        float geometrySchlickGGX(float NdotV, float roughness)
+        {
+            float a = roughness;
+            float k = (a * a) / 2.0;
+
+            float nom = NdotV;
+            float denom = NdotV * (1.0 - k) + k;
+
+            return nom / max(denom, 0.0001);
+        }
+
+        float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
+        {
+            float NdotV = max(dot(N, V), 0.0);
+            float NdotL = max(dot(N, L), 0.0);
+            float ggx2 = geometrySchlickGGX(NdotV, roughness);
+            float ggx1 = geometrySchlickGGX(NdotL, roughness);
+
+            return ggx1 * ggx2;
+        }
+
+        vec2 integrateBRDF(float NdotV, float roughness)
+        {
+            vec3 V;
+            V.x = sqrt(1.0 - NdotV * NdotV);
+            V.y = 0.0;
+            V.z = NdotV;
+
+            float A = 0.0;
+            float B = 0.0;
+
+            vec3 N = vec3(0.0, 0.0, 1.0);
+
+            const uint SAMPLE_COUNT = 1024u;
+            for (uint i = 0u; i < SAMPLE_COUNT; ++i)
+            {
+                vec2 Xi = hammersley(i, SAMPLE_COUNT);
+                vec3 H = importanceSampleGGX(Xi, N, roughness);
+                vec3 L = normalize(2.0 * dot(V, H) * H - V);
+
+                float NdotL = max(L.z, 0.0);
+                float NdotH = max(H.z, 0.0);
+                float VdotH = max(dot(V, H), 0.0);
+
+                if (NdotL > 0.0)
+                {
+                    float G = geometrySmith(N, V, L, roughness);
+                    float G_Vis = (G * VdotH) / max(NdotH * NdotV, 0.0001);
+                    float Fc = pow(1.0 - VdotH, 5.0);
+
+                    A += (1.0 - Fc) * G_Vis;
+                    B += Fc * G_Vis;
+                }
+            }
+
+            A /= float(SAMPLE_COUNT);
+            B /= float(SAMPLE_COUNT);
+
+            return vec2(A, B);
+        }
+
+        void main()
+        {
+            vec2 integratedBRDF = integrateBRDF(vTexCoord.x, vTexCoord.y);
+            FragColor = integratedBRDF;
+        }
+        """;
+
+    /// <summary>
+    /// Skybox fragment shader for rendering the environment as a background.
+    /// </summary>
+    public const string SkyboxFragmentShader = """
+        #version 330 core
+
+        in vec3 vLocalPos;
+
+        uniform samplerCube uEnvironmentMap;
+        uniform float uExposure;
+        uniform float uMipLevel;
+        uniform float uRotation; // Y-axis rotation in radians
+
+        out vec4 FragColor;
+
+        void main()
+        {
+            // Apply rotation around Y axis
+            float cosR = cos(uRotation);
+            float sinR = sin(uRotation);
+            vec3 dir = normalize(vLocalPos);
+            dir = vec3(
+                dir.x * cosR + dir.z * sinR,
+                dir.y,
+                -dir.x * sinR + dir.z * cosR
+            );
+
+            vec3 color = textureLod(uEnvironmentMap, dir, uMipLevel).rgb;
+
+            // Apply exposure
+            color *= uExposure;
+
+            // Tone mapping (Reinhard)
+            color = color / (color + vec3(1.0));
+
+            // Gamma correction
+            color = pow(color, vec3(1.0 / 2.2));
+
+            FragColor = vec4(color, 1.0);
+        }
+        """;
+}

--- a/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
@@ -295,6 +295,7 @@ file sealed class MockGraphicsContext : IGraphicsContext
     public ShaderHandle SolidShader => new(3);
     public ShaderHandle PbrShader => new(4);
     public ShaderHandle PbrShadowShader => new(8);
+    public ShaderHandle PbrIblShader => new(9);
     public TextureHandle WhiteTexture => new(1);
     public ShaderHandle InstancedLitShader => new(5);
     public ShaderHandle InstancedUnlitShader => new(6);
@@ -314,10 +315,13 @@ file sealed class MockGraphicsContext : IGraphicsContext
 
     // Texture operations
     public TextureHandle CreateTexture(int width, int height, ReadOnlySpan<byte> pixels) => new(1);
+    public TextureHandle CreateHdrTexture(int width, int height, ReadOnlySpan<float> pixels) => new(1, width, height);
     public TextureHandle CreateCompressedTexture(int width, int height, CompressedTextureFormat format, ReadOnlySpan<ReadOnlyMemory<byte>> mipmaps) => new(1, width, height);
     public TextureHandle LoadTexture(string path) => new(1);
     public void DeleteTexture(TextureHandle handle) => DisposedTextures.Add(handle);
     public void BindTexture(TextureHandle handle, int unit = 0) { }
+    public void BindCubemapTexture(TextureHandle handle, int unit) { }
+    public void DeleteCubemapTexture(TextureHandle handle) { }
 
     // Shader operations
     public ShaderHandle CreateShader(string vertexSource, string fragmentSource) => new(1);
@@ -355,7 +359,9 @@ file sealed class MockGraphicsContext : IGraphicsContext
     public TextureHandle GetRenderTargetDepthTexture(RenderTargetHandle target) => new(101, target.Width, target.Height);
     public TextureHandle GetCubemapRenderTargetTexture(CubemapRenderTargetHandle target) => new(102, target.Size, target.Size);
     public void DeleteRenderTarget(RenderTargetHandle target) { }
+    public void DeleteRenderTargetKeepTexture(RenderTargetHandle target) { }
     public void DeleteCubemapRenderTarget(CubemapRenderTargetHandle target) { }
+    public void DeleteCubemapRenderTargetKeepTexture(CubemapRenderTargetHandle target) { }
 
     public void Dispose() { }
 }

--- a/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
+++ b/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
@@ -128,6 +128,11 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
         Calls.Add($"BufferData({target}, {data.Length} bytes, {usage})");
     }
 
+    public void BufferData(BufferTarget target, ReadOnlySpan<float> data, BufferUsage usage)
+    {
+        Calls.Add($"BufferData({target}, {data.Length * sizeof(float)} bytes (float), {usage})");
+    }
+
     public void DeleteVertexArray(uint vao)
     {
         DeletedVAOs.Add(vao);
@@ -180,6 +185,11 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     public void TexImage2D(TextureTarget target, int level, int width, int height, PixelFormat format, ReadOnlySpan<byte> data)
     {
         Calls.Add($"TexImage2D({target}, {level}, {width}x{height}, {format}, {data.Length} bytes)");
+    }
+
+    public void TexImage2D(TextureTarget target, int level, int width, int height, PixelFormat format, ReadOnlySpan<float> data)
+    {
+        Calls.Add($"TexImage2D({target}, {level}, {width}x{height}, {format}, {data.Length * sizeof(float)} bytes (float))");
     }
 
     public void TexSubImage2D(TextureTarget target, int level, int xOffset, int yOffset, int width, int height, PixelFormat format, ReadOnlySpan<byte> data)


### PR DESCRIPTION
## Summary

This PR implements two major lighting features for the graphics system:

**Shadow Mapping with Cascaded Shadow Maps (CSM)** (#897):
- Depth-only shadow map rendering for directional lights
- Cascaded Shadow Maps with configurable cascade count (1-4)
- PCF (Percentage Closer Filtering) for soft shadow edges
- Shadow bias and cascade split configuration
- Integration with PBR shader for shadow sampling

**Image-Based Lighting (IBL)** (#896):
- Environment component for scene-wide lighting settings
- HDR environment map loading and processing
- Irradiance map generation via cubemap convolution
- Specular pre-filtering with importance sampling
- BRDF lookup table generation (split-sum approximation)
- PBR+IBL shader variant with full environment lighting
- Environment rotation and intensity controls

**Shared Foundation**:
- Render target abstraction for off-screen rendering
- Cubemap render target support with mipmap levels
- HDR texture creation and binding
- Float buffer/texture upload support

## Test plan

- [x] All 13,358 unit tests pass
- [x] Build succeeds with 0 warnings
- [x] Code formatted per .editorconfig

## Related Issues

Closes #896
Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)