### PR TITLE
feat(kesl): Add texture and sampler support for vertex/fragment shaders

### DIFF
--- a/editor/KeenEyes.Graph.Kesl/Compiler/KeslGraphCompiler.cs
+++ b/editor/KeenEyes.Graph.Kesl/Compiler/KeslGraphCompiler.cs
@@ -133,6 +133,8 @@ public sealed class KeslGraphCompiler
             shaderData.ShaderName,
             inputBlock,
             outputBlock,
+            null, // Textures - not yet supported in graph editor
+            null, // Samplers - not yet supported in graph editor
             paramsBlock,
             executeBlock,
             GeneratedLocation);
@@ -177,6 +179,8 @@ public sealed class KeslGraphCompiler
             shaderData.ShaderName,
             inputBlock,
             outputBlock,
+            null, // Textures - not yet supported in graph editor
+            null, // Samplers - not yet supported in graph editor
             paramsBlock,
             executeBlock,
             GeneratedLocation);

--- a/editor/KeenEyes.Shaders.Compiler/Lexing/Lexer.cs
+++ b/editor/KeenEyes.Shaders.Compiler/Lexing/Lexer.cs
@@ -18,6 +18,12 @@ public sealed class Lexer
         ["execute"] = TokenKind.Execute,
         ["vertex"] = TokenKind.Vertex,
         ["fragment"] = TokenKind.Fragment,
+        ["geometry"] = TokenKind.Geometry,
+        ["pipeline"] = TokenKind.Pipeline,
+
+        // Texture/Sampler blocks
+        ["textures"] = TokenKind.Textures,
+        ["samplers"] = TokenKind.Samplers,
 
         // Shader I/O
         ["in"] = TokenKind.In,
@@ -46,6 +52,10 @@ public sealed class Lexer
         ["uint"] = TokenKind.Uint,
         ["bool"] = TokenKind.Bool,
         ["mat4"] = TokenKind.Mat4,
+        ["texture2D"] = TokenKind.Texture2D,
+        ["textureCube"] = TokenKind.TextureCube,
+        ["texture3D"] = TokenKind.Texture3D,
+        ["sampler"] = TokenKind.Sampler,
 
         // Literals
         ["true"] = TokenKind.True,

--- a/editor/KeenEyes.Shaders.Compiler/Lexing/TokenKind.cs
+++ b/editor/KeenEyes.Shaders.Compiler/Lexing/TokenKind.cs
@@ -21,6 +21,12 @@ public enum TokenKind
     Execute,
     Vertex,
     Fragment,
+    Geometry,
+    Pipeline,
+
+    // Keywords - Texture/Sampler blocks
+    Textures,
+    Samplers,
 
     // Keywords - Shader I/O
     In,
@@ -49,6 +55,10 @@ public enum TokenKind
     Uint,
     Bool,
     Mat4,
+    Texture2D,
+    TextureCube,
+    Texture3D,
+    Sampler,
 
     // Keywords - Literals
     True,

