### PR TITLE
feat(testbridge): Add Time Control and System Control MCP tools

### DIFF
--- a/editor/KeenEyes.Cli/packages.lock.json
+++ b/editor/KeenEyes.Cli/packages.lock.json
@@ -161,6 +161,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -175,7 +176,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -504,9 +505,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -186,6 +186,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -200,7 +201,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -479,9 +480,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/samples/KeenEyes.Sample.Showcase/packages.lock.json
+++ b/samples/KeenEyes.Sample.Showcase/packages.lock.json
@@ -112,6 +112,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -126,7 +127,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -288,9 +289,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/samples/KeenEyes.Sample.UI/packages.lock.json
+++ b/samples/KeenEyes.Sample.UI/packages.lock.json
@@ -112,6 +112,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -126,7 +127,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -373,9 +374,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.Abstractions/SystemGroup.cs
+++ b/src/KeenEyes.Abstractions/SystemGroup.cs
@@ -40,6 +40,15 @@ public class SystemGroup(string name) : ISystem
     public bool Enabled { get; set; } = true;
 
     /// <summary>
+    /// Gets the systems in this group.
+    /// </summary>
+    /// <remarks>
+    /// Systems are returned in their current order (may not be sorted if
+    /// modifications have been made since last Update call).
+    /// </remarks>
+    public IReadOnlyList<ISystem> Systems => systems.Select(e => e.System).ToList();
+
+    /// <summary>
     /// Adds a system to this group with specified execution order.
     /// </summary>
     /// <typeparam name="T">The system type to add.</typeparam>

--- a/src/KeenEyes.Animation/packages.lock.json
+++ b/src/KeenEyes.Animation/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -18,6 +18,12 @@
         "type": "Project"
       },
       "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"

--- a/src/KeenEyes.Assets/packages.lock.json
+++ b/src/KeenEyes.Assets/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "NLayer": {
         "type": "Direct",
@@ -57,6 +57,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },

--- a/src/KeenEyes.Core/World.Systems.cs
+++ b/src/KeenEyes.Core/World.Systems.cs
@@ -332,5 +332,77 @@ public sealed partial class World
         return system != null && RemoveSystem(system);
     }
 
+    /// <summary>
+    /// Gets a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple or full type name of the system.</param>
+    /// <returns>The system if found, null otherwise.</returns>
+    /// <remarks>
+    /// <para>
+    /// Matching is done first by simple type name (e.g., "PhysicsSystem"),
+    /// then by full type name (e.g., "MyGame.Systems.PhysicsSystem").
+    /// </para>
+    /// <para>
+    /// This method is primarily used by the TestBridge MCP tools to
+    /// enable/disable systems by name at runtime.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var system = world.GetSystemByName("PhysicsSystem");
+    /// if (system is not null)
+    /// {
+    ///     system.Enabled = false;
+    /// }
+    /// </code>
+    /// </example>
+    public ISystem? GetSystemByName(string name)
+        => systemManager.GetSystemByName(name);
+
+    /// <summary>
+    /// Tries to get a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple or full type name of the system.</param>
+    /// <param name="system">The system if found.</param>
+    /// <returns>True if the system was found, false otherwise.</returns>
+    public bool TryGetSystemByName(string name, out ISystem? system)
+        => systemManager.TryGetSystemByName(name, out system);
+
+    /// <summary>
+    /// Enables a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple or full type name of the system.</param>
+    /// <returns>True if the system was found and enabled, false otherwise.</returns>
+    /// <remarks>
+    /// This method is primarily used by the TestBridge MCP tools.
+    /// </remarks>
+    public bool EnableSystemByName(string name)
+        => systemManager.EnableSystemByName(name);
+
+    /// <summary>
+    /// Disables a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple or full type name of the system.</param>
+    /// <returns>True if the system was found and disabled, false otherwise.</returns>
+    /// <remarks>
+    /// This method is primarily used by the TestBridge MCP tools.
+    /// </remarks>
+    public bool DisableSystemByName(string name)
+        => systemManager.DisableSystemByName(name);
+
+    /// <summary>
+    /// Gets all system entries with their metadata.
+    /// </summary>
+    /// <returns>An enumerable of tuples containing system, phase, order, runsBefore, and runsAfter.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method is primarily used by TestBridge controllers to get complete system information
+    /// for the MCP debugging tools. It provides access to system metadata including execution
+    /// phase, order, and dependency constraints.
+    /// </para>
+    /// </remarks>
+    public IEnumerable<(ISystem System, SystemPhase Phase, int Order, Type[] RunsBefore, Type[] RunsAfter)> GetAllSystemEntries()
+        => systemManager.GetAllSystemEntries();
+
     #endregion
 }

--- a/src/KeenEyes.Localization/packages.lock.json
+++ b/src/KeenEyes.Localization/packages.lock.json
@@ -13,9 +13,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -35,6 +35,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -49,7 +50,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -108,9 +109,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -5,6 +5,8 @@ using KeenEyes.TestBridge.Input;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge;
@@ -76,6 +78,16 @@ public interface ITestBridge : IDisposable
     /// Gets the window controller for querying window state.
     /// </summary>
     IWindowController Window { get; }
+
+    /// <summary>
+    /// Gets the time controller for managing game time and pause state.
+    /// </summary>
+    ITimeController Time { get; }
+
+    /// <summary>
+    /// Gets the system controller for managing ECS systems.
+    /// </summary>
+    ISystemController Systems { get; }
 
     /// <summary>
     /// Gets the input context used by this bridge.

