### PR TITLE
feat(testbridge): Add AI Debugging MCP tools (#947)

### DIFF
--- a/editor/KeenEyes.Cli/packages.lock.json
+++ b/editor/KeenEyes.Cli/packages.lock.json
@@ -200,6 +200,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.editor": {
         "type": "Project",
         "dependencies": {
@@ -365,7 +373,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -225,6 +225,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.editor.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -365,7 +373,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/samples/KeenEyes.Sample.UI/packages.lock.json
+++ b/samples/KeenEyes.Sample.UI/packages.lock.json
@@ -108,6 +108,16 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.animation": {
         "type": "Project",
         "dependencies": {
@@ -149,6 +159,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.editor.abstractions": {
@@ -245,6 +263,19 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -283,7 +314,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/src/KeenEyes.TestBridge.Abstractions/AI/AIStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/AIStatisticsSnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Statistics about AI usage in the world.
+/// </summary>
+public sealed record AIStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets the total number of entities with state machine components.
+    /// </summary>
+    public int StateMachineCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of enabled state machines.
+    /// </summary>
+    public int ActiveStateMachineCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of entities with behavior tree components.
+    /// </summary>
+    public int BehaviorTreeCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of enabled behavior trees.
+    /// </summary>
+    public int ActiveBehaviorTreeCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of entities with utility AI components.
+    /// </summary>
+    public int UtilityAICount { get; init; }
+
+    /// <summary>
+    /// Gets the number of enabled utility AI systems.
+    /// </summary>
+    public int ActiveUtilityAICount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of AI components.
+    /// </summary>
+    public int TotalCount => StateMachineCount + BehaviorTreeCount + UtilityAICount;
+
+    /// <summary>
+    /// Gets the total number of active AI components.
+    /// </summary>
+    public int TotalActiveCount => ActiveStateMachineCount + ActiveBehaviorTreeCount + ActiveUtilityAICount;
+}

--- a/src/KeenEyes.TestBridge.Abstractions/AI/BehaviorTreeSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/BehaviorTreeSnapshot.cs
@@ -1,0 +1,73 @@
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Snapshot of a behavior tree's current state.
+/// </summary>
+public sealed record BehaviorTreeSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the behavior tree is enabled.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the behavior tree is initialized.
+    /// </summary>
+    public required bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the name of the behavior tree definition.
+    /// </summary>
+    public string? TreeName { get; init; }
+
+    /// <summary>
+    /// Gets the last execution result.
+    /// </summary>
+    public required string LastResult { get; init; }
+
+    /// <summary>
+    /// Gets the name of the currently running node, if any.
+    /// </summary>
+    public string? RunningNodeName { get; init; }
+
+    /// <summary>
+    /// Gets the type of the currently running node, if any.
+    /// </summary>
+    public string? RunningNodeType { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+}
+
+/// <summary>
+/// Detailed snapshot of a behavior tree node.
+/// </summary>
+public sealed record BehaviorTreeNodeSnapshot
+{
+    /// <summary>
+    /// Gets the node name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the node type (e.g., "Selector", "Sequence", "ActionNode").
+    /// </summary>
+    public required string NodeType { get; init; }
+
+    /// <summary>
+    /// Gets the last execution state.
+    /// </summary>
+    public required string LastState { get; init; }
+
+    /// <summary>
+    /// Gets the child nodes, if this is a composite or decorator node.
+    /// </summary>
+    public IReadOnlyList<BehaviorTreeNodeSnapshot>? Children { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/AI/BlackboardEntrySnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/BlackboardEntrySnapshot.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Snapshot of a single blackboard entry.
+/// </summary>
+public sealed record BlackboardEntrySnapshot
+{
+    /// <summary>
+    /// Gets the entry key.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Gets the value type name.
+    /// </summary>
+    public required string ValueType { get; init; }
+
+    /// <summary>
+    /// Gets the value as a JSON element for serialization.
+    /// </summary>
+    public JsonElement? Value { get; init; }
+
+    /// <summary>
+    /// Gets the value as a string representation for display.
+    /// </summary>
+    public string? ValueString { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/AI/IAIController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/IAIController.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Controller interface for AI debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to AI state including behavior trees,
+/// finite state machines (FSMs), utility AI, and blackboard data. It enables
+/// inspection and manipulation of AI components for debugging and testing.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires the AIPlugin to be installed on the world
+/// for full functionality.
+/// </para>
+/// </remarks>
+public interface IAIController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about AI component usage in the world.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about AI components.</returns>
+    Task<AIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Behavior Tree Operations
+
+    /// <summary>
+    /// Gets all entities with behavior tree components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have behavior tree components.</returns>
+    Task<IReadOnlyList<int>> GetBehaviorTreeEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of a behavior tree for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The behavior tree state, or null if the entity has no behavior tree.</returns>
+    Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resets a behavior tree to its initial state.
+    /// </summary>
+    /// <param name="entityId">The entity ID to reset.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the reset was successful.</returns>
+    Task<bool> ResetBehaviorTreeAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region FSM Operations
+
+    /// <summary>
+    /// Gets all entities with state machine components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have state machine components.</returns>
+    Task<IReadOnlyList<int>> GetStateMachineEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of a state machine for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The state machine state, or null if the entity has no state machine.</returns>
+    Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Forces a state transition in a state machine.
+    /// </summary>
+    /// <param name="entityId">The entity ID to transition.</param>
+    /// <param name="stateIndex">The index of the target state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the transition was successful.</returns>
+    Task<bool> ForceStateTransitionAsync(int entityId, int stateIndex, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Forces a state transition in a state machine by state name.
+    /// </summary>
+    /// <param name="entityId">The entity ID to transition.</param>
+    /// <param name="stateName">The name of the target state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the transition was successful.</returns>
+    Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Utility AI Operations
+
+    /// <summary>
+    /// Gets all entities with utility AI components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have utility AI components.</returns>
+    Task<IReadOnlyList<int>> GetUtilityAIEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of utility AI for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The utility AI state, or null if the entity has no utility AI.</returns>
+    Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Scores all actions for a utility AI entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to evaluate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of action scores, sorted by score descending.</returns>
+    Task<IReadOnlyList<UtilityScoreSnapshot>> ScoreAllActionsAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Forces a re-evaluation of utility AI on the next tick.
+    /// </summary>
+    /// <param name="entityId">The entity ID to re-evaluate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the entity has a utility component.</returns>
+    Task<bool> ForceUtilityEvaluationAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Blackboard Operations
+
+    /// <summary>
+    /// Gets all entries from an entity's blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of blackboard entries.</returns>
+    Task<IReadOnlyList<BlackboardEntrySnapshot>> GetBlackboardAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a single value from an entity's blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="key">The blackboard key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The blackboard entry, or null if not found.</returns>
+    Task<BlackboardEntrySnapshot?> GetBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets a value in an entity's blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="key">The blackboard key.</param>
+    /// <param name="value">The value as JSON.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the value was set successfully.</returns>
+    Task<bool> SetBlackboardValueAsync(int entityId, string key, JsonElement value, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a value from an entity's blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="key">The blackboard key to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the value was removed.</returns>
+    Task<bool> RemoveBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears all values from an entity's blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to clear.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the blackboard was cleared.</returns>
+    Task<bool> ClearBlackboardAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/AI/StateMachineSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/StateMachineSnapshot.cs
@@ -1,0 +1,108 @@
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Snapshot of a state machine's current state.
+/// </summary>
+public sealed record StateMachineSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the state machine is enabled.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the state machine is initialized.
+    /// </summary>
+    public required bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the name of the state machine definition.
+    /// </summary>
+    public string? MachineName { get; init; }
+
+    /// <summary>
+    /// Gets the current state index.
+    /// </summary>
+    public required int CurrentStateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the current state name.
+    /// </summary>
+    public string? CurrentStateName { get; init; }
+
+    /// <summary>
+    /// Gets the previous state index.
+    /// </summary>
+    public int? PreviousStateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the previous state name.
+    /// </summary>
+    public string? PreviousStateName { get; init; }
+
+    /// <summary>
+    /// Gets the time spent in the current state in seconds.
+    /// </summary>
+    public required float TimeInState { get; init; }
+
+    /// <summary>
+    /// Gets whether the state was just entered this frame.
+    /// </summary>
+    public required bool StateJustEntered { get; init; }
+
+    /// <summary>
+    /// Gets the list of available states.
+    /// </summary>
+    public IReadOnlyList<StateInfoSnapshot>? States { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+}
+
+/// <summary>
+/// Information about a state in a state machine.
+/// </summary>
+public sealed record StateInfoSnapshot
+{
+    /// <summary>
+    /// Gets the state index.
+    /// </summary>
+    public required int Index { get; init; }
+
+    /// <summary>
+    /// Gets the state name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets whether this is the current state.
+    /// </summary>
+    public required bool IsCurrent { get; init; }
+
+    /// <summary>
+    /// Gets the number of enter actions.
+    /// </summary>
+    public int EnterActionCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of update actions.
+    /// </summary>
+    public int UpdateActionCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of exit actions.
+    /// </summary>
+    public int ExitActionCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of transitions from this state.
+    /// </summary>
+    public int TransitionCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/AI/UtilityAISnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/AI/UtilityAISnapshot.cs
@@ -1,0 +1,93 @@
+namespace KeenEyes.TestBridge.AI;
+
+/// <summary>
+/// Snapshot of a utility AI's current state.
+/// </summary>
+public sealed record UtilityAISnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the utility AI is enabled.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the utility AI is initialized.
+    /// </summary>
+    public required bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the name of the utility AI definition.
+    /// </summary>
+    public string? AIName { get; init; }
+
+    /// <summary>
+    /// Gets the name of the currently executing action.
+    /// </summary>
+    public string? CurrentActionName { get; init; }
+
+    /// <summary>
+    /// Gets the selection mode (HighestScore, WeightedRandom, TopN).
+    /// </summary>
+    public required string SelectionMode { get; init; }
+
+    /// <summary>
+    /// Gets the evaluation interval in seconds.
+    /// </summary>
+    public required float EvaluationInterval { get; init; }
+
+    /// <summary>
+    /// Gets the time since last evaluation in seconds.
+    /// </summary>
+    public required float TimeSinceEvaluation { get; init; }
+
+    /// <summary>
+    /// Gets the selection threshold (actions below this score are ignored).
+    /// </summary>
+    public required float SelectionThreshold { get; init; }
+
+    /// <summary>
+    /// Gets the total number of actions available.
+    /// </summary>
+    public required int ActionCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+}
+
+/// <summary>
+/// Score information for a utility AI action.
+/// </summary>
+public sealed record UtilityScoreSnapshot
+{
+    /// <summary>
+    /// Gets the action name.
+    /// </summary>
+    public required string ActionName { get; init; }
+
+    /// <summary>
+    /// Gets the calculated score (0-1 typically, but can be weighted higher).
+    /// </summary>
+    public required float Score { get; init; }
+
+    /// <summary>
+    /// Gets the action weight.
+    /// </summary>
+    public required float Weight { get; init; }
+
+    /// <summary>
+    /// Gets whether this action is currently selected.
+    /// </summary>
+    public required bool IsSelected { get; init; }
+
+    /// <summary>
+    /// Gets the number of considerations for this action.
+    /// </summary>
+    public required int ConsiderationCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -1,4 +1,5 @@
 using KeenEyes.Input.Abstractions;
+using KeenEyes.TestBridge.AI;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -127,6 +128,18 @@ public interface ITestBridge : IDisposable
     /// </para>
     /// </remarks>
     ISnapshotController Snapshot { get; }
+
+    /// <summary>
+    /// Gets the AI controller for inspecting and debugging AI components.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The AI controller provides access to behavior trees, state machines,
+    /// utility AI, and blackboard data. Requires the AIPlugin to be installed
+    /// for full functionality.
+    /// </para>
+    /// </remarks>
+    IAIController AI { get; }
 
     /// <summary>
     /// Gets the input context used by this bridge.

--- a/src/KeenEyes.TestBridge.Client/RemoteAIController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteAIController.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.AI;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IAIController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteAIController(TestBridgeClient client) : IAIController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<AIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<AIStatisticsSnapshot>(
+            "ai.getStatistics",
+            null,
+            cancellationToken) ?? new AIStatisticsSnapshot();
+    }
+
+    #endregion
+
+    #region Behavior Tree Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetBehaviorTreeEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "ai.getBehaviorTreeEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<BehaviorTreeSnapshot?>(
+            "ai.getBehaviorTreeState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ResetBehaviorTreeAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.resetBehaviorTree",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region FSM Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetStateMachineEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "ai.getStateMachineEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<StateMachineSnapshot?>(
+            "ai.getStateMachineState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ForceStateTransitionAsync(int entityId, int stateIndex, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.forceStateTransition",
+            new { entityId, stateIndex },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.forceStateTransitionByName",
+            new { entityId, stateName },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Utility AI Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetUtilityAIEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "ai.getUtilityAIEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UtilityAISnapshot?>(
+            "ai.getUtilityAIState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UtilityScoreSnapshot>> ScoreAllActionsAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<UtilityScoreSnapshot[]>(
+            "ai.scoreAllActions",
+            new { entityId },
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ForceUtilityEvaluationAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.forceUtilityEvaluation",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Blackboard Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BlackboardEntrySnapshot>> GetBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<BlackboardEntrySnapshot[]>(
+            "ai.getBlackboard",
+            new { entityId },
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<BlackboardEntrySnapshot?> GetBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<BlackboardEntrySnapshot?>(
+            "ai.getBlackboardValue",
+            new { entityId, key },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetBlackboardValueAsync(int entityId, string key, JsonElement value, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.setBlackboardValue",
+            new { entityId, key, value },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.removeBlackboardValue",
+            new { entityId, key },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ClearBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ai.clearBlackboard",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using KeenEyes.Input.Abstractions;
+using KeenEyes.TestBridge.AI;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -79,6 +80,7 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         Mutation = new RemoteMutationController(this);
         Profile = new RemoteProfileController(this);
         Snapshot = new RemoteSnapshotController(this);
+        AI = new RemoteAIController(this);
 
         transport.MessageReceived += OnMessageReceived;
         transport.ConnectionChanged += OnConnectionChanged;
@@ -124,6 +126,9 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public ISnapshotController Snapshot { get; }
+
+    /// <inheritdoc />
+    public IAIController AI { get; }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/KeenEyes.TestBridge.Client/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Client/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -16,6 +16,16 @@
       },
       "keeneyes.abstractions": {
         "type": "Project"
+      },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.common": {
         "type": "Project",
@@ -27,6 +37,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics.abstractions": {
@@ -48,6 +66,19 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -64,7 +95,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/AICommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/AICommandHandler.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.AI;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles AI debugging commands for behavior trees, FSMs, utility AI, and blackboards.
+/// </summary>
+internal sealed class AICommandHandler(IAIController aiController) : ICommandHandler
+{
+    public string Prefix => "ai";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await aiController.GetStatisticsAsync(cancellationToken),
+
+            // Behavior Tree
+            "getBehaviorTreeEntities" => await aiController.GetBehaviorTreeEntitiesAsync(cancellationToken),
+            "getBehaviorTreeState" => await HandleGetBehaviorTreeStateAsync(args, cancellationToken),
+            "resetBehaviorTree" => await HandleResetBehaviorTreeAsync(args, cancellationToken),
+
+            // FSM
+            "getStateMachineEntities" => await aiController.GetStateMachineEntitiesAsync(cancellationToken),
+            "getStateMachineState" => await HandleGetStateMachineStateAsync(args, cancellationToken),
+            "forceStateTransition" => await HandleForceStateTransitionAsync(args, cancellationToken),
+            "forceStateTransitionByName" => await HandleForceStateTransitionByNameAsync(args, cancellationToken),
+
+            // Utility AI
+            "getUtilityAIEntities" => await aiController.GetUtilityAIEntitiesAsync(cancellationToken),
+            "getUtilityAIState" => await HandleGetUtilityAIStateAsync(args, cancellationToken),
+            "scoreAllActions" => await HandleScoreAllActionsAsync(args, cancellationToken),
+            "forceUtilityEvaluation" => await HandleForceUtilityEvaluationAsync(args, cancellationToken),
+
+            // Blackboard
+            "getBlackboard" => await HandleGetBlackboardAsync(args, cancellationToken),
+            "getBlackboardValue" => await HandleGetBlackboardValueAsync(args, cancellationToken),
+            "setBlackboardValue" => await HandleSetBlackboardValueAsync(args, cancellationToken),
+            "removeBlackboardValue" => await HandleRemoveBlackboardValueAsync(args, cancellationToken),
+            "clearBlackboard" => await HandleClearBlackboardAsync(args, cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown AI command: {command}")
+        };
+    }
+
+    #region Behavior Tree Handlers
+
+    private async Task<BehaviorTreeSnapshot?> HandleGetBehaviorTreeStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.GetBehaviorTreeStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleResetBehaviorTreeAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.ResetBehaviorTreeAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region FSM Handlers
+
+    private async Task<StateMachineSnapshot?> HandleGetStateMachineStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.GetStateMachineStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleForceStateTransitionAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var stateIndex = GetRequiredInt(args, "stateIndex");
+        return await aiController.ForceStateTransitionAsync(entityId, stateIndex, cancellationToken);
+    }
+
+    private async Task<bool> HandleForceStateTransitionByNameAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var stateName = GetRequiredString(args, "stateName");
+        return await aiController.ForceStateTransitionByNameAsync(entityId, stateName, cancellationToken);
+    }
+
+    #endregion
+
+    #region Utility AI Handlers
+
+    private async Task<UtilityAISnapshot?> HandleGetUtilityAIStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.GetUtilityAIStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<UtilityScoreSnapshot>> HandleScoreAllActionsAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.ScoreAllActionsAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleForceUtilityEvaluationAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.ForceUtilityEvaluationAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Blackboard Handlers
+
+    private async Task<IReadOnlyList<BlackboardEntrySnapshot>> HandleGetBlackboardAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.GetBlackboardAsync(entityId, cancellationToken);
+    }
+
+    private async Task<BlackboardEntrySnapshot?> HandleGetBlackboardValueAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var key = GetRequiredString(args, "key");
+        return await aiController.GetBlackboardValueAsync(entityId, key, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetBlackboardValueAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var key = GetRequiredString(args, "key");
+        var value = GetRequiredJsonElement(args, "value");
+        return await aiController.SetBlackboardValueAsync(entityId, key, value, cancellationToken);
+    }
+
+    private async Task<bool> HandleRemoveBlackboardValueAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var key = GetRequiredString(args, "key");
+        return await aiController.RemoveBlackboardValueAsync(entityId, key, cancellationToken);
+    }
+
+    private async Task<bool> HandleClearBlackboardAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await aiController.ClearBlackboardAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static string GetRequiredString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetString() ?? throw new ArgumentException($"Invalid value for argument: {name}");
+    }
+
+    private static JsonElement GetRequiredJsonElement(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop;
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
+++ b/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
@@ -72,7 +72,8 @@ public sealed class IpcBridgeServer : IDisposable
             ["system"] = new SystemCommandHandler(bridge.Systems),
             ["mutation"] = new MutationCommandHandler(bridge.Mutation),
             ["profile"] = new ProfileCommandHandler(bridge.Profile),
-            ["snapshot"] = new SnapshotCommandHandler(bridge.Snapshot)
+            ["snapshot"] = new SnapshotCommandHandler(bridge.Snapshot),
+            ["ai"] = new AICommandHandler(bridge.AI)
         };
 
         transport.MessageReceived += OnMessageReceived;

--- a/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using KeenEyes.Input.Abstractions;
+using KeenEyes.TestBridge.AI;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
@@ -141,6 +142,23 @@ namespace KeenEyes.TestBridge.Ipc.Protocol;
 [JsonSerializable(typeof(TimelineSystemStatsSnapshot[]))]
 [JsonSerializable(typeof(IReadOnlyList<TimelineSystemStatsSnapshot>))]
 [JsonSerializable(typeof(List<TimelineSystemStatsSnapshot>))]
+// AI types
+[JsonSerializable(typeof(AIStatisticsSnapshot))]
+[JsonSerializable(typeof(BehaviorTreeSnapshot))]
+[JsonSerializable(typeof(StateMachineSnapshot))]
+[JsonSerializable(typeof(StateInfoSnapshot))]
+[JsonSerializable(typeof(StateInfoSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<StateInfoSnapshot>))]
+[JsonSerializable(typeof(List<StateInfoSnapshot>))]
+[JsonSerializable(typeof(UtilityAISnapshot))]
+[JsonSerializable(typeof(UtilityScoreSnapshot))]
+[JsonSerializable(typeof(UtilityScoreSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<UtilityScoreSnapshot>))]
+[JsonSerializable(typeof(List<UtilityScoreSnapshot>))]
+[JsonSerializable(typeof(BlackboardEntrySnapshot))]
+[JsonSerializable(typeof(BlackboardEntrySnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<BlackboardEntrySnapshot>))]
+[JsonSerializable(typeof(List<BlackboardEntrySnapshot>))]
 // Input command arguments
 [JsonSerializable(typeof(KeyActionArgs))]
 [JsonSerializable(typeof(KeyPressArgs))]

--- a/src/KeenEyes.TestBridge.Ipc/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Ipc/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -16,6 +16,16 @@
       },
       "keeneyes.abstractions": {
         "type": "Project"
+      },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
       },
       "keeneyes.common": {
         "type": "Project",
@@ -27,6 +37,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics.abstractions": {
@@ -48,6 +66,19 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -64,7 +95,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/src/KeenEyes.TestBridge/AIImpl/AIControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/AIImpl/AIControllerImpl.cs
@@ -1,0 +1,520 @@
+using System.Text.Json;
+using KeenEyes.AI;
+using KeenEyes.AI.BehaviorTree;
+using KeenEyes.AI.FSM;
+using KeenEyes.AI.Utility;
+using KeenEyes.TestBridge.AI;
+
+namespace KeenEyes.TestBridge.AIImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="IAIController"/>.
+/// </summary>
+internal sealed class AIControllerImpl(World world) : IAIController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<AIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(new AIStatisticsSnapshot());
+        }
+
+        var stats = ai.GetStatistics();
+        return Task.FromResult(new AIStatisticsSnapshot
+        {
+            StateMachineCount = stats.StateMachineCount,
+            ActiveStateMachineCount = stats.ActiveStateMachineCount,
+            BehaviorTreeCount = stats.BehaviorTreeCount,
+            ActiveBehaviorTreeCount = stats.ActiveBehaviorTreeCount,
+            UtilityAICount = stats.UtilityAICount,
+            ActiveUtilityAICount = stats.ActiveUtilityAICount
+        });
+    }
+
+    #endregion
+
+    #region Behavior Tree Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetBehaviorTreeEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<BehaviorTreeComponent>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<BehaviorTreeComponent>(entity))
+        {
+            return Task.FromResult<BehaviorTreeSnapshot?>(null);
+        }
+
+        ref readonly var component = ref world.Get<BehaviorTreeComponent>(entity);
+
+        return Task.FromResult<BehaviorTreeSnapshot?>(new BehaviorTreeSnapshot
+        {
+            EntityId = entityId,
+            Enabled = component.Enabled,
+            IsInitialized = component.IsInitialized,
+            TreeName = component.Definition?.Name,
+            LastResult = component.LastResult.ToString(),
+            RunningNodeName = component.RunningNode?.Name,
+            RunningNodeType = component.RunningNode?.GetType().Name,
+            BlackboardEntryCount = component.Blackboard?.Count ?? 0
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ResetBehaviorTreeAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(ai.ResetBehaviorTree(entity));
+    }
+
+    #endregion
+
+    #region FSM Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetStateMachineEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<StateMachineComponent>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<StateMachineComponent>(entity))
+        {
+            return Task.FromResult<StateMachineSnapshot?>(null);
+        }
+
+        ref readonly var component = ref world.Get<StateMachineComponent>(entity);
+        var definition = component.Definition;
+
+        List<StateInfoSnapshot>? stateInfos = null;
+        if (definition != null)
+        {
+            stateInfos = [];
+            for (var i = 0; i < definition.States.Count; i++)
+            {
+                var state = definition.States[i];
+                stateInfos.Add(new StateInfoSnapshot
+                {
+                    Index = i,
+                    Name = state.Name,
+                    IsCurrent = i == component.CurrentStateIndex,
+                    EnterActionCount = state.OnEnterActions?.Count ?? 0,
+                    UpdateActionCount = state.OnUpdateActions?.Count ?? 0,
+                    ExitActionCount = state.OnExitActions?.Count ?? 0,
+                    TransitionCount = definition.Transitions.Count(t => t.FromStateIndex == i)
+                });
+            }
+        }
+
+        string? previousStateName = null;
+        if (definition != null && component.PreviousStateIndex >= 0 && component.PreviousStateIndex < definition.States.Count)
+        {
+            previousStateName = definition.States[component.PreviousStateIndex].Name;
+        }
+
+        return Task.FromResult<StateMachineSnapshot?>(new StateMachineSnapshot
+        {
+            EntityId = entityId,
+            Enabled = component.Enabled,
+            IsInitialized = component.IsInitialized,
+            MachineName = definition?.Name,
+            CurrentStateIndex = component.CurrentStateIndex,
+            CurrentStateName = component.CurrentStateName,
+            PreviousStateIndex = component.PreviousStateIndex >= 0 ? component.PreviousStateIndex : null,
+            PreviousStateName = previousStateName,
+            TimeInState = component.TimeInState,
+            StateJustEntered = component.StateJustEntered,
+            States = stateInfos,
+            BlackboardEntryCount = component.Blackboard?.Count ?? 0
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ForceStateTransitionAsync(int entityId, int stateIndex, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(ai.ForceStateTransition(entity, stateIndex));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<StateMachineComponent>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref readonly var component = ref world.Get<StateMachineComponent>(entity);
+        var definition = component.Definition;
+        if (definition == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        // Find state index by name
+        var stateIndex = -1;
+        for (var i = 0; i < definition.States.Count; i++)
+        {
+            if (string.Equals(definition.States[i].Name, stateName, StringComparison.OrdinalIgnoreCase))
+            {
+                stateIndex = i;
+                break;
+            }
+        }
+
+        if (stateIndex < 0)
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(ai.ForceStateTransition(entity, stateIndex));
+    }
+
+    #endregion
+
+    #region Utility AI Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetUtilityAIEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<UtilityComponent>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UtilityComponent>(entity))
+        {
+            return Task.FromResult<UtilityAISnapshot?>(null);
+        }
+
+        ref readonly var component = ref world.Get<UtilityComponent>(entity);
+        var definition = component.Definition;
+
+        return Task.FromResult<UtilityAISnapshot?>(new UtilityAISnapshot
+        {
+            EntityId = entityId,
+            Enabled = component.Enabled,
+            IsInitialized = component.IsInitialized,
+            AIName = definition?.Name,
+            CurrentActionName = component.CurrentAction?.Name,
+            SelectionMode = definition?.SelectionMode.ToString() ?? "Unknown",
+            EvaluationInterval = component.EvaluationInterval,
+            TimeSinceEvaluation = component.TimeSinceEvaluation,
+            SelectionThreshold = definition?.SelectionThreshold ?? 0f,
+            ActionCount = definition?.Actions.Count ?? 0,
+            BlackboardEntryCount = component.Blackboard?.Count ?? 0
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<UtilityScoreSnapshot>> ScoreAllActionsAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UtilityComponent>(entity))
+        {
+            return Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
+        }
+
+        ref readonly var component = ref world.Get<UtilityComponent>(entity);
+        var currentAction = component.CurrentAction;
+        var scores = ai.ScoreAllActions(entity);
+
+        var snapshots = new List<UtilityScoreSnapshot>();
+        foreach (var (action, score) in scores)
+        {
+            snapshots.Add(new UtilityScoreSnapshot
+            {
+                ActionName = action.Name,
+                Score = score,
+                Weight = action.Weight,
+                IsSelected = action == currentAction,
+                ConsiderationCount = action.Considerations.Count
+            });
+        }
+
+        return Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>(snapshots);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ForceUtilityEvaluationAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(ai.ForceUtilityEvaluation(entity));
+    }
+
+    #endregion
+
+    #region Blackboard Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<BlackboardEntrySnapshot>> GetBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
+        }
+
+        var blackboard = ai.GetBlackboard(entity);
+        if (blackboard == null)
+        {
+            return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
+        }
+
+        var entries = GetBlackboardEntries(blackboard);
+        return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>(entries);
+    }
+
+    /// <inheritdoc />
+    public Task<BlackboardEntrySnapshot?> GetBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult<BlackboardEntrySnapshot?>(null);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult<BlackboardEntrySnapshot?>(null);
+        }
+
+        var blackboard = ai.GetBlackboard(entity);
+        if (blackboard == null || !blackboard.Has(key))
+        {
+            return Task.FromResult<BlackboardEntrySnapshot?>(null);
+        }
+
+        // Get value using reflection-free approach
+        // We need to use object since Blackboard stores as object internally
+        if (!blackboard.TryGet<object>(key, out var value) || value == null)
+        {
+            return Task.FromResult<BlackboardEntrySnapshot?>(null);
+        }
+
+        return Task.FromResult<BlackboardEntrySnapshot?>(CreateBlackboardEntry(key, value));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetBlackboardValueAsync(int entityId, string key, JsonElement value, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        var blackboard = ai.GetBlackboard(entity);
+        if (blackboard == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        // Convert JsonElement to appropriate type
+        var convertedValue = ConvertJsonValue(value);
+        if (convertedValue == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        blackboard.Set(key, convertedValue);
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> RemoveBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        var blackboard = ai.GetBlackboard(entity);
+        if (blackboard == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(blackboard.Remove(key));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ClearBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AIContext>(out var ai))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        var blackboard = ai.GetBlackboard(entity);
+        if (blackboard == null)
+        {
+            return Task.FromResult(false);
+        }
+
+        blackboard.Clear();
+        return Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields - Acceptable for debug tooling
+    private static List<BlackboardEntrySnapshot> GetBlackboardEntries(Blackboard blackboard)
+    {
+        // Blackboard doesn't expose its keys directly, so we need to use reflection
+        // This is acceptable for debug tooling
+        var entries = new List<BlackboardEntrySnapshot>();
+
+        var dataField = typeof(Blackboard).GetField("data", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        if (dataField?.GetValue(blackboard) is Dictionary<string, object> data)
+        {
+            foreach (var kvp in data)
+            {
+                entries.Add(CreateBlackboardEntry(kvp.Key, kvp.Value));
+            }
+        }
+
+        return entries;
+    }
+#pragma warning restore S3011
+
+#pragma warning disable IL2026, IL3050 // AOT compatibility - Acceptable for debug tooling which uses dynamic serialization
+    private static BlackboardEntrySnapshot CreateBlackboardEntry(string key, object value)
+    {
+        var valueType = value.GetType();
+        string? valueString;
+        JsonElement? jsonValue = null;
+
+        try
+        {
+            // Try to serialize the value to JSON
+            var jsonString = JsonSerializer.Serialize(value);
+            jsonValue = JsonDocument.Parse(jsonString).RootElement.Clone();
+            valueString = valueType.IsPrimitive || value is string ? value.ToString() : jsonString;
+        }
+        catch
+        {
+            // If serialization fails, just use ToString()
+            valueString = value.ToString();
+        }
+#pragma warning restore IL2026, IL3050
+
+        return new BlackboardEntrySnapshot
+        {
+            Key = key,
+            ValueType = valueType.Name,
+            Value = jsonValue,
+            ValueString = valueString
+        };
+    }
+
+    private static object? ConvertJsonValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number when element.TryGetInt32(out var intVal) => intVal,
+            JsonValueKind.Number when element.TryGetInt64(out var longVal) => longVal,
+            JsonValueKind.Number when element.TryGetDouble(out var doubleVal) => (float)doubleVal,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.GetRawText() // For objects and arrays, store as string
+        };
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -1,6 +1,8 @@
 using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Input.Abstractions;
 using KeenEyes.Logging;
+using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.AIImpl;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -54,6 +56,7 @@ public sealed class InProcessBridge : ITestBridge
     private readonly MutationControllerImpl mutationController;
     private readonly ProfileControllerImpl profileController;
     private readonly SnapshotControllerImpl snapshotController;
+    private readonly AIControllerImpl aiController;
     private readonly TestBridgeOptions options;
     private bool disposed;
 
@@ -91,6 +94,7 @@ public sealed class InProcessBridge : ITestBridge
         mutationController = new MutationControllerImpl(world);
         profileController = new ProfileControllerImpl(world);
         snapshotController = new SnapshotControllerImpl(world);
+        aiController = new AIControllerImpl(world);
 
         // Wire up log controller to state controller for WorldStats
         stateController.SetLogController(logController);
@@ -131,6 +135,9 @@ public sealed class InProcessBridge : ITestBridge
 
     /// <inheritdoc />
     public ISnapshotController Snapshot => snapshotController;
+
+    /// <inheritdoc />
+    public IAIController AI => aiController;
 
     /// <inheritdoc />
     public IInputContext InputContext => compositeInputContext is not null

--- a/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
+++ b/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
     <ProjectReference Include="..\KeenEyes.Logging\KeenEyes.Logging.csproj" />
     <ProjectReference Include="..\KeenEyes.Debugging\KeenEyes.Debugging.csproj" />
+    <ProjectReference Include="..\KeenEyes.AI\KeenEyes.AI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.TestBridge/packages.lock.json
+++ b/src/KeenEyes.TestBridge/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -23,6 +23,16 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -33,6 +43,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics.abstractions": {
@@ -49,6 +67,19 @@
         }
       },
       "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"

--- a/tests/KeenEyes.Cli.Tests/packages.lock.json
+++ b/tests/KeenEyes.Cli.Tests/packages.lock.json
@@ -385,6 +385,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.editor": {
         "type": "Project",
         "dependencies": {
@@ -550,7 +558,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
@@ -378,6 +378,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.editor": {
         "type": "Project",
         "dependencies": {
@@ -543,7 +551,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/tests/KeenEyes.Editor.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Tests/packages.lock.json
@@ -378,6 +378,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.editor": {
         "type": "Project",
         "dependencies": {
@@ -543,7 +551,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Direct",
-        "requested": "[18.3.1, )",
-        "resolved": "18.3.1",
-        "contentHash": "kjIVTE93IKEK6ZPZCD95Ahq9mWBmQBB0C1RJzO1eFQDx8bsKLsl6U3EdXjqkiMX/CSGQLC45un/lqtWIicgkwQ==",
+        "requested": "[18.3.2, )",
+        "resolved": "18.3.2",
+        "contentHash": "EQ/Xt/zJzbFUfY9XFYjdPcKIPcSmE7xUS57CiiBK8tQ4LO1l2zs37ZXqCTYukBQbaGN0yT/OT5HIE+hJnNwkcw==",
         "dependencies": {
           "Microsoft.DiaSymReader": "2.0.0",
           "Microsoft.Extensions.DependencyModel": "6.0.2",
@@ -475,6 +475,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.graphics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -515,12 +523,21 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"

--- a/tests/KeenEyes.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.TestBridge.Tests/packages.lock.json
@@ -200,6 +200,16 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -210,6 +220,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics.abstractions": {
@@ -231,6 +249,19 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -247,7 +278,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/tests/KeenEyes.Testing.Tests/packages.lock.json
+++ b/tests/KeenEyes.Testing.Tests/packages.lock.json
@@ -194,6 +194,16 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -204,6 +214,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics.abstractions": {
@@ -225,6 +243,19 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -241,7 +272,9 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/AITools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/AITools.cs
@@ -1,0 +1,766 @@
+using System.ComponentModel;
+using System.Text.Json;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.AI;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for AI debugging: behavior trees, state machines, utility AI, and blackboards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose the AIPlugin debugging infrastructure via MCP, allowing inspection
+/// and manipulation of AI components in running games.
+/// </para>
+/// <para>
+/// Note: These tools require the AIPlugin to be installed in the target world.
+/// Entities must have the appropriate AI component (BehaviorTreeComponent,
+/// StateMachineComponent, or UtilityComponent) for the operations to work.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class AITools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "ai_get_statistics")]
+    [Description("Get overall AI statistics including counts of behavior trees, state machines, and utility AI instances.")]
+    public async Task<AIStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.AI.GetStatisticsAsync();
+        return AIStatisticsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Behavior Trees
+
+    [McpServerTool(Name = "ai_behavior_tree_list")]
+    [Description("List all entities that have a BehaviorTreeComponent.")]
+    public async Task<EntityListResult> GetBehaviorTreeEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.AI.GetBehaviorTreeEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "ai_behavior_tree_get")]
+    [Description("Get the current state of an entity's behavior tree.")]
+    public async Task<BehaviorTreeResult> GetBehaviorTreeState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.AI.GetBehaviorTreeStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new BehaviorTreeResult
+            {
+                Success = false,
+                Error = $"No behavior tree found on entity {entityId}"
+            };
+        }
+
+        return BehaviorTreeResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "ai_behavior_tree_reset")]
+    [Description("Reset an entity's behavior tree to its initial state.")]
+    public async Task<OperationResult> ResetBehaviorTree(
+        [Description("The entity ID to reset")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.ResetBehaviorTreeAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to reset behavior tree on entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region State Machines
+
+    [McpServerTool(Name = "ai_state_machine_list")]
+    [Description("List all entities that have a StateMachineComponent.")]
+    public async Task<EntityListResult> GetStateMachineEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.AI.GetStateMachineEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "ai_state_machine_get")]
+    [Description("Get the current state of an entity's state machine, including all states and transitions.")]
+    public async Task<StateMachineResult> GetStateMachineState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.AI.GetStateMachineStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new StateMachineResult
+            {
+                Success = false,
+                Error = $"No state machine found on entity {entityId}"
+            };
+        }
+
+        return StateMachineResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "ai_state_machine_force_state")]
+    [Description("Force a state machine to transition to a specific state by index.")]
+    public async Task<OperationResult> ForceStateTransition(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The state index to transition to")]
+        int stateIndex)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.ForceStateTransitionAsync(entityId, stateIndex);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to transition to state {stateIndex} on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "ai_state_machine_force_state_by_name")]
+    [Description("Force a state machine to transition to a specific state by name.")]
+    public async Task<OperationResult> ForceStateTransitionByName(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The state name to transition to")]
+        string stateName)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.ForceStateTransitionByNameAsync(entityId, stateName);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to transition to state '{stateName}' on entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Utility AI
+
+    [McpServerTool(Name = "ai_utility_list")]
+    [Description("List all entities that have a UtilityComponent.")]
+    public async Task<EntityListResult> GetUtilityAIEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.AI.GetUtilityAIEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "ai_utility_get")]
+    [Description("Get the current state of an entity's utility AI, including current action and evaluation settings.")]
+    public async Task<UtilityAIResult> GetUtilityAIState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.AI.GetUtilityAIStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new UtilityAIResult
+            {
+                Success = false,
+                Error = $"No utility AI found on entity {entityId}"
+            };
+        }
+
+        return UtilityAIResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "ai_utility_score_all")]
+    [Description("Evaluate and return scores for all available actions on a utility AI entity.")]
+    public async Task<UtilityScoresResult> ScoreAllActions(
+        [Description("The entity ID to score")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var scores = await bridge.AI.ScoreAllActionsAsync(entityId);
+        return new UtilityScoresResult
+        {
+            Success = true,
+            EntityId = entityId,
+            Scores = scores,
+            Count = scores.Count
+        };
+    }
+
+    [McpServerTool(Name = "ai_utility_force_evaluation")]
+    [Description("Force an immediate utility AI evaluation, bypassing the normal evaluation interval.")]
+    public async Task<OperationResult> ForceUtilityEvaluation(
+        [Description("The entity ID")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.ForceUtilityEvaluationAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to force utility evaluation on entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Blackboard
+
+    [McpServerTool(Name = "ai_blackboard_get")]
+    [Description("Get all entries in an entity's AI blackboard.")]
+    public async Task<BlackboardResult> GetBlackboard(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var entries = await bridge.AI.GetBlackboardAsync(entityId);
+        return new BlackboardResult
+        {
+            Success = true,
+            EntityId = entityId,
+            Entries = entries,
+            Count = entries.Count
+        };
+    }
+
+    [McpServerTool(Name = "ai_blackboard_get_value")]
+    [Description("Get a specific value from an entity's AI blackboard.")]
+    public async Task<BlackboardValueResult> GetBlackboardValue(
+        [Description("The entity ID to query")]
+        int entityId,
+        [Description("The blackboard key")]
+        string key)
+    {
+        var bridge = connection.GetBridge();
+        var entry = await bridge.AI.GetBlackboardValueAsync(entityId, key);
+
+        if (entry == null)
+        {
+            return new BlackboardValueResult
+            {
+                Success = false,
+                Error = $"Key '{key}' not found in blackboard for entity {entityId}"
+            };
+        }
+
+        return new BlackboardValueResult
+        {
+            Success = true,
+            EntityId = entityId,
+            Entry = entry
+        };
+    }
+
+    [McpServerTool(Name = "ai_blackboard_set_value")]
+    [Description("Set a value in an entity's AI blackboard. Supports strings, numbers, booleans, and null.")]
+    public async Task<OperationResult> SetBlackboardValue(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The blackboard key")]
+        string key,
+        [Description("The value to set (as JSON)")]
+        JsonElement value)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.SetBlackboardValueAsync(entityId, key, value);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set blackboard value '{key}' on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "ai_blackboard_remove_value")]
+    [Description("Remove a value from an entity's AI blackboard.")]
+    public async Task<OperationResult> RemoveBlackboardValue(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The blackboard key to remove")]
+        string key)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.RemoveBlackboardValueAsync(entityId, key);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to remove blackboard key '{key}' on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "ai_blackboard_clear")]
+    [Description("Clear all entries from an entity's AI blackboard.")]
+    public async Task<OperationResult> ClearBlackboard(
+        [Description("The entity ID")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.AI.ClearBlackboardAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to clear blackboard on entity {entityId}"
+        };
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for AI statistics.
+/// </summary>
+public sealed record AIStatisticsResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>
+    /// Gets the total number of state machines.
+    /// </summary>
+    public int StateMachineCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of active (enabled) state machines.
+    /// </summary>
+    public int ActiveStateMachineCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of behavior trees.
+    /// </summary>
+    public int BehaviorTreeCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of active (enabled) behavior trees.
+    /// </summary>
+    public int ActiveBehaviorTreeCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of utility AI instances.
+    /// </summary>
+    public int UtilityAICount { get; init; }
+
+    /// <summary>
+    /// Gets the number of active (enabled) utility AI instances.
+    /// </summary>
+    public int ActiveUtilityAICount { get; init; }
+
+    internal static AIStatisticsResult FromSnapshot(AIStatisticsSnapshot snapshot)
+    {
+        return new AIStatisticsResult
+        {
+            StateMachineCount = snapshot.StateMachineCount,
+            ActiveStateMachineCount = snapshot.ActiveStateMachineCount,
+            BehaviorTreeCount = snapshot.BehaviorTreeCount,
+            ActiveBehaviorTreeCount = snapshot.ActiveBehaviorTreeCount,
+            UtilityAICount = snapshot.UtilityAICount,
+            ActiveUtilityAICount = snapshot.ActiveUtilityAICount
+        };
+    }
+}
+
+/// <summary>
+/// Result for entity list queries.
+/// </summary>
+public sealed record EntityListResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the list of entity IDs.
+    /// </summary>
+    public IReadOnlyList<int>? EntityIds { get; init; }
+
+    /// <summary>
+    /// Gets the count of entities.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for behavior tree queries.
+/// </summary>
+public sealed record BehaviorTreeResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the behavior tree is enabled.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the behavior tree is initialized.
+    /// </summary>
+    public bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the tree definition name.
+    /// </summary>
+    public string? TreeName { get; init; }
+
+    /// <summary>
+    /// Gets the last result (Running, Success, Failure).
+    /// </summary>
+    public string? LastResult { get; init; }
+
+    /// <summary>
+    /// Gets the currently running node name.
+    /// </summary>
+    public string? RunningNodeName { get; init; }
+
+    /// <summary>
+    /// Gets the currently running node type.
+    /// </summary>
+    public string? RunningNodeType { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static BehaviorTreeResult FromSnapshot(BehaviorTreeSnapshot snapshot)
+    {
+        return new BehaviorTreeResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            Enabled = snapshot.Enabled,
+            IsInitialized = snapshot.IsInitialized,
+            TreeName = snapshot.TreeName,
+            LastResult = snapshot.LastResult,
+            RunningNodeName = snapshot.RunningNodeName,
+            RunningNodeType = snapshot.RunningNodeType,
+            BlackboardEntryCount = snapshot.BlackboardEntryCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for state machine queries.
+/// </summary>
+public sealed record StateMachineResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the state machine is enabled.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the state machine is initialized.
+    /// </summary>
+    public bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the state machine definition name.
+    /// </summary>
+    public string? MachineName { get; init; }
+
+    /// <summary>
+    /// Gets the current state index.
+    /// </summary>
+    public int CurrentStateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the current state name.
+    /// </summary>
+    public string? CurrentStateName { get; init; }
+
+    /// <summary>
+    /// Gets the previous state index.
+    /// </summary>
+    public int? PreviousStateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the previous state name.
+    /// </summary>
+    public string? PreviousStateName { get; init; }
+
+    /// <summary>
+    /// Gets the time spent in the current state.
+    /// </summary>
+    public float TimeInState { get; init; }
+
+    /// <summary>
+    /// Gets whether the state was just entered this frame.
+    /// </summary>
+    public bool StateJustEntered { get; init; }
+
+    /// <summary>
+    /// Gets all states in the machine.
+    /// </summary>
+    public IReadOnlyList<StateInfoSnapshot>? States { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static StateMachineResult FromSnapshot(StateMachineSnapshot snapshot)
+    {
+        return new StateMachineResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            Enabled = snapshot.Enabled,
+            IsInitialized = snapshot.IsInitialized,
+            MachineName = snapshot.MachineName,
+            CurrentStateIndex = snapshot.CurrentStateIndex,
+            CurrentStateName = snapshot.CurrentStateName,
+            PreviousStateIndex = snapshot.PreviousStateIndex,
+            PreviousStateName = snapshot.PreviousStateName,
+            TimeInState = snapshot.TimeInState,
+            StateJustEntered = snapshot.StateJustEntered,
+            States = snapshot.States,
+            BlackboardEntryCount = snapshot.BlackboardEntryCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for utility AI queries.
+/// </summary>
+public sealed record UtilityAIResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the utility AI is enabled.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the utility AI is initialized.
+    /// </summary>
+    public bool IsInitialized { get; init; }
+
+    /// <summary>
+    /// Gets the AI definition name.
+    /// </summary>
+    public string? AIName { get; init; }
+
+    /// <summary>
+    /// Gets the currently selected action name.
+    /// </summary>
+    public string? CurrentActionName { get; init; }
+
+    /// <summary>
+    /// Gets the selection mode (HighestScore, Weighted, etc.).
+    /// </summary>
+    public string? SelectionMode { get; init; }
+
+    /// <summary>
+    /// Gets the evaluation interval in seconds.
+    /// </summary>
+    public float EvaluationInterval { get; init; }
+
+    /// <summary>
+    /// Gets the time since last evaluation.
+    /// </summary>
+    public float TimeSinceEvaluation { get; init; }
+
+    /// <summary>
+    /// Gets the selection threshold for action changes.
+    /// </summary>
+    public float SelectionThreshold { get; init; }
+
+    /// <summary>
+    /// Gets the number of available actions.
+    /// </summary>
+    public int ActionCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of entries in the blackboard.
+    /// </summary>
+    public int BlackboardEntryCount { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static UtilityAIResult FromSnapshot(UtilityAISnapshot snapshot)
+    {
+        return new UtilityAIResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            Enabled = snapshot.Enabled,
+            IsInitialized = snapshot.IsInitialized,
+            AIName = snapshot.AIName,
+            CurrentActionName = snapshot.CurrentActionName,
+            SelectionMode = snapshot.SelectionMode,
+            EvaluationInterval = snapshot.EvaluationInterval,
+            TimeSinceEvaluation = snapshot.TimeSinceEvaluation,
+            SelectionThreshold = snapshot.SelectionThreshold,
+            ActionCount = snapshot.ActionCount,
+            BlackboardEntryCount = snapshot.BlackboardEntryCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for utility action scoring.
+/// </summary>
+public sealed record UtilityScoresResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the action scores.
+    /// </summary>
+    public IReadOnlyList<UtilityScoreSnapshot>? Scores { get; init; }
+
+    /// <summary>
+    /// Gets the count of actions scored.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for blackboard queries.
+/// </summary>
+public sealed record BlackboardResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the blackboard entries.
+    /// </summary>
+    public IReadOnlyList<BlackboardEntrySnapshot>? Entries { get; init; }
+
+    /// <summary>
+    /// Gets the count of entries.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for single blackboard value queries.
+/// </summary>
+public sealed record BlackboardValueResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the blackboard entry.
+    /// </summary>
+    public BlackboardEntrySnapshot? Entry { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -332,6 +332,14 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
       "keeneyes.graphics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -364,12 +372,21 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"


### PR DESCRIPTION
## Summary
- Adds Phase 6a of the MCP Tools Expansion Initiative (AI Debugging tools)
- Implements 17 new MCP tools for inspecting and manipulating AI components
- Supports behavior trees, state machines, utility AI, and blackboards

## New MCP Tools

### Statistics
- `ai_get_statistics` - Get overall AI stats (counts of each AI type)

### Behavior Trees
- `ai_behavior_tree_list` - List entities with BehaviorTreeComponent
- `ai_behavior_tree_get` - Get current tree state (running node, last result)
- `ai_behavior_tree_reset` - Reset tree to initial state

### State Machines
- `ai_state_machine_list` - List entities with StateMachineComponent
- `ai_state_machine_get` - Get current state, all states, and transitions
- `ai_state_machine_force_state` - Force transition by state index
- `ai_state_machine_force_state_by_name` - Force transition by state name

### Utility AI
- `ai_utility_list` - List entities with UtilityComponent
- `ai_utility_get` - Get current action, selection mode, evaluation settings
- `ai_utility_score_all` - Evaluate and return scores for all actions
- `ai_utility_force_evaluation` - Force immediate evaluation

### Blackboard
- `ai_blackboard_get` - Get all entries in entity's blackboard
- `ai_blackboard_get_value` - Get specific entry by key
- `ai_blackboard_set_value` - Set entry value (supports JSON primitives)
- `ai_blackboard_remove_value` - Remove entry by key
- `ai_blackboard_clear` - Clear all entries

## Test Plan
- [x] All TestBridge tests pass (247/248, 1 Windows-only skip)
- [x] Full solution builds with zero warnings
- [x] Code formatting verified

## Related Issues
Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)