--- a/editor/KeenEyes.Shaders.Compiler/Parsing/Ast/AstNode.cs
+++ b/editor/KeenEyes.Shaders.Compiler/Parsing/Ast/AstNode.cs
@@ -57,12 +57,16 @@ public record ComputeDeclaration(
 /// <param name="Name">The shader name.</param>
 /// <param name="Inputs">The input attributes block.</param>
 /// <param name="Outputs">The output attributes block.</param>
+/// <param name="Textures">Optional textures block.</param>
+/// <param name="Samplers">Optional samplers block.</param>
 /// <param name="Params">Optional parameters block.</param>
 /// <param name="Execute">The execute block containing shader logic.</param>
 public record VertexDeclaration(
     string Name,
     InputBlock Inputs,
     OutputBlock Outputs,
+    TexturesBlock? Textures,
+    SamplersBlock? Samplers,
     ParamsBlock? Params,
     ExecuteBlock Execute,
     SourceLocation Location
@@ -74,12 +78,16 @@ public record VertexDeclaration(
 /// <param name="Name">The shader name.</param>
 /// <param name="Inputs">The input attributes block.</param>
 /// <param name="Outputs">The output attributes block.</param>
+/// <param name="Textures">Optional textures block.</param>
+/// <param name="Samplers">Optional samplers block.</param>
 /// <param name="Params">Optional parameters block.</param>
 /// <param name="Execute">The execute block containing shader logic.</param>
 public record FragmentDeclaration(
     string Name,
     InputBlock Inputs,
     OutputBlock Outputs,
+    TexturesBlock? Textures,
+    SamplersBlock? Samplers,
     ParamsBlock? Params,
     ExecuteBlock Execute,
     SourceLocation Location
@@ -185,3 +193,63 @@ public enum PrimitiveTypeKind
     Bool,
     Mat4
 }
+
+/// <summary>
+/// Represents the textures block of a vertex or fragment shader.
+/// </summary>
+/// <param name="Textures">The texture declarations.</param>
+public record TexturesBlock(IReadOnlyList<TextureDeclaration> Textures, SourceLocation Location) : AstNode(Location);
+
+/// <summary>
+/// A single texture declaration with binding slot.
+/// </summary>
+/// <param name="Name">The texture name.</param>
+/// <param name="TextureKind">The texture type (2D, Cube, 3D).</param>
+/// <param name="BindingSlot">The binding slot index.</param>
+public record TextureDeclaration(
+    string Name,
+    TextureKind TextureKind,
+    int BindingSlot,
+    SourceLocation Location
+) : AstNode(Location);
+
+/// <summary>
+/// The kinds of texture types in KESL.
+/// </summary>
+public enum TextureKind
+{
+    /// <summary>2D texture.</summary>
+    Texture2D,
+    /// <summary>Cube map texture.</summary>
+    TextureCube,
+    /// <summary>3D volume texture.</summary>
+    Texture3D
+}
+
+/// <summary>
+/// Represents the samplers block of a vertex or fragment shader.
+/// </summary>
+/// <param name="Samplers">The sampler declarations.</param>
+public record SamplersBlock(IReadOnlyList<SamplerDeclaration> Samplers, SourceLocation Location) : AstNode(Location);
+
+/// <summary>
+/// A single sampler declaration with binding slot.
+/// </summary>
+/// <param name="Name">The sampler name.</param>
+/// <param name="BindingSlot">The binding slot index.</param>
+public record SamplerDeclaration(
+    string Name,
+    int BindingSlot,
+    SourceLocation Location
+) : AstNode(Location);
+
+/// <summary>
+/// A texture type reference (texture2D, textureCube, texture3D).
+/// </summary>
+/// <param name="Kind">The texture type kind.</param>
+public record TextureType(TextureKind Kind, SourceLocation Location) : TypeRef(Location);
+
+/// <summary>
+/// A sampler type reference.
+/// </summary>
+public record SamplerType(SourceLocation Location) : TypeRef(Location);

--- a/tests/KeenEyes.Shaders.Compiler.Tests/CodeGen/HlslGeneratorTests.cs
+++ b/tests/KeenEyes.Shaders.Compiler.Tests/CodeGen/HlslGeneratorTests.cs
@@ -498,6 +498,68 @@ public class HlslGeneratorTests
 
     #endregion
 
+    #region Texture and Sampler Support
+
+    [Fact]
+    public void GenerateFragmentShader_WithTextures_GeneratesTexture2DDeclarations()
+    {
+        var hlsl = GenerateFragmentHlsl(FragmentShaderWithTextures);
+
+        Assert.Contains("Texture2D diffuseMap : register(t0);", hlsl);
+        Assert.Contains("Texture2D normalMap : register(t1);", hlsl);
+    }
+
+    [Fact]
+    public void GenerateFragmentShader_WithSamplers_GeneratesSamplerStateDeclarations()
+    {
+        var hlsl = GenerateFragmentHlsl(FragmentShaderWithSamplers);
+
+        Assert.Contains("SamplerState linearSampler : register(s0);", hlsl);
+    }
+
+    [Fact]
+    public void GenerateFragmentShader_WithTextureCube_GeneratesTextureCubeDeclaration()
+    {
+        var hlsl = GenerateFragmentHlsl(FragmentShaderWithTextureCube);
+
+        Assert.Contains("TextureCube skybox : register(t0);", hlsl);
+    }
+
+    [Fact]
+    public void GenerateFragmentShader_WithTexture3D_GeneratesTexture3DDeclaration()
+    {
+        var hlsl = GenerateFragmentHlsl(FragmentShaderWithTexture3D);
+
+        Assert.Contains("Texture3D volumeMap : register(t0);", hlsl);
+    }
+
+    [Fact]
+    public void GenerateFragmentShader_SampleFunction_UsesHlslSampleSyntax()
+    {
+        var hlsl = GenerateFragmentHlsl(FragmentShaderWithSample);
+
+        // In HLSL, sample(texture, sampler, uv) becomes texture.Sample(sampler, uv)
+        Assert.Contains("diffuseMap.Sample(linearSampler, input.uv)", hlsl);
+    }
+
+    [Fact]
+    public void GenerateVertexShader_WithTextures_GeneratesTextureDeclaration()
+    {
+        var hlsl = GenerateVertexHlsl(VertexShaderWithTextures);
+
+        Assert.Contains("Texture2D heightMap : register(t0);", hlsl);
+    }
+
+    [Fact]
+    public void GenerateVertexShader_WithSamplers_GeneratesSamplerDeclaration()
+    {
+        var hlsl = GenerateVertexHlsl(VertexShaderWithSamplers);
+
+        Assert.Contains("SamplerState linearSampler : register(s0);", hlsl);
+    }
+
+    #endregion
+
     #region Compute Shader Test Sources
 
     private const string SimplePhysicsShader = @"
@@ -659,6 +721,134 @@ public class HlslGeneratorTests
                 } else {
                     outPos = position;
                 }
+            }
+        }
+    ";
+
+    #endregion
+
+    #region Texture/Sampler Shader Test Sources
+
+    private const string FragmentShaderWithTextures = @"
+        fragment TexturedSurface {
+            in {
+                uv: float2
+            }
+            out {
+                fragColor: float4 @ 0
+            }
+            textures {
+                diffuseMap: texture2D @ 0
+                normalMap: texture2D @ 1
+            }
+            execute() {
+                fragColor = uv;
+            }
+        }
+    ";
+
+    private const string FragmentShaderWithSamplers = @"
+        fragment SampledSurface {
+            in {
+                uv: float2
+            }
+            out {
+                fragColor: float4 @ 0
+            }
+            samplers {
+                linearSampler: sampler @ 0
+            }
+            execute() {
+                fragColor = uv;
+            }
+        }
+    ";
+
+    private const string FragmentShaderWithTextureCube = @"
+        fragment SkyboxSurface {
+            in {
+                direction: float3
+            }
+            out {
+                fragColor: float4 @ 0
+            }
+            textures {
+                skybox: textureCube @ 0
+            }
+            execute() {
+                fragColor = direction;
+            }
+        }
+    ";
+
+    private const string FragmentShaderWithTexture3D = @"
+        fragment VolumeSurface {
+            in {
+                uvw: float3
+            }
+            out {
+                fragColor: float4 @ 0
+            }
+            textures {
+                volumeMap: texture3D @ 0
+            }
+            execute() {
+                fragColor = uvw;
+            }
+        }
+    ";
+
+    private const string FragmentShaderWithSample = @"
+        fragment TexturedWithSample {
+            in {
+                uv: float2
+            }
+            out {
+                fragColor: float4 @ 0
+            }
+            textures {
+                diffuseMap: texture2D @ 0
+            }
+            samplers {
+                linearSampler: sampler @ 0
+            }
+            execute() {
+                fragColor = sample(diffuseMap, linearSampler, uv);
+            }
+        }
+    ";
+
+    private const string VertexShaderWithTextures = @"
+        vertex DisplacementVertex {
+            in {
+                position: float3 @ 0
+                uv: float2 @ 1
+            }
+            out {
+                outPos: float3
+            }
+            textures {
+                heightMap: texture2D @ 0
+            }
+            execute() {
+                outPos = position;
+            }
+        }
+    ";
+
+    private const string VertexShaderWithSamplers = @"
+        vertex SampledVertex {
+            in {
+                position: float3 @ 0
+            }
+            out {
+                outPos: float3
+            }
+            samplers {
+                linearSampler: sampler @ 0
+            }
+            execute() {
+                outPos = position;
             }
         }
     ";


### PR DESCRIPTION
## Summary
- Add texture and sampler block support to KESL vertex and fragment shaders
- Implement `textures { name: texture2D @ slot }` and `samplers { name: sampler @ slot }` syntax
- Add `sample(texture, sampler, uv)` function with backend-appropriate code generation:
  - GLSL: Combined `sampler2D` uniforms with `texture()` function
  - HLSL: Separate `Texture2D`/`SamplerState` with `.Sample()` method

## Test plan
- [x] Added 8 parser tests for texture/sampler parsing
- [x] Added 5 GLSL generator tests for texture support
- [x] Added 8 HLSL generator tests for texture/sampler support
- [x] All 206 shader compiler tests pass
- [x] Build passes with zero warnings

## Example Usage
```kesl
fragment TexturedSurface {
    in { uv: float2 }
    out { fragColor: float4 @ 0 }
    textures {
        diffuseMap: texture2D @ 0
        normalMap: texture2D @ 1
    }
    samplers {
        linearSampler: sampler @ 0
    }
    execute() {
        fragColor = sample(diffuseMap, linearSampler, uv);
    }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)