### PR TITLE
feat(animation): Add IKManager for rig and chain registration

### DIFF
--- a/src/KeenEyes.Animation/IKManager.cs
+++ b/src/KeenEyes.Animation/IKManager.cs
@@ -1,0 +1,185 @@
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+
+namespace KeenEyes.Animation;
+
+/// <summary>
+/// Manages IK rig definitions, chain configurations, and solver instances.
+/// </summary>
+public sealed class IKManager : IDisposable
+{
+    private readonly Dictionary<int, IKRigDefinition> rigs = [];
+    private readonly Dictionary<int, IKChainDefinition> chains = [];
+    private readonly Dictionary<IKSolverType, IIKSolver> solvers = [];
+
+    private int nextRigId = 1;
+    private int nextChainId = 1;
+    private bool isDisposed;
+
+    /// <summary>Number of registered rigs.</summary>
+    public int RigCount => rigs.Count;
+
+    /// <summary>Number of registered chains.</summary>
+    public int ChainCount => chains.Count;
+
+    /// <summary>Number of registered solvers.</summary>
+    public int SolverCount => solvers.Count;
+
+    #region Rig Registration
+
+    /// <summary>Registers an IK rig definition and returns its ID.</summary>
+    /// <param name="rig">The rig definition to register.</param>
+    /// <returns>The assigned rig ID.</returns>
+    public int RegisterRig(IKRigDefinition rig)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        ArgumentNullException.ThrowIfNull(rig);
+
+        var id = nextRigId++;
+        rigs[id] = rig;
+
+        // Also register all chains from the rig
+        foreach (var chain in rig.Chains)
+        {
+            RegisterChain(chain);
+        }
+
+        return id;
+    }
+
+    /// <summary>Gets a rig by ID.</summary>
+    /// <param name="rigId">The rig ID.</param>
+    /// <returns>The rig definition.</returns>
+    public IKRigDefinition GetRig(int rigId) => rigs[rigId];
+
+    /// <summary>Tries to get a rig by ID.</summary>
+    /// <param name="rigId">The rig ID.</param>
+    /// <param name="rig">The rig definition if found.</param>
+    /// <returns>True if the rig was found.</returns>
+    public bool TryGetRig(int rigId, out IKRigDefinition? rig)
+        => rigs.TryGetValue(rigId, out rig);
+
+    /// <summary>Unregisters a rig by ID.</summary>
+    /// <param name="rigId">The rig ID to unregister.</param>
+    /// <returns>True if the rig was removed.</returns>
+    public bool UnregisterRig(int rigId) => rigs.Remove(rigId);
+
+    #endregion
+
+    #region Chain Registration
+
+    /// <summary>Registers an IK chain definition and returns its ID.</summary>
+    /// <param name="chain">The chain definition to register.</param>
+    /// <returns>The assigned chain ID.</returns>
+    public int RegisterChain(IKChainDefinition chain)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        ArgumentNullException.ThrowIfNull(chain);
+
+        var id = nextChainId++;
+        chains[id] = chain;
+        return id;
+    }
+
+    /// <summary>Gets a chain by ID.</summary>
+    /// <param name="chainId">The chain ID.</param>
+    /// <returns>The chain definition.</returns>
+    public IKChainDefinition GetChain(int chainId) => chains[chainId];
+
+    /// <summary>Tries to get a chain by ID.</summary>
+    /// <param name="chainId">The chain ID.</param>
+    /// <param name="chain">The chain definition if found.</param>
+    /// <returns>True if the chain was found.</returns>
+    public bool TryGetChain(int chainId, out IKChainDefinition? chain)
+        => chains.TryGetValue(chainId, out chain);
+
+    /// <summary>Unregisters a chain by ID.</summary>
+    /// <param name="chainId">The chain ID to unregister.</param>
+    /// <returns>True if the chain was removed.</returns>
+    public bool UnregisterChain(int chainId) => chains.Remove(chainId);
+
+    #endregion
+
+    #region Solver Management
+
+    /// <summary>Registers a solver instance for its solver type.</summary>
+    /// <param name="solver">The solver instance to register.</param>
+    public void RegisterSolver(IIKSolver solver)
+    {
+        ObjectDisposedException.ThrowIf(isDisposed, this);
+        ArgumentNullException.ThrowIfNull(solver);
+
+        solvers[solver.SolverType] = solver;
+    }
+
+    /// <summary>Gets the solver for a chain by chain ID.</summary>
+    /// <param name="chainId">The chain ID.</param>
+    /// <returns>The solver for the chain's solver type.</returns>
+    /// <exception cref="KeyNotFoundException">If the chain ID is not found.</exception>
+    /// <exception cref="InvalidOperationException">If no solver is registered for the chain's type.</exception>
+    public IIKSolver GetSolver(int chainId)
+    {
+        if (!TryGetChain(chainId, out var chain) || chain is null)
+        {
+            throw new KeyNotFoundException($"Chain with ID {chainId} not found.");
+        }
+
+        return GetSolverForType(chain.SolverType);
+    }
+
+    /// <summary>Gets a solver by type.</summary>
+    /// <param name="solverType">The solver type.</param>
+    /// <returns>The registered solver.</returns>
+    /// <exception cref="InvalidOperationException">If no solver is registered for the type.</exception>
+    public IIKSolver GetSolverForType(IKSolverType solverType)
+    {
+        if (solvers.TryGetValue(solverType, out var solver))
+        {
+            return solver;
+        }
+
+        throw new InvalidOperationException(
+            $"No solver registered for type {solverType}. " +
+            "Register solvers using RegisterSolver().");
+    }
+
+    /// <summary>Tries to get a solver by type.</summary>
+    /// <param name="solverType">The solver type.</param>
+    /// <param name="solver">The solver if found.</param>
+    /// <returns>True if the solver was found.</returns>
+    public bool TryGetSolver(IKSolverType solverType, out IIKSolver? solver)
+        => solvers.TryGetValue(solverType, out solver);
+
+    /// <summary>Checks if a solver is registered for the given type.</summary>
+    /// <param name="solverType">The solver type to check.</param>
+    /// <returns>True if a solver is registered.</returns>
+    public bool HasSolver(IKSolverType solverType) => solvers.ContainsKey(solverType);
+
+    #endregion
+
+    #region Cleanup
+
+    /// <summary>Clears all registered rigs, chains, and solvers.</summary>
+    public void Clear()
+    {
+        rigs.Clear();
+        chains.Clear();
+        solvers.Clear();
+        nextRigId = 1;
+        nextChainId = 1;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        Clear();
+        isDisposed = true;
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Animation.Tests/IK/IKManagerTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/IKManagerTests.cs
@@ -1,0 +1,332 @@
+using System.Numerics;
+
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Tests for IKManager registration and retrieval.
+/// </summary>
+public class IKManagerTests
+{
+    #region Rig Registration Tests
+
+    [Fact]
+    public void RegisterRig_ReturnsUniqueId()
+    {
+        using var manager = new IKManager();
+        var rig1 = new IKRigDefinition { Name = "Rig1" };
+        var rig2 = new IKRigDefinition { Name = "Rig2" };
+
+        var id1 = manager.RegisterRig(rig1);
+        var id2 = manager.RegisterRig(rig2);
+
+        id1.ShouldNotBe(id2);
+        id1.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void GetRig_ReturnsRegisteredRig()
+    {
+        using var manager = new IKManager();
+        var rig = new IKRigDefinition { Name = "TestRig" };
+
+        var id = manager.RegisterRig(rig);
+        var retrieved = manager.GetRig(id);
+
+        retrieved.ShouldBe(rig);
+        retrieved.Name.ShouldBe("TestRig");
+    }
+
+    [Fact]
+    public void TryGetRig_ReturnsTrueForRegistered()
+    {
+        using var manager = new IKManager();
+        var rig = new IKRigDefinition { Name = "TestRig" };
+        var id = manager.RegisterRig(rig);
+
+        var found = manager.TryGetRig(id, out var retrieved);
+
+        found.ShouldBeTrue();
+        retrieved.ShouldBe(rig);
+    }
+
+    [Fact]
+    public void TryGetRig_ReturnsFalseForUnknownId()
+    {
+        using var manager = new IKManager();
+
+        var found = manager.TryGetRig(999, out var retrieved);
+
+        found.ShouldBeFalse();
+        retrieved.ShouldBeNull();
+    }
+
+    [Fact]
+    public void UnregisterRig_RemovesRig()
+    {
+        using var manager = new IKManager();
+        var rig = new IKRigDefinition { Name = "TestRig" };
+        var id = manager.RegisterRig(rig);
+
+        var removed = manager.UnregisterRig(id);
+
+        removed.ShouldBeTrue();
+        manager.TryGetRig(id, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RigCount_ReturnsCorrectCount()
+    {
+        using var manager = new IKManager();
+
+        manager.RigCount.ShouldBe(0);
+
+        manager.RegisterRig(new IKRigDefinition { Name = "Rig1" });
+        manager.RegisterRig(new IKRigDefinition { Name = "Rig2" });
+
+        manager.RigCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Chain Registration Tests
+
+    [Fact]
+    public void RegisterChain_ReturnsUniqueId()
+    {
+        using var manager = new IKManager();
+        var chain1 = IKChainDefinition.TwoBone("Arm", "A", "B", "C", Vector3.UnitZ);
+        var chain2 = IKChainDefinition.TwoBone("Leg", "D", "E", "F", Vector3.UnitZ);
+
+        var id1 = manager.RegisterChain(chain1);
+        var id2 = manager.RegisterChain(chain2);
+
+        id1.ShouldNotBe(id2);
+        id1.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TryGetChain_ReturnsRegisteredChain()
+    {
+        using var manager = new IKManager();
+        var chain = IKChainDefinition.TwoBone("LeftArm", "Shoulder", "Elbow", "Hand", Vector3.UnitZ);
+
+        var id = manager.RegisterChain(chain);
+        var found = manager.TryGetChain(id, out var retrieved);
+
+        found.ShouldBeTrue();
+        retrieved.ShouldBe(chain);
+        retrieved!.Name.ShouldBe("LeftArm");
+    }
+
+    [Fact]
+    public void TryGetChain_ReturnsFalseForUnknownId()
+    {
+        using var manager = new IKManager();
+
+        var found = manager.TryGetChain(999, out var retrieved);
+
+        found.ShouldBeFalse();
+        retrieved.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RegisterRig_AlsoRegistersContainedChains()
+    {
+        using var manager = new IKManager();
+        var rig = new IKRigDefinition { Name = "Humanoid" }
+            .AddTwoBoneChain("LeftArm", "A", "B", "C", Vector3.UnitZ)
+            .AddTwoBoneChain("RightArm", "D", "E", "F", Vector3.UnitZ);
+
+        manager.RegisterRig(rig);
+
+        // Rig has 2 chains, so ChainCount should be 2
+        manager.ChainCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void UnregisterChain_RemovesChain()
+    {
+        using var manager = new IKManager();
+        var chain = IKChainDefinition.TwoBone("Arm", "A", "B", "C", Vector3.UnitZ);
+        var id = manager.RegisterChain(chain);
+
+        var removed = manager.UnregisterChain(id);
+
+        removed.ShouldBeTrue();
+        manager.TryGetChain(id, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ChainCount_ReturnsCorrectCount()
+    {
+        using var manager = new IKManager();
+
+        manager.ChainCount.ShouldBe(0);
+
+        manager.RegisterChain(IKChainDefinition.TwoBone("C1", "A", "B", "C", Vector3.UnitZ));
+        manager.RegisterChain(IKChainDefinition.TwoBone("C2", "D", "E", "F", Vector3.UnitZ));
+
+        manager.ChainCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Solver Tests
+
+    [Fact]
+    public void RegisterSolver_AddsSolver()
+    {
+        using var manager = new IKManager();
+        var solver = new MockSolver(IKSolverType.TwoBone);
+
+        manager.RegisterSolver(solver);
+
+        manager.HasSolver(IKSolverType.TwoBone).ShouldBeTrue();
+        manager.SolverCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetSolverForType_ReturnsRegisteredSolver()
+    {
+        using var manager = new IKManager();
+        var solver = new MockSolver(IKSolverType.FABRIK);
+        manager.RegisterSolver(solver);
+
+        var retrieved = manager.GetSolverForType(IKSolverType.FABRIK);
+
+        retrieved.ShouldBe(solver);
+    }
+
+    [Fact]
+    public void GetSolverForType_ThrowsForUnregisteredType()
+    {
+        using var manager = new IKManager();
+
+        Should.Throw<InvalidOperationException>(() =>
+            manager.GetSolverForType(IKSolverType.TwoBone));
+    }
+
+    [Fact]
+    public void TryGetSolver_ReturnsFalseForUnregistered()
+    {
+        using var manager = new IKManager();
+
+        var found = manager.TryGetSolver(IKSolverType.CCD, out var solver);
+
+        found.ShouldBeFalse();
+        solver.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetSolver_ByChainId_ReturnsSolverForChainType()
+    {
+        using var manager = new IKManager();
+        var chain = IKChainDefinition.TwoBone("Arm", "A", "B", "C", Vector3.UnitZ);
+        var solver = new MockSolver(IKSolverType.TwoBone);
+
+        var chainId = manager.RegisterChain(chain);
+        manager.RegisterSolver(solver);
+
+        var retrieved = manager.GetSolver(chainId);
+
+        retrieved.ShouldBe(solver);
+    }
+
+    [Fact]
+    public void GetSolver_ByChainId_ThrowsForUnknownChain()
+    {
+        using var manager = new IKManager();
+
+        Should.Throw<KeyNotFoundException>(() => manager.GetSolver(999));
+    }
+
+    [Fact]
+    public void HasSolver_ReturnsFalseForUnregistered()
+    {
+        using var manager = new IKManager();
+
+        manager.HasSolver(IKSolverType.CCD).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Cleanup Tests
+
+    [Fact]
+    public void Clear_RemovesAllAssets()
+    {
+        using var manager = new IKManager();
+        manager.RegisterRig(new IKRigDefinition { Name = "Rig" });
+        manager.RegisterChain(IKChainDefinition.TwoBone("C", "A", "B", "C", Vector3.UnitZ));
+        manager.RegisterSolver(new MockSolver(IKSolverType.TwoBone));
+
+        manager.Clear();
+
+        manager.RigCount.ShouldBe(0);
+        manager.ChainCount.ShouldBe(0);
+        manager.SolverCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Clear_ResetsIdCounters()
+    {
+        using var manager = new IKManager();
+        manager.RegisterRig(new IKRigDefinition { Name = "Rig1" });
+        manager.RegisterRig(new IKRigDefinition { Name = "Rig2" });
+
+        manager.Clear();
+
+        var id = manager.RegisterRig(new IKRigDefinition { Name = "NewRig" });
+        id.ShouldBe(1); // IDs reset to 1
+    }
+
+    [Fact]
+    public void Dispose_PreventsRegistration()
+    {
+        var manager = new IKManager();
+        manager.Dispose();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            manager.RegisterRig(new IKRigDefinition { Name = "Test" }));
+    }
+
+    [Fact]
+    public void Dispose_PreventsChainRegistration()
+    {
+        var manager = new IKManager();
+        manager.Dispose();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            manager.RegisterChain(IKChainDefinition.TwoBone("C", "A", "B", "C", Vector3.UnitZ)));
+    }
+
+    [Fact]
+    public void Dispose_PreventsSolverRegistration()
+    {
+        var manager = new IKManager();
+        manager.Dispose();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            manager.RegisterSolver(new MockSolver(IKSolverType.TwoBone)));
+    }
+
+    #endregion
+
+    #region Mock Solver
+
+    private sealed class MockSolver(IKSolverType solverType) : IIKSolver
+    {
+        public string Name => $"Mock{solverType}Solver";
+        public IKSolverType SolverType => solverType;
+
+        public IKSolverResult Solve(in IKSolverContext context)
+            => IKSolverResult.Success();
+
+        public bool CanHandle(int boneCount) => true;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implement `IKManager` following the `AnimationManager` pattern
- Support rig and chain registration with auto-incrementing IDs
- AOT-compatible solver registration (manual, no reflection)
- Rigs auto-register their contained chains
- `TryGetRig`, `TryGetChain`, `TryGetSolver` methods
- `GetSolver(chainId)` looks up solver by chain's solver type
- `IDisposable` pattern with `Clear()` and `Dispose()`

## Test plan
- [x] 24 unit tests covering all registration and retrieval methods
- [x] Build passes with zero warnings
- [x] All 56 IK tests pass

## Related Issues
Closes #952


🤖 Generated with [Claude Code](https://claude.com/claude-code)