### PR TITLE
fix: Address nightly code review issues (#932, #919, #894)

### DIFF
--- a/editor/KeenEyes.Generators/AttributeUsageAnalyzer.cs
+++ b/editor/KeenEyes.Generators/AttributeUsageAnalyzer.cs
@@ -1,0 +1,259 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace KeenEyes.Generators;
+
+/// <summary>
+/// Roslyn analyzer that validates [Component], [TagComponent], [System], and [Query] attribute usage.
+/// Reports compile-time errors when these attributes are applied to incorrect type kinds or non-partial types.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
+{
+    private const string ComponentAttribute = "KeenEyes.ComponentAttribute";
+    private const string TagComponentAttribute = "KeenEyes.TagComponentAttribute";
+    private const string SystemAttribute = "KeenEyes.SystemAttribute";
+    private const string QueryAttribute = "KeenEyes.QueryAttribute";
+
+    #region System Diagnostics (KEEN007-008)
+
+    /// <summary>
+    /// KEEN007: [System] must be applied to a class.
+    /// </summary>
+    public static readonly DiagnosticDescriptor SystemMustBeClass = new(
+        id: "KEEN007",
+        title: "System must be a class",
+        messageFormat: "Type '{0}' is marked with [System] but is not a class",
+        category: "KeenEyes.System",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [System] attribute can only be applied to class types. Systems must be classes that inherit from SystemBase or implement ISystem.");
+
+    /// <summary>
+    /// KEEN008: [System] class must be partial.
+    /// </summary>
+    public static readonly DiagnosticDescriptor SystemMustBePartial = new(
+        id: "KEEN008",
+        title: "System must be partial",
+        messageFormat: "System class '{0}' must be declared with 'partial' modifier",
+        category: "KeenEyes.System",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "System classes must be declared as 'partial' to allow source generators to augment them with metadata properties.");
+
+    #endregion
+
+    #region Component Diagnostics (KEEN015-016)
+
+    /// <summary>
+    /// KEEN015: [Component] or [TagComponent] must be applied to a struct.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComponentMustBeStruct = new(
+        id: "KEEN015",
+        title: "Component must be a struct",
+        messageFormat: "Type '{0}' is marked with [{1}] but is not a struct",
+        category: "KeenEyes.Component",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [Component] and [TagComponent] attributes can only be applied to struct types. Components must be value types for cache efficiency.");
+
+    /// <summary>
+    /// KEEN016: Component struct must be partial.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComponentMustBePartial = new(
+        id: "KEEN016",
+        title: "Component must be partial",
+        messageFormat: "Component struct '{0}' must be declared with 'partial' modifier",
+        category: "KeenEyes.Component",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Component structs must be declared as 'partial' to allow source generators to implement the IComponent interface.");
+
+    #endregion
+
+    #region Query Diagnostics (KEEN052-054)
+
+    /// <summary>
+    /// KEEN052: [Query] must be applied to a struct.
+    /// </summary>
+    public static readonly DiagnosticDescriptor QueryMustBeStruct = new(
+        id: "KEEN052",
+        title: "Query must be a struct",
+        messageFormat: "Type '{0}' is marked with [Query] but is not a struct",
+        category: "KeenEyes.Query",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [Query] attribute can only be applied to struct types. Queries must be value types to avoid heap allocations.");
+
+    /// <summary>
+    /// KEEN053: Query struct must be partial.
+    /// </summary>
+    public static readonly DiagnosticDescriptor QueryMustBePartial = new(
+        id: "KEEN053",
+        title: "Query must be partial",
+        messageFormat: "Query struct '{0}' must be declared with 'partial' modifier",
+        category: "KeenEyes.Query",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Query structs must be declared as 'partial' to allow source generators to implement the query iterator.");
+
+    #endregion
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            SystemMustBeClass,
+            SystemMustBePartial,
+            ComponentMustBeStruct,
+            ComponentMustBePartial,
+            QueryMustBeStruct,
+            QueryMustBePartial);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        foreach (var attribute in typeSymbol.GetAttributes())
+        {
+            var attributeName = attribute.AttributeClass?.ToDisplayString();
+
+            if (attributeName == ComponentAttribute || attributeName == TagComponentAttribute)
+            {
+                AnalyzeComponentAttribute(context, typeSymbol, attributeName);
+            }
+            else if (attributeName == SystemAttribute)
+            {
+                AnalyzeSystemAttribute(context, typeSymbol);
+            }
+            else if (attributeName == QueryAttribute)
+            {
+                AnalyzeQueryAttribute(context, typeSymbol);
+            }
+        }
+    }
+
+    private static void AnalyzeComponentAttribute(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol typeSymbol,
+        string attributeName)
+    {
+        var location = typeSymbol.Locations.FirstOrDefault();
+        if (location == null)
+        {
+            return;
+        }
+
+        // Extract short attribute name for message
+        var shortName = attributeName.EndsWith("Attribute")
+            ? attributeName.Substring(attributeName.LastIndexOf('.') + 1).Replace("Attribute", "")
+            : attributeName;
+
+        // KEEN015: Check if it's a struct
+        if (typeSymbol.TypeKind != TypeKind.Struct)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ComponentMustBeStruct,
+                location,
+                typeSymbol.Name,
+                shortName));
+            return;
+        }
+
+        // KEEN016: Check if it's partial
+        if (!IsPartialType(typeSymbol))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ComponentMustBePartial,
+                location,
+                typeSymbol.Name));
+        }
+    }
+
+    private static void AnalyzeSystemAttribute(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol typeSymbol)
+    {
+        var location = typeSymbol.Locations.FirstOrDefault();
+        if (location == null)
+        {
+            return;
+        }
+
+        // KEEN007: Check if it's a class
+        if (typeSymbol.TypeKind != TypeKind.Class)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                SystemMustBeClass,
+                location,
+                typeSymbol.Name));
+            return;
+        }
+
+        // KEEN008: Check if it's partial
+        if (!IsPartialType(typeSymbol))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                SystemMustBePartial,
+                location,
+                typeSymbol.Name));
+        }
+    }
+
+    private static void AnalyzeQueryAttribute(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol typeSymbol)
+    {
+        var location = typeSymbol.Locations.FirstOrDefault();
+        if (location == null)
+        {
+            return;
+        }
+
+        // KEEN052: Check if it's a struct
+        if (typeSymbol.TypeKind != TypeKind.Struct)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                QueryMustBeStruct,
+                location,
+                typeSymbol.Name));
+            return;
+        }
+
+        // KEEN053: Check if it's partial
+        if (!IsPartialType(typeSymbol))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                QueryMustBePartial,
+                location,
+                typeSymbol.Name));
+        }
+    }
+
+    private static bool IsPartialType(INamedTypeSymbol typeSymbol)
+    {
+        // Check if any declaration has the partial modifier
+        foreach (var syntaxRef in typeSymbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl &&
+                typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/editor/KeenEyes.Generators/DiagnosticIds.cs
+++ b/editor/KeenEyes.Generators/DiagnosticIds.cs
@@ -19,11 +19,11 @@ namespace KeenEyes.Generators;
 /// </listheader>
 /// <item>
 /// <term>KEEN001-KEEN009</term>
-/// <description>System ordering and execution (SystemOrderingAnalyzer, PluginExtensionGenerator)</description>
+/// <description>System ordering and execution (SystemOrderingAnalyzer, PluginExtensionGenerator, AttributeUsageAnalyzer)</description>
 /// </item>
 /// <item>
 /// <term>KEEN010-KEEN019</term>
-/// <description>Component validation constraints (ComponentValidationAnalyzer)</description>
+/// <description>Component validation constraints (ComponentValidationAnalyzer, AttributeUsageAnalyzer)</description>
 /// </item>
 /// <item>
 /// <term>KEEN020-KEEN025</term>
@@ -43,7 +43,7 @@ namespace KeenEyes.Generators;
 /// </item>
 /// <item>
 /// <term>KEEN050-KEEN059</term>
-/// <description>Query validation (IWorldCastAnalyzer, QueryGenerator)</description>
+/// <description>Query validation (IWorldCastAnalyzer, QueryGenerator, AttributeUsageAnalyzer)</description>
 /// </item>
 /// <item>
 /// <term>KEEN060-KEEN069</term>

--- a/editor/KeenEyes.Generators/SerializationGenerator.cs
+++ b/editor/KeenEyes.Generators/SerializationGenerator.cs
@@ -101,7 +101,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
                 continue;
             }
 
-            var isNullable = field.Type.NullableAnnotation == NullableAnnotation.Annotated;
+            var isNullable = IsNullableType(field.Type);
 
             // Extract [DefaultValue] attribute if present
             string? defaultValueLiteral = null;
@@ -182,6 +182,27 @@ public sealed class SerializationGenerator : IIncrementalGenerator
             "string" or "System.String" => "String",
             _ => "Object" // For complex types, use generic deserialization
         };