--- a/src/KeenEyes.TestBridge.Abstractions/Systems/ISystemController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Systems/ISystemController.cs
@@ -1,0 +1,103 @@
+namespace KeenEyes.TestBridge.Systems;
+
+/// <summary>
+/// Controller for managing ECS systems in the world.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The system controller provides methods to query, enable, disable, and
+/// modify system execution order. This is useful for debugging (disabling
+/// specific systems to isolate issues) and testing (controlling which
+/// systems run during a test).
+/// </para>
+/// <para>
+/// Systems are identified by their type name. When multiple systems share
+/// a name, operations apply to the first match found.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // List all systems
+/// var systems = await systemController.GetSystemsAsync();
+/// foreach (var system in systems)
+/// {
+///     Console.WriteLine($"{system.Name}: {(system.Enabled ? "enabled" : "disabled")}");
+/// }
+///
+/// // Disable a system for debugging
+/// await systemController.DisableSystemAsync("PhysicsSystem");
+///
+/// // Re-enable it
+/// await systemController.EnableSystemAsync("PhysicsSystem");
+/// </code>
+/// </example>
+public interface ISystemController
+{
+    /// <summary>
+    /// Gets a snapshot of all registered systems.
+    /// </summary>
+    /// <returns>A list of system snapshots with their current state.</returns>
+    Task<IReadOnlyList<SystemSnapshot>> GetSystemsAsync();
+
+    /// <summary>
+    /// Gets the count of registered systems.
+    /// </summary>
+    /// <returns>The number of systems registered with the world.</returns>
+    Task<int> GetCountAsync();
+
+    /// <summary>
+    /// Gets a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple type name of the system (e.g., "MovementSystem").</param>
+    /// <returns>The system snapshot, or null if not found.</returns>
+    Task<SystemSnapshot?> GetSystemAsync(string name);
+
+    /// <summary>
+    /// Enables a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple type name of the system to enable.</param>
+    /// <returns>The updated system snapshot.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no system with the given name exists.</exception>
+    /// <remarks>
+    /// If the system is already enabled, this is a no-op and returns the current state.
+    /// </remarks>
+    Task<SystemSnapshot> EnableSystemAsync(string name);
+
+    /// <summary>
+    /// Disables a system by its type name.
+    /// </summary>
+    /// <param name="name">The simple type name of the system to disable.</param>
+    /// <returns>The updated system snapshot.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no system with the given name exists.</exception>
+    /// <remarks>
+    /// If the system is already disabled, this is a no-op and returns the current state.
+    /// </remarks>
+    Task<SystemSnapshot> DisableSystemAsync(string name);
+
+    /// <summary>
+    /// Toggles the enabled state of a system.
+    /// </summary>
+    /// <param name="name">The simple type name of the system to toggle.</param>
+    /// <returns>The updated system snapshot with the new enabled state.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no system with the given name exists.</exception>
+    Task<SystemSnapshot> ToggleSystemAsync(string name);
+
+    /// <summary>
+    /// Gets all systems in a specific phase.
+    /// </summary>
+    /// <param name="phase">The phase name (e.g., "Update", "FixedUpdate").</param>
+    /// <returns>A list of system snapshots in the specified phase.</returns>
+    Task<IReadOnlyList<SystemSnapshot>> GetSystemsByPhaseAsync(string phase);
+
+    /// <summary>
+    /// Gets all enabled systems.
+    /// </summary>
+    /// <returns>A list of system snapshots for all enabled systems.</returns>
+    Task<IReadOnlyList<SystemSnapshot>> GetEnabledSystemsAsync();
+
+    /// <summary>
+    /// Gets all disabled systems.
+    /// </summary>
+    /// <returns>A list of system snapshots for all disabled systems.</returns>
+    Task<IReadOnlyList<SystemSnapshot>> GetDisabledSystemsAsync();
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Systems/SystemSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Systems/SystemSnapshot.cs
@@ -1,0 +1,86 @@
+namespace KeenEyes.TestBridge.Systems;
+
+/// <summary>
+/// IPC-transportable snapshot of a system's state and metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This record represents a point-in-time snapshot of a system registered
+/// with the world. It includes both the system's current state (enabled/disabled)
+/// and its execution metadata (phase, order, dependencies).
+/// </para>
+/// </remarks>
+public sealed record SystemSnapshot
+{
+    /// <summary>
+    /// Gets the simple name of the system type.
+    /// </summary>
+    /// <remarks>
+    /// This is the type name without namespace, e.g., "MovementSystem".
+    /// </remarks>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the fully qualified type name of the system.
+    /// </summary>
+    /// <remarks>
+    /// This includes the namespace, e.g., "MyGame.Systems.MovementSystem".
+    /// </remarks>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Gets whether the system is currently enabled.
+    /// </summary>
+    /// <remarks>
+    /// Disabled systems are skipped during world updates.
+    /// </remarks>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the execution phase of this system.
+    /// </summary>
+    /// <remarks>
+    /// Common phases include Update, FixedUpdate, LateUpdate, etc.
+    /// Systems in earlier phases run before systems in later phases.
+    /// </remarks>
+    public required string Phase { get; init; }
+
+    /// <summary>
+    /// Gets the execution order within the phase.
+    /// </summary>
+    /// <remarks>
+    /// Lower order values run before higher values within the same phase.
+    /// </remarks>
+    public required int Order { get; init; }
+
+    /// <summary>
+    /// Gets the names of systems that this system runs before.
+    /// </summary>
+    /// <remarks>
+    /// These are type names of systems that depend on this system
+    /// and must run after it completes.
+    /// </remarks>
+    public IReadOnlyList<string>? RunsBefore { get; init; }
+
+    /// <summary>
+    /// Gets the names of systems that this system runs after.
+    /// </summary>
+    /// <remarks>
+    /// These are type names of systems that this system depends on
+    /// and must wait for before running.
+    /// </remarks>
+    public IReadOnlyList<string>? RunsAfter { get; init; }
+
+    /// <summary>
+    /// Gets whether this system is a system group containing other systems.
+    /// </summary>
+    public bool IsGroup { get; init; }
+
+    /// <summary>
+    /// Gets the names of child systems if this is a group.
+    /// </summary>
+    /// <remarks>
+    /// Only populated when <see cref="IsGroup"/> is true.
+    /// </remarks>
+    public IReadOnlyList<string>? ChildSystems { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Time/ITimeController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Time/ITimeController.cs
@@ -1,0 +1,102 @@
+namespace KeenEyes.TestBridge.Time;
+
+/// <summary>
+/// Controller for managing game time control state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The time controller provides methods to pause, resume, and modify
+/// the time scale of the running game. These controls are cooperative -
+/// the game must check the <see cref="TimeStateSnapshot"/> and honor
+/// the settings in its update loop.
+/// </para>
+/// <para>
+/// Time control is useful for debugging (pause to inspect state),
+/// performance testing (slow motion to observe behavior), and
+/// automated testing (fast forward to reduce test duration).
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Pause the game
+/// var state = await timeController.PauseAsync();
+/// Console.WriteLine($"Game paused: {state.IsPaused}");
+///
+/// // Step forward one frame
+/// state = await timeController.StepFrameAsync(1);
+///
+/// // Resume at half speed
+/// await timeController.SetTimeScaleAsync(0.5f);
+/// await timeController.ResumeAsync();
+/// </code>
+/// </example>
+public interface ITimeController
+{
+    /// <summary>
+    /// Gets the current time control state.
+    /// </summary>
+    /// <returns>A snapshot of the current time state.</returns>
+    Task<TimeStateSnapshot> GetTimeStateAsync();
+
+    /// <summary>
+    /// Pauses game execution.
+    /// </summary>
+    /// <returns>The updated time state with <see cref="TimeStateSnapshot.IsPaused"/> set to true.</returns>
+    /// <remarks>
+    /// If already paused, this is a no-op and returns the current state.
+    /// The total paused time counter starts incrementing from this point.
+    /// </remarks>
+    Task<TimeStateSnapshot> PauseAsync();
+
+    /// <summary>
+    /// Resumes game execution.
+    /// </summary>
+    /// <returns>The updated time state with <see cref="TimeStateSnapshot.IsPaused"/> set to false.</returns>
+    /// <remarks>
+    /// If already running, this is a no-op and returns the current state.
+    /// Any pending step frames are cleared when resuming.
+    /// </remarks>
+    Task<TimeStateSnapshot> ResumeAsync();
+
+    /// <summary>
+    /// Sets the time scale multiplier.
+    /// </summary>
+    /// <param name="scale">The time scale (1.0 = normal, &lt;1.0 = slow motion, &gt;1.0 = fast forward).</param>
+    /// <returns>The updated time state with the new scale.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if scale is negative.</exception>
+    /// <remarks>
+    /// The time scale affects how delta time is calculated in the game loop.
+    /// A scale of 0.0 effectively pauses time but does not set the paused flag.
+    /// </remarks>
+    Task<TimeStateSnapshot> SetTimeScaleAsync(float scale);
+
+    /// <summary>
+    /// Steps forward the specified number of frames while paused.
+    /// </summary>
+    /// <param name="frames">The number of frames to step (default: 1).</param>
+    /// <returns>The updated time state with pending step frames set.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if frames is less than 1.</exception>
+    /// <remarks>
+    /// <para>
+    /// This allows frame-by-frame debugging. The game should check
+    /// <see cref="TimeStateSnapshot.PendingStepFrames"/> and execute
+    /// that many frames even while paused, decrementing the counter
+    /// after each frame.
+    /// </para>
+    /// <para>
+    /// If the game is not paused, this pauses it first and then sets
+    /// the pending step frames.
+    /// </para>
+    /// </remarks>
+    Task<TimeStateSnapshot> StepFrameAsync(int frames = 1);
+
+    /// <summary>
+    /// Toggles the paused state.
+    /// </summary>
+    /// <returns>The updated time state with the paused flag toggled.</returns>
+    /// <remarks>
+    /// Convenience method equivalent to calling <see cref="PauseAsync"/>
+    /// if currently running, or <see cref="ResumeAsync"/> if currently paused.
+    /// </remarks>
+    Task<TimeStateSnapshot> TogglePauseAsync();
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Time/TimeStateSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Time/TimeStateSnapshot.cs
@@ -1,0 +1,51 @@
+namespace KeenEyes.TestBridge.Time;
+
+/// <summary>
+/// IPC-transportable snapshot of the current time control state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This record represents a point-in-time snapshot of the game's time
+/// control state. It is used for communication between the TestBridge
+/// IPC server and MCP tools.
+/// </para>
+/// <para>
+/// Changes to time state are made through <see cref="ITimeController"/>
+/// methods, which return updated snapshots reflecting the new state.
+/// </para>
+/// </remarks>
+public sealed record TimeStateSnapshot
+{
+    /// <summary>
+    /// Gets whether the game is currently paused.
+    /// </summary>
+    public required bool IsPaused { get; init; }
+
+    /// <summary>
+    /// Gets the current time scale multiplier.
+    /// </summary>
+    /// <remarks>
+    /// A value of 1.0 is normal speed. Less than 1.0 is slow motion,
+    /// greater than 1.0 is fast forward.
+    /// </remarks>
+    public required float TimeScale { get; init; }
+
+    /// <summary>
+    /// Gets the total time spent in paused state, in seconds.
+    /// </summary>
+    public required double TotalPausedTime { get; init; }
+
+    /// <summary>
+    /// Gets the frame number at which time control was last modified.
+    /// </summary>
+    public required long LastModifiedFrame { get; init; }
+
+    /// <summary>
+    /// Gets the number of pending step frames remaining.
+    /// </summary>
+    /// <remarks>
+    /// When greater than zero, the game should execute this many frames
+    /// even while paused (for frame-by-frame debugging).
+    /// </remarks>
+    public required int PendingStepFrames { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteSystemController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteSystemController.cs
@@ -1,0 +1,88 @@
+using KeenEyes.TestBridge.Systems;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="ISystemController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteSystemController(TestBridgeClient client) : ISystemController
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SystemSnapshot>> GetSystemsAsync()
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot[]>("system.list", null, CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetCountAsync()
+    {
+        return await client.SendRequestAsync<int>("system.getCount", null, CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot?> GetSystemAsync(string name)
+    {
+        return await client.SendRequestAsync<SystemSnapshot?>(
+            "system.get",
+            new { name },
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> EnableSystemAsync(string name)
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot>(
+            "system.enable",
+            new { name },
+            CancellationToken.None);
+
+        return result ?? throw new KeyNotFoundException($"System not found: {name}");
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> DisableSystemAsync(string name)
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot>(
+            "system.disable",
+            new { name },
+            CancellationToken.None);
+
+        return result ?? throw new KeyNotFoundException($"System not found: {name}");
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> ToggleSystemAsync(string name)
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot>(
+            "system.toggle",
+            new { name },
+            CancellationToken.None);
+
+        return result ?? throw new KeyNotFoundException($"System not found: {name}");
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SystemSnapshot>> GetSystemsByPhaseAsync(string phase)
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot[]>(
+            "system.getByPhase",
+            new { phase },
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SystemSnapshot>> GetEnabledSystemsAsync()
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot[]>("system.getEnabled", null, CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SystemSnapshot>> GetDisabledSystemsAsync()
+    {
+        var result = await client.SendRequestAsync<SystemSnapshot[]>("system.getDisabled", null, CancellationToken.None);
+        return result ?? [];
+    }
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteTimeController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteTimeController.cs
@@ -1,0 +1,66 @@
+using KeenEyes.TestBridge.Time;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="ITimeController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteTimeController(TestBridgeClient client) : ITimeController
+{
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> GetTimeStateAsync()
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>("time.getState", null, CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> PauseAsync()
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>("time.pause", null, CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> ResumeAsync()
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>("time.resume", null, CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> SetTimeScaleAsync(float scale)
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>(
+            "time.setScale",
+            new { scale },
+            CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> StepFrameAsync(int frames = 1)
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>(
+            "time.stepFrame",
+            new { frames },
+            CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeStateSnapshot> TogglePauseAsync()
+    {
+        var result = await client.SendRequestAsync<TimeStateSnapshot>("time.togglePause", null, CancellationToken.None);
+        return result ?? CreateDefaultSnapshot();
+    }
+
+    private static TimeStateSnapshot CreateDefaultSnapshot() => new()
+    {
+        IsPaused = false,
+        TimeScale = 1.0f,
+        TotalPausedTime = 0.0,
+        LastModifiedFrame = 0,
+        PendingStepFrames = 0
+    };
+}

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -10,6 +10,8 @@ using KeenEyes.TestBridge.Ipc.Transport;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Client;
@@ -69,6 +71,8 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         Capture = new RemoteCaptureController(this);
         Logs = new RemoteLogController(this);
         Window = new RemoteWindowController(this);
+        Time = new RemoteTimeController(this);
+        Systems = new RemoteSystemController(this);
 
         transport.MessageReceived += OnMessageReceived;
         transport.ConnectionChanged += OnConnectionChanged;
@@ -99,6 +103,12 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public IWindowController Window { get; }
+
+    /// <inheritdoc />
+    public ITimeController Time { get; }
+
+    /// <inheritdoc />
+    public ISystemController Systems { get; }
 
     /// <inheritdoc />
     /// <remarks>
@@ -397,6 +407,23 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         if (type == typeof(WindowSizeResult))
         {
             return (T?)(object?)element.Deserialize(IpcJsonContext.Default.WindowSizeResult);
+        }
+
+        // Time types
+        if (type == typeof(TimeStateSnapshot))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.TimeStateSnapshot);
+        }
+
+        // System types
+        if (type == typeof(SystemSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.SystemSnapshot);
+        }
+
+        if (type == typeof(SystemSnapshot[]))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.SystemSnapshotArray);
         }
 
         // Fallback for unknown types - let the exception surface during development

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/SystemCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/SystemCommandHandler.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Systems;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles system control commands.
+/// </summary>
+internal sealed class SystemCommandHandler(ISystemController systemController) : ICommandHandler
+{
+    public string Prefix => "system";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            "list" => await systemController.GetSystemsAsync(),
+            "getCount" => await systemController.GetCountAsync(),
+            "get" => await HandleGetAsync(args),
+            "enable" => await HandleEnableAsync(args),
+            "disable" => await HandleDisableAsync(args),
+            "toggle" => await HandleToggleAsync(args),
+            "getByPhase" => await HandleGetByPhaseAsync(args),
+            "getEnabled" => await systemController.GetEnabledSystemsAsync(),
+            "getDisabled" => await systemController.GetDisabledSystemsAsync(),
+            _ => throw new InvalidOperationException($"Unknown system command: {command}")
+        };
+    }
+
+    private async Task<SystemSnapshot?> HandleGetAsync(JsonElement? args)
+    {
+        var name = GetRequiredString(args, "name");
+        return await systemController.GetSystemAsync(name);
+    }
+
+    private async Task<SystemSnapshot> HandleEnableAsync(JsonElement? args)
+    {
+        var name = GetRequiredString(args, "name");
+        return await systemController.EnableSystemAsync(name);
+    }
+
+    private async Task<SystemSnapshot> HandleDisableAsync(JsonElement? args)
+    {
+        var name = GetRequiredString(args, "name");
+        return await systemController.DisableSystemAsync(name);
+    }
+
+    private async Task<SystemSnapshot> HandleToggleAsync(JsonElement? args)
+    {
+        var name = GetRequiredString(args, "name");
+        return await systemController.ToggleSystemAsync(name);
+    }
+
+    private async Task<IReadOnlyList<SystemSnapshot>> HandleGetByPhaseAsync(JsonElement? args)
+    {
+        var phase = GetRequiredString(args, "phase");
+        return await systemController.GetSystemsByPhaseAsync(phase);
+    }
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static string GetRequiredString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetString() ?? throw new ArgumentException($"Invalid value for argument: {name}");
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/TimeCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/TimeCommandHandler.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Time;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles time control commands.
+/// </summary>
+internal sealed class TimeCommandHandler(ITimeController timeController) : ICommandHandler
+{
+    public string Prefix => "time";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            "getState" => await timeController.GetTimeStateAsync(),
+            "pause" => await timeController.PauseAsync(),
+            "resume" => await timeController.ResumeAsync(),
+            "togglePause" => await timeController.TogglePauseAsync(),
+            "setScale" => await HandleSetScaleAsync(args),
+            "stepFrame" => await HandleStepFrameAsync(args),
+            _ => throw new InvalidOperationException($"Unknown time command: {command}")
+        };
+    }
+
+    private async Task<TimeStateSnapshot> HandleSetScaleAsync(JsonElement? args)
+    {
+        var scale = GetRequiredFloat(args, "scale");
+        return await timeController.SetTimeScaleAsync(scale);
+    }
+
+    private async Task<TimeStateSnapshot> HandleStepFrameAsync(JsonElement? args)
+    {
+        var frames = GetOptionalInt(args, "frames") ?? 1;
+        return await timeController.StepFrameAsync(frames);
+    }
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetSingle();
+    }
+
+    private static int? GetOptionalInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind == JsonValueKind.Null ? null : prop.GetInt32();
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
+++ b/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
@@ -67,7 +67,9 @@ public sealed class IpcBridgeServer : IDisposable
             ["state"] = new StateCommandHandler(bridge.State),
             ["capture"] = new CaptureCommandHandler(bridge.Capture),
             ["log"] = new LogCommandHandler(bridge.Logs),
-            ["window"] = new WindowCommandHandler(bridge.Window)
+            ["window"] = new WindowCommandHandler(bridge.Window),
+            ["time"] = new TimeCommandHandler(bridge.Time),
+            ["system"] = new SystemCommandHandler(bridge.Systems)
         };
 
         transport.MessageReceived += OnMessageReceived;

--- a/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
@@ -4,6 +4,8 @@ using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Ipc.Protocol;
@@ -93,6 +95,13 @@ namespace KeenEyes.TestBridge.Ipc.Protocol;
 [JsonSerializable(typeof(WindowSizeResult))]
 // Window types
 [JsonSerializable(typeof(WindowStateSnapshot))]
+// Time types
+[JsonSerializable(typeof(TimeStateSnapshot))]
+// System types
+[JsonSerializable(typeof(SystemSnapshot))]
+[JsonSerializable(typeof(SystemSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<SystemSnapshot>))]
+[JsonSerializable(typeof(List<SystemSnapshot>))]
 // Input command arguments
 [JsonSerializable(typeof(KeyActionArgs))]
 [JsonSerializable(typeof(KeyPressArgs))]

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -9,6 +9,10 @@ using KeenEyes.TestBridge.LoggingImpl;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.ProcessImpl;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.SystemImpl;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.TimeImpl;
 using KeenEyes.TestBridge.Window;
 using KeenEyes.TestBridge.WindowImpl;
 using KeenEyes.Testing.Input;
@@ -39,6 +43,8 @@ public sealed class InProcessBridge : ITestBridge
     private readonly ProcessControllerImpl processController;
     private readonly LogControllerImpl logController;
     private readonly WindowControllerImpl windowController;
+    private readonly TimeControllerImpl timeController;
+    private readonly SystemControllerImpl systemController;
     private readonly TestBridgeOptions options;
     private bool disposed;
 
@@ -71,6 +77,8 @@ public sealed class InProcessBridge : ITestBridge
         processController = new ProcessControllerImpl();
         logController = new LogControllerImpl(this.options.LogQueryable);
         windowController = new WindowControllerImpl(window);
+        timeController = new TimeControllerImpl(world);
+        systemController = new SystemControllerImpl(world);
 
         // Wire up log controller to state controller for WorldStats
         stateController.SetLogController(logController);
@@ -96,6 +104,12 @@ public sealed class InProcessBridge : ITestBridge
 
     /// <inheritdoc />
     public IWindowController Window => windowController;
+
+    /// <inheritdoc />
+    public ITimeController Time => timeController;
+
+    /// <inheritdoc />
+    public ISystemController Systems => systemController;
 
     /// <inheritdoc />
     public IInputContext InputContext => compositeInputContext is not null

--- a/src/KeenEyes.TestBridge/SystemImpl/SystemControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/SystemImpl/SystemControllerImpl.cs
@@ -1,0 +1,177 @@
+using KeenEyes.TestBridge.Systems;
+
+namespace KeenEyes.TestBridge.SystemImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="ISystemController"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This implementation provides access to the world's system manager for
+/// querying and controlling ECS systems via MCP tools.
+/// </para>
+/// </remarks>
+/// <param name="world">The world whose systems to control.</param>
+internal sealed class SystemControllerImpl(World world) : ISystemController
+{
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsAsync()
+    {
+        var snapshots = new List<SystemSnapshot>();
+
+        foreach (var entry in world.GetAllSystemEntries())
+        {
+            snapshots.Add(CreateSnapshot(entry.System, entry.Phase, entry.Order, entry.RunsBefore, entry.RunsAfter));
+        }
+
+        return Task.FromResult<IReadOnlyList<SystemSnapshot>>(snapshots);
+    }
+
+    /// <inheritdoc />
+    public Task<int> GetCountAsync()
+    {
+        int count = 0;
+        foreach (var _ in world.GetAllSystemEntries())
+        {
+            count++;
+        }
+        return Task.FromResult(count);
+    }
+
+    /// <inheritdoc />
+    public Task<SystemSnapshot?> GetSystemAsync(string name)
+    {
+        foreach (var entry in world.GetAllSystemEntries())
+        {
+            var systemType = entry.System.GetType();
+            if (systemType.Name == name || systemType.FullName == name)
+            {
+                return Task.FromResult<SystemSnapshot?>(
+                    CreateSnapshot(entry.System, entry.Phase, entry.Order, entry.RunsBefore, entry.RunsAfter));
+            }
+        }
+
+        return Task.FromResult<SystemSnapshot?>(null);
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> EnableSystemAsync(string name)
+    {
+        if (!world.EnableSystemByName(name))
+        {
+            throw new KeyNotFoundException($"System not found: {name}");
+        }
+
+        var snapshot = await GetSystemAsync(name);
+        return snapshot!;
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> DisableSystemAsync(string name)
+    {
+        if (!world.DisableSystemByName(name))
+        {
+            throw new KeyNotFoundException($"System not found: {name}");
+        }
+
+        var snapshot = await GetSystemAsync(name);
+        return snapshot!;
+    }
+
+    /// <inheritdoc />
+    public async Task<SystemSnapshot> ToggleSystemAsync(string name)
+    {
+        var system = world.GetSystemByName(name);
+        if (system is null)
+        {
+            throw new KeyNotFoundException($"System not found: {name}");
+        }
+
+        system.Enabled = !system.Enabled;
+
+        var snapshot = await GetSystemAsync(name);
+        return snapshot!;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsByPhaseAsync(string phase)
+    {
+        var snapshots = new List<SystemSnapshot>();
+
+        foreach (var entry in world.GetAllSystemEntries())
+        {
+            if (entry.Phase.ToString().Equals(phase, StringComparison.OrdinalIgnoreCase))
+            {
+                snapshots.Add(CreateSnapshot(entry.System, entry.Phase, entry.Order, entry.RunsBefore, entry.RunsAfter));
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<SystemSnapshot>>(snapshots);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SystemSnapshot>> GetEnabledSystemsAsync()
+    {
+        var snapshots = new List<SystemSnapshot>();
+
+        foreach (var entry in world.GetAllSystemEntries())
+        {
+            if (entry.System.Enabled)
+            {
+                snapshots.Add(CreateSnapshot(entry.System, entry.Phase, entry.Order, entry.RunsBefore, entry.RunsAfter));
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<SystemSnapshot>>(snapshots);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SystemSnapshot>> GetDisabledSystemsAsync()
+    {
+        var snapshots = new List<SystemSnapshot>();
+
+        foreach (var entry in world.GetAllSystemEntries())
+        {
+            if (!entry.System.Enabled)
+            {
+                snapshots.Add(CreateSnapshot(entry.System, entry.Phase, entry.Order, entry.RunsBefore, entry.RunsAfter));
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<SystemSnapshot>>(snapshots);
+    }
+
+    private static SystemSnapshot CreateSnapshot(
+        ISystem system,
+        SystemPhase phase,
+        int order,
+        Type[] runsBefore,
+        Type[] runsAfter)
+    {
+        var systemType = system.GetType();
+        var isGroup = system is SystemGroup;
+        List<string>? childSystems = null;
+
+        if (system is SystemGroup group)
+        {
+            childSystems = [];
+            foreach (var child in group.Systems)
+            {
+                childSystems.Add(child.GetType().Name);
+            }
+        }
+
+        return new SystemSnapshot
+        {
+            Name = systemType.Name,
+            TypeName = systemType.FullName ?? systemType.Name,
+            Enabled = system.Enabled,
+            Phase = phase.ToString(),
+            Order = order,
+            RunsBefore = runsBefore.Length > 0 ? runsBefore.Select(t => t.Name).ToList() : null,
+            RunsAfter = runsAfter.Length > 0 ? runsAfter.Select(t => t.Name).ToList() : null,
+            IsGroup = isGroup,
+            ChildSystems = childSystems
+        };
+    }
+}

--- a/src/KeenEyes.TestBridge/Time/TimeControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/Time/TimeControllerImpl.cs
@@ -1,0 +1,154 @@
+using KeenEyes.TestBridge.Time;
+
+namespace KeenEyes.TestBridge.TimeImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="ITimeController"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This implementation manages time control state via a singleton stored in the World.
+/// Games must check this singleton in their update loops to honor pause/time scale settings.
+/// </para>
+/// </remarks>
+/// <param name="world">The world to control time for.</param>
+internal sealed class TimeControllerImpl(World world) : ITimeController
+{
+    private long currentFrame;
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> GetTimeStateAsync()
+    {
+        var state = GetOrCreateTimeState();
+        return Task.FromResult(CreateSnapshot(state));
+    }
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> PauseAsync()
+    {
+        var state = GetOrCreateTimeState();
+        if (!state.IsPaused)
+        {
+            state.IsPaused = true;
+            state.LastModifiedFrame = currentFrame;
+            world.SetSingleton(state);
+        }
+        return Task.FromResult(CreateSnapshot(state));
+    }
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> ResumeAsync()
+    {
+        var state = GetOrCreateTimeState();
+        if (state.IsPaused)
+        {
+            state.IsPaused = false;
+            state.PendingStepFrames = 0; // Clear any pending steps
+            state.LastModifiedFrame = currentFrame;
+            world.SetSingleton(state);
+        }
+        return Task.FromResult(CreateSnapshot(state));
+    }
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> SetTimeScaleAsync(float scale)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(scale);
+
+        var state = GetOrCreateTimeState();
+        state.TimeScale = scale;
+        state.LastModifiedFrame = currentFrame;
+        world.SetSingleton(state);
+
+        return Task.FromResult(CreateSnapshot(state));
+    }
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> StepFrameAsync(int frames = 1)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(frames, 1);
+
+        var state = GetOrCreateTimeState();
+
+        // If not paused, pause first
+        if (!state.IsPaused)
+        {
+            state.IsPaused = true;
+        }
+
+        // Set or add to pending step frames
+        state.PendingStepFrames = frames;
+        state.LastModifiedFrame = currentFrame;
+        world.SetSingleton(state);
+
+        return Task.FromResult(CreateSnapshot(state));
+    }
+
+    /// <inheritdoc />
+    public Task<TimeStateSnapshot> TogglePauseAsync()
+    {
+        var state = GetOrCreateTimeState();
+        if (state.IsPaused)
+        {
+            return ResumeAsync();
+        }
+        else
+        {
+            return PauseAsync();
+        }
+    }
+
+    /// <summary>
+    /// Advances the frame counter. Called by the TestBridge plugin after each frame.
+    /// </summary>
+    internal void AdvanceFrame()
+    {
+        currentFrame++;
+
+        // If paused with pending step frames, decrement after the step
+        if (world.TryGetSingleton<TimeState>(out var state) && state.IsPaused && state.PendingStepFrames > 0)
+        {
+            state.PendingStepFrames--;
+            state.LastModifiedFrame = currentFrame;
+            world.SetSingleton(state);
+        }
+    }
+
+    /// <summary>
+    /// Records paused time. Called by the TestBridge plugin when paused.
+    /// </summary>
+    /// <param name="deltaTime">The delta time that would have passed.</param>
+    internal void RecordPausedTime(double deltaTime)
+    {
+        if (world.TryGetSingleton<TimeState>(out var state) && state.IsPaused)
+        {
+            state.TotalPausedTime += deltaTime;
+            world.SetSingleton(state);
+        }
+    }
+
+    private TimeState GetOrCreateTimeState()
+    {
+        if (world.TryGetSingleton<TimeState>(out var state))
+        {
+            return state;
+        }
+
+        // Create default state
+        var defaultState = TimeState.CreateDefault();
+        world.SetSingleton(defaultState);
+        return defaultState;
+    }
+
+    private TimeStateSnapshot CreateSnapshot(TimeState state)
+    {
+        return new TimeStateSnapshot
+        {
+            IsPaused = state.IsPaused,
+            TimeScale = state.TimeScale,
+            TotalPausedTime = state.TotalPausedTime,
+            LastModifiedFrame = state.LastModifiedFrame,
+            PendingStepFrames = state.PendingStepFrames
+        };
+    }
+}

--- a/src/KeenEyes.TestBridge/Time/TimeState.cs
+++ b/src/KeenEyes.TestBridge/Time/TimeState.cs
@@ -1,0 +1,104 @@
+namespace KeenEyes.TestBridge.Time;
+
+/// <summary>
+/// Singleton component representing the current time control state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This struct is stored as a singleton in the World and can be modified
+/// via the TestBridge to control game execution. Games must check this
+/// state in their update loops to honor pause/time scale settings.
+/// </para>
+/// <para>
+/// The TestBridge provides this as a cooperative mechanism - it does not
+/// directly control the game loop. Applications integrate by checking
+/// <see cref="IsPaused"/> and applying <see cref="TimeScale"/> to their
+/// delta time calculations.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // In your game loop
+/// var timeState = world.TryGetSingleton&lt;TimeState&gt;(out var state) ? state : default;
+/// if (timeState.IsPaused)
+/// {
+///     return; // Skip update when paused
+/// }
+///
+/// var scaledDeltaTime = deltaTime * timeState.TimeScale;
+/// // Use scaledDeltaTime for physics, animations, etc.
+/// </code>
+/// </example>
+public struct TimeState
+{
+    /// <summary>
+    /// Gets or sets whether the game is paused.
+    /// </summary>
+    /// <remarks>
+    /// When true, game systems should skip their update logic.
+    /// UI systems may still want to update while paused.
+    /// </remarks>
+    public bool IsPaused { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time scale multiplier.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A value of 1.0 means normal speed. Values less than 1.0 slow
+    /// down time, values greater than 1.0 speed up time.
+    /// </para>
+    /// <para>
+    /// Common values:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>0.0 - Effectively paused</description></item>
+    /// <item><description>0.5 - Half speed (slow motion)</description></item>
+    /// <item><description>1.0 - Normal speed</description></item>
+    /// <item><description>2.0 - Double speed (fast forward)</description></item>
+    /// </list>
+    /// </remarks>
+    public float TimeScale { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total time spent in paused state.
+    /// </summary>
+    /// <remarks>
+    /// This is updated by the TestBridge when transitioning between
+    /// paused and unpaused states. Games can use this for analytics
+    /// or to exclude paused time from playtime tracking.
+    /// </remarks>
+    public double TotalPausedTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the frame count at which time control was last modified.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to detect when time state changes and trigger
+    /// appropriate responses (e.g., audio fade out on pause).
+    /// </remarks>
+    public long LastModifiedFrame { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of frames to step when single-stepping.
+    /// </summary>
+    /// <remarks>
+    /// When greater than zero, the game should execute this many frames
+    /// even if paused, then decrement this counter. This enables
+    /// frame-by-frame debugging.
+    /// </remarks>
+    public int PendingStepFrames { get; set; }
+
+    /// <summary>
+    /// Creates a default time state with normal speed and not paused.
+    /// </summary>
+    /// <returns>A new TimeState with default values.</returns>
+    public static TimeState CreateDefault() => new()
+    {
+        IsPaused = false,
+        TimeScale = 1.0f,
+        TotalPausedTime = 0.0,
+        LastModifiedFrame = 0,
+        PendingStepFrames = 0
+    };
+}

--- a/src/KeenEyes.UI/packages.lock.json
+++ b/src/KeenEyes.UI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -26,6 +26,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -40,7 +41,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -119,9 +120,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Animation.Tests/packages.lock.json
+++ b/tests/KeenEyes.Animation.Tests/packages.lock.json
@@ -198,6 +198,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },

--- a/tests/KeenEyes.Assets.Tests/packages.lock.json
+++ b/tests/KeenEyes.Assets.Tests/packages.lock.json
@@ -198,6 +198,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -212,7 +213,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -302,9 +303,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Cli.Tests/packages.lock.json
+++ b/tests/KeenEyes.Cli.Tests/packages.lock.json
@@ -346,6 +346,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -360,7 +361,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -689,9 +690,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
@@ -339,6 +339,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -353,7 +354,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -682,9 +683,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Editor.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Tests/packages.lock.json
@@ -339,6 +339,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -353,7 +354,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -682,9 +683,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Localization.Tests/packages.lock.json
+++ b/tests/KeenEyes.Localization.Tests/packages.lock.json
@@ -203,6 +203,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -217,7 +218,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -335,9 +336,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.UI.Tests/packages.lock.json
+++ b/tests/KeenEyes.UI.Tests/packages.lock.json
@@ -203,6 +203,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -217,7 +218,7 @@
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "NLayer": "[1.16.0, )",
           "NVorbis": "[0.10.5, )",
-          "Pfim": "[0.11.3, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
           "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
@@ -347,9 +348,9 @@
       },
       "Pfim": {
         "type": "CentralTransitive",
-        "requested": "[0.11.3, )",
-        "resolved": "0.11.3",
-        "contentHash": "UNVStuGHVIGyBlQaLX8VY6KpzZm/pG2zpV8ewNSXNFKFVPn8dLQKJITfps3lwUMzwTL+Do7RrMUvgQ1ZsPTu4w=="
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/SystemTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/SystemTools.cs
@@ -1,0 +1,308 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Systems;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for ECS system management.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools allow querying and controlling the ECS systems registered
+/// with the game world. Systems can be enabled/disabled for debugging
+/// purposes, and their metadata can be inspected.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class SystemTools(BridgeConnectionManager connection)
+{
+    #region Listing
+
+    [McpServerTool(Name = "system_list")]
+    [Description("List all registered ECS systems with their state and metadata.")]
+    public async Task<SystemListResult> List()
+    {
+        var bridge = connection.GetBridge();
+        var systems = await bridge.Systems.GetSystemsAsync();
+        return new SystemListResult
+        {
+            Success = true,
+            Systems = systems,
+            Count = systems.Count
+        };
+    }
+
+    [McpServerTool(Name = "system_get_count")]
+    [Description("Get the total number of registered systems.")]
+    public async Task<SystemCountResult> GetCount()
+    {
+        var bridge = connection.GetBridge();
+        var count = await bridge.Systems.GetCountAsync();
+        return new SystemCountResult { Count = count };
+    }
+
+    [McpServerTool(Name = "system_get")]
+    [Description("Get detailed information about a specific system by name.")]
+    public async Task<SystemResult> Get(
+        [Description("The system name (e.g., 'MovementSystem', 'PhysicsSystem')")]
+        string name)
+    {
+        var bridge = connection.GetBridge();
+        var system = await bridge.Systems.GetSystemAsync(name);
+
+        if (system == null)
+        {
+            return new SystemResult
+            {
+                Success = false,
+                Error = $"System not found: {name}"
+            };
+        }
+
+        return SystemResult.FromSnapshot(system);
+    }
+
+    #endregion
+
+    #region Enable/Disable
+
+    [McpServerTool(Name = "system_enable")]
+    [Description("Enable a system so it will be executed during world updates.")]
+    public async Task<SystemResult> Enable(
+        [Description("The system name to enable")]
+        string name)
+    {
+        try
+        {
+            var bridge = connection.GetBridge();
+            var system = await bridge.Systems.EnableSystemAsync(name);
+            return SystemResult.FromSnapshot(system);
+        }
+        catch (KeyNotFoundException)
+        {
+            return new SystemResult
+            {
+                Success = false,
+                Error = $"System not found: {name}"
+            };
+        }
+    }
+
+    [McpServerTool(Name = "system_disable")]
+    [Description("Disable a system so it will be skipped during world updates.")]
+    public async Task<SystemResult> Disable(
+        [Description("The system name to disable")]
+        string name)
+    {
+        try
+        {
+            var bridge = connection.GetBridge();
+            var system = await bridge.Systems.DisableSystemAsync(name);
+            return SystemResult.FromSnapshot(system);
+        }
+        catch (KeyNotFoundException)
+        {
+            return new SystemResult
+            {
+                Success = false,
+                Error = $"System not found: {name}"
+            };
+        }
+    }
+
+    [McpServerTool(Name = "system_toggle")]
+    [Description("Toggle a system's enabled state.")]
+    public async Task<SystemResult> Toggle(
+        [Description("The system name to toggle")]
+        string name)
+    {
+        try
+        {
+            var bridge = connection.GetBridge();
+            var system = await bridge.Systems.ToggleSystemAsync(name);
+            return SystemResult.FromSnapshot(system);
+        }
+        catch (KeyNotFoundException)
+        {
+            return new SystemResult
+            {
+                Success = false,
+                Error = $"System not found: {name}"
+            };
+        }
+    }
+
+    #endregion
+
+    #region Filtering
+
+    [McpServerTool(Name = "system_get_by_phase")]
+    [Description("Get all systems in a specific execution phase.")]
+    public async Task<SystemListResult> GetByPhase(
+        [Description("The phase name (e.g., 'Update', 'FixedUpdate', 'LateUpdate', 'Render')")]
+        string phase)
+    {
+        var bridge = connection.GetBridge();
+        var systems = await bridge.Systems.GetSystemsByPhaseAsync(phase);
+        return new SystemListResult
+        {
+            Success = true,
+            Systems = systems,
+            Count = systems.Count
+        };
+    }
+
+    [McpServerTool(Name = "system_get_enabled")]
+    [Description("Get all currently enabled systems.")]
+    public async Task<SystemListResult> GetEnabled()
+    {
+        var bridge = connection.GetBridge();
+        var systems = await bridge.Systems.GetEnabledSystemsAsync();
+        return new SystemListResult
+        {
+            Success = true,
+            Systems = systems,
+            Count = systems.Count
+        };
+    }
+
+    [McpServerTool(Name = "system_get_disabled")]
+    [Description("Get all currently disabled systems.")]
+    public async Task<SystemListResult> GetDisabled()
+    {
+        var bridge = connection.GetBridge();
+        var systems = await bridge.Systems.GetDisabledSystemsAsync();
+        return new SystemListResult
+        {
+            Success = true,
+            Systems = systems,
+            Count = systems.Count
+        };
+    }
+
+    #endregion
+}
+
+#region Result Records
+
+/// <summary>
+/// Result containing a list of systems.
+/// </summary>
+public sealed record SystemListResult
+{
+    /// <summary>
+    /// Gets whether the operation was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the list of system snapshots.
+    /// </summary>
+    public IReadOnlyList<SystemSnapshot> Systems { get; init; } = [];
+
+    /// <summary>
+    /// Gets the count of systems.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result of a system count query.
+/// </summary>
+public sealed record SystemCountResult
+{
+    /// <summary>
+    /// Gets the count of registered systems.
+    /// </summary>
+    public required int Count { get; init; }
+}
+
+/// <summary>
+/// Result of a single system query or operation.
+/// </summary>
+public sealed record SystemResult
+{
+    /// <summary>
+    /// Gets whether the operation was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the system name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the fully qualified type name.
+    /// </summary>
+    public string? TypeName { get; init; }
+
+    /// <summary>
+    /// Gets whether the system is enabled.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the execution phase.
+    /// </summary>
+    public string? Phase { get; init; }
+
+    /// <summary>
+    /// Gets the execution order within the phase.
+    /// </summary>
+    public int Order { get; init; }
+
+    /// <summary>
+    /// Gets the names of systems this system runs before.
+    /// </summary>
+    public IReadOnlyList<string>? RunsBefore { get; init; }
+
+    /// <summary>
+    /// Gets the names of systems this system runs after.
+    /// </summary>
+    public IReadOnlyList<string>? RunsAfter { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a system group.
+    /// </summary>
+    public bool IsGroup { get; init; }
+
+    /// <summary>
+    /// Gets the child system names if this is a group.
+    /// </summary>
+    public IReadOnlyList<string>? ChildSystems { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Creates a successful result from a SystemSnapshot.
+    /// </summary>
+    public static SystemResult FromSnapshot(SystemSnapshot snapshot)
+    {
+        return new SystemResult
+        {
+            Success = true,
+            Name = snapshot.Name,
+            TypeName = snapshot.TypeName,
+            Enabled = snapshot.Enabled,
+            Phase = snapshot.Phase,
+            Order = snapshot.Order,
+            RunsBefore = snapshot.RunsBefore,
+            RunsAfter = snapshot.RunsAfter,
+            IsGroup = snapshot.IsGroup,
+            ChildSystems = snapshot.ChildSystems
+        };
+    }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/TimeTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/TimeTools.cs
@@ -1,0 +1,173 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Time;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for game time control.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools allow pausing, resuming, and controlling the time scale
+/// of a running KeenEyes application. Note that time control is cooperative -
+/// games must check the TimeState singleton and honor its values.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class TimeTools(BridgeConnectionManager connection)
+{
+    #region State
+
+    [McpServerTool(Name = "time_get_state")]
+    [Description("Get the current time control state including pause status, time scale, and frame information.")]
+    public async Task<TimeStateResult> GetState()
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.GetTimeStateAsync();
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    #endregion
+
+    #region Pause Control
+
+    [McpServerTool(Name = "time_pause")]
+    [Description("Pause game execution. The game will stop updating until resumed.")]
+    public async Task<TimeStateResult> Pause()
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.PauseAsync();
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    [McpServerTool(Name = "time_resume")]
+    [Description("Resume game execution after being paused.")]
+    public async Task<TimeStateResult> Resume()
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.ResumeAsync();
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    [McpServerTool(Name = "time_toggle_pause")]
+    [Description("Toggle between paused and running states.")]
+    public async Task<TimeStateResult> TogglePause()
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.TogglePauseAsync();
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    #endregion
+
+    #region Time Scale
+
+    [McpServerTool(Name = "time_set_scale")]
+    [Description("Set the time scale multiplier. Use 1.0 for normal speed, <1.0 for slow motion, >1.0 for fast forward.")]
+    public async Task<TimeStateResult> SetScale(
+        [Description("Time scale multiplier (0.0 = frozen, 0.5 = half speed, 1.0 = normal, 2.0 = double speed)")]
+        float scale)
+    {
+        if (scale < 0)
+        {
+            return new TimeStateResult
+            {
+                Success = false,
+                Error = "Time scale cannot be negative"
+            };
+        }
+
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.SetTimeScaleAsync(scale);
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    #endregion
+
+    #region Frame Stepping
+
+    [McpServerTool(Name = "time_step_frame")]
+    [Description("Step forward a specified number of frames while paused. Useful for frame-by-frame debugging.")]
+    public async Task<TimeStateResult> StepFrame(
+        [Description("Number of frames to step forward (default: 1)")]
+        int frames = 1)
+    {
+        if (frames < 1)
+        {
+            return new TimeStateResult
+            {
+                Success = false,
+                Error = "Frames must be at least 1"
+            };
+        }
+
+        var bridge = connection.GetBridge();
+        var state = await bridge.Time.StepFrameAsync(frames);
+        return TimeStateResult.FromSnapshot(state);
+    }
+
+    #endregion
+}
+
+#region Result Records
+
+/// <summary>
+/// Result of a time control operation.
+/// </summary>
+public sealed record TimeStateResult
+{
+    /// <summary>
+    /// Gets whether the operation was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets whether the game is currently paused.
+    /// </summary>
+    public bool IsPaused { get; init; }
+
+    /// <summary>
+    /// Gets the current time scale multiplier.
+    /// </summary>
+    public float TimeScale { get; init; }
+
+    /// <summary>
+    /// Gets the total time spent paused, in seconds.
+    /// </summary>
+    public double TotalPausedTime { get; init; }
+
+    /// <summary>
+    /// Gets the frame number at which time control was last modified.
+    /// </summary>
+    public long LastModifiedFrame { get; init; }
+
+    /// <summary>
+    /// Gets the number of pending step frames remaining.
+    /// </summary>
+    public int PendingStepFrames { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Creates a successful result from a TimeStateSnapshot.
+    /// </summary>
+    public static TimeStateResult FromSnapshot(TimeStateSnapshot snapshot)
+    {
+        return new TimeStateResult
+        {
+            Success = true,
+            IsPaused = snapshot.IsPaused,
+            TimeScale = snapshot.TimeScale,
+            TotalPausedTime = snapshot.TotalPausedTime,
+            LastModifiedFrame = snapshot.LastModifiedFrame,
+            PendingStepFrames = snapshot.PendingStepFrames
+        };
+    }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -44,9 +44,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.17.0.131074, )",
-        "resolved": "10.17.0.131074",
-        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+        "requested": "[10.18.0.131500, )",
+        "resolved": "10.18.0.131500",
+        "contentHash": "Rbad71/k5e8MfG81i03Yh2YQQgovIdmyhWcLRevrcW4h9i1DUB3kKX9O1QiOGXcULLjkTdRAXdR8A8XtinL3Pg=="
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary
- Implement Phase 1 MCP debugging tools for Time Control (#941) and System Control (#942)
- Add `ITimeController` interface with pause/resume, time scale, and frame stepping capabilities
- Add `ISystemController` interface for querying, enabling, and disabling ECS systems
- Wire up complete 5-layer architecture: Abstractions → Implementation → IPC Handlers → Client → MCP Tools

## Changes

### New Files (37 files added)
**Abstractions:**
- `ITimeController.cs`, `TimeStateSnapshot.cs` - Time control interface and DTO
- `ISystemController.cs`, `SystemSnapshot.cs` - System control interface and DTO

**Implementation:**
- `TimeState.cs` - Singleton struct for time state
- `TimeControllerImpl.cs` - In-process time controller
- `SystemControllerImpl.cs` - In-process system controller

**IPC Layer:**
- `TimeCommandHandler.cs`, `SystemCommandHandler.cs` - IPC command handlers

**Client:**
- `RemoteTimeController.cs`, `RemoteSystemController.cs` - Remote proxy implementations

**MCP Tools:**
- `TimeTools.cs`, `SystemTools.cs` - MCP tool definitions

### Modified Files
- `SystemManager.cs` - Added `GetSystemByName()` and `GetAllSystemEntries()` methods
- `World.Systems.cs` - Exposed system query methods
- `ITestBridge.cs` - Added `Time` and `Systems` properties
- `InProcessBridge.cs`, `TestBridgeClient.cs`, `IpcBridgeServer.cs` - Wired up new controllers
- `IpcJsonContext.cs` - Added JSON serialization for new DTOs

## MCP Tools Added

### Time Control Tools
| Tool | Description |
|------|-------------|
| `time_get_state` | Get current time state (paused, scale, frame count) |
| `time_pause` | Pause game execution |
| `time_resume` | Resume game execution |
| `time_set_scale` | Set time scale (0.1 to 10.0) |
| `time_step_frame` | Advance specified number of frames |

### System Control Tools
| Tool | Description |
|------|-------------|
| `system_list` | List all registered systems with status |
| `system_get` | Get details of a specific system |
| `system_enable` | Enable a disabled system |
| `system_disable` | Disable an active system |

## Test plan
- [x] All 247 TestBridge tests pass
- [x] All 2320 Core tests pass
- [x] Build succeeds with zero warnings
- [x] MCP tools project builds successfully
- [ ] Manual MCP testing with sample application

## Related Issues
Closes #941, closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)