+    }
+
+    /// <summary>
+    /// Checks if a type is nullable (either nullable reference type or Nullable&lt;T&gt; value type).
+    /// </summary>
+    private static bool IsNullableType(ITypeSymbol type)
+    {
+        // Check for nullable reference types (string?)
+        if (type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return true;
+        }
+
+        // Check for Nullable<T> value types (int?)
+        if (type is INamedTypeSymbol namedType &&
+            namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static string? GetCSharpLiteral(object? value, ITypeSymbol targetType)

--- a/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
@@ -155,17 +155,17 @@ public sealed class ArchetypeChunk : IDisposable
             swappedEntity = lastEntity;
 
             // Swap all component arrays
-            foreach (var array in componentArrays.Values)
+            foreach (var kvp in componentArrays)
             {
-                array.RemoveAtSwapBack(index);
+                kvp.Value.RemoveAtSwapBack(index);
             }
         }
         else
         {
             // Just remove the last element
-            foreach (var array in componentArrays.Values)
+            foreach (var kvp in componentArrays)
             {
-                array.RemoveAtSwapBack(index);
+                kvp.Value.RemoveAtSwapBack(index);
             }
         }
 
@@ -319,9 +319,9 @@ public sealed class ArchetypeChunk : IDisposable
         Array.Clear(entities, 0, count);
         entityIdToIndex.Clear();
 
-        foreach (var array in componentArrays.Values)
+        foreach (var kvp in componentArrays)
         {
-            array.Clear();
+            kvp.Value.Clear();
         }
 
         count = 0;
@@ -341,9 +341,9 @@ public sealed class ArchetypeChunk : IDisposable
             return;
         }
 
-        foreach (var array in componentArrays.Values)
+        foreach (var kvp in componentArrays)
         {
-            if (array is IDisposable disposable)
+            if (kvp.Value is IDisposable disposable)
             {
                 disposable.Dispose();
             }

--- a/src/KeenEyes.Core/Queries/QueryBuilder.cs
+++ b/src/KeenEyes.Core/Queries/QueryBuilder.cs
@@ -49,7 +49,21 @@ public sealed class QueryDescription
         {
             if (allRequiredCache is null)
             {
-                allRequiredCache = read.Concat(write).Concat(with).Distinct().ToImmutableArray();
+                // Avoid LINQ allocations by using HashSet directly
+                var hashSet = new HashSet<Type>();
+                foreach (var t in read)
+                {
+                    hashSet.Add(t);
+                }
+                foreach (var t in write)
+                {
+                    hashSet.Add(t);
+                }
+                foreach (var t in with)
+                {
+                    hashSet.Add(t);
+                }
+                allRequiredCache = [.. hashSet];
             }
             return allRequiredCache.Value;
         }

--- a/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
@@ -21,14 +21,28 @@ namespace KeenEyes.UI;
 /// </remarks>
 public sealed class UIColorPickerSystem : SystemBase
 {
-    /// <inheritdoc />
-    public override void Initialize(IWorld world)
-    {
-        base.Initialize(world);
+    private EventSubscription? dragSubscription;
+    private EventSubscription? clickSubscription;
 
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
         // Subscribe to drag events for saturation-value area
-        world.Subscribe<UIDragEvent>(OnDrag);
-        world.Subscribe<UIClickEvent>(OnClick);
+        dragSubscription = World.Subscribe<UIDragEvent>(OnDrag);
+        clickSubscription = World.Subscribe<UIClickEvent>(OnClick);
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            dragSubscription?.Dispose();
+            clickSubscription?.Dispose();
+            dragSubscription = null;
+            clickSubscription = null;
+        }
+        base.Dispose(disposing);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.UI/Systems/UIDataGridSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIDataGridSystem.cs
@@ -18,22 +18,48 @@ namespace KeenEyes.UI;
 /// </remarks>
 public sealed class UIDataGridSystem : SystemBase
 {
-    /// <inheritdoc />
-    public override void Initialize(IWorld world)
-    {
-        base.Initialize(world);
+    private EventSubscription? clickSubscription;
+    private EventSubscription? dragStartSubscription;
+    private EventSubscription? dragSubscription;
+    private EventSubscription? dragEndSubscription;
+    private EventSubscription? pointerEnterSubscription;
+    private EventSubscription? pointerExitSubscription;
 
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
         // Subscribe to click events for header and row clicks
-        world.Subscribe<UIClickEvent>(OnClick);
+        clickSubscription = World.Subscribe<UIClickEvent>(OnClick);
 
         // Subscribe to drag events for column resizing
-        world.Subscribe<UIDragStartEvent>(OnDragStart);
-        world.Subscribe<UIDragEvent>(OnDrag);
-        world.Subscribe<UIDragEndEvent>(OnDragEnd);
+        dragStartSubscription = World.Subscribe<UIDragStartEvent>(OnDragStart);
+        dragSubscription = World.Subscribe<UIDragEvent>(OnDrag);
+        dragEndSubscription = World.Subscribe<UIDragEndEvent>(OnDragEnd);
 
         // Subscribe to hover events for row highlighting
-        world.Subscribe<UIPointerEnterEvent>(OnPointerEnter);
-        world.Subscribe<UIPointerExitEvent>(OnPointerExit);
+        pointerEnterSubscription = World.Subscribe<UIPointerEnterEvent>(OnPointerEnter);
+        pointerExitSubscription = World.Subscribe<UIPointerExitEvent>(OnPointerExit);
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            clickSubscription?.Dispose();
+            dragStartSubscription?.Dispose();
+            dragSubscription?.Dispose();
+            dragEndSubscription?.Dispose();
+            pointerEnterSubscription?.Dispose();
+            pointerExitSubscription?.Dispose();
+            clickSubscription = null;
+            dragStartSubscription = null;
+            dragSubscription = null;
+            dragEndSubscription = null;
+            pointerEnterSubscription = null;
+            pointerExitSubscription = null;
+        }
+        base.Dispose(disposing);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.UI/Systems/UIDatePickerSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIDatePickerSystem.cs
@@ -20,13 +20,24 @@ namespace KeenEyes.UI;
 /// </remarks>
 public sealed class UIDatePickerSystem : SystemBase
 {
-    /// <inheritdoc />
-    public override void Initialize(IWorld world)
-    {
-        base.Initialize(world);
+    private EventSubscription? clickSubscription;
 
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
         // Subscribe to click events for calendar days and navigation
-        world.Subscribe<UIClickEvent>(OnClick);
+        clickSubscription = World.Subscribe<UIClickEvent>(OnClick);
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            clickSubscription?.Dispose();
+            clickSubscription = null;
+        }
+        base.Dispose(disposing);
     }
 
     /// <inheritdoc />

--- a/tests/KeenEyes.Core.Tests/ExtensionTests.cs
+++ b/tests/KeenEyes.Core.Tests/ExtensionTests.cs
@@ -1,6 +1,34 @@
 namespace KeenEyes.Tests;
 
 /// <summary>
+/// Disposable extension for testing disposal behavior.
+/// </summary>
+public sealed class DisposableTestExtension : IDisposable
+{
+    public bool IsDisposed { get; private set; }
+    public int DisposeCount { get; private set; }
+
+    public void Dispose()
+    {
+        DisposeCount++;
+        IsDisposed = true;
+    }
+}
+
+/// <summary>
+/// Another disposable extension for testing multiple disposals.
+/// </summary>
+public sealed class DisposableTestExtension2 : IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose()
+    {
+        IsDisposed = true;
+    }
+}
+
+/// <summary>
 /// Tests for World extension API.
 /// </summary>
 public class WorldExtensionTests
@@ -137,6 +165,214 @@ public class WorldExtensionTests
         Assert.Equal(-9.81f, physics.Gravity);
         Assert.Equal(100, renderer.DrawCalls);
     }
+
+    #region Disposal Tests
+
+    [Fact]
+    public void SetExtension_WhenReplacing_DisposesOldExtension()
+    {
+        using var world = new World();
+        var original = new DisposableTestExtension();
+
+        world.SetExtension(original);
+        world.SetExtension(new DisposableTestExtension());
+
+        Assert.True(original.IsDisposed);
+        Assert.Equal(1, original.DisposeCount);
+    }
+
+    [Fact]
+    public void SetExtension_WhenReplacingNonDisposable_DoesNotThrow()
+    {
+        using var world = new World();
+        var original = new TestPhysicsWorld { Gravity = -9.81f };
+
+        world.SetExtension(original);
+
+        // Replacing a non-disposable extension should not throw
+        var exception = Record.Exception(() =>
+            world.SetExtension(new TestPhysicsWorld { Gravity = -10.0f }));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void RemoveExtension_WithDisposable_DisposesExtension()
+    {
+        using var world = new World();
+        var extension = new DisposableTestExtension();
+
+        world.SetExtension(extension);
+        world.RemoveExtension<DisposableTestExtension>();
+
+        Assert.True(extension.IsDisposed);
+        Assert.Equal(1, extension.DisposeCount);
+    }
+
+    [Fact]
+    public void RemoveExtension_WithNonDisposable_DoesNotThrow()
+    {
+        using var world = new World();
+        world.SetExtension(new TestPhysicsWorld());
+
+        var exception = Record.Exception(() =>
+            world.RemoveExtension<TestPhysicsWorld>());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void WorldDispose_WithDisposableExtensions_DisposesAll()
+    {
+        var extension1 = new DisposableTestExtension();
+        var extension2 = new DisposableTestExtension2();
+
+        var world = new World();
+        world.SetExtension(extension1);
+        world.SetExtension(extension2);
+
+        world.Dispose();
+
+        Assert.True(extension1.IsDisposed);
+        Assert.True(extension2.IsDisposed);
+    }
+
+    [Fact]
+    public void WorldDispose_WithMixedExtensions_DisposesOnlyDisposable()
+    {
+        var disposable = new DisposableTestExtension();
+        var nonDisposable = new TestPhysicsWorld();
+
+        var world = new World();
+        world.SetExtension(disposable);
+        world.SetExtension(nonDisposable);
+
+        // Should not throw and should dispose the disposable extension
+        var exception = Record.Exception(() => world.Dispose());
+
+        Assert.Null(exception);
+        Assert.True(disposable.IsDisposed);
+    }
+
+    [Fact]
+    public void SetExtension_ReplacingMultipleTimes_DisposesEachPrevious()
+    {
+        using var world = new World();
+        var first = new DisposableTestExtension();
+        var second = new DisposableTestExtension();
+        var third = new DisposableTestExtension();
+
+        world.SetExtension(first);
+        world.SetExtension(second);
+        world.SetExtension(third);
+
+        Assert.True(first.IsDisposed);
+        Assert.True(second.IsDisposed);
+        Assert.False(third.IsDisposed);
+    }
+
+    #endregion
+
+    #region Concurrent Access Tests
+
+    [Fact]
+    public void SetExtension_ConcurrentAccess_ThreadSafe()
+    {
+        using var world = new World();
+        const int iterations = 1000;
+        var exceptions = new List<Exception>();
+
+        Parallel.For(0, iterations, i =>
+        {
+            try
+            {
+                world.SetExtension(new TestPhysicsWorld { Gravity = -9.81f * i });
+            }
+            catch (Exception ex)
+            {
+                lock (exceptions)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+        });
+
+        Assert.Empty(exceptions);
+        Assert.True(world.HasExtension<TestPhysicsWorld>());
+    }
+
+    [Fact]
+    public void GetExtension_ConcurrentAccess_ThreadSafe()
+    {
+        using var world = new World();
+        world.SetExtension(new TestPhysicsWorld { Gravity = -9.81f });
+        const int iterations = 1000;
+        var exceptions = new List<Exception>();
+
+        Parallel.For(0, iterations, _ =>
+        {
+            try
+            {
+                var extension = world.GetExtension<TestPhysicsWorld>();
+                Assert.NotNull(extension);
+            }
+            catch (Exception ex)
+            {
+                lock (exceptions)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+        });
+
+        Assert.Empty(exceptions);
+    }
+
+    [Fact]
+    public void MixedExtensionOperations_ConcurrentAccess_ThreadSafe()
+    {
+        using var world = new World();
+        const int iterations = 100;
+        var exceptions = new List<Exception>();
+
+        // Start with an extension
+        world.SetExtension(new TestPhysicsWorld());
+
+        Parallel.For(0, iterations, i =>
+        {
+            try
+            {
+                switch (i % 4)
+                {
+                    case 0:
+                        world.SetExtension(new TestPhysicsWorld { Gravity = i });
+                        break;
+                    case 1:
+                        world.TryGetExtension<TestPhysicsWorld>(out _);
+                        break;
+                    case 2:
+                        world.HasExtension<TestPhysicsWorld>();
+                        break;
+                    case 3:
+                        // Set then remove
+                        world.SetExtension(new TestRenderer { DrawCalls = i });
+                        world.RemoveExtension<TestRenderer>();
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (exceptions)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+        });
+
+        Assert.Empty(exceptions);
+    }
+
+    #endregion
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Fix resource leaks in ExtensionManager (dispose IDisposable extensions on Clear/Remove/Replace)
- Fix event subscription leaks in UI systems (UIDatePickerSystem, UIColorPickerSystem, UIDataGridSystem)
- Add AttributeUsageAnalyzer for compile-time validation of [Component], [TagComponent], [System], and [Query] attributes
- Fix SerializationGenerator nullable type detection for both reference and value types
- Reduce LINQ allocations in QueryBuilder and ComponentDependencies hot paths
- Fix Dictionary.Values enumeration allocation in ArchetypeChunk
- Add comprehensive ExtensionManager tests for disposal behavior and thread safety

## Test plan
- [x] All 2320 Core tests pass
- [x] Build passes with zero warnings
- [x] Code formatted per .editorconfig

Note: 33 pre-existing test failures in AI.Tests and Navigation.Tests are unrelated to this PR (GridNavigationProvider disposal issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)