### PR TITLE
feat(testbridge): Add Phase 6 MCP tools - Physics, Navigation, Network, Animation, UI

### DIFF
--- a/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationClipSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationClipSnapshot.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.TestBridge.Animation;
+
+/// <summary>
+/// Snapshot of an animation clip asset.
+/// </summary>
+public sealed record AnimationClipSnapshot
+{
+    /// <summary>
+    /// Gets or sets the clip ID.
+    /// </summary>
+    public required int ClipId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the clip name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets or sets the duration in seconds.
+    /// </summary>
+    public required float Duration { get; init; }
+
+    /// <summary>
+    /// Gets or sets the wrap mode.
+    /// </summary>
+    public required string WrapMode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of bone tracks in this clip.
+    /// </summary>
+    public required int BoneTrackCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationPlayerSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationPlayerSnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.Animation;
+
+/// <summary>
+/// Snapshot of an animation player component state.
+/// </summary>
+public sealed record AnimationPlayerSnapshot
+{
+    /// <summary>
+    /// Gets or sets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the animation clip ID.
+    /// </summary>
+    public required int ClipId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current playback time in seconds.
+    /// </summary>
+    public required float Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the playback speed multiplier.
+    /// </summary>
+    public required float Speed { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the animation is currently playing.
+    /// </summary>
+    public required bool IsPlaying { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the animation has completed (for non-looping animations).
+    /// </summary>
+    public required bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Gets or sets the blend weight for this animation (0-1).
+    /// </summary>
+    public required float Weight { get; init; }
+
+    /// <summary>
+    /// Gets or sets the wrap mode override, if any.
+    /// </summary>
+    public required string? WrapModeOverride { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Animation/AnimationStatisticsSnapshot.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.TestBridge.Animation;
+
+/// <summary>
+/// Snapshot of animation system statistics.
+/// </summary>
+public sealed record AnimationStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets or sets the number of registered animation clips.
+    /// </summary>
+    public required int ClipCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of registered animator controllers.
+    /// </summary>
+    public required int ControllerCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of registered sprite sheets.
+    /// </summary>
+    public required int SpriteSheetCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of entities with active animation players.
+    /// </summary>
+    public required int ActivePlayerCount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of entities with active animators.
+    /// </summary>
+    public required int ActiveAnimatorCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Animation/AnimatorSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Animation/AnimatorSnapshot.cs
@@ -1,0 +1,62 @@
+namespace KeenEyes.TestBridge.Animation;
+
+/// <summary>
+/// Snapshot of an animator component state.
+/// </summary>
+public sealed record AnimatorSnapshot
+{
+    /// <summary>
+    /// Gets or sets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the animator controller ID.
+    /// </summary>
+    public required int ControllerId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current state hash.
+    /// </summary>
+    public required int CurrentStateHash { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current state name, if available.
+    /// </summary>
+    public required string? CurrentStateName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the playback time within the current state.
+    /// </summary>
+    public required float StateTime { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the animator is currently transitioning between states.
+    /// </summary>
+    public required bool IsTransitioning { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transition progress (0-1) when transitioning.
+    /// </summary>
+    public required float TransitionProgress { get; init; }
+
+    /// <summary>
+    /// Gets or sets the global speed multiplier.
+    /// </summary>
+    public required float Speed { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the animator is enabled.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets or sets the next state hash during transitions, or 0 if not transitioning.
+    /// </summary>
+    public required int NextStateHash { get; init; }
+
+    /// <summary>
+    /// Gets or sets the next state name during transitions, if available.
+    /// </summary>
+    public required string? NextStateName { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Animation/IAnimationController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Animation/IAnimationController.cs
@@ -1,0 +1,131 @@
+namespace KeenEyes.TestBridge.Animation;
+
+/// <summary>
+/// Controller interface for animation debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to animation state including animation players,
+/// animators, animation clips, and sprite sheets. It enables inspection and
+/// manipulation of animation components for debugging and testing.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires the AnimationPlugin to be installed on the world
+/// for full functionality.
+/// </para>
+/// </remarks>
+public interface IAnimationController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about animation component usage in the world.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about animation components and assets.</returns>
+    Task<AnimationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Animation Player Operations
+
+    /// <summary>
+    /// Gets all entities with animation player components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have animation player components.</returns>
+    Task<IReadOnlyList<int>> GetAnimationPlayerEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of an animation player for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The animation player state, or null if the entity has no animation player.</returns>
+    Task<AnimationPlayerSnapshot?> GetAnimationPlayerStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the playing state of an animation player.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="isPlaying">Whether the animation should be playing.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the state was set successfully.</returns>
+    Task<bool> SetAnimationPlayerPlayingAsync(int entityId, bool isPlaying, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the playback time of an animation player.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="time">The playback time in seconds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the time was set successfully.</returns>
+    Task<bool> SetAnimationPlayerTimeAsync(int entityId, float time, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the playback speed of an animation player.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="speed">The playback speed multiplier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the speed was set successfully.</returns>
+    Task<bool> SetAnimationPlayerSpeedAsync(int entityId, float speed, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Animator Operations
+
+    /// <summary>
+    /// Gets all entities with animator components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have animator components.</returns>
+    Task<IReadOnlyList<int>> GetAnimatorEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of an animator for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The animator state, or null if the entity has no animator.</returns>
+    Task<AnimatorSnapshot?> GetAnimatorStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Triggers a state transition in an animator by state hash.
+    /// </summary>
+    /// <param name="entityId">The entity ID to transition.</param>
+    /// <param name="stateHash">The hash of the target state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the trigger was set successfully.</returns>
+    Task<bool> TriggerAnimatorStateAsync(int entityId, int stateHash, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Triggers a state transition in an animator by state name.
+    /// </summary>
+    /// <param name="entityId">The entity ID to transition.</param>
+    /// <param name="stateName">The name of the target state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the trigger was set successfully.</returns>
+    Task<bool> TriggerAnimatorStateByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Animation Clip Operations
+
+    /// <summary>
+    /// Gets information about an animation clip by ID.
+    /// </summary>
+    /// <param name="clipId">The clip ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The clip information, or null if not found.</returns>
+    Task<AnimationClipSnapshot?> GetClipInfoAsync(int clipId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all registered animation clips.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of all registered animation clips.</returns>
+    Task<IReadOnlyList<AnimationClipSnapshot>> ListClipsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -7,6 +7,7 @@ using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
 using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
@@ -140,6 +141,18 @@ public interface ITestBridge : IDisposable
     /// </para>
     /// </remarks>
     IAIController AI { get; }
+
+    /// <summary>
+    /// Gets the replay controller for recording and playback of gameplay sessions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The replay controller enables recording input events and world state,
+    /// then playing them back for bug reproduction and determinism validation.
+    /// Requires the ReplayPlugin to be installed for full functionality.
+    /// </para>
+    /// </remarks>
+    IReplayController Replay { get; }
 
     /// <summary>
     /// Gets the input context used by this bridge.

--- a/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/ITestBridge.cs
@@ -1,10 +1,14 @@
 using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.Animation;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.Physics;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.Profile;
 using KeenEyes.TestBridge.Replay;
@@ -12,6 +16,7 @@ using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
 using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.UI;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge;
@@ -153,6 +158,66 @@ public interface ITestBridge : IDisposable
     /// </para>
     /// </remarks>
     IReplayController Replay { get; }
+
+    /// <summary>
+    /// Gets the physics controller for inspecting and debugging physics simulation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The physics controller provides access to raycasting, overlap queries,
+    /// body state inspection, and force application for debugging physics interactions.
+    /// Requires the PhysicsPlugin to be installed for full functionality.
+    /// </para>
+    /// </remarks>
+    IPhysicsController Physics { get; }
+
+    /// <summary>
+    /// Gets the animation controller for inspecting and debugging animation components.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The animation controller provides access to animation players, animators,
+    /// and animation clips. Requires the AnimationPlugin to be installed
+    /// for full functionality.
+    /// </para>
+    /// </remarks>
+    IAnimationController Animation { get; }
+
+    /// <summary>
+    /// Gets the navigation controller for inspecting and debugging navigation agents and paths.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The navigation controller provides access to navigation agents, pathfinding,
+    /// and navmesh queries. Requires the NavigationPlugin to be installed
+    /// for full functionality.
+    /// </para>
+    /// </remarks>
+    INavigationController Navigation { get; }
+
+    /// <summary>
+    /// Gets the network controller for inspecting and debugging network state and replication.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The network controller provides access to connection state, networked entities,
+    /// ownership information, and replication state. Requires either NetworkClientPlugin
+    /// or NetworkServerPlugin to be installed for full functionality.
+    /// </para>
+    /// </remarks>
+    INetworkController Network { get; }
+
+    /// <summary>
+    /// Gets the UI controller for inspecting and debugging UI elements.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The UI controller provides access to UI element hierarchy, focus management,
+    /// hit testing, and interaction simulation. Requires the UIPlugin to be installed
+    /// for full functionality.
+    /// </para>
+    /// </remarks>
+    IUIController UI { get; }
 
     /// <summary>
     /// Gets the input context used by this bridge.

--- a/src/KeenEyes.TestBridge.Abstractions/Navigation/INavigationController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Navigation/INavigationController.cs
@@ -1,0 +1,139 @@
+namespace KeenEyes.TestBridge.Navigation;
+
+/// <summary>
+/// Controller interface for navigation debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to navigation state including navmesh agents,
+/// pathfinding, and navigation mesh queries. It enables inspection and manipulation
+/// of navigation components for debugging and testing.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires the NavigationPlugin to be installed on the world
+/// for full functionality.
+/// </para>
+/// </remarks>
+public interface INavigationController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about navigation system usage in the world.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about navigation components and state.</returns>
+    Task<NavigationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets whether the navigation system is ready and initialized.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the navigation provider is ready.</returns>
+    Task<bool> IsReadyAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Agent Operations
+
+    /// <summary>
+    /// Gets all entities with NavMeshAgent components.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs that have navigation agent components.</returns>
+    Task<IReadOnlyList<int>> GetNavigationEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the state of a navigation agent for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The agent state, or null if the entity has no agent component.</returns>
+    Task<NavAgentSnapshot?> GetAgentStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current path for a navigation agent.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The agent's path, or null if the entity has no active path.</returns>
+    Task<NavPathSnapshot?> GetPathAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets a destination for a navigation agent.
+    /// </summary>
+    /// <param name="entityId">The entity ID to command.</param>
+    /// <param name="x">The destination X coordinate.</param>
+    /// <param name="y">The destination Y coordinate.</param>
+    /// <param name="z">The destination Z coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the destination was set successfully.</returns>
+    Task<bool> SetDestinationAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops a navigation agent and clears its path.
+    /// </summary>
+    /// <param name="entityId">The entity ID to stop.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the agent was stopped successfully.</returns>
+    Task<bool> StopAgentAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resumes navigation for a stopped agent.
+    /// </summary>
+    /// <param name="entityId">The entity ID to resume.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the agent was resumed successfully.</returns>
+    Task<bool> ResumeAgentAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Warps an agent to a position without pathfinding.
+    /// </summary>
+    /// <param name="entityId">The entity ID to warp.</param>
+    /// <param name="x">The destination X coordinate.</param>
+    /// <param name="y">The destination Y coordinate.</param>
+    /// <param name="z">The destination Z coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the position is on the navmesh.</returns>
+    Task<bool> WarpAgentAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Path Queries
+
+    /// <summary>
+    /// Finds a path between two positions.
+    /// </summary>
+    /// <param name="startX">The start X coordinate.</param>
+    /// <param name="startY">The start Y coordinate.</param>
+    /// <param name="startZ">The start Z coordinate.</param>
+    /// <param name="endX">The end X coordinate.</param>
+    /// <param name="endY">The end Y coordinate.</param>
+    /// <param name="endZ">The end Z coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The computed path, or null if no path exists.</returns>
+    Task<NavPathSnapshot?> FindPathAsync(float startX, float startY, float startZ, float endX, float endY, float endZ, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a position is navigable.
+    /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
+    /// <param name="z">The Z coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the position is on the navigation mesh.</returns>
+    Task<bool> IsNavigableAsync(float x, float y, float z, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds the nearest navigable point to a position.
+    /// </summary>
+    /// <param name="x">The query X coordinate.</param>
+    /// <param name="y">The query Y coordinate.</param>
+    /// <param name="z">The query Z coordinate.</param>
+    /// <param name="searchRadius">Maximum distance to search.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The nearest navigable point, or null if none found.</returns>
+    Task<NavPointSnapshot?> FindNearestPointAsync(float x, float y, float z, float searchRadius, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Navigation/NavAgentSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Navigation/NavAgentSnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.Navigation;
+
+/// <summary>
+/// Snapshot of a navigation agent's current state.
+/// </summary>
+public sealed record NavAgentSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the agent has a valid path.
+    /// </summary>
+    public required bool HasPath { get; init; }
+
+    /// <summary>
+    /// Gets whether the agent is stopped.
+    /// </summary>
+    public required bool IsStopped { get; init; }
+
+    /// <summary>
+    /// Gets whether a path request is pending.
+    /// </summary>
+    public required bool PathPending { get; init; }
+
+    /// <summary>
+    /// Gets the current waypoint index in the path.
+    /// </summary>
+    public required int CurrentWaypointIndex { get; init; }
+
+    /// <summary>
+    /// Gets the distance traveled along the current path.
+    /// </summary>
+    public required float DistanceTraveled { get; init; }
+
+    /// <summary>
+    /// Gets the agent's movement speed.
+    /// </summary>
+    public required float Speed { get; init; }
+
+    /// <summary>
+    /// Gets the agent's destination, if set.
+    /// </summary>
+    public NavPointSnapshot? Destination { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Navigation/NavPathSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Navigation/NavPathSnapshot.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.TestBridge.Navigation;
+
+/// <summary>
+/// Snapshot of a navigation path.
+/// </summary>
+public sealed record NavPathSnapshot
+{
+    /// <summary>
+    /// Gets whether this path is valid (has waypoints).
+    /// </summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets whether this path reaches the intended destination.
+    /// </summary>
+    public required bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Gets the total traversal cost of the path.
+    /// </summary>
+    public required float TotalCost { get; init; }
+
+    /// <summary>
+    /// Gets the total length of the path in world units.
+    /// </summary>
+    public required float Length { get; init; }
+
+    /// <summary>
+    /// Gets the waypoints comprising the path.
+    /// </summary>
+    public required IReadOnlyList<NavPointSnapshot> Waypoints { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Navigation/NavPointSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Navigation/NavPointSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Navigation;
+
+/// <summary>
+/// Snapshot of a navigation point with position and metadata.
+/// </summary>
+public sealed record NavPointSnapshot
+{
+    /// <summary>
+    /// Gets the X coordinate.
+    /// </summary>
+    public required float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y coordinate.
+    /// </summary>
+    public required float Y { get; init; }
+
+    /// <summary>
+    /// Gets the Z coordinate.
+    /// </summary>
+    public required float Z { get; init; }
+
+    /// <summary>
+    /// Gets the navigation area type name at this point.
+    /// </summary>
+    public required string AreaType { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Navigation/NavigationStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Navigation/NavigationStatisticsSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Navigation;
+
+/// <summary>
+/// Statistics about navigation system usage in the world.
+/// </summary>
+public sealed record NavigationStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets whether the navigation system is ready and initialized.
+    /// </summary>
+    public required bool IsReady { get; init; }
+
+    /// <summary>
+    /// Gets the name of the current navigation strategy.
+    /// </summary>
+    public required string Strategy { get; init; }
+
+    /// <summary>
+    /// Gets the total number of active navigation agents.
+    /// </summary>
+    public required int ActiveAgentCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of pending path requests.
+    /// </summary>
+    public required int PendingRequestCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Network/ClientSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Network/ClientSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Network;
+
+/// <summary>
+/// Snapshot of a connected client's state (server-side view).
+/// </summary>
+public sealed record ClientSnapshot
+{
+    /// <summary>
+    /// Gets the client ID.
+    /// </summary>
+    public required int ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the last acknowledged server tick from this client.
+    /// </summary>
+    public required uint LastAckedTick { get; init; }
+
+    /// <summary>
+    /// Gets whether the client needs a full snapshot.
+    /// </summary>
+    public required bool NeedsFullSnapshot { get; init; }
+
+    /// <summary>
+    /// Gets the round-trip time to this client in milliseconds.
+    /// </summary>
+    public required float RoundTripTimeMs { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Network/ConnectionStatsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Network/ConnectionStatsSnapshot.cs
@@ -1,0 +1,37 @@
+namespace KeenEyes.TestBridge.Network;
+
+/// <summary>
+/// Connection statistics for a network client.
+/// </summary>
+public sealed record ConnectionStatsSnapshot
+{
+    /// <summary>
+    /// Gets the round-trip time to the server in milliseconds.
+    /// </summary>
+    public required float RoundTripTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the packet loss percentage (0-100).
+    /// </summary>
+    public required float PacketLossPercent { get; init; }
+
+    /// <summary>
+    /// Gets the total bytes sent to the server.
+    /// </summary>
+    public required long BytesSent { get; init; }
+
+    /// <summary>
+    /// Gets the total bytes received from the server.
+    /// </summary>
+    public required long BytesReceived { get; init; }
+
+    /// <summary>
+    /// Gets the total packets sent to the server.
+    /// </summary>
+    public required long PacketsSent { get; init; }
+
+    /// <summary>
+    /// Gets the total packets received from the server.
+    /// </summary>
+    public required long PacketsReceived { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Network/INetworkController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Network/INetworkController.cs
@@ -1,0 +1,114 @@
+namespace KeenEyes.TestBridge.Network;
+
+/// <summary>
+/// Controller interface for network debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to network statistics, connection state,
+/// and entity replication data for both client and server network plugins.
+/// It enables inspection of networked entities, ownership, and replication state.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires either NetworkClientPlugin or NetworkServerPlugin
+/// to be installed on the world for full functionality.
+/// </para>
+/// </remarks>
+public interface INetworkController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about network state and connections.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Network statistics snapshot.</returns>
+    Task<NetworkStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Connection State
+
+    /// <summary>
+    /// Gets whether the network plugin is connected (client connected to server, or server listening).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if connected; false otherwise.</returns>
+    Task<bool> IsConnectedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets whether this is a server instance.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if server; false if client or no network plugin.</returns>
+    Task<bool> IsServerAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current network tick.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current tick value.</returns>
+    Task<uint> GetCurrentTickAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the round-trip latency to the server in milliseconds (client only).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Round-trip time in milliseconds, or 0 if not a client or not connected.</returns>
+    Task<float> GetLatencyAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets detailed connection statistics for the local connection (client only).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Connection statistics, or null if not a client or not connected.</returns>
+    Task<ConnectionStatsSnapshot?> GetConnectionStatsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Server Operations
+
+    /// <summary>
+    /// Gets all connected clients (server only).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of connected client snapshots, or empty list if not a server.</returns>
+    Task<IReadOnlyList<ClientSnapshot>> GetConnectedClientsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Entity Replication
+
+    /// <summary>
+    /// Gets all networked entity IDs.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of entity IDs that have NetworkId components.</returns>
+    Task<IReadOnlyList<int>> GetNetworkedEntitiesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the network ID for an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The network ID, or null if the entity has no network ID.</returns>
+    Task<uint?> GetNetworkIdAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the owner client ID for a networked entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The owner client ID (0 for server), or null if the entity has no NetworkOwner component.</returns>
+    Task<int?> GetOwnershipAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the replication state for a networked entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Replication state snapshot, or null if the entity has no NetworkState component.</returns>
+    Task<ReplicationStateSnapshot?> GetReplicationStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Network/NetworkStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Network/NetworkStatisticsSnapshot.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.TestBridge.Network;
+
+/// <summary>
+/// Statistics about network state and connections.
+/// </summary>
+public sealed record NetworkStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets whether the network plugin is connected.
+    /// </summary>
+    public required bool IsConnected { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a server instance.
+    /// </summary>
+    public required bool IsServer { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a client instance.
+    /// </summary>
+    public required bool IsClient { get; init; }
+
+    /// <summary>
+    /// Gets the current network tick.
+    /// </summary>
+    public required uint CurrentTick { get; init; }
+
+    /// <summary>
+    /// Gets the local client ID (0 for server, assigned ID for clients).
+    /// </summary>
+    public required int LocalClientId { get; init; }
+
+    /// <summary>
+    /// Gets the number of connected clients (server only, 0 for clients).
+    /// </summary>
+    public required int ClientCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of networked entities.
+    /// </summary>
+    public required int NetworkedEntityCount { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Network/ReplicationStateSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Network/ReplicationStateSnapshot.cs
@@ -1,0 +1,52 @@
+namespace KeenEyes.TestBridge.Network;
+
+/// <summary>
+/// Snapshot of an entity's network replication state.
+/// </summary>
+public sealed record ReplicationStateSnapshot
+{
+    /// <summary>
+    /// Gets the network ID assigned to this entity.
+    /// </summary>
+    public required uint NetworkId { get; init; }
+
+    /// <summary>
+    /// Gets the owner client ID (0 for server-owned).
+    /// </summary>
+    public required int OwnerId { get; init; }
+
+    /// <summary>
+    /// Gets the last tick this entity was sent to clients (server only).
+    /// </summary>
+    public required uint LastSentTick { get; init; }
+
+    /// <summary>
+    /// Gets the last tick received from the server (client only).
+    /// </summary>
+    public required uint LastReceivedTick { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity needs a full synchronization.
+    /// </summary>
+    public required bool NeedsFullSync { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is locally owned.
+    /// </summary>
+    public required bool IsLocallyOwned { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is remotely owned.
+    /// </summary>
+    public required bool IsRemotelyOwned { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is predicted (client-side prediction enabled).
+    /// </summary>
+    public required bool IsPredicted { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is interpolated (remote entity interpolation enabled).
+    /// </summary>
+    public required bool IsInterpolated { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/IPhysicsController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/IPhysicsController.cs
@@ -1,0 +1,147 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Controller interface for physics debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to physics simulation state including raycasting,
+/// overlap queries, body state inspection, and force application. It enables inspection
+/// and manipulation of physics bodies for debugging and testing.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires the PhysicsPlugin to be installed on the world
+/// for full functionality.
+/// </para>
+/// </remarks>
+public interface IPhysicsController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about the physics simulation.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about physics bodies and simulation state.</returns>
+    Task<PhysicsStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Raycasting and Queries
+
+    /// <summary>
+    /// Casts a ray and returns the first hit.
+    /// </summary>
+    /// <param name="origin">The starting point of the ray.</param>
+    /// <param name="direction">The direction of the ray (should be normalized).</param>
+    /// <param name="maxDistance">Maximum distance to check for hits.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Information about the hit, or null if nothing was hit.</returns>
+    Task<RayHitSnapshot?> RaycastAsync(Vector3Snapshot origin, Vector3Snapshot direction, float maxDistance, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds all entities within a sphere.
+    /// </summary>
+    /// <param name="center">The center of the sphere.</param>
+    /// <param name="radius">The radius of the sphere.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs overlapping the sphere.</returns>
+    Task<IReadOnlyList<int>> OverlapSphereAsync(Vector3Snapshot center, float radius, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds all entities within a box.
+    /// </summary>
+    /// <param name="center">The center of the box.</param>
+    /// <param name="halfExtents">The half-extents of the box.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs overlapping the box.</returns>
+    Task<IReadOnlyList<int>> OverlapBoxAsync(Vector3Snapshot center, Vector3Snapshot halfExtents, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Body State
+
+    /// <summary>
+    /// Gets the state of a physics body.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The body state, or null if the entity has no physics body.</returns>
+    Task<PhysicsBodySnapshot?> GetBodyStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the linear velocity of an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The linear velocity, or null if the entity has no physics body.</returns>
+    Task<Vector3Snapshot?> GetVelocityAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the linear velocity of an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to modify.</param>
+    /// <param name="velocity">The new velocity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the velocity was set successfully.</returns>
+    Task<bool> SetVelocityAsync(int entityId, Vector3Snapshot velocity, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a body is awake (not sleeping).
+    /// </summary>
+    /// <param name="entityId">The entity ID to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if awake, false if sleeping, null if no physics body.</returns>
+    Task<bool?> IsAwakeAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Wakes up a sleeping body.
+    /// </summary>
+    /// <param name="entityId">The entity ID to wake.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the entity was woken up successfully.</returns>
+    Task<bool> WakeUpAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Forces and Impulses
+
+    /// <summary>
+    /// Applies a force to an entity at its center of mass.
+    /// </summary>
+    /// <param name="entityId">The entity ID to apply force to.</param>
+    /// <param name="force">The force vector in world space.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the force was applied successfully.</returns>
+    Task<bool> ApplyForceAsync(int entityId, Vector3Snapshot force, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies an impulse to an entity at its center of mass.
+    /// </summary>
+    /// <param name="entityId">The entity ID to apply impulse to.</param>
+    /// <param name="impulse">The impulse vector in world space.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the impulse was applied successfully.</returns>
+    Task<bool> ApplyImpulseAsync(int entityId, Vector3Snapshot impulse, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Gravity
+
+    /// <summary>
+    /// Gets the current gravity vector.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The gravity vector.</returns>
+    Task<Vector3Snapshot> GetGravityAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the gravity vector for the simulation.
+    /// </summary>
+    /// <param name="gravity">The new gravity vector.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if gravity was set successfully.</returns>
+    Task<bool> SetGravityAsync(Vector3Snapshot gravity, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/PhysicsBodySnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/PhysicsBodySnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Snapshot of a physics body's state.
+/// </summary>
+public sealed record PhysicsBodySnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the world position.
+    /// </summary>
+    public required Vector3Snapshot Position { get; init; }
+
+    /// <summary>
+    /// Gets the rotation quaternion.
+    /// </summary>
+    public required QuaternionSnapshot Rotation { get; init; }
+
+    /// <summary>
+    /// Gets the linear velocity.
+    /// </summary>
+    public required Vector3Snapshot LinearVelocity { get; init; }
+
+    /// <summary>
+    /// Gets the angular velocity.
+    /// </summary>
+    public required Vector3Snapshot AngularVelocity { get; init; }
+
+    /// <summary>
+    /// Gets the mass in kilograms.
+    /// </summary>
+    public required float Mass { get; init; }
+
+    /// <summary>
+    /// Gets the body type (Dynamic, Kinematic, Static).
+    /// </summary>
+    public required string BodyType { get; init; }
+
+    /// <summary>
+    /// Gets whether the body is currently awake (not sleeping).
+    /// </summary>
+    public required bool IsAwake { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/PhysicsStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/PhysicsStatisticsSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Statistics about physics simulation state.
+/// </summary>
+public sealed record PhysicsStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets the total number of physics bodies (dynamic + kinematic).
+    /// </summary>
+    public required int BodyCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of static bodies.
+    /// </summary>
+    public required int StaticCount { get; init; }
+
+    /// <summary>
+    /// Gets the interpolation alpha for smooth rendering (0-1).
+    /// </summary>
+    public required float InterpolationAlpha { get; init; }
+
+    /// <summary>
+    /// Gets the total count of all physics objects.
+    /// </summary>
+    public int TotalCount => BodyCount + StaticCount;
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/QuaternionSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/QuaternionSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Snapshot of a quaternion for serialization.
+/// </summary>
+public sealed record QuaternionSnapshot
+{
+    /// <summary>
+    /// Gets the X component.
+    /// </summary>
+    public required float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y component.
+    /// </summary>
+    public required float Y { get; init; }
+
+    /// <summary>
+    /// Gets the Z component.
+    /// </summary>
+    public required float Z { get; init; }
+
+    /// <summary>
+    /// Gets the W (scalar) component.
+    /// </summary>
+    public required float W { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/RayHitSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/RayHitSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Information about a raycast hit.
+/// </summary>
+public sealed record RayHitSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID that was hit.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the world position of the hit point.
+    /// </summary>
+    public required Vector3Snapshot Position { get; init; }
+
+    /// <summary>
+    /// Gets the surface normal at the hit point.
+    /// </summary>
+    public required Vector3Snapshot Normal { get; init; }
+
+    /// <summary>
+    /// Gets the distance from the ray origin to the hit point.
+    /// </summary>
+    public required float Distance { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Physics/Vector3Snapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Physics/Vector3Snapshot.cs
@@ -1,0 +1,22 @@
+namespace KeenEyes.TestBridge.Physics;
+
+/// <summary>
+/// Snapshot of a 3D vector for serialization.
+/// </summary>
+public sealed record Vector3Snapshot
+{
+    /// <summary>
+    /// Gets the X component.
+    /// </summary>
+    public required float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y component.
+    /// </summary>
+    public required float Y { get; init; }
+
+    /// <summary>
+    /// Gets the Z component.
+    /// </summary>
+    public required float Z { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/DeterminismResultSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/DeterminismResultSnapshot.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Result of checking replay determinism.
+/// </summary>
+public sealed record DeterminismResultSnapshot
+{
+    /// <summary>
+    /// Gets whether the replay is deterministic.
+    /// </summary>
+    public required bool IsDeterministic { get; init; }
+
+    /// <summary>
+    /// Gets the total frames checked.
+    /// </summary>
+    public required int TotalFramesChecked { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames with checksums.
+    /// </summary>
+    public required int FramesWithChecksums { get; init; }
+
+    /// <summary>
+    /// Gets the first frame where a desync was detected, if any.
+    /// </summary>
+    public int? FirstDesyncFrame { get; init; }
+
+    /// <summary>
+    /// Gets the expected checksum at the desync frame.
+    /// </summary>
+    public uint? ExpectedChecksum { get; init; }
+
+    /// <summary>
+    /// Gets the actual checksum at the desync frame.
+    /// </summary>
+    public uint? ActualChecksum { get; init; }
+
+    /// <summary>
+    /// Gets details about the desync, if any.
+    /// </summary>
+    public string? DesyncDetails { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/IReplayController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/IReplayController.cs
@@ -1,0 +1,240 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Provides replay recording and playback control for debugging sessions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The replay controller enables recording gameplay sessions and playing them back
+/// for debugging, bug reproduction, and determinism validation.
+/// </para>
+/// <para>
+/// Recording captures:
+/// <list type="bullet">
+/// <item><description>Input events (keyboard, mouse, gamepad)</description></item>
+/// <item><description>World state snapshots at intervals</description></item>
+/// <item><description>System and entity events</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// Playback supports:
+/// <list type="bullet">
+/// <item><description>Variable speed playback (0.25x to 4x)</description></item>
+/// <item><description>Frame-by-frame stepping</description></item>
+/// <item><description>Seeking to specific frames or times</description></item>
+/// <item><description>Determinism validation via checksums</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public interface IReplayController
+{
+    #region Recording Control
+
+    /// <summary>
+    /// Starts a new recording session.
+    /// </summary>
+    /// <param name="name">Optional name for the recording.</param>
+    /// <param name="maxFrames">Maximum frames to record (default: 36000 = 10 minutes at 60fps).</param>
+    /// <param name="snapshotIntervalMs">Interval between snapshots in milliseconds (default: 5000).</param>
+    /// <returns>The result of the operation with recording info.</returns>
+    Task<ReplayOperationResult> StartRecordingAsync(
+        string? name = null,
+        int maxFrames = 36000,
+        int snapshotIntervalMs = 5000);
+
+    /// <summary>
+    /// Stops the current recording and returns the recorded data.
+    /// </summary>
+    /// <returns>The result with recording info, or failure if not recording.</returns>
+    Task<ReplayOperationResult> StopRecordingAsync();
+
+    /// <summary>
+    /// Cancels the current recording without saving data.
+    /// </summary>
+    /// <returns>The result of the operation.</returns>
+    Task<ReplayOperationResult> CancelRecordingAsync();
+
+    /// <summary>
+    /// Gets whether recording is currently active.
+    /// </summary>
+    /// <returns>True if recording; otherwise, false.</returns>
+    Task<bool> IsRecordingAsync();
+
+    /// <summary>
+    /// Gets information about the current recording session.
+    /// </summary>
+    /// <returns>Recording info, or null if not recording.</returns>
+    Task<RecordingInfoSnapshot?> GetRecordingInfoAsync();
+
+    /// <summary>
+    /// Forces a snapshot capture at the current frame.
+    /// </summary>
+    /// <returns>The result of the operation.</returns>
+    Task<ReplayOperationResult> ForceSnapshotAsync();
+
+    #endregion
+
+    #region Recording Management
+
+    /// <summary>
+    /// Saves the current recording to a file.
+    /// </summary>
+    /// <param name="path">The file path to save to.</param>
+    /// <returns>The result of the operation.</returns>
+    Task<ReplayOperationResult> SaveAsync(string path);
+
+    /// <summary>
+    /// Loads a recording from a file for playback.
+    /// </summary>
+    /// <param name="path">The file path to load from.</param>
+    /// <returns>The result with replay metadata.</returns>
+    Task<ReplayOperationResult> LoadAsync(string path);
+
+    /// <summary>
+    /// Lists available recording files in a directory.
+    /// </summary>
+    /// <param name="directory">The directory to search (default: current directory).</param>
+    /// <returns>List of replay file information.</returns>
+    Task<IReadOnlyList<ReplayFileSnapshot>> ListAsync(string? directory = null);
+
+    /// <summary>
+    /// Deletes a recording file.
+    /// </summary>
+    /// <param name="path">The file path to delete.</param>
+    /// <returns>True if deleted; otherwise, false.</returns>
+    Task<bool> DeleteAsync(string path);
+
+    /// <summary>
+    /// Gets metadata from a recording file without loading it.
+    /// </summary>
+    /// <param name="path">The file path to read.</param>
+    /// <returns>The replay metadata, or null if invalid.</returns>
+    Task<ReplayMetadataSnapshot?> GetMetadataAsync(string path);
+
+    #endregion
+
+    #region Playback Control
+
+    /// <summary>
+    /// Starts or resumes playback.
+    /// </summary>
+    /// <returns>The result with current playback state.</returns>
+    Task<ReplayOperationResult> PlayAsync();
+
+    /// <summary>
+    /// Pauses playback at the current position.
+    /// </summary>
+    /// <returns>The result with current playback state.</returns>
+    Task<ReplayOperationResult> PauseAsync();
+
+    /// <summary>
+    /// Stops playback and resets to the beginning.
+    /// </summary>
+    /// <returns>The result with current playback state.</returns>
+    Task<ReplayOperationResult> StopPlaybackAsync();
+
+    /// <summary>
+    /// Gets the current playback state.
+    /// </summary>
+    /// <returns>The current playback state.</returns>
+    Task<PlaybackStateSnapshot> GetPlaybackStateAsync();
+
+    /// <summary>
+    /// Sets the playback speed multiplier.
+    /// </summary>
+    /// <param name="speed">Speed multiplier (0.25 to 4.0).</param>
+    /// <returns>The result with updated playback state.</returns>
+    Task<ReplayOperationResult> SetSpeedAsync(float speed);
+
+    #endregion
+
+    #region Playback Navigation
+
+    /// <summary>
+    /// Seeks to a specific frame number.
+    /// </summary>
+    /// <param name="frame">The 0-based frame number.</param>
+    /// <returns>The result with updated playback state.</returns>
+    Task<ReplayOperationResult> SeekFrameAsync(int frame);
+
+    /// <summary>
+    /// Seeks to a specific time in seconds.
+    /// </summary>
+    /// <param name="seconds">The time in seconds from the start.</param>
+    /// <returns>The result with updated playback state.</returns>
+    Task<ReplayOperationResult> SeekTimeAsync(float seconds);
+
+    /// <summary>
+    /// Steps forward by a number of frames.
+    /// </summary>
+    /// <param name="frames">Number of frames to step (default: 1).</param>
+    /// <returns>The result with updated playback state.</returns>
+    Task<ReplayOperationResult> StepForwardAsync(int frames = 1);
+
+    /// <summary>
+    /// Steps backward by a number of frames.
+    /// </summary>
+    /// <param name="frames">Number of frames to step back (default: 1).</param>
+    /// <returns>The result with updated playback state.</returns>
+    Task<ReplayOperationResult> StepBackwardAsync(int frames = 1);
+
+    #endregion
+
+    #region Frame Inspection
+
+    /// <summary>
+    /// Gets data for a specific frame.
+    /// </summary>
+    /// <param name="frame">The 0-based frame number.</param>
+    /// <returns>The frame data, or null if not found.</returns>
+    Task<ReplayFrameSnapshot?> GetFrameAsync(int frame);
+
+    /// <summary>
+    /// Gets a range of frames.
+    /// </summary>
+    /// <param name="startFrame">The starting frame number.</param>
+    /// <param name="count">Number of frames to retrieve.</param>
+    /// <returns>List of frame data.</returns>
+    Task<IReadOnlyList<ReplayFrameSnapshot>> GetFrameRangeAsync(int startFrame, int count);
+
+    /// <summary>
+    /// Gets input events in a frame range.
+    /// </summary>
+    /// <param name="startFrame">The starting frame number.</param>
+    /// <param name="endFrame">The ending frame number (inclusive).</param>
+    /// <returns>List of input events.</returns>
+    Task<IReadOnlyList<InputEventSnapshot>> GetInputsAsync(int startFrame, int endFrame);
+
+    /// <summary>
+    /// Gets replay events in a frame range.
+    /// </summary>
+    /// <param name="startFrame">The starting frame number.</param>
+    /// <param name="endFrame">The ending frame number (inclusive).</param>
+    /// <returns>List of replay events.</returns>
+    Task<IReadOnlyList<ReplayEventSnapshot>> GetEventsAsync(int startFrame, int endFrame);
+
+    /// <summary>
+    /// Gets all snapshot markers in the loaded replay.
+    /// </summary>
+    /// <returns>List of snapshot marker info.</returns>
+    Task<IReadOnlyList<SnapshotMarkerSnapshot>> GetSnapshotsAsync();
+
+    #endregion
+
+    #region Validation
+
+    /// <summary>
+    /// Validates a replay file for integrity.
+    /// </summary>
+    /// <param name="path">The file path to validate.</param>
+    /// <returns>The validation result.</returns>
+    Task<ValidationResultSnapshot> ValidateAsync(string path);
+
+    /// <summary>
+    /// Checks if the loaded replay is deterministic by comparing checksums.
+    /// </summary>
+    /// <returns>The determinism check result.</returns>
+    Task<DeterminismResultSnapshot> CheckDeterminismAsync();
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/InputEventSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/InputEventSnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Snapshot of a recorded input event.
+/// </summary>
+public sealed record InputEventSnapshot
+{
+    /// <summary>
+    /// Gets the type of input event.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the frame number when this input occurred.
+    /// </summary>
+    public required int Frame { get; init; }
+
+    /// <summary>
+    /// Gets the key or button identifier, if applicable.
+    /// </summary>
+    public string? Key { get; init; }
+
+    /// <summary>
+    /// Gets the numeric value (axis value, scroll delta, etc.).
+    /// </summary>
+    public float? Value { get; init; }
+
+    /// <summary>
+    /// Gets the X position, if applicable.
+    /// </summary>
+    public float? PositionX { get; init; }
+
+    /// <summary>
+    /// Gets the Y position, if applicable.
+    /// </summary>
+    public float? PositionY { get; init; }
+
+    /// <summary>
+    /// Gets the custom type name for custom input events.
+    /// </summary>
+    public string? CustomType { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp offset within the frame in milliseconds.
+    /// </summary>
+    public float? TimestampMs { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/PlaybackStateSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/PlaybackStateSnapshot.cs
@@ -1,0 +1,64 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Current state of replay playback.
+/// </summary>
+public sealed record PlaybackStateSnapshot
+{
+    /// <summary>
+    /// Gets whether a replay is loaded.
+    /// </summary>
+    public required bool IsLoaded { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is currently active.
+    /// </summary>
+    public required bool IsPlaying { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is paused.
+    /// </summary>
+    public required bool IsPaused { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is stopped.
+    /// </summary>
+    public required bool IsStopped { get; init; }
+
+    /// <summary>
+    /// Gets the current frame index (0-based).
+    /// </summary>
+    public required int CurrentFrame { get; init; }
+
+    /// <summary>
+    /// Gets the total number of frames in the replay.
+    /// </summary>
+    public required int TotalFrames { get; init; }
+
+    /// <summary>
+    /// Gets the current playback time in seconds.
+    /// </summary>
+    public required float CurrentTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the total duration in seconds.
+    /// </summary>
+    public required float TotalTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the current playback speed multiplier.
+    /// </summary>
+    public required float PlaybackSpeed { get; init; }
+
+    /// <summary>
+    /// Gets the name of the loaded replay.
+    /// </summary>
+    public string? ReplayName { get; init; }
+
+    /// <summary>
+    /// Gets the progress as a percentage (0-100).
+    /// </summary>
+    public float ProgressPercent => TotalFrames > 0
+        ? (float)CurrentFrame / TotalFrames * 100f
+        : 0f;
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/RecordingInfoSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/RecordingInfoSnapshot.cs
@@ -1,0 +1,37 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Information about the current recording session.
+/// </summary>
+public sealed record RecordingInfoSnapshot
+{
+    /// <summary>
+    /// Gets whether recording is currently active.
+    /// </summary>
+    public required bool IsRecording { get; init; }
+
+    /// <summary>
+    /// Gets the name of the recording.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the current frame count.
+    /// </summary>
+    public required int FrameCount { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed recording duration in seconds.
+    /// </summary>
+    public required float DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the number of snapshots captured.
+    /// </summary>
+    public required int SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp when recording started (UTC).
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayEventSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayEventSnapshot.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Snapshot of a recorded replay event.
+/// </summary>
+public sealed record ReplayEventSnapshot
+{
+    /// <summary>
+    /// Gets the type of replay event.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the frame number when this event occurred.
+    /// </summary>
+    public required int Frame { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp offset within the frame in milliseconds.
+    /// </summary>
+    public required float TimestampMs { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID involved, if applicable.
+    /// </summary>
+    public int? EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the component type name, if applicable.
+    /// </summary>
+    public string? ComponentTypeName { get; init; }
+
+    /// <summary>
+    /// Gets the system type name, if applicable.
+    /// </summary>
+    public string? SystemTypeName { get; init; }
+
+    /// <summary>
+    /// Gets the custom event type name.
+    /// </summary>
+    public string? CustomType { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayFileSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayFileSnapshot.cs
@@ -1,0 +1,37 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Information about a replay file on disk.
+/// </summary>
+public sealed record ReplayFileSnapshot
+{
+    /// <summary>
+    /// Gets the full file path.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the file name without path.
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public required long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets the last modified timestamp.
+    /// </summary>
+    public required DateTimeOffset LastModified { get; init; }
+
+    /// <summary>
+    /// Gets the replay metadata, if readable.
+    /// </summary>
+    public ReplayMetadataSnapshot? Metadata { get; init; }
+
+    /// <summary>
+    /// Gets any validation error for the file.
+    /// </summary>
+    public string? ValidationError { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayFrameSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayFrameSnapshot.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Snapshot of a single replay frame.
+/// </summary>
+public sealed record ReplayFrameSnapshot
+{
+    /// <summary>
+    /// Gets the frame number (0-based).
+    /// </summary>
+    public required int FrameNumber { get; init; }
+
+    /// <summary>
+    /// Gets the delta time for this frame in seconds.
+    /// </summary>
+    public required float DeltaTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed time from the start of the replay in seconds.
+    /// </summary>
+    public required float ElapsedTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the number of input events in this frame.
+    /// </summary>
+    public required int InputEventCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of replay events in this frame.
+    /// </summary>
+    public required int EventCount { get; init; }
+
+    /// <summary>
+    /// Gets whether this frame has a preceding snapshot.
+    /// </summary>
+    public required bool HasSnapshot { get; init; }
+
+    /// <summary>
+    /// Gets the checksum for this frame, if recorded.
+    /// </summary>
+    public uint? Checksum { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayMetadataSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayMetadataSnapshot.cs
@@ -1,0 +1,62 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Metadata from a replay file.
+/// </summary>
+public sealed record ReplayMetadataSnapshot
+{
+    /// <summary>
+    /// Gets the name of the recording.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the description of the recording.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp when recording started (UTC).
+    /// </summary>
+    public required DateTimeOffset RecordingStarted { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp when recording ended (UTC).
+    /// </summary>
+    public DateTimeOffset? RecordingEnded { get; init; }
+
+    /// <summary>
+    /// Gets the total duration in seconds.
+    /// </summary>
+    public required float DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the total number of frames.
+    /// </summary>
+    public required int FrameCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of snapshots in the recording.
+    /// </summary>
+    public required int SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets the average frame rate.
+    /// </summary>
+    public required float AverageFrameRate { get; init; }
+
+    /// <summary>
+    /// Gets the replay data version.
+    /// </summary>
+    public required int DataVersion { get; init; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public long? FileSizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets whether the file has a checksum.
+    /// </summary>
+    public bool? HasChecksum { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayOperationResult.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ReplayOperationResult.cs
@@ -1,0 +1,72 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Result of a replay operation.
+/// </summary>
+public sealed record ReplayOperationResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets the file path involved in the operation, if any.
+    /// </summary>
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// Gets recording info if available after the operation.
+    /// </summary>
+    public RecordingInfoSnapshot? RecordingInfo { get; init; }
+
+    /// <summary>
+    /// Gets playback state if available after the operation.
+    /// </summary>
+    public PlaybackStateSnapshot? PlaybackState { get; init; }
+
+    /// <summary>
+    /// Gets replay metadata if available after the operation.
+    /// </summary>
+    public ReplayMetadataSnapshot? Metadata { get; init; }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static ReplayOperationResult Ok() => new() { Success = true };
+
+    /// <summary>
+    /// Creates a successful result with a path.
+    /// </summary>
+    public static ReplayOperationResult Ok(string path) =>
+        new() { Success = true, Path = path };
+
+    /// <summary>
+    /// Creates a successful result with recording info.
+    /// </summary>
+    public static ReplayOperationResult Ok(RecordingInfoSnapshot info) =>
+        new() { Success = true, RecordingInfo = info };
+
+    /// <summary>
+    /// Creates a successful result with playback state.
+    /// </summary>
+    public static ReplayOperationResult Ok(PlaybackStateSnapshot state) =>
+        new() { Success = true, PlaybackState = state };
+
+    /// <summary>
+    /// Creates a successful result with metadata.
+    /// </summary>
+    public static ReplayOperationResult Ok(ReplayMetadataSnapshot metadata) =>
+        new() { Success = true, Metadata = metadata };
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    public static ReplayOperationResult Fail(string error) =>
+        new() { Success = false, Error = error };
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/SnapshotMarkerSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/SnapshotMarkerSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Information about a snapshot marker in a replay.
+/// </summary>
+public sealed record SnapshotMarkerSnapshot
+{
+    /// <summary>
+    /// Gets the frame number where the snapshot was taken.
+    /// </summary>
+    public required int FrameNumber { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed time from the start in seconds.
+    /// </summary>
+    public required float ElapsedTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the checksum of the snapshot, if recorded.
+    /// </summary>
+    public uint? Checksum { get; init; }
+
+    /// <summary>
+    /// Gets the index of this snapshot in the replay.
+    /// </summary>
+    public required int Index { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/Replay/ValidationResultSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/Replay/ValidationResultSnapshot.cs
@@ -1,0 +1,37 @@
+namespace KeenEyes.TestBridge.Replay;
+
+/// <summary>
+/// Result of validating a replay file.
+/// </summary>
+public sealed record ValidationResultSnapshot
+{
+    /// <summary>
+    /// Gets whether the file is valid.
+    /// </summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets the file path that was validated.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the total number of frames in the file.
+    /// </summary>
+    public int? TotalFrames { get; init; }
+
+    /// <summary>
+    /// Gets the number of snapshots in the file.
+    /// </summary>
+    public int? SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets the data version of the replay file.
+    /// </summary>
+    public int? DataVersion { get; init; }
+
+    /// <summary>
+    /// Gets any validation errors found.
+    /// </summary>
+    public IReadOnlyList<string>? Errors { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/IUIController.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/IUIController.cs
@@ -1,0 +1,152 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Controller interface for UI debugging and inspection operations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides access to UI state including element hierarchy,
+/// focus management, hit testing, and interaction simulation. It enables
+/// inspection and manipulation of UI components for debugging and testing.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Requires the UIPlugin to be installed on the world
+/// for full functionality.
+/// </para>
+/// </remarks>
+public interface IUIController
+{
+    #region Statistics
+
+    /// <summary>
+    /// Gets statistics about UI element usage in the world.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about UI elements.</returns>
+    Task<UIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Focus Management
+
+    /// <summary>
+    /// Gets the currently focused UI element.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The entity ID of the focused element, or null if none.</returns>
+    Task<int?> GetFocusedElementAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets focus to a specific UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to focus.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if focus was set successfully.</returns>
+    Task<bool> SetFocusAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears focus from the currently focused element.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if focus was cleared.</returns>
+    Task<bool> ClearFocusAsync(CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Element Inspection
+
+    /// <summary>
+    /// Gets information about a specific UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The element snapshot, or null if the entity is not a UI element.</returns>
+    Task<UIElementSnapshot?> GetElementAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the entire UI element tree starting from a root (or all roots if null).
+    /// </summary>
+    /// <param name="rootEntityId">The root entity ID, or null for all roots.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of UI elements in hierarchical order.</returns>
+    Task<IReadOnlyList<UIElementSnapshot>> GetElementTreeAsync(int? rootEntityId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all root UI elements (canvases).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of root element entity IDs.</returns>
+    Task<IReadOnlyList<int>> GetRootElementsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the bounds of a UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The element bounds, or null if the entity has no UIRect.</returns>
+    Task<UIBoundsSnapshot?> GetElementBoundsAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the style of a UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The element style, or null if the entity has no UIStyle.</returns>
+    Task<UIStyleSnapshot?> GetElementStyleAsync(int entityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the interaction state of a UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The interaction state, or null if the entity has no UIInteractable.</returns>
+    Task<UIInteractionSnapshot?> GetInteractionStateAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Hit Testing
+
+    /// <summary>
+    /// Finds the topmost UI element at a screen position.
+    /// </summary>
+    /// <param name="x">The X screen coordinate.</param>
+    /// <param name="y">The Y screen coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The entity ID at the position, or null if none.</returns>
+    Task<int?> HitTestAsync(float x, float y, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds all UI elements at a screen position.
+    /// </summary>
+    /// <param name="x">The X screen coordinate.</param>
+    /// <param name="y">The Y screen coordinate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of entity IDs at the position, sorted topmost first.</returns>
+    Task<IReadOnlyList<int>> HitTestAllAsync(float x, float y, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Element Search
+
+    /// <summary>
+    /// Finds a UI element by name.
+    /// </summary>
+    /// <param name="name">The element name to search for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The entity ID of the first matching element, or null if not found.</returns>
+    Task<int?> FindElementByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Interaction Simulation
+
+    /// <summary>
+    /// Simulates a click on a UI element.
+    /// </summary>
+    /// <param name="entityId">The entity ID to click.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the click was simulated successfully.</returns>
+    Task<bool> SimulateClickAsync(int entityId, CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/UIBoundsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/UIBoundsSnapshot.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Snapshot of a UI element's bounds.
+/// </summary>
+public sealed record UIBoundsSnapshot
+{
+    /// <summary>
+    /// Gets the X position in screen coordinates.
+    /// </summary>
+    public required float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y position in screen coordinates.
+    /// </summary>
+    public required float Y { get; init; }
+
+    /// <summary>
+    /// Gets the width in pixels.
+    /// </summary>
+    public required float Width { get; init; }
+
+    /// <summary>
+    /// Gets the height in pixels.
+    /// </summary>
+    public required float Height { get; init; }
+
+    /// <summary>
+    /// Gets the local Z-index for render ordering.
+    /// </summary>
+    public required short LocalZIndex { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/UIElementSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/UIElementSnapshot.cs
@@ -1,0 +1,52 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Snapshot of a UI element's state.
+/// </summary>
+public sealed record UIElementSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the element's name, or null if unnamed.
+    /// </summary>
+    public required string? Name { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is visible.
+    /// </summary>
+    public required bool IsVisible { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can receive pointer events.
+    /// </summary>
+    public required bool IsRaycastTarget { get; init; }
+
+    /// <summary>
+    /// Gets the parent entity ID, or null if root.
+    /// </summary>
+    public required int? ParentId { get; init; }
+
+    /// <summary>
+    /// Gets the list of child entity IDs.
+    /// </summary>
+    public required IReadOnlyList<int> ChildIds { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIInteractable component.
+    /// </summary>
+    public required bool HasInteractable { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIText component.
+    /// </summary>
+    public required bool HasText { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIStyle component.
+    /// </summary>
+    public required bool HasStyle { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/UIInteractionSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/UIInteractionSnapshot.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Snapshot of a UI element's interaction state.
+/// </summary>
+public sealed record UIInteractionSnapshot
+{
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can receive keyboard focus.
+    /// </summary>
+    public required bool CanFocus { get; init; }
+
+    /// <summary>
+    /// Gets whether the element responds to click/tap events.
+    /// </summary>
+    public required bool CanClick { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can be dragged.
+    /// </summary>
+    public required bool CanDrag { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is currently hovered.
+    /// </summary>
+    public required bool IsHovered { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is currently pressed.
+    /// </summary>
+    public required bool IsPressed { get; init; }
+
+    /// <summary>
+    /// Gets whether the element currently has focus.
+    /// </summary>
+    public required bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is being dragged.
+    /// </summary>
+    public required bool IsDragging { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/UIStatisticsSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/UIStatisticsSnapshot.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Statistics about UI usage in the world.
+/// </summary>
+public sealed record UIStatisticsSnapshot
+{
+    /// <summary>
+    /// Gets the total number of UI elements.
+    /// </summary>
+    public required int TotalElementCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of visible UI elements.
+    /// </summary>
+    public required int VisibleElementCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of interactable UI elements.
+    /// </summary>
+    public required int InteractableCount { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID of the currently focused element, or null if none.
+    /// </summary>
+    public required int? FocusedElementId { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Abstractions/UI/UIStyleSnapshot.cs
+++ b/src/KeenEyes.TestBridge.Abstractions/UI/UIStyleSnapshot.cs
@@ -1,0 +1,57 @@
+namespace KeenEyes.TestBridge.UI;
+
+/// <summary>
+/// Snapshot of a UI element's style.
+/// </summary>
+public sealed record UIStyleSnapshot
+{
+    /// <summary>
+    /// Gets the background color red component (0-1).
+    /// </summary>
+    public required float BackgroundColorR { get; init; }
+
+    /// <summary>
+    /// Gets the background color green component (0-1).
+    /// </summary>
+    public required float BackgroundColorG { get; init; }
+
+    /// <summary>
+    /// Gets the background color blue component (0-1).
+    /// </summary>
+    public required float BackgroundColorB { get; init; }
+
+    /// <summary>
+    /// Gets the background color alpha component (0-1).
+    /// </summary>
+    public required float BackgroundColorA { get; init; }
+
+    /// <summary>
+    /// Gets the border width in pixels.
+    /// </summary>
+    public required float BorderWidth { get; init; }
+
+    /// <summary>
+    /// Gets the corner radius for rounded rectangles.
+    /// </summary>
+    public required float CornerRadius { get; init; }
+
+    /// <summary>
+    /// Gets the left padding in pixels.
+    /// </summary>
+    public required float PaddingLeft { get; init; }
+
+    /// <summary>
+    /// Gets the right padding in pixels.
+    /// </summary>
+    public required float PaddingRight { get; init; }
+
+    /// <summary>
+    /// Gets the top padding in pixels.
+    /// </summary>
+    public required float PaddingTop { get; init; }
+
+    /// <summary>
+    /// Gets the bottom padding in pixels.
+    /// </summary>
+    public required float PaddingBottom { get; init; }
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteAnimationController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteAnimationController.cs
@@ -1,0 +1,143 @@
+using KeenEyes.TestBridge.Animation;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IAnimationController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteAnimationController(TestBridgeClient client) : IAnimationController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<AnimationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<AnimationStatisticsSnapshot>(
+            "animation.getStatistics",
+            null,
+            cancellationToken) ?? new AnimationStatisticsSnapshot
+            {
+                ClipCount = 0,
+                ControllerCount = 0,
+                SpriteSheetCount = 0,
+                ActivePlayerCount = 0,
+                ActiveAnimatorCount = 0
+            };
+    }
+
+    #endregion
+
+    #region Animation Player Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetAnimationPlayerEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "animation.getAnimationPlayerEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<AnimationPlayerSnapshot?> GetAnimationPlayerStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<AnimationPlayerSnapshot?>(
+            "animation.getAnimationPlayerState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetAnimationPlayerPlayingAsync(int entityId, bool isPlaying, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "animation.setAnimationPlayerPlaying",
+            new { entityId, isPlaying },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetAnimationPlayerTimeAsync(int entityId, float time, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "animation.setAnimationPlayerTime",
+            new { entityId, time },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetAnimationPlayerSpeedAsync(int entityId, float speed, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "animation.setAnimationPlayerSpeed",
+            new { entityId, speed },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Animator Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetAnimatorEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "animation.getAnimatorEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<AnimatorSnapshot?> GetAnimatorStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<AnimatorSnapshot?>(
+            "animation.getAnimatorState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TriggerAnimatorStateAsync(int entityId, int stateHash, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "animation.triggerAnimatorState",
+            new { entityId, stateHash },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TriggerAnimatorStateByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "animation.triggerAnimatorStateByName",
+            new { entityId, stateName },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Animation Clip Operations
+
+    /// <inheritdoc />
+    public async Task<AnimationClipSnapshot?> GetClipInfoAsync(int clipId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<AnimationClipSnapshot?>(
+            "animation.getClipInfo",
+            new { clipId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AnimationClipSnapshot>> ListClipsAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<AnimationClipSnapshot[]>(
+            "animation.listClips",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteNavigationController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteNavigationController.cs
@@ -1,0 +1,136 @@
+using KeenEyes.TestBridge.Navigation;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="INavigationController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteNavigationController(TestBridgeClient client) : INavigationController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<NavigationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NavigationStatisticsSnapshot>(
+            "navigation.getStatistics",
+            null,
+            cancellationToken) ?? new NavigationStatisticsSnapshot
+            {
+                IsReady = false,
+                Strategy = "None",
+                ActiveAgentCount = 0,
+                PendingRequestCount = 0
+            };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsReadyAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.isReady",
+            null,
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Agent Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetNavigationEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "navigation.getNavigationEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<NavAgentSnapshot?> GetAgentStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NavAgentSnapshot?>(
+            "navigation.getAgentState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<NavPathSnapshot?> GetPathAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NavPathSnapshot?>(
+            "navigation.getPath",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetDestinationAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.setDestination",
+            new { entityId, x, y, z },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> StopAgentAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.stopAgent",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ResumeAgentAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.resumeAgent",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> WarpAgentAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.warpAgent",
+            new { entityId, x, y, z },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Path Queries
+
+    /// <inheritdoc />
+    public async Task<NavPathSnapshot?> FindPathAsync(float startX, float startY, float startZ, float endX, float endY, float endZ, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NavPathSnapshot?>(
+            "navigation.findPath",
+            new { startX, startY, startZ, endX, endY, endZ },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsNavigableAsync(float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "navigation.isNavigable",
+            new { x, y, z },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<NavPointSnapshot?> FindNearestPointAsync(float x, float y, float z, float searchRadius, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NavPointSnapshot?>(
+            "navigation.findNearestPoint",
+            new { x, y, z, searchRadius },
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteNetworkController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteNetworkController.cs
@@ -1,0 +1,135 @@
+using KeenEyes.TestBridge.Network;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="INetworkController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteNetworkController(TestBridgeClient client) : INetworkController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<NetworkStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<NetworkStatisticsSnapshot>(
+            "network.getStatistics",
+            null,
+            cancellationToken) ?? new NetworkStatisticsSnapshot
+            {
+                IsConnected = false,
+                IsServer = false,
+                IsClient = false,
+                CurrentTick = 0,
+                LocalClientId = 0,
+                ClientCount = 0,
+                NetworkedEntityCount = 0
+            };
+    }
+
+    #endregion
+
+    #region Connection State
+
+    /// <inheritdoc />
+    public async Task<bool> IsConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "network.isConnected",
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsServerAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "network.isServer",
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<uint> GetCurrentTickAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<uint>(
+            "network.getCurrentTick",
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<float> GetLatencyAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<float>(
+            "network.getLatency",
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ConnectionStatsSnapshot?> GetConnectionStatsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<ConnectionStatsSnapshot?>(
+            "network.getConnectionStats",
+            null,
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Server Operations
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ClientSnapshot>> GetConnectedClientsAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<ClientSnapshot[]>(
+            "network.getConnectedClients",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    #endregion
+
+    #region Entity Replication
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetNetworkedEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "network.getNetworkedEntities",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<uint?> GetNetworkIdAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<uint?>(
+            "network.getNetworkId",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<int?> GetOwnershipAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<int?>(
+            "network.getOwnership",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplicationStateSnapshot?> GetReplicationStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<ReplicationStateSnapshot?>(
+            "network.getReplicationState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/RemotePhysicsController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemotePhysicsController.cs
@@ -1,0 +1,148 @@
+using KeenEyes.TestBridge.Physics;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IPhysicsController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemotePhysicsController(TestBridgeClient client) : IPhysicsController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<PhysicsStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<PhysicsStatisticsSnapshot>(
+            "physics.getStatistics",
+            null,
+            cancellationToken) ?? new PhysicsStatisticsSnapshot { BodyCount = 0, StaticCount = 0, InterpolationAlpha = 0f };
+    }
+
+    #endregion
+
+    #region Raycasting and Queries
+
+    /// <inheritdoc />
+    public async Task<RayHitSnapshot?> RaycastAsync(Vector3Snapshot origin, Vector3Snapshot direction, float maxDistance, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<RayHitSnapshot?>(
+            "physics.raycast",
+            new { origin, direction, maxDistance },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> OverlapSphereAsync(Vector3Snapshot center, float radius, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "physics.overlapSphere",
+            new { center, radius },
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> OverlapBoxAsync(Vector3Snapshot center, Vector3Snapshot halfExtents, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "physics.overlapBox",
+            new { center, halfExtents },
+            cancellationToken);
+        return result ?? [];
+    }
+
+    #endregion
+
+    #region Body State
+
+    /// <inheritdoc />
+    public async Task<PhysicsBodySnapshot?> GetBodyStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<PhysicsBodySnapshot?>(
+            "physics.getBodyState",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Vector3Snapshot?> GetVelocityAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<Vector3Snapshot?>(
+            "physics.getVelocity",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetVelocityAsync(int entityId, Vector3Snapshot velocity, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "physics.setVelocity",
+            new { entityId, velocity },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool?> IsAwakeAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool?>(
+            "physics.isAwake",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> WakeUpAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "physics.wakeUp",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Forces and Impulses
+
+    /// <inheritdoc />
+    public async Task<bool> ApplyForceAsync(int entityId, Vector3Snapshot force, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "physics.applyForce",
+            new { entityId, force },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ApplyImpulseAsync(int entityId, Vector3Snapshot impulse, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "physics.applyImpulse",
+            new { entityId, impulse },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Gravity
+
+    /// <inheritdoc />
+    public async Task<Vector3Snapshot> GetGravityAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<Vector3Snapshot>(
+            "physics.getGravity",
+            null,
+            cancellationToken) ?? new Vector3Snapshot { X = 0f, Y = 0f, Z = 0f };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetGravityAsync(Vector3Snapshot gravity, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "physics.setGravity",
+            new { gravity },
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteReplayController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteReplayController.cs
@@ -1,0 +1,336 @@
+using KeenEyes.TestBridge.Replay;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IReplayController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteReplayController(TestBridgeClient client) : IReplayController
+{
+    #region Recording Control
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> StartRecordingAsync(
+        string? name = null,
+        int maxFrames = 36000,
+        int snapshotIntervalMs = 5000)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.startRecording",
+            new { name, maxFrames, snapshotIntervalMs },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> StopRecordingAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.stopRecording",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> CancelRecordingAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.cancelRecording",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsRecordingAsync()
+    {
+        var result = await client.SendRequestAsync<bool>(
+            "replay.isRecording",
+            null,
+            CancellationToken.None);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<RecordingInfoSnapshot?> GetRecordingInfoAsync()
+    {
+        return await client.SendRequestAsync<RecordingInfoSnapshot>(
+            "replay.getRecordingInfo",
+            null,
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> ForceSnapshotAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.forceSnapshot",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    #endregion
+
+    #region Recording Management
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> SaveAsync(string path)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.save",
+            new { path },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> LoadAsync(string path)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.load",
+            new { path },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ReplayFileSnapshot>> ListAsync(string? directory = null)
+    {
+        var result = await client.SendRequestAsync<List<ReplayFileSnapshot>>(
+            "replay.list",
+            new { directory },
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(string path)
+    {
+        var result = await client.SendRequestAsync<bool>(
+            "replay.delete",
+            new { path },
+            CancellationToken.None);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayMetadataSnapshot?> GetMetadataAsync(string path)
+    {
+        return await client.SendRequestAsync<ReplayMetadataSnapshot>(
+            "replay.getMetadata",
+            new { path },
+            CancellationToken.None);
+    }
+
+    #endregion
+
+    #region Playback Control
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> PlayAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.play",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> PauseAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.pause",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> StopPlaybackAsync()
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.stopPlayback",
+            null,
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<PlaybackStateSnapshot> GetPlaybackStateAsync()
+    {
+        var result = await client.SendRequestAsync<PlaybackStateSnapshot>(
+            "replay.getPlaybackState",
+            null,
+            CancellationToken.None);
+        return result ?? CreateEmptyPlaybackState();
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> SetSpeedAsync(float speed)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.setSpeed",
+            new { speed },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    #endregion
+
+    #region Playback Navigation
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> SeekFrameAsync(int frame)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.seekFrame",
+            new { frame },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> SeekTimeAsync(float seconds)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.seekTime",
+            new { seconds },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> StepForwardAsync(int frames = 1)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.stepForward",
+            new { frames },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<ReplayOperationResult> StepBackwardAsync(int frames = 1)
+    {
+        var result = await client.SendRequestAsync<ReplayOperationResult>(
+            "replay.stepBackward",
+            new { frames },
+            CancellationToken.None);
+        return result ?? ReplayOperationResult.Fail("No response from server");
+    }
+
+    #endregion
+
+    #region Frame Inspection
+
+    /// <inheritdoc />
+    public async Task<ReplayFrameSnapshot?> GetFrameAsync(int frame)
+    {
+        return await client.SendRequestAsync<ReplayFrameSnapshot>(
+            "replay.getFrame",
+            new { frame },
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ReplayFrameSnapshot>> GetFrameRangeAsync(int startFrame, int count)
+    {
+        var result = await client.SendRequestAsync<List<ReplayFrameSnapshot>>(
+            "replay.getFrameRange",
+            new { startFrame, count },
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<InputEventSnapshot>> GetInputsAsync(int startFrame, int endFrame)
+    {
+        var result = await client.SendRequestAsync<List<InputEventSnapshot>>(
+            "replay.getInputs",
+            new { startFrame, endFrame },
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ReplayEventSnapshot>> GetEventsAsync(int startFrame, int endFrame)
+    {
+        var result = await client.SendRequestAsync<List<ReplayEventSnapshot>>(
+            "replay.getEvents",
+            new { startFrame, endFrame },
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SnapshotMarkerSnapshot>> GetSnapshotsAsync()
+    {
+        var result = await client.SendRequestAsync<List<SnapshotMarkerSnapshot>>(
+            "replay.getSnapshots",
+            null,
+            CancellationToken.None);
+        return result ?? [];
+    }
+
+    #endregion
+
+    #region Validation
+
+    /// <inheritdoc />
+    public async Task<ValidationResultSnapshot> ValidateAsync(string path)
+    {
+        var result = await client.SendRequestAsync<ValidationResultSnapshot>(
+            "replay.validate",
+            new { path },
+            CancellationToken.None);
+        return result ?? CreateErrorValidationResult(path, "No response from server");
+    }
+
+    /// <inheritdoc />
+    public async Task<DeterminismResultSnapshot> CheckDeterminismAsync()
+    {
+        var result = await client.SendRequestAsync<DeterminismResultSnapshot>(
+            "replay.checkDeterminism",
+            null,
+            CancellationToken.None);
+        return result ?? CreateErrorDeterminismResult("No response from server");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static PlaybackStateSnapshot CreateEmptyPlaybackState() => new()
+    {
+        IsLoaded = false,
+        IsPlaying = false,
+        IsPaused = false,
+        IsStopped = true,
+        CurrentFrame = 0,
+        TotalFrames = 0,
+        CurrentTimeSeconds = 0f,
+        TotalTimeSeconds = 0f,
+        PlaybackSpeed = 1.0f,
+        ReplayName = null
+    };
+
+    private static ValidationResultSnapshot CreateErrorValidationResult(string path, string error) => new()
+    {
+        Path = path,
+        IsValid = false,
+        Errors = [error]
+    };
+
+    private static DeterminismResultSnapshot CreateErrorDeterminismResult(string error) => new()
+    {
+        IsDeterministic = false,
+        TotalFramesChecked = 0,
+        FramesWithChecksums = 0,
+        DesyncDetails = error
+    };
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/RemoteUIController.cs
+++ b/src/KeenEyes.TestBridge.Client/RemoteUIController.cs
@@ -1,0 +1,168 @@
+using KeenEyes.TestBridge.UI;
+
+namespace KeenEyes.TestBridge.Client;
+
+/// <summary>
+/// Remote implementation of <see cref="IUIController"/> that communicates over IPC.
+/// </summary>
+internal sealed class RemoteUIController(TestBridgeClient client) : IUIController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public async Task<UIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UIStatisticsSnapshot>(
+            "ui.getStatistics",
+            null,
+            cancellationToken) ?? new UIStatisticsSnapshot
+            {
+                TotalElementCount = 0,
+                VisibleElementCount = 0,
+                InteractableCount = 0,
+                FocusedElementId = null
+            };
+    }
+
+    #endregion
+
+    #region Focus Management
+
+    /// <inheritdoc />
+    public async Task<int?> GetFocusedElementAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<int?>(
+            "ui.getFocused",
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SetFocusAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ui.setFocus",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ClearFocusAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ui.clearFocus",
+            null,
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Element Inspection
+
+    /// <inheritdoc />
+    public async Task<UIElementSnapshot?> GetElementAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UIElementSnapshot?>(
+            "ui.getElement",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UIElementSnapshot>> GetElementTreeAsync(int? rootEntityId = null, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<UIElementSnapshot[]>(
+            "ui.getTree",
+            rootEntityId.HasValue ? new { rootEntityId } : null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> GetRootElementsAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "ui.getRoots",
+            null,
+            cancellationToken);
+        return result ?? [];
+    }
+
+    /// <inheritdoc />
+    public async Task<UIBoundsSnapshot?> GetElementBoundsAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UIBoundsSnapshot?>(
+            "ui.getBounds",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<UIStyleSnapshot?> GetElementStyleAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UIStyleSnapshot?>(
+            "ui.getStyle",
+            new { entityId },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<UIInteractionSnapshot?> GetInteractionStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<UIInteractionSnapshot?>(
+            "ui.getInteraction",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Hit Testing
+
+    /// <inheritdoc />
+    public async Task<int?> HitTestAsync(float x, float y, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<int?>(
+            "ui.hitTest",
+            new { x, y },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<int>> HitTestAllAsync(float x, float y, CancellationToken cancellationToken = default)
+    {
+        var result = await client.SendRequestAsync<int[]>(
+            "ui.hitTestAll",
+            new { x, y },
+            cancellationToken);
+        return result ?? [];
+    }
+
+    #endregion
+
+    #region Element Search
+
+    /// <inheritdoc />
+    public async Task<int?> FindElementByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<int?>(
+            "ui.findByName",
+            new { name },
+            cancellationToken);
+    }
+
+    #endregion
+
+    #region Interaction Simulation
+
+    /// <inheritdoc />
+    public async Task<bool> SimulateClickAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        return await client.SendRequestAsync<bool>(
+            "ui.simulateClick",
+            new { entityId },
+            cancellationToken);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.Animation;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -10,6 +11,9 @@ using KeenEyes.TestBridge.Ipc.Protocol;
 using KeenEyes.TestBridge.Ipc.Transport;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.Physics;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.Profile;
 using KeenEyes.TestBridge.Replay;
@@ -17,6 +21,7 @@ using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
 using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.UI;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Client;
@@ -83,6 +88,11 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         Snapshot = new RemoteSnapshotController(this);
         AI = new RemoteAIController(this);
         Replay = new RemoteReplayController(this);
+        Animation = new RemoteAnimationController(this);
+        Physics = new RemotePhysicsController(this);
+        Navigation = new RemoteNavigationController(this);
+        Network = new RemoteNetworkController(this);
+        UI = new RemoteUIController(this);
 
         transport.MessageReceived += OnMessageReceived;
         transport.ConnectionChanged += OnConnectionChanged;
@@ -134,6 +144,21 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public IReplayController Replay { get; }
+
+    /// <inheritdoc />
+    public IAnimationController Animation { get; }
+
+    /// <inheritdoc />
+    public IPhysicsController Physics { get; }
+
+    /// <inheritdoc />
+    public INavigationController Navigation { get; }
+
+    /// <inheritdoc />
+    public INetworkController Network { get; }
+
+    /// <inheritdoc />
+    public IUIController UI { get; }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -12,6 +12,7 @@ using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
 using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
@@ -81,6 +82,7 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         Profile = new RemoteProfileController(this);
         Snapshot = new RemoteSnapshotController(this);
         AI = new RemoteAIController(this);
+        Replay = new RemoteReplayController(this);
 
         transport.MessageReceived += OnMessageReceived;
         transport.ConnectionChanged += OnConnectionChanged;
@@ -129,6 +131,9 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
 
     /// <inheritdoc />
     public IAIController AI { get; }
+
+    /// <inheritdoc />
+    public IReplayController Replay { get; }
 
     /// <inheritdoc />
     /// <remarks>
@@ -532,6 +537,72 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
         if (type == typeof(SnapshotDiff))
         {
             return (T?)(object?)element.Deserialize(IpcJsonContext.Default.SnapshotDiff);
+        }
+
+        // Replay types
+        if (type == typeof(ReplayOperationResult))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.ReplayOperationResult);
+        }
+
+        if (type == typeof(RecordingInfoSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.RecordingInfoSnapshot);
+        }
+
+        if (type == typeof(PlaybackStateSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.PlaybackStateSnapshot);
+        }
+
+        if (type == typeof(ReplayFrameSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.ReplayFrameSnapshot);
+        }
+
+        if (type == typeof(List<ReplayFrameSnapshot>))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.ListReplayFrameSnapshot);
+        }
+
+        if (type == typeof(ReplayMetadataSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.ReplayMetadataSnapshot);
+        }
+
+        if (type == typeof(ReplayFileSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.ReplayFileSnapshot);
+        }
+
+        if (type == typeof(List<ReplayFileSnapshot>))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.ListReplayFileSnapshot);
+        }
+
+        if (type == typeof(List<InputEventSnapshot>))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.ListInputEventSnapshot);
+        }
+
+        if (type == typeof(List<ReplayEventSnapshot>))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.ListReplayEventSnapshot);
+        }
+
+        if (type == typeof(List<SnapshotMarkerSnapshot>))
+        {
+            return (T?)(object?)element.Deserialize(IpcJsonContext.Default.ListSnapshotMarkerSnapshot);
+        }
+
+        if (type == typeof(ValidationResultSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.ValidationResultSnapshot);
+        }
+
+        if (type == typeof(DeterminismResultSnapshot))
+        {
+            return element.ValueKind == JsonValueKind.Null ? default : (T?)(object?)element.Deserialize(IpcJsonContext.Default.DeterminismResultSnapshot);
         }
 
         // Fallback for unknown types - let the exception surface during development

--- a/src/KeenEyes.TestBridge.Client/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Client/packages.lock.json
@@ -14,6 +14,11 @@
         "resolved": "10.18.0.131500",
         "contentHash": "Rbad71/k5e8MfG81i03Yh2YQQgovIdmyhWcLRevrcW4h9i1DUB3kKX9O1QiOGXcULLjkTdRAXdR8A8XtinL3Pg=="
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.10",
+        "contentHash": "u7gAG7JgxF8VSJUGPSudAcPxOt+ymJKQCSxNRxiuKV+klCQbHljQR75SilpedCTfhPWDhtUwIJpnDVtspr9nMg=="
+      },
       "keeneyes.abstractions": {
         "type": "Project"
       },
@@ -25,6 +30,37 @@
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Navigation": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[1.16.0, )",
+          "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
       "keeneyes.common": {
@@ -60,6 +96,17 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[7.1.3, )"
+        }
+      },
       "keeneyes.logging": {
         "type": "Project",
         "dependencies": {
@@ -79,6 +126,13 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.network": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -92,16 +146,37 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
+      "keeneyes.physics": {
+        "type": "Project",
+        "dependencies": {
+          "BepuPhysics": "[2.4.0, )",
+          "BepuUtilities": "[2.4.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.AI": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Network": "[1.0.0, )",
+          "KeenEyes.Physics": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
+          "KeenEyes.UI": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"
         }
       },
@@ -132,6 +207,86 @@
           "KeenEyes.Persistence": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "BepuPhysics": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "Ck/BJgSQrBqYrj0T9jGljDdHNILBP5kTPTylc7N/hCzR1XJJc7p6ORzwtjTfjgoYkkdajvLHxEQv6BRC8kaysQ==",
+        "dependencies": {
+          "BepuUtilities": "2.4.0"
+        }
+      },
+      "BepuUtilities": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "KNMxkzKLHAvV7jRtErxs3rPv71fHToqo/WN96HlT6iomWuwL97tohEbt0B1WA8A6sO5t6PP+qF08d4T9A8k2uA=="
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "go1/KHij1AB5K3nKiKKzSuSVIAKivgAnC3P6FAOOhB/WMg7y6lw9n95LCyABVuoewk4CNI8S0RZVvC6gkeTp7g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       },
       "StbImageWriteSharp": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/AnimationCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/AnimationCommandHandler.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Animation;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles animation debugging commands for animation players, animators, and clips.
+/// </summary>
+internal sealed class AnimationCommandHandler(IAnimationController animationController) : ICommandHandler
+{
+    public string Prefix => "animation";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await animationController.GetStatisticsAsync(cancellationToken),
+
+            // Animation Player
+            "getAnimationPlayerEntities" => await animationController.GetAnimationPlayerEntitiesAsync(cancellationToken),
+            "getAnimationPlayerState" => await HandleGetAnimationPlayerStateAsync(args, cancellationToken),
+            "setAnimationPlayerPlaying" => await HandleSetAnimationPlayerPlayingAsync(args, cancellationToken),
+            "setAnimationPlayerTime" => await HandleSetAnimationPlayerTimeAsync(args, cancellationToken),
+            "setAnimationPlayerSpeed" => await HandleSetAnimationPlayerSpeedAsync(args, cancellationToken),
+
+            // Animator
+            "getAnimatorEntities" => await animationController.GetAnimatorEntitiesAsync(cancellationToken),
+            "getAnimatorState" => await HandleGetAnimatorStateAsync(args, cancellationToken),
+            "triggerAnimatorState" => await HandleTriggerAnimatorStateAsync(args, cancellationToken),
+            "triggerAnimatorStateByName" => await HandleTriggerAnimatorStateByNameAsync(args, cancellationToken),
+
+            // Animation Clips
+            "getClipInfo" => await HandleGetClipInfoAsync(args, cancellationToken),
+            "listClips" => await animationController.ListClipsAsync(cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown animation command: {command}")
+        };
+    }
+
+    #region Animation Player Handlers
+
+    private async Task<AnimationPlayerSnapshot?> HandleGetAnimationPlayerStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await animationController.GetAnimationPlayerStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetAnimationPlayerPlayingAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var isPlaying = GetRequiredBool(args, "isPlaying");
+        return await animationController.SetAnimationPlayerPlayingAsync(entityId, isPlaying, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetAnimationPlayerTimeAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var time = GetRequiredFloat(args, "time");
+        return await animationController.SetAnimationPlayerTimeAsync(entityId, time, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetAnimationPlayerSpeedAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var speed = GetRequiredFloat(args, "speed");
+        return await animationController.SetAnimationPlayerSpeedAsync(entityId, speed, cancellationToken);
+    }
+
+    #endregion
+
+    #region Animator Handlers
+
+    private async Task<AnimatorSnapshot?> HandleGetAnimatorStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await animationController.GetAnimatorStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleTriggerAnimatorStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var stateHash = GetRequiredInt(args, "stateHash");
+        return await animationController.TriggerAnimatorStateAsync(entityId, stateHash, cancellationToken);
+    }
+
+    private async Task<bool> HandleTriggerAnimatorStateByNameAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var stateName = GetRequiredString(args, "stateName");
+        return await animationController.TriggerAnimatorStateByNameAsync(entityId, stateName, cancellationToken);
+    }
+
+    #endregion
+
+    #region Animation Clip Handlers
+
+    private async Task<AnimationClipSnapshot?> HandleGetClipInfoAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var clipId = GetRequiredInt(args, "clipId");
+        return await animationController.GetClipInfoAsync(clipId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetSingle();
+    }
+
+    private static bool GetRequiredBool(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetBoolean();
+    }
+
+    private static string GetRequiredString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetString() ?? throw new ArgumentException($"Invalid value for argument: {name}");
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/NavigationCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/NavigationCommandHandler.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Navigation;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles navigation debugging commands for agents, paths, and navmesh queries.
+/// </summary>
+internal sealed class NavigationCommandHandler(INavigationController navigationController) : ICommandHandler
+{
+    public string Prefix => "navigation";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await navigationController.GetStatisticsAsync(cancellationToken),
+            "isReady" => await navigationController.IsReadyAsync(cancellationToken),
+
+            // Agent operations
+            "getNavigationEntities" => await navigationController.GetNavigationEntitiesAsync(cancellationToken),
+            "getAgentState" => await HandleGetAgentStateAsync(args, cancellationToken),
+            "getPath" => await HandleGetPathAsync(args, cancellationToken),
+            "setDestination" => await HandleSetDestinationAsync(args, cancellationToken),
+            "stopAgent" => await HandleStopAgentAsync(args, cancellationToken),
+            "resumeAgent" => await HandleResumeAgentAsync(args, cancellationToken),
+            "warpAgent" => await HandleWarpAgentAsync(args, cancellationToken),
+
+            // Path queries
+            "findPath" => await HandleFindPathAsync(args, cancellationToken),
+            "isNavigable" => await HandleIsNavigableAsync(args, cancellationToken),
+            "findNearestPoint" => await HandleFindNearestPointAsync(args, cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown navigation command: {command}")
+        };
+    }
+
+    #region Agent Handlers
+
+    private async Task<NavAgentSnapshot?> HandleGetAgentStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await navigationController.GetAgentStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<NavPathSnapshot?> HandleGetPathAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await navigationController.GetPathAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetDestinationAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        var z = GetRequiredFloat(args, "z");
+        return await navigationController.SetDestinationAsync(entityId, x, y, z, cancellationToken);
+    }
+
+    private async Task<bool> HandleStopAgentAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await navigationController.StopAgentAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleResumeAgentAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await navigationController.ResumeAgentAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleWarpAgentAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        var z = GetRequiredFloat(args, "z");
+        return await navigationController.WarpAgentAsync(entityId, x, y, z, cancellationToken);
+    }
+
+    #endregion
+
+    #region Path Query Handlers
+
+    private async Task<NavPathSnapshot?> HandleFindPathAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var startX = GetRequiredFloat(args, "startX");
+        var startY = GetRequiredFloat(args, "startY");
+        var startZ = GetRequiredFloat(args, "startZ");
+        var endX = GetRequiredFloat(args, "endX");
+        var endY = GetRequiredFloat(args, "endY");
+        var endZ = GetRequiredFloat(args, "endZ");
+        return await navigationController.FindPathAsync(startX, startY, startZ, endX, endY, endZ, cancellationToken);
+    }
+
+    private async Task<bool> HandleIsNavigableAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        var z = GetRequiredFloat(args, "z");
+        return await navigationController.IsNavigableAsync(x, y, z, cancellationToken);
+    }
+
+    private async Task<NavPointSnapshot?> HandleFindNearestPointAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        var z = GetRequiredFloat(args, "z");
+        var searchRadius = GetRequiredFloat(args, "searchRadius");
+        return await navigationController.FindNearestPointAsync(x, y, z, searchRadius, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return (float)prop.GetDouble();
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/NetworkCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/NetworkCommandHandler.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Network;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles network debugging commands for connection state, replication, and statistics.
+/// </summary>
+internal sealed class NetworkCommandHandler(INetworkController networkController) : ICommandHandler
+{
+    public string Prefix => "network";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await networkController.GetStatisticsAsync(cancellationToken),
+
+            // Connection State
+            "isConnected" => await networkController.IsConnectedAsync(cancellationToken),
+            "isServer" => await networkController.IsServerAsync(cancellationToken),
+            "getCurrentTick" => await networkController.GetCurrentTickAsync(cancellationToken),
+            "getLatency" => await networkController.GetLatencyAsync(cancellationToken),
+            "getConnectionStats" => await networkController.GetConnectionStatsAsync(cancellationToken),
+
+            // Server Operations
+            "getConnectedClients" => await networkController.GetConnectedClientsAsync(cancellationToken),
+
+            // Entity Replication
+            "getNetworkedEntities" => await networkController.GetNetworkedEntitiesAsync(cancellationToken),
+            "getNetworkId" => await HandleGetNetworkIdAsync(args, cancellationToken),
+            "getOwnership" => await HandleGetOwnershipAsync(args, cancellationToken),
+            "getReplicationState" => await HandleGetReplicationStateAsync(args, cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown network command: {command}")
+        };
+    }
+
+    #region Entity Replication Handlers
+
+    private async Task<uint?> HandleGetNetworkIdAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await networkController.GetNetworkIdAsync(entityId, cancellationToken);
+    }
+
+    private async Task<int?> HandleGetOwnershipAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await networkController.GetOwnershipAsync(entityId, cancellationToken);
+    }
+
+    private async Task<ReplicationStateSnapshot?> HandleGetReplicationStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await networkController.GetReplicationStateAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/PhysicsCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/PhysicsCommandHandler.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Physics;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles physics debugging commands for raycasting, queries, and body manipulation.
+/// </summary>
+internal sealed class PhysicsCommandHandler(IPhysicsController physicsController) : ICommandHandler
+{
+    public string Prefix => "physics";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await physicsController.GetStatisticsAsync(cancellationToken),
+
+            // Raycasting and Queries
+            "raycast" => await HandleRaycastAsync(args, cancellationToken),
+            "overlapSphere" => await HandleOverlapSphereAsync(args, cancellationToken),
+            "overlapBox" => await HandleOverlapBoxAsync(args, cancellationToken),
+
+            // Body State
+            "getBodyState" => await HandleGetBodyStateAsync(args, cancellationToken),
+            "getVelocity" => await HandleGetVelocityAsync(args, cancellationToken),
+            "setVelocity" => await HandleSetVelocityAsync(args, cancellationToken),
+            "isAwake" => await HandleIsAwakeAsync(args, cancellationToken),
+            "wakeUp" => await HandleWakeUpAsync(args, cancellationToken),
+
+            // Forces and Impulses
+            "applyForce" => await HandleApplyForceAsync(args, cancellationToken),
+            "applyImpulse" => await HandleApplyImpulseAsync(args, cancellationToken),
+
+            // Gravity
+            "getGravity" => await physicsController.GetGravityAsync(cancellationToken),
+            "setGravity" => await HandleSetGravityAsync(args, cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown physics command: {command}")
+        };
+    }
+
+    #region Raycast and Query Handlers
+
+    private async Task<RayHitSnapshot?> HandleRaycastAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var origin = GetRequiredVector3(args, "origin");
+        var direction = GetRequiredVector3(args, "direction");
+        var maxDistance = GetRequiredFloat(args, "maxDistance");
+        return await physicsController.RaycastAsync(origin, direction, maxDistance, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<int>> HandleOverlapSphereAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var center = GetRequiredVector3(args, "center");
+        var radius = GetRequiredFloat(args, "radius");
+        return await physicsController.OverlapSphereAsync(center, radius, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<int>> HandleOverlapBoxAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var center = GetRequiredVector3(args, "center");
+        var halfExtents = GetRequiredVector3(args, "halfExtents");
+        return await physicsController.OverlapBoxAsync(center, halfExtents, cancellationToken);
+    }
+
+    #endregion
+
+    #region Body State Handlers
+
+    private async Task<PhysicsBodySnapshot?> HandleGetBodyStateAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await physicsController.GetBodyStateAsync(entityId, cancellationToken);
+    }
+
+    private async Task<Vector3Snapshot?> HandleGetVelocityAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await physicsController.GetVelocityAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleSetVelocityAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var velocity = GetRequiredVector3(args, "velocity");
+        return await physicsController.SetVelocityAsync(entityId, velocity, cancellationToken);
+    }
+
+    private async Task<bool?> HandleIsAwakeAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await physicsController.IsAwakeAsync(entityId, cancellationToken);
+    }
+
+    private async Task<bool> HandleWakeUpAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await physicsController.WakeUpAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Force and Impulse Handlers
+
+    private async Task<bool> HandleApplyForceAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var force = GetRequiredVector3(args, "force");
+        return await physicsController.ApplyForceAsync(entityId, force, cancellationToken);
+    }
+
+    private async Task<bool> HandleApplyImpulseAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        var impulse = GetRequiredVector3(args, "impulse");
+        return await physicsController.ApplyImpulseAsync(entityId, impulse, cancellationToken);
+    }
+
+    #endregion
+
+    #region Gravity Handlers
+
+    private async Task<bool> HandleSetGravityAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var gravity = GetRequiredVector3(args, "gravity");
+        return await physicsController.SetGravityAsync(gravity, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetSingle();
+    }
+
+    private static Vector3Snapshot GetRequiredVector3(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return new Vector3Snapshot
+        {
+            X = prop.GetProperty("x").GetSingle(),
+            Y = prop.GetProperty("y").GetSingle(),
+            Z = prop.GetProperty("z").GetSingle()
+        };
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/ReplayCommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/ReplayCommandHandler.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Replay;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles replay recording and playback commands.
+/// </summary>
+internal sealed class ReplayCommandHandler(IReplayController replayController) : ICommandHandler
+{
+    public string Prefix => "replay";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Recording control
+            "startRecording" => await HandleStartRecordingAsync(args),
+            "stopRecording" => await replayController.StopRecordingAsync(),
+            "cancelRecording" => await replayController.CancelRecordingAsync(),
+            "isRecording" => await replayController.IsRecordingAsync(),
+            "getRecordingInfo" => await replayController.GetRecordingInfoAsync(),
+            "forceSnapshot" => await replayController.ForceSnapshotAsync(),
+
+            // Recording management
+            "save" => await HandleSaveAsync(args),
+            "load" => await HandleLoadAsync(args),
+            "list" => await HandleListAsync(args),
+            "delete" => await HandleDeleteAsync(args),
+            "getMetadata" => await HandleGetMetadataAsync(args),
+
+            // Playback control
+            "play" => await replayController.PlayAsync(),
+            "pause" => await replayController.PauseAsync(),
+            "stopPlayback" => await replayController.StopPlaybackAsync(),
+            "getPlaybackState" => await replayController.GetPlaybackStateAsync(),
+            "setSpeed" => await HandleSetSpeedAsync(args),
+
+            // Playback navigation
+            "seekFrame" => await HandleSeekFrameAsync(args),
+            "seekTime" => await HandleSeekTimeAsync(args),
+            "stepForward" => await HandleStepForwardAsync(args),
+            "stepBackward" => await HandleStepBackwardAsync(args),
+
+            // Frame inspection
+            "getFrame" => await HandleGetFrameAsync(args),
+            "getFrameRange" => await HandleGetFrameRangeAsync(args),
+            "getInputs" => await HandleGetInputsAsync(args),
+            "getEvents" => await HandleGetEventsAsync(args),
+            "getSnapshots" => await replayController.GetSnapshotsAsync(),
+
+            // Validation
+            "validate" => await HandleValidateAsync(args),
+            "checkDeterminism" => await replayController.CheckDeterminismAsync(),
+
+            _ => throw new InvalidOperationException($"Unknown replay command: {command}")
+        };
+    }
+
+    #region Recording Control Handlers
+
+    private async Task<ReplayOperationResult> HandleStartRecordingAsync(JsonElement? args)
+    {
+        var name = GetOptionalString(args, "name");
+        var maxFrames = GetOptionalInt(args, "maxFrames") ?? 36000;
+        var snapshotIntervalMs = GetOptionalInt(args, "snapshotIntervalMs") ?? 5000;
+
+        return await replayController.StartRecordingAsync(name, maxFrames, snapshotIntervalMs);
+    }
+
+    #endregion
+
+    #region Recording Management Handlers
+
+    private async Task<ReplayOperationResult> HandleSaveAsync(JsonElement? args)
+    {
+        var path = GetRequiredString(args, "path");
+        return await replayController.SaveAsync(path);
+    }
+
+    private async Task<ReplayOperationResult> HandleLoadAsync(JsonElement? args)
+    {
+        var path = GetRequiredString(args, "path");
+        return await replayController.LoadAsync(path);
+    }
+
+    private async Task<IReadOnlyList<ReplayFileSnapshot>> HandleListAsync(JsonElement? args)
+    {
+        var directory = GetOptionalString(args, "directory");
+        return await replayController.ListAsync(directory);
+    }
+
+    private async Task<bool> HandleDeleteAsync(JsonElement? args)
+    {
+        var path = GetRequiredString(args, "path");
+        return await replayController.DeleteAsync(path);
+    }
+
+    private async Task<ReplayMetadataSnapshot?> HandleGetMetadataAsync(JsonElement? args)
+    {
+        var path = GetRequiredString(args, "path");
+        return await replayController.GetMetadataAsync(path);
+    }
+
+    #endregion
+
+    #region Playback Control Handlers
+
+    private async Task<ReplayOperationResult> HandleSetSpeedAsync(JsonElement? args)
+    {
+        var speed = GetRequiredFloat(args, "speed");
+        return await replayController.SetSpeedAsync(speed);
+    }
+
+    #endregion
+
+    #region Playback Navigation Handlers
+
+    private async Task<ReplayOperationResult> HandleSeekFrameAsync(JsonElement? args)
+    {
+        var frame = GetRequiredInt(args, "frame");
+        return await replayController.SeekFrameAsync(frame);
+    }
+
+    private async Task<ReplayOperationResult> HandleSeekTimeAsync(JsonElement? args)
+    {
+        var seconds = GetRequiredFloat(args, "seconds");
+        return await replayController.SeekTimeAsync(seconds);
+    }
+
+    private async Task<ReplayOperationResult> HandleStepForwardAsync(JsonElement? args)
+    {
+        var frames = GetOptionalInt(args, "frames") ?? 1;
+        return await replayController.StepForwardAsync(frames);
+    }
+
+    private async Task<ReplayOperationResult> HandleStepBackwardAsync(JsonElement? args)
+    {
+        var frames = GetOptionalInt(args, "frames") ?? 1;
+        return await replayController.StepBackwardAsync(frames);
+    }
+
+    #endregion
+
+    #region Frame Inspection Handlers
+
+    private async Task<ReplayFrameSnapshot?> HandleGetFrameAsync(JsonElement? args)
+    {
+        var frame = GetRequiredInt(args, "frame");
+        return await replayController.GetFrameAsync(frame);
+    }
+
+    private async Task<IReadOnlyList<ReplayFrameSnapshot>> HandleGetFrameRangeAsync(JsonElement? args)
+    {
+        var startFrame = GetRequiredInt(args, "startFrame");
+        var count = GetRequiredInt(args, "count");
+        return await replayController.GetFrameRangeAsync(startFrame, count);
+    }
+
+    private async Task<IReadOnlyList<InputEventSnapshot>> HandleGetInputsAsync(JsonElement? args)
+    {
+        var startFrame = GetRequiredInt(args, "startFrame");
+        var endFrame = GetRequiredInt(args, "endFrame");
+        return await replayController.GetInputsAsync(startFrame, endFrame);
+    }
+
+    private async Task<IReadOnlyList<ReplayEventSnapshot>> HandleGetEventsAsync(JsonElement? args)
+    {
+        var startFrame = GetRequiredInt(args, "startFrame");
+        var endFrame = GetRequiredInt(args, "endFrame");
+        return await replayController.GetEventsAsync(startFrame, endFrame);
+    }
+
+    #endregion
+
+    #region Validation Handlers
+
+    private async Task<ValidationResultSnapshot> HandleValidateAsync(JsonElement? args)
+    {
+        var path = GetRequiredString(args, "path");
+        return await replayController.ValidateAsync(path);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static string GetRequiredString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetString() ?? throw new ArgumentException($"Argument '{name}' cannot be null");
+    }
+
+    private static string? GetOptionalString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind == JsonValueKind.Null ? null : prop.GetString();
+    }
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static int? GetOptionalInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            return null;
+        }
+
+        if (prop.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetSingle();
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/Handlers/UICommandHandler.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Handlers/UICommandHandler.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.UI;
+
+namespace KeenEyes.TestBridge.Ipc.Handlers;
+
+/// <summary>
+/// Handles UI debugging commands for element inspection, focus management, and interaction.
+/// </summary>
+internal sealed class UICommandHandler(IUIController uiController) : ICommandHandler
+{
+    public string Prefix => "ui";
+
+    public async ValueTask<object?> HandleAsync(string command, JsonElement? args, CancellationToken cancellationToken)
+    {
+        return command switch
+        {
+            // Statistics
+            "getStatistics" => await uiController.GetStatisticsAsync(cancellationToken),
+
+            // Focus Management
+            "getFocused" => await uiController.GetFocusedElementAsync(cancellationToken),
+            "setFocus" => await HandleSetFocusAsync(args, cancellationToken),
+            "clearFocus" => await uiController.ClearFocusAsync(cancellationToken),
+
+            // Element Inspection
+            "getElement" => await HandleGetElementAsync(args, cancellationToken),
+            "getTree" => await HandleGetTreeAsync(args, cancellationToken),
+            "getRoots" => await uiController.GetRootElementsAsync(cancellationToken),
+            "getBounds" => await HandleGetBoundsAsync(args, cancellationToken),
+            "getStyle" => await HandleGetStyleAsync(args, cancellationToken),
+            "getInteraction" => await HandleGetInteractionAsync(args, cancellationToken),
+
+            // Hit Testing
+            "hitTest" => await HandleHitTestAsync(args, cancellationToken),
+            "hitTestAll" => await HandleHitTestAllAsync(args, cancellationToken),
+
+            // Element Search
+            "findByName" => await HandleFindByNameAsync(args, cancellationToken),
+
+            // Interaction Simulation
+            "simulateClick" => await HandleSimulateClickAsync(args, cancellationToken),
+
+            _ => throw new InvalidOperationException($"Unknown UI command: {command}")
+        };
+    }
+
+    #region Focus Management Handlers
+
+    private async Task<bool> HandleSetFocusAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.SetFocusAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Element Inspection Handlers
+
+    private async Task<UIElementSnapshot?> HandleGetElementAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.GetElementAsync(entityId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<UIElementSnapshot>> HandleGetTreeAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var rootEntityId = GetOptionalInt(args, "rootEntityId");
+        return await uiController.GetElementTreeAsync(rootEntityId, cancellationToken);
+    }
+
+    private async Task<UIBoundsSnapshot?> HandleGetBoundsAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.GetElementBoundsAsync(entityId, cancellationToken);
+    }
+
+    private async Task<UIStyleSnapshot?> HandleGetStyleAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.GetElementStyleAsync(entityId, cancellationToken);
+    }
+
+    private async Task<UIInteractionSnapshot?> HandleGetInteractionAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.GetInteractionStateAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Hit Testing Handlers
+
+    private async Task<int?> HandleHitTestAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        return await uiController.HitTestAsync(x, y, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<int>> HandleHitTestAllAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var x = GetRequiredFloat(args, "x");
+        var y = GetRequiredFloat(args, "y");
+        return await uiController.HitTestAllAsync(x, y, cancellationToken);
+    }
+
+    #endregion
+
+    #region Element Search Handlers
+
+    private async Task<int?> HandleFindByNameAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var name = GetRequiredString(args, "name");
+        return await uiController.FindElementByNameAsync(name, cancellationToken);
+    }
+
+    #endregion
+
+    #region Interaction Simulation Handlers
+
+    private async Task<bool> HandleSimulateClickAsync(JsonElement? args, CancellationToken cancellationToken)
+    {
+        var entityId = GetRequiredInt(args, "entityId");
+        return await uiController.SimulateClickAsync(entityId, cancellationToken);
+    }
+
+    #endregion
+
+    #region Typed Argument Helpers (AOT-compatible)
+
+    private static int GetRequiredInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetInt32();
+    }
+
+    private static int? GetOptionalInt(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind == JsonValueKind.Null ? null : prop.GetInt32();
+    }
+
+    private static float GetRequiredFloat(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetSingle();
+    }
+
+    private static string GetRequiredString(JsonElement? args, string name)
+    {
+        if (!args.HasValue || !args.Value.TryGetProperty(name, out var prop))
+        {
+            throw new ArgumentException($"Missing required argument: {name}");
+        }
+
+        return prop.GetString() ?? throw new ArgumentException($"Invalid value for argument: {name}");
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
+++ b/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
@@ -74,7 +74,12 @@ public sealed class IpcBridgeServer : IDisposable
             ["profile"] = new ProfileCommandHandler(bridge.Profile),
             ["snapshot"] = new SnapshotCommandHandler(bridge.Snapshot),
             ["ai"] = new AICommandHandler(bridge.AI),
-            ["replay"] = new ReplayCommandHandler(bridge.Replay)
+            ["replay"] = new ReplayCommandHandler(bridge.Replay),
+            ["animation"] = new AnimationCommandHandler(bridge.Animation),
+            ["physics"] = new PhysicsCommandHandler(bridge.Physics),
+            ["navigation"] = new NavigationCommandHandler(bridge.Navigation),
+            ["network"] = new NetworkCommandHandler(bridge.Network),
+            ["ui"] = new UICommandHandler(bridge.UI)
         };
 
         transport.MessageReceived += OnMessageReceived;

--- a/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
+++ b/src/KeenEyes.TestBridge.Ipc/IpcBridgeServer.cs
@@ -73,7 +73,8 @@ public sealed class IpcBridgeServer : IDisposable
             ["mutation"] = new MutationCommandHandler(bridge.Mutation),
             ["profile"] = new ProfileCommandHandler(bridge.Profile),
             ["snapshot"] = new SnapshotCommandHandler(bridge.Snapshot),
-            ["ai"] = new AICommandHandler(bridge.AI)
+            ["ai"] = new AICommandHandler(bridge.AI),
+            ["replay"] = new ReplayCommandHandler(bridge.Replay)
         };
 
         transport.MessageReceived += OnMessageReceived;

--- a/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
@@ -2,15 +2,20 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.Animation;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.Physics;
 using KeenEyes.TestBridge.Profile;
 using KeenEyes.TestBridge.Replay;
 using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
 using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.UI;
 using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.TestBridge.Ipc.Protocol;
@@ -239,6 +244,45 @@ namespace KeenEyes.TestBridge.Ipc.Protocol;
 [JsonSerializable(typeof(List<SnapshotMarkerSnapshot>))]
 [JsonSerializable(typeof(ValidationResultSnapshot))]
 [JsonSerializable(typeof(DeterminismResultSnapshot))]
+// Animation types
+[JsonSerializable(typeof(AnimationStatisticsSnapshot))]
+[JsonSerializable(typeof(AnimationPlayerSnapshot))]
+[JsonSerializable(typeof(AnimatorSnapshot))]
+[JsonSerializable(typeof(AnimationClipSnapshot))]
+[JsonSerializable(typeof(AnimationClipSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<AnimationClipSnapshot>))]
+[JsonSerializable(typeof(List<AnimationClipSnapshot>))]
+// Physics types
+[JsonSerializable(typeof(PhysicsStatisticsSnapshot))]
+[JsonSerializable(typeof(Vector3Snapshot))]
+[JsonSerializable(typeof(QuaternionSnapshot))]
+[JsonSerializable(typeof(RayHitSnapshot))]
+[JsonSerializable(typeof(PhysicsBodySnapshot))]
+// Navigation types
+[JsonSerializable(typeof(NavigationStatisticsSnapshot))]
+[JsonSerializable(typeof(NavAgentSnapshot))]
+[JsonSerializable(typeof(NavPathSnapshot))]
+[JsonSerializable(typeof(NavPointSnapshot))]
+[JsonSerializable(typeof(NavPointSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<NavPointSnapshot>))]
+[JsonSerializable(typeof(List<NavPointSnapshot>))]
+// Network types
+[JsonSerializable(typeof(NetworkStatisticsSnapshot))]
+[JsonSerializable(typeof(ConnectionStatsSnapshot))]
+[JsonSerializable(typeof(ClientSnapshot))]
+[JsonSerializable(typeof(ClientSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<ClientSnapshot>))]
+[JsonSerializable(typeof(List<ClientSnapshot>))]
+[JsonSerializable(typeof(ReplicationStateSnapshot))]
+// UI types
+[JsonSerializable(typeof(UIStatisticsSnapshot))]
+[JsonSerializable(typeof(UIElementSnapshot))]
+[JsonSerializable(typeof(UIElementSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<UIElementSnapshot>))]
+[JsonSerializable(typeof(List<UIElementSnapshot>))]
+[JsonSerializable(typeof(UIBoundsSnapshot))]
+[JsonSerializable(typeof(UIStyleSnapshot))]
+[JsonSerializable(typeof(UIInteractionSnapshot))]
 internal partial class IpcJsonContext : JsonSerializerContext
 {
 }

--- a/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Protocol/IpcJsonContext.cs
@@ -6,6 +6,7 @@ using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.Mutation;
 using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
 using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
 using KeenEyes.TestBridge.Systems;
@@ -211,6 +212,33 @@ namespace KeenEyes.TestBridge.Ipc.Protocol;
 [JsonSerializable(typeof(FieldDiff[]))]
 [JsonSerializable(typeof(IReadOnlyList<FieldDiff>))]
 [JsonSerializable(typeof(List<FieldDiff>))]
+// Replay types
+[JsonSerializable(typeof(ReplayOperationResult))]
+[JsonSerializable(typeof(RecordingInfoSnapshot))]
+[JsonSerializable(typeof(PlaybackStateSnapshot))]
+[JsonSerializable(typeof(ReplayFrameSnapshot))]
+[JsonSerializable(typeof(ReplayFrameSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<ReplayFrameSnapshot>))]
+[JsonSerializable(typeof(List<ReplayFrameSnapshot>))]
+[JsonSerializable(typeof(ReplayMetadataSnapshot))]
+[JsonSerializable(typeof(ReplayFileSnapshot))]
+[JsonSerializable(typeof(ReplayFileSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<ReplayFileSnapshot>))]
+[JsonSerializable(typeof(List<ReplayFileSnapshot>))]
+[JsonSerializable(typeof(InputEventSnapshot))]
+[JsonSerializable(typeof(InputEventSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<InputEventSnapshot>))]
+[JsonSerializable(typeof(List<InputEventSnapshot>))]
+[JsonSerializable(typeof(ReplayEventSnapshot))]
+[JsonSerializable(typeof(ReplayEventSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<ReplayEventSnapshot>))]
+[JsonSerializable(typeof(List<ReplayEventSnapshot>))]
+[JsonSerializable(typeof(SnapshotMarkerSnapshot))]
+[JsonSerializable(typeof(SnapshotMarkerSnapshot[]))]
+[JsonSerializable(typeof(IReadOnlyList<SnapshotMarkerSnapshot>))]
+[JsonSerializable(typeof(List<SnapshotMarkerSnapshot>))]
+[JsonSerializable(typeof(ValidationResultSnapshot))]
+[JsonSerializable(typeof(DeterminismResultSnapshot))]
 internal partial class IpcJsonContext : JsonSerializerContext
 {
 }

--- a/src/KeenEyes.TestBridge.Ipc/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Ipc/packages.lock.json
@@ -14,6 +14,11 @@
         "resolved": "10.18.0.131500",
         "contentHash": "Rbad71/k5e8MfG81i03Yh2YQQgovIdmyhWcLRevrcW4h9i1DUB3kKX9O1QiOGXcULLjkTdRAXdR8A8XtinL3Pg=="
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.10",
+        "contentHash": "u7gAG7JgxF8VSJUGPSudAcPxOt+ymJKQCSxNRxiuKV+klCQbHljQR75SilpedCTfhPWDhtUwIJpnDVtspr9nMg=="
+      },
       "keeneyes.abstractions": {
         "type": "Project"
       },
@@ -25,6 +30,37 @@
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Navigation": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[1.16.0, )",
+          "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
       "keeneyes.common": {
@@ -60,6 +96,17 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[7.1.3, )"
+        }
+      },
       "keeneyes.logging": {
         "type": "Project",
         "dependencies": {
@@ -79,6 +126,13 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.network": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -92,16 +146,37 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
+      "keeneyes.physics": {
+        "type": "Project",
+        "dependencies": {
+          "BepuPhysics": "[2.4.0, )",
+          "BepuUtilities": "[2.4.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.AI": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Network": "[1.0.0, )",
+          "KeenEyes.Physics": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
+          "KeenEyes.UI": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"
         }
       },
@@ -124,6 +199,86 @@
           "KeenEyes.Persistence": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "BepuPhysics": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "Ck/BJgSQrBqYrj0T9jGljDdHNILBP5kTPTylc7N/hCzR1XJJc7p6ORzwtjTfjgoYkkdajvLHxEQv6BRC8kaysQ==",
+        "dependencies": {
+          "BepuUtilities": "2.4.0"
+        }
+      },
+      "BepuUtilities": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "KNMxkzKLHAvV7jRtErxs3rPv71fHToqo/WN96HlT6iomWuwL97tohEbt0B1WA8A6sO5t6PP+qF08d4T9A8k2uA=="
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "go1/KHij1AB5K3nKiKKzSuSVIAKivgAnC3P6FAOOhB/WMg7y6lw9n95LCyABVuoewk4CNI8S0RZVvC6gkeTp7g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       },
       "StbImageWriteSharp": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.TestBridge/AnimationImpl/AnimationControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/AnimationImpl/AnimationControllerImpl.cs
@@ -1,0 +1,291 @@
+using KeenEyes.Animation;
+using KeenEyes.Animation.Components;
+using KeenEyes.TestBridge.Animation;
+
+namespace KeenEyes.TestBridge.AnimationImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="IAnimationController"/>.
+/// </summary>
+internal sealed class AnimationControllerImpl(World world) : IAnimationController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<AnimationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AnimationManager>(out var animationManager))
+        {
+            return Task.FromResult(new AnimationStatisticsSnapshot
+            {
+                ClipCount = 0,
+                ControllerCount = 0,
+                SpriteSheetCount = 0,
+                ActivePlayerCount = 0,
+                ActiveAnimatorCount = 0
+            });
+        }
+
+        // Count active players and animators
+        var activePlayerCount = 0;
+        foreach (var _ in world.Query<AnimationPlayer>())
+        {
+            activePlayerCount++;
+        }
+
+        var activeAnimatorCount = 0;
+        foreach (var _ in world.Query<Animator>())
+        {
+            activeAnimatorCount++;
+        }
+
+        return Task.FromResult(new AnimationStatisticsSnapshot
+        {
+            ClipCount = animationManager.ClipCount,
+            ControllerCount = animationManager.ControllerCount,
+            SpriteSheetCount = animationManager.SpriteSheetCount,
+            ActivePlayerCount = activePlayerCount,
+            ActiveAnimatorCount = activeAnimatorCount
+        });
+    }
+
+    #endregion
+
+    #region Animation Player Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetAnimationPlayerEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<AnimationPlayer>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<AnimationPlayerSnapshot?> GetAnimationPlayerStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<AnimationPlayer>(entity))
+        {
+            return Task.FromResult<AnimationPlayerSnapshot?>(null);
+        }
+
+        ref readonly var player = ref world.Get<AnimationPlayer>(entity);
+
+        return Task.FromResult<AnimationPlayerSnapshot?>(new AnimationPlayerSnapshot
+        {
+            EntityId = entityId,
+            ClipId = player.ClipId,
+            Time = player.Time,
+            Speed = player.Speed,
+            IsPlaying = player.IsPlaying,
+            IsComplete = player.IsComplete,
+            Weight = player.Weight,
+            WrapModeOverride = player.WrapModeOverride?.ToString()
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetAnimationPlayerPlayingAsync(int entityId, bool isPlaying, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<AnimationPlayer>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref var player = ref world.Get<AnimationPlayer>(entity);
+        player.IsPlaying = isPlaying;
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetAnimationPlayerTimeAsync(int entityId, float time, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<AnimationPlayer>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref var player = ref world.Get<AnimationPlayer>(entity);
+        player.Time = time;
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetAnimationPlayerSpeedAsync(int entityId, float speed, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<AnimationPlayer>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref var player = ref world.Get<AnimationPlayer>(entity);
+        player.Speed = speed;
+        return Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Animator Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetAnimatorEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<Animator>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<AnimatorSnapshot?> GetAnimatorStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<Animator>(entity))
+        {
+            return Task.FromResult<AnimatorSnapshot?>(null);
+        }
+
+        ref readonly var animator = ref world.Get<Animator>(entity);
+
+        // Try to get state names from controller
+        string? currentStateName = null;
+        string? nextStateName = null;
+        if (world.TryGetExtension<AnimationManager>(out var animationManager) &&
+            animationManager.TryGetController(animator.ControllerId, out var controller) &&
+            controller is not null)
+        {
+            if (controller.TryGetState(animator.CurrentStateHash, out var currentState) && currentState is not null)
+            {
+                currentStateName = currentState.Name;
+            }
+
+            if (animator.NextStateHash != 0 &&
+                controller.TryGetState(animator.NextStateHash, out var nextState) &&
+                nextState is not null)
+            {
+                nextStateName = nextState.Name;
+            }
+        }
+
+        return Task.FromResult<AnimatorSnapshot?>(new AnimatorSnapshot
+        {
+            EntityId = entityId,
+            ControllerId = animator.ControllerId,
+            CurrentStateHash = animator.CurrentStateHash,
+            CurrentStateName = currentStateName,
+            StateTime = animator.StateTime,
+            IsTransitioning = animator.NextStateHash != 0,
+            TransitionProgress = animator.TransitionProgress,
+            Speed = animator.Speed,
+            Enabled = animator.Enabled,
+            NextStateHash = animator.NextStateHash,
+            NextStateName = nextStateName
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> TriggerAnimatorStateAsync(int entityId, int stateHash, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<Animator>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref var animator = ref world.Get<Animator>(entity);
+        animator.TriggerStateHash = stateHash;
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> TriggerAnimatorStateByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<Animator>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        var stateHash = Animator.GetStateHash(stateName);
+        ref var animator = ref world.Get<Animator>(entity);
+        animator.TriggerStateHash = stateHash;
+        return Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Animation Clip Operations
+
+    /// <inheritdoc />
+    public Task<AnimationClipSnapshot?> GetClipInfoAsync(int clipId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AnimationManager>(out var animationManager))
+        {
+            return Task.FromResult<AnimationClipSnapshot?>(null);
+        }
+
+        if (!animationManager.TryGetClip(clipId, out var clip) || clip == null)
+        {
+            return Task.FromResult<AnimationClipSnapshot?>(null);
+        }
+
+        return Task.FromResult<AnimationClipSnapshot?>(new AnimationClipSnapshot
+        {
+            ClipId = clipId,
+            Name = clip.Name,
+            Duration = clip.Duration,
+            WrapMode = clip.WrapMode.ToString(),
+            BoneTrackCount = clip.BoneTracks.Count
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<AnimationClipSnapshot>> ListClipsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<AnimationManager>(out var animationManager))
+        {
+            return Task.FromResult<IReadOnlyList<AnimationClipSnapshot>>([]);
+        }
+
+        var clips = new List<AnimationClipSnapshot>();
+
+        // AnimationManager doesn't expose registered clips directly, so we need to iterate through valid IDs
+        // Since clip IDs are sequential starting from 1, we can try to get clips up to a reasonable limit
+        // This is not ideal but works for debugging purposes
+        for (var clipId = 1; clipId <= 10000; clipId++)
+        {
+            if (animationManager.TryGetClip(clipId, out var clip))
+            {
+                if (clip != null)
+                {
+                    clips.Add(new AnimationClipSnapshot
+                    {
+                        ClipId = clipId,
+                        Name = clip.Name,
+                        Duration = clip.Duration,
+                        WrapMode = clip.WrapMode.ToString(),
+                        BoneTrackCount = clip.BoneTracks.Count
+                    });
+                }
+            }
+            else if (clips.Count > 0 && clipId - clips.Count > 100)
+            {
+                // If we've tried 100 IDs beyond the last found clip, stop
+                break;
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<AnimationClipSnapshot>>(clips);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -3,6 +3,8 @@ using KeenEyes.Input.Abstractions;
 using KeenEyes.Logging;
 using KeenEyes.TestBridge.AI;
 using KeenEyes.TestBridge.AIImpl;
+using KeenEyes.TestBridge.Animation;
+using KeenEyes.TestBridge.AnimationImpl;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
@@ -10,6 +12,12 @@ using KeenEyes.TestBridge.Logging;
 using KeenEyes.TestBridge.LoggingImpl;
 using KeenEyes.TestBridge.Mutation;
 using KeenEyes.TestBridge.MutationImpl;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.NavigationImpl;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.NetworkImpl;
+using KeenEyes.TestBridge.Physics;
+using KeenEyes.TestBridge.PhysicsImpl;
 using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.ProcessImpl;
 using KeenEyes.TestBridge.Profile;
@@ -23,6 +31,8 @@ using KeenEyes.TestBridge.SystemImpl;
 using KeenEyes.TestBridge.Systems;
 using KeenEyes.TestBridge.Time;
 using KeenEyes.TestBridge.TimeImpl;
+using KeenEyes.TestBridge.UI;
+using KeenEyes.TestBridge.UIImpl;
 using KeenEyes.TestBridge.Window;
 using KeenEyes.TestBridge.WindowImpl;
 using KeenEyes.Testing.Input;
@@ -60,6 +70,11 @@ public sealed class InProcessBridge : ITestBridge
     private readonly SnapshotControllerImpl snapshotController;
     private readonly AIControllerImpl aiController;
     private readonly ReplayControllerImpl replayController;
+    private readonly AnimationControllerImpl animationController;
+    private readonly PhysicsControllerImpl physicsController;
+    private readonly NavigationControllerImpl navigationController;
+    private readonly NetworkControllerImpl networkController;
+    private readonly UIControllerImpl uiController;
     private readonly TestBridgeOptions options;
     private bool disposed;
 
@@ -99,6 +114,11 @@ public sealed class InProcessBridge : ITestBridge
         snapshotController = new SnapshotControllerImpl(world);
         aiController = new AIControllerImpl(world);
         replayController = new ReplayControllerImpl(world);
+        animationController = new AnimationControllerImpl(world);
+        physicsController = new PhysicsControllerImpl(world);
+        navigationController = new NavigationControllerImpl(world);
+        networkController = new NetworkControllerImpl(world);
+        uiController = new UIControllerImpl(world);
 
         // Wire up log controller to state controller for WorldStats
         stateController.SetLogController(logController);
@@ -145,6 +165,21 @@ public sealed class InProcessBridge : ITestBridge
 
     /// <inheritdoc />
     public IReplayController Replay => replayController;
+
+    /// <inheritdoc />
+    public IAnimationController Animation => animationController;
+
+    /// <inheritdoc />
+    public IPhysicsController Physics => physicsController;
+
+    /// <inheritdoc />
+    public INavigationController Navigation => navigationController;
+
+    /// <inheritdoc />
+    public INetworkController Network => networkController;
+
+    /// <inheritdoc />
+    public IUIController UI => uiController;
 
     /// <inheritdoc />
     public IInputContext InputContext => compositeInputContext is not null

--- a/src/KeenEyes.TestBridge/InProcessBridge.cs
+++ b/src/KeenEyes.TestBridge/InProcessBridge.cs
@@ -14,6 +14,8 @@ using KeenEyes.TestBridge.Process;
 using KeenEyes.TestBridge.ProcessImpl;
 using KeenEyes.TestBridge.Profile;
 using KeenEyes.TestBridge.ProfileImpl;
+using KeenEyes.TestBridge.Replay;
+using KeenEyes.TestBridge.ReplayImpl;
 using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.SnapshotImpl;
 using KeenEyes.TestBridge.State;
@@ -57,6 +59,7 @@ public sealed class InProcessBridge : ITestBridge
     private readonly ProfileControllerImpl profileController;
     private readonly SnapshotControllerImpl snapshotController;
     private readonly AIControllerImpl aiController;
+    private readonly ReplayControllerImpl replayController;
     private readonly TestBridgeOptions options;
     private bool disposed;
 
@@ -95,6 +98,7 @@ public sealed class InProcessBridge : ITestBridge
         profileController = new ProfileControllerImpl(world);
         snapshotController = new SnapshotControllerImpl(world);
         aiController = new AIControllerImpl(world);
+        replayController = new ReplayControllerImpl(world);
 
         // Wire up log controller to state controller for WorldStats
         stateController.SetLogController(logController);
@@ -138,6 +142,9 @@ public sealed class InProcessBridge : ITestBridge
 
     /// <inheritdoc />
     public IAIController AI => aiController;
+
+    /// <inheritdoc />
+    public IReplayController Replay => replayController;
 
     /// <inheritdoc />
     public IInputContext InputContext => compositeInputContext is not null

--- a/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
+++ b/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
@@ -24,6 +24,11 @@
     <ProjectReference Include="..\KeenEyes.Debugging\KeenEyes.Debugging.csproj" />
     <ProjectReference Include="..\KeenEyes.AI\KeenEyes.AI.csproj" />
     <ProjectReference Include="..\KeenEyes.Replay\KeenEyes.Replay.csproj" />
+    <ProjectReference Include="..\KeenEyes.Animation\KeenEyes.Animation.csproj" />
+    <ProjectReference Include="..\KeenEyes.Physics\KeenEyes.Physics.csproj" />
+    <ProjectReference Include="..\KeenEyes.UI\KeenEyes.UI.csproj" />
+    <ProjectReference Include="..\KeenEyes.Network\KeenEyes.Network.csproj" />
+    <ProjectReference Include="..\KeenEyes.Navigation\KeenEyes.Navigation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
+++ b/src/KeenEyes.TestBridge/KeenEyes.TestBridge.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\KeenEyes.Logging\KeenEyes.Logging.csproj" />
     <ProjectReference Include="..\KeenEyes.Debugging\KeenEyes.Debugging.csproj" />
     <ProjectReference Include="..\KeenEyes.AI\KeenEyes.AI.csproj" />
+    <ProjectReference Include="..\KeenEyes.Replay\KeenEyes.Replay.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.TestBridge/NavigationImpl/NavigationControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/NavigationImpl/NavigationControllerImpl.cs
@@ -1,0 +1,377 @@
+using System.Numerics;
+using KeenEyes.Navigation;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.TestBridge.Navigation;
+
+namespace KeenEyes.TestBridge.NavigationImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="INavigationController"/>.
+/// </summary>
+internal sealed class NavigationControllerImpl(World world) : INavigationController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<NavigationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(new NavigationStatisticsSnapshot
+            {
+                IsReady = false,
+                Strategy = "None",
+                ActiveAgentCount = 0,
+                PendingRequestCount = 0
+            });
+        }
+
+        return Task.FromResult(new NavigationStatisticsSnapshot
+        {
+            IsReady = nav.IsReady,
+            Strategy = nav.Strategy.ToString(),
+            ActiveAgentCount = nav.ActiveAgentCount,
+            PendingRequestCount = nav.PendingRequestCount
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(nav.IsReady);
+    }
+
+    #endregion
+
+    #region Agent Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetNavigationEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<NavMeshAgent>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<NavAgentSnapshot?> GetAgentStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult<NavAgentSnapshot?>(null);
+        }
+
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+
+        NavPointSnapshot? destination = null;
+        if (agent.HasPath || agent.PathPending)
+        {
+            destination = new NavPointSnapshot
+            {
+                X = agent.Destination.X,
+                Y = agent.Destination.Y,
+                Z = agent.Destination.Z,
+                AreaType = "Unknown"
+            };
+        }
+
+        int currentWaypointIndex = 0;
+        float distanceTraveled = 0f;
+
+        if (world.TryGetExtension<NavigationContext>(out var nav) && nav.TryGetAgentState(entity, out var state))
+        {
+            currentWaypointIndex = state.CurrentWaypointIndex;
+            distanceTraveled = state.DistanceTraveled;
+        }
+
+        return Task.FromResult<NavAgentSnapshot?>(new NavAgentSnapshot
+        {
+            EntityId = entityId,
+            HasPath = agent.HasPath,
+            IsStopped = agent.IsStopped,
+            PathPending = agent.PathPending,
+            CurrentWaypointIndex = currentWaypointIndex,
+            DistanceTraveled = distanceTraveled,
+            Speed = agent.Speed,
+            Destination = destination
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<NavPathSnapshot?> GetPathAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        if (!nav.TryGetAgentState(entity, out var state))
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        var path = state.Path;
+        if (!path.IsValid)
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        var waypoints = new List<NavPointSnapshot>();
+        foreach (var point in path)
+        {
+            waypoints.Add(new NavPointSnapshot
+            {
+                X = point.Position.X,
+                Y = point.Position.Y,
+                Z = point.Position.Z,
+                AreaType = point.AreaType.ToString()
+            });
+        }
+
+        return Task.FromResult<NavPathSnapshot?>(new NavPathSnapshot
+        {
+            IsValid = path.IsValid,
+            IsComplete = path.IsComplete,
+            TotalCost = path.TotalCost,
+            Length = path.Length,
+            Waypoints = waypoints
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetDestinationAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var destination = new Vector3(x, y, z);
+            nav.SetDestination(entity, destination);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> StopAgentAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            nav.Stop(entity);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ResumeAgentAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            nav.Resume(entity);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> WarpAgentAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NavMeshAgent>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var position = new Vector3(x, y, z);
+            return Task.FromResult(nav.Warp(entity, position));
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    #endregion
+
+    #region Path Queries
+
+    /// <inheritdoc />
+    public Task<NavPathSnapshot?> FindPathAsync(float startX, float startY, float startZ, float endX, float endY, float endZ, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        if (!nav.IsReady)
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+
+        try
+        {
+            var start = new Vector3(startX, startY, startZ);
+            var end = new Vector3(endX, endY, endZ);
+            var agent = AgentSettings.Default;
+
+            var path = nav.FindPath(start, end, agent);
+            if (!path.IsValid)
+            {
+                return Task.FromResult<NavPathSnapshot?>(null);
+            }
+
+            var waypoints = new List<NavPointSnapshot>();
+            foreach (var point in path)
+            {
+                waypoints.Add(new NavPointSnapshot
+                {
+                    X = point.Position.X,
+                    Y = point.Position.Y,
+                    Z = point.Position.Z,
+                    AreaType = point.AreaType.ToString()
+                });
+            }
+
+            return Task.FromResult<NavPathSnapshot?>(new NavPathSnapshot
+            {
+                IsValid = path.IsValid,
+                IsComplete = path.IsComplete,
+                TotalCost = path.TotalCost,
+                Length = path.Length,
+                Waypoints = waypoints
+            });
+        }
+        catch
+        {
+            return Task.FromResult<NavPathSnapshot?>(null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsNavigableAsync(float x, float y, float z, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!nav.IsReady)
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var position = new Vector3(x, y, z);
+            var agent = AgentSettings.Default;
+            return Task.FromResult(nav.IsNavigable(position, agent));
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<NavPointSnapshot?> FindNearestPointAsync(float x, float y, float z, float searchRadius, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NavigationContext>(out var nav))
+        {
+            return Task.FromResult<NavPointSnapshot?>(null);
+        }
+
+        if (!nav.IsReady)
+        {
+            return Task.FromResult<NavPointSnapshot?>(null);
+        }
+
+        try
+        {
+            var position = new Vector3(x, y, z);
+            var nearestPoint = nav.FindNearestPoint(position, searchRadius);
+
+            if (!nearestPoint.HasValue)
+            {
+                return Task.FromResult<NavPointSnapshot?>(null);
+            }
+
+            return Task.FromResult<NavPointSnapshot?>(new NavPointSnapshot
+            {
+                X = nearestPoint.Value.Position.X,
+                Y = nearestPoint.Value.Position.Y,
+                Z = nearestPoint.Value.Position.Z,
+                AreaType = nearestPoint.Value.AreaType.ToString()
+            });
+        }
+        catch
+        {
+            return Task.FromResult<NavPointSnapshot?>(null);
+        }
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/NetworkImpl/NetworkControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/NetworkImpl/NetworkControllerImpl.cs
@@ -1,0 +1,243 @@
+using KeenEyes.Network;
+using KeenEyes.Network.Components;
+using KeenEyes.TestBridge.Network;
+
+namespace KeenEyes.TestBridge.NetworkImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="INetworkController"/>.
+/// </summary>
+internal sealed class NetworkControllerImpl(World world) : INetworkController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<NetworkStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        // Try to get network plugin (either server or client)
+        var isServer = world.TryGetExtension<NetworkServerPlugin>(out var serverPlugin);
+        var isClient = world.TryGetExtension<NetworkClientPlugin>(out var clientPlugin);
+
+        if (!isServer && !isClient)
+        {
+            // No network plugin installed
+            return Task.FromResult(new NetworkStatisticsSnapshot
+            {
+                IsConnected = false,
+                IsServer = false,
+                IsClient = false,
+                CurrentTick = 0,
+                LocalClientId = 0,
+                ClientCount = 0,
+                NetworkedEntityCount = 0
+            });
+        }
+
+        // Count networked entities
+        var networkedEntityCount = 0;
+        foreach (var _ in world.Query<NetworkId>())
+        {
+            networkedEntityCount++;
+        }
+
+        if (isServer)
+        {
+            return Task.FromResult(new NetworkStatisticsSnapshot
+            {
+                IsConnected = true,
+                IsServer = true,
+                IsClient = false,
+                CurrentTick = serverPlugin!.CurrentTick,
+                LocalClientId = serverPlugin.LocalClientId,
+                ClientCount = serverPlugin.ClientCount,
+                NetworkedEntityCount = networkedEntityCount
+            });
+        }
+        else
+        {
+            return Task.FromResult(new NetworkStatisticsSnapshot
+            {
+                IsConnected = clientPlugin!.IsConnected,
+                IsServer = false,
+                IsClient = true,
+                CurrentTick = clientPlugin.CurrentTick,
+                LocalClientId = clientPlugin.LocalClientId,
+                ClientCount = 0,
+                NetworkedEntityCount = networkedEntityCount
+            });
+        }
+    }
+
+    #endregion
+
+    #region Connection State
+
+    /// <inheritdoc />
+    public Task<bool> IsConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        if (world.TryGetExtension<NetworkServerPlugin>(out _))
+        {
+            return Task.FromResult(true); // Server is always "connected" when listening
+        }
+
+        if (world.TryGetExtension<NetworkClientPlugin>(out var clientPlugin))
+        {
+            return Task.FromResult(clientPlugin.IsConnected);
+        }
+
+        return Task.FromResult(false);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsServerAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(world.TryGetExtension<NetworkServerPlugin>(out _));
+    }
+
+    /// <inheritdoc />
+    public Task<uint> GetCurrentTickAsync(CancellationToken cancellationToken = default)
+    {
+        if (world.TryGetExtension<NetworkServerPlugin>(out var serverPlugin))
+        {
+            return Task.FromResult(serverPlugin.CurrentTick);
+        }
+
+        if (world.TryGetExtension<NetworkClientPlugin>(out var clientPlugin))
+        {
+            return Task.FromResult(clientPlugin.CurrentTick);
+        }
+
+        return Task.FromResult(0u);
+    }
+
+    /// <inheritdoc />
+    public Task<float> GetLatencyAsync(CancellationToken cancellationToken = default)
+    {
+        if (world.TryGetExtension<NetworkClientPlugin>(out var clientPlugin))
+        {
+            return Task.FromResult(clientPlugin.RoundTripTimeMs);
+        }
+
+        return Task.FromResult(0f);
+    }
+
+    /// <inheritdoc />
+    public Task<ConnectionStatsSnapshot?> GetConnectionStatsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NetworkClientPlugin>(out var clientPlugin) || !clientPlugin.IsConnected)
+        {
+            return Task.FromResult<ConnectionStatsSnapshot?>(null);
+        }
+
+        // Get stats from transport if available (connectionId 0 = server connection for clients)
+        var transport = clientPlugin.Transport;
+        var stats = transport.GetStatistics(0);
+
+        return Task.FromResult<ConnectionStatsSnapshot?>(new ConnectionStatsSnapshot
+        {
+            RoundTripTimeMs = clientPlugin.RoundTripTimeMs,
+            PacketLossPercent = stats.PacketLossPercent,
+            BytesSent = stats.BytesSent,
+            BytesReceived = stats.BytesReceived,
+            PacketsSent = stats.PacketsSent,
+            PacketsReceived = stats.PacketsReceived
+        });
+    }
+
+    #endregion
+
+    #region Server Operations
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ClientSnapshot>> GetConnectedClientsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<NetworkServerPlugin>(out var serverPlugin))
+        {
+            return Task.FromResult<IReadOnlyList<ClientSnapshot>>([]);
+        }
+
+        var clients = new List<ClientSnapshot>();
+        foreach (var clientState in serverPlugin.GetConnectedClients())
+        {
+            clients.Add(new ClientSnapshot
+            {
+                ClientId = clientState.ClientId,
+                LastAckedTick = clientState.LastAckedTick,
+                NeedsFullSnapshot = clientState.NeedsFullSnapshot,
+                RoundTripTimeMs = clientState.RoundTripTimeMs
+            });
+        }
+
+        return Task.FromResult<IReadOnlyList<ClientSnapshot>>(clients);
+    }
+
+    #endregion
+
+    #region Entity Replication
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetNetworkedEntitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = new List<int>();
+        foreach (var entity in world.Query<NetworkId>())
+        {
+            entities.Add(entity.Id);
+        }
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<uint?> GetNetworkIdAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NetworkId>(entity))
+        {
+            return Task.FromResult<uint?>(null);
+        }
+
+        ref readonly var networkId = ref world.Get<NetworkId>(entity);
+        return Task.FromResult<uint?>(networkId.Value);
+    }
+
+    /// <inheritdoc />
+    public Task<int?> GetOwnershipAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NetworkOwner>(entity))
+        {
+            return Task.FromResult<int?>(null);
+        }
+
+        ref readonly var owner = ref world.Get<NetworkOwner>(entity);
+        return Task.FromResult<int?>(owner.ClientId);
+    }
+
+    /// <inheritdoc />
+    public Task<ReplicationStateSnapshot?> GetReplicationStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<NetworkState>(entity))
+        {
+            return Task.FromResult<ReplicationStateSnapshot?>(null);
+        }
+
+        ref readonly var state = ref world.Get<NetworkState>(entity);
+        ref readonly var networkId = ref world.Get<NetworkId>(entity);
+        ref readonly var owner = ref world.Get<NetworkOwner>(entity);
+
+        return Task.FromResult<ReplicationStateSnapshot?>(new ReplicationStateSnapshot
+        {
+            NetworkId = networkId.Value,
+            OwnerId = owner.ClientId,
+            LastSentTick = state.LastSentTick,
+            LastReceivedTick = state.LastReceivedTick,
+            NeedsFullSync = state.NeedsFullSync,
+            IsLocallyOwned = world.Has<LocallyOwned>(entity),
+            IsRemotelyOwned = world.Has<RemotelyOwned>(entity),
+            IsPredicted = world.Has<Predicted>(entity),
+            IsInterpolated = world.Has<Interpolated>(entity)
+        });
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/PhysicsImpl/PhysicsControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/PhysicsImpl/PhysicsControllerImpl.cs
@@ -1,0 +1,363 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Physics.Components;
+using KeenEyes.Physics.Core;
+using KeenEyes.TestBridge.Physics;
+
+namespace KeenEyes.TestBridge.PhysicsImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="IPhysicsController"/>.
+/// </summary>
+internal sealed class PhysicsControllerImpl(World world) : IPhysicsController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<PhysicsStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(new PhysicsStatisticsSnapshot
+            {
+                BodyCount = 0,
+                StaticCount = 0,
+                InterpolationAlpha = 0f
+            });
+        }
+
+        return Task.FromResult(new PhysicsStatisticsSnapshot
+        {
+            BodyCount = physics.BodyCount,
+            StaticCount = physics.StaticCount,
+            InterpolationAlpha = physics.InterpolationAlpha
+        });
+    }
+
+    #endregion
+
+    #region Raycasting and Queries
+
+    /// <inheritdoc />
+    public Task<RayHitSnapshot?> RaycastAsync(Vector3Snapshot origin, Vector3Snapshot direction, float maxDistance, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<RayHitSnapshot?>(null);
+        }
+
+        var originVec = new Vector3(origin.X, origin.Y, origin.Z);
+        var directionVec = new Vector3(direction.X, direction.Y, direction.Z);
+
+        if (physics.Raycast(originVec, directionVec, maxDistance, out var hit))
+        {
+            return Task.FromResult<RayHitSnapshot?>(new RayHitSnapshot
+            {
+                EntityId = hit.Entity.Id,
+                Position = new Vector3Snapshot { X = hit.Position.X, Y = hit.Position.Y, Z = hit.Position.Z },
+                Normal = new Vector3Snapshot { X = hit.Normal.X, Y = hit.Normal.Y, Z = hit.Normal.Z },
+                Distance = hit.Distance
+            });
+        }
+
+        return Task.FromResult<RayHitSnapshot?>(null);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> OverlapSphereAsync(Vector3Snapshot center, float radius, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<IReadOnlyList<int>>([]);
+        }
+
+        var centerVec = new Vector3(center.X, center.Y, center.Z);
+        var entities = physics.OverlapSphere(centerVec, radius).Select(e => e.Id).ToList();
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> OverlapBoxAsync(Vector3Snapshot center, Vector3Snapshot halfExtents, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<IReadOnlyList<int>>([]);
+        }
+
+        var centerVec = new Vector3(center.X, center.Y, center.Z);
+        var halfExtentsVec = new Vector3(halfExtents.X, halfExtents.Y, halfExtents.Z);
+        var entities = physics.OverlapBox(centerVec, halfExtentsVec).Select(e => e.Id).ToList();
+        return Task.FromResult<IReadOnlyList<int>>(entities);
+    }
+
+    #endregion
+
+    #region Body State
+
+    /// <inheritdoc />
+    public Task<PhysicsBodySnapshot?> GetBodyStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<PhysicsBodySnapshot?>(null);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !physics.HasPhysicsBody(entity))
+        {
+            return Task.FromResult<PhysicsBodySnapshot?>(null);
+        }
+
+        // Get transform
+        Vector3 position = Vector3.Zero;
+        Quaternion rotation = Quaternion.Identity;
+        if (world.Has<Transform3D>(entity))
+        {
+            ref readonly var transform = ref world.Get<Transform3D>(entity);
+            position = transform.Position;
+            rotation = transform.Rotation;
+        }
+
+        // Get velocities
+        Vector3 linearVelocity = Vector3.Zero;
+        Vector3 angularVelocity = Vector3.Zero;
+        try
+        {
+            linearVelocity = physics.GetVelocity(entity);
+            angularVelocity = physics.GetAngularVelocity(entity);
+        }
+        catch
+        {
+            // Entity might not have dynamic body
+        }
+
+        // Get body properties
+        float mass = 0f;
+        string bodyType = "Unknown";
+        if (world.Has<RigidBody>(entity))
+        {
+            ref readonly var rigidBody = ref world.Get<RigidBody>(entity);
+            mass = rigidBody.Mass;
+            bodyType = rigidBody.BodyType.ToString();
+        }
+
+        bool isAwake = false;
+        try
+        {
+            isAwake = physics.IsAwake(entity);
+        }
+        catch
+        {
+            // Entity might not support awake state (static bodies)
+        }
+
+        return Task.FromResult<PhysicsBodySnapshot?>(new PhysicsBodySnapshot
+        {
+            EntityId = entityId,
+            Position = new Vector3Snapshot { X = position.X, Y = position.Y, Z = position.Z },
+            Rotation = new QuaternionSnapshot { X = rotation.X, Y = rotation.Y, Z = rotation.Z, W = rotation.W },
+            LinearVelocity = new Vector3Snapshot { X = linearVelocity.X, Y = linearVelocity.Y, Z = linearVelocity.Z },
+            AngularVelocity = new Vector3Snapshot { X = angularVelocity.X, Y = angularVelocity.Y, Z = angularVelocity.Z },
+            Mass = mass,
+            BodyType = bodyType,
+            IsAwake = isAwake
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<Vector3Snapshot?> GetVelocityAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<Vector3Snapshot?>(null);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !physics.HasPhysicsBody(entity))
+        {
+            return Task.FromResult<Vector3Snapshot?>(null);
+        }
+
+        try
+        {
+            var velocity = physics.GetVelocity(entity);
+            return Task.FromResult<Vector3Snapshot?>(new Vector3Snapshot
+            {
+                X = velocity.X,
+                Y = velocity.Y,
+                Z = velocity.Z
+            });
+        }
+        catch
+        {
+            return Task.FromResult<Vector3Snapshot?>(null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetVelocityAsync(int entityId, Vector3Snapshot velocity, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var velocityVec = new Vector3(velocity.X, velocity.Y, velocity.Z);
+            physics.SetVelocity(entity, velocityVec);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool?> IsAwakeAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult<bool?>(null);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !physics.HasPhysicsBody(entity))
+        {
+            return Task.FromResult<bool?>(null);
+        }
+
+        try
+        {
+            return Task.FromResult<bool?>(physics.IsAwake(entity));
+        }
+        catch
+        {
+            return Task.FromResult<bool?>(null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> WakeUpAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            physics.WakeUp(entity);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    #endregion
+
+    #region Forces and Impulses
+
+    /// <inheritdoc />
+    public Task<bool> ApplyForceAsync(int entityId, Vector3Snapshot force, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var forceVec = new Vector3(force.X, force.Y, force.Z);
+            physics.ApplyForce(entity, forceVec);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ApplyImpulseAsync(int entityId, Vector3Snapshot impulse, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        try
+        {
+            var impulseVec = new Vector3(impulse.X, impulse.Y, impulse.Z);
+            physics.ApplyImpulse(entity, impulseVec);
+            return Task.FromResult(true);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    #endregion
+
+    #region Gravity
+
+    /// <inheritdoc />
+    public Task<Vector3Snapshot> GetGravityAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(new Vector3Snapshot { X = 0f, Y = 0f, Z = 0f });
+        }
+
+        var gravity = physics.Gravity;
+        return Task.FromResult(new Vector3Snapshot
+        {
+            X = gravity.X,
+            Y = gravity.Y,
+            Z = gravity.Z
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetGravityAsync(Vector3Snapshot gravity, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<PhysicsWorld>(out var physics))
+        {
+            return Task.FromResult(false);
+        }
+
+        var gravityVec = new Vector3(gravity.X, gravity.Y, gravity.Z);
+        physics.SetGravity(gravityVec);
+        return Task.FromResult(true);
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/ReplayImpl/ReplayControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/ReplayImpl/ReplayControllerImpl.cs
@@ -1,0 +1,895 @@
+using System.Diagnostics.CodeAnalysis;
+using KeenEyes.Replay;
+using KeenEyes.Serialization;
+using KeenEyes.TestBridge.Replay;
+
+namespace KeenEyes.TestBridge.ReplayImpl;
+
+/// <summary>
+/// Implementation of <see cref="IReplayController"/> that wraps the existing Replay infrastructure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This controller provides TestBridge access to replay recording and playback functionality.
+/// Recording requires the ReplayPlugin to be installed on the world; playback can be done
+/// independently using the ReplayPlayer.
+/// </para>
+/// </remarks>
+internal sealed class ReplayControllerImpl(World world) : IReplayController
+{
+    private readonly ReplayPlayer player = new();
+    private readonly Lock syncLock = new();
+    private ReplayData? lastRecordingData;
+
+    #region Recording Control
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> StartRecordingAsync(
+        string? name = null,
+        int maxFrames = 36000,
+        int snapshotIntervalMs = 5000)
+    {
+        try
+        {
+            if (!world.TryGetExtension<ReplayRecorder>(out var recorder))
+            {
+                return Task.FromResult(ReplayOperationResult.Fail(
+                    "ReplayPlugin is not installed. Install the ReplayPlugin on the world to enable recording."));
+            }
+
+            if (recorder.IsRecording)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("Recording is already in progress."));
+            }
+
+            // Note: The recorder uses options set at plugin install time.
+            // MCP tools can't dynamically change maxFrames/snapshotInterval without reinstalling the plugin.
+            // For now, we start with the configured options.
+            recorder.StartRecording(name);
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreateRecordingInfo(recorder)));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> StopRecordingAsync()
+    {
+        try
+        {
+            if (!world.TryGetExtension<ReplayRecorder>(out var recorder))
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("ReplayPlugin is not installed."));
+            }
+
+            if (!recorder.IsRecording)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("No recording is in progress."));
+            }
+
+            lastRecordingData = recorder.StopRecording();
+            if (lastRecordingData is null)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("Failed to stop recording."));
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(new RecordingInfoSnapshot
+            {
+                IsRecording = false,
+                Name = lastRecordingData.Name,
+                FrameCount = lastRecordingData.FrameCount,
+                DurationSeconds = (float)lastRecordingData.Duration.TotalSeconds,
+                SnapshotCount = lastRecordingData.Snapshots.Count,
+                StartedAt = lastRecordingData.RecordingStarted
+            }));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> CancelRecordingAsync()
+    {
+        try
+        {
+            if (!world.TryGetExtension<ReplayRecorder>(out var recorder))
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("ReplayPlugin is not installed."));
+            }
+
+            recorder.CancelRecording();
+            return Task.FromResult(ReplayOperationResult.Ok());
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> IsRecordingAsync()
+    {
+        if (!world.TryGetExtension<ReplayRecorder>(out var recorder))
+        {
+            return Task.FromResult(false);
+        }
+
+        return Task.FromResult(recorder.IsRecording);
+    }
+
+    /// <inheritdoc/>
+    public Task<RecordingInfoSnapshot?> GetRecordingInfoAsync()
+    {
+        if (!world.TryGetExtension<ReplayRecorder>(out var recorder) || !recorder.IsRecording)
+        {
+            return Task.FromResult<RecordingInfoSnapshot?>(null);
+        }
+
+        return Task.FromResult<RecordingInfoSnapshot?>(CreateRecordingInfo(recorder));
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> ForceSnapshotAsync()
+    {
+        try
+        {
+            if (!world.TryGetExtension<ReplayRecorder>(out var recorder))
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("ReplayPlugin is not installed."));
+            }
+
+            if (!recorder.IsRecording)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("No recording is in progress."));
+            }
+
+            recorder.CaptureSnapshot();
+            return Task.FromResult(ReplayOperationResult.Ok(CreateRecordingInfo(recorder)));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    #endregion
+
+    #region Recording Management
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> SaveAsync(string path)
+    {
+        try
+        {
+            // Try to stop current recording if no data is available
+            if (lastRecordingData is null
+                && world.TryGetExtension<ReplayRecorder>(out var recorder)
+                && recorder.IsRecording)
+            {
+                lastRecordingData = recorder.StopRecording();
+            }
+
+            if (lastRecordingData is null)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("No recording data available to save."));
+            }
+
+            ReplayFileFormat.WriteToFile(path, lastRecordingData);
+            return Task.FromResult(ReplayOperationResult.Ok(path));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> LoadAsync(string path)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                player.LoadReplay(path);
+            }
+
+            var metadata = CreateMetadataFromPlayer();
+            if (metadata is null)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("Failed to load replay metadata."));
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(metadata));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<ReplayFileSnapshot>> ListAsync(string? directory = null)
+    {
+        try
+        {
+            var dir = directory ?? Environment.CurrentDirectory;
+            var files = Directory.GetFiles(dir, "*" + ReplayFileFormat.Extension);
+
+            var results = new List<ReplayFileSnapshot>();
+            foreach (var file in files)
+            {
+                var fileInfo = new FileInfo(file);
+                ReplayMetadataSnapshot? metadata = null;
+                string? error = null;
+
+                try
+                {
+                    var replayInfo = ReplayFileFormat.ReadMetadataFromFile(file);
+                    metadata = CreateMetadataFromFileInfo(replayInfo);
+                    if (replayInfo.ValidationError is not null)
+                    {
+                        error = replayInfo.ValidationError;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    error = ex.Message;
+                }
+
+                results.Add(new ReplayFileSnapshot
+                {
+                    Path = file,
+                    FileName = fileInfo.Name,
+                    SizeBytes = fileInfo.Length,
+                    LastModified = new DateTimeOffset(fileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                    Metadata = metadata,
+                    ValidationError = error
+                });
+            }
+
+            return Task.FromResult<IReadOnlyList<ReplayFileSnapshot>>(results);
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<ReplayFileSnapshot>>([]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> DeleteAsync(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                return Task.FromResult(true);
+            }
+            return Task.FromResult(false);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayMetadataSnapshot?> GetMetadataAsync(string path)
+    {
+        try
+        {
+            var info = ReplayFileFormat.ReadMetadataFromFile(path);
+            return Task.FromResult<ReplayMetadataSnapshot?>(CreateMetadataFromFileInfo(info));
+        }
+        catch
+        {
+            return Task.FromResult<ReplayMetadataSnapshot?>(null);
+        }
+    }
+
+    #endregion
+
+    #region Playback Control
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> PlayAsync()
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(ReplayOperationResult.Fail("No replay is loaded."));
+                }
+
+                player.Play();
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> PauseAsync()
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                player.Pause();
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> StopPlaybackAsync()
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                player.Stop();
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<PlaybackStateSnapshot> GetPlaybackStateAsync()
+    {
+        return Task.FromResult(CreatePlaybackState());
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> SetSpeedAsync(float speed)
+    {
+        try
+        {
+            if (speed < 0.25f || speed > 4.0f)
+            {
+                return Task.FromResult(ReplayOperationResult.Fail("Speed must be between 0.25 and 4.0."));
+            }
+
+            lock (syncLock)
+            {
+                player.PlaybackSpeed = speed;
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    #endregion
+
+    #region Playback Navigation
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> SeekFrameAsync(int frame)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(ReplayOperationResult.Fail("No replay is loaded."));
+                }
+
+                player.SeekToFrame(frame);
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> SeekTimeAsync(float seconds)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(ReplayOperationResult.Fail("No replay is loaded."));
+                }
+
+                player.SeekToTime(TimeSpan.FromSeconds(seconds));
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> StepForwardAsync(int frames = 1)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(ReplayOperationResult.Fail("No replay is loaded."));
+                }
+
+                player.Step(frames);
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReplayOperationResult> StepBackwardAsync(int frames = 1)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(ReplayOperationResult.Fail("No replay is loaded."));
+                }
+
+                player.Step(-frames);
+            }
+
+            return Task.FromResult(ReplayOperationResult.Ok(CreatePlaybackState()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ReplayOperationResult.Fail(ex.Message));
+        }
+    }
+
+    #endregion
+
+    #region Frame Inspection
+
+    /// <inheritdoc/>
+    public Task<ReplayFrameSnapshot?> GetFrameAsync(int frame)
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult<ReplayFrameSnapshot?>(null);
+                }
+
+                var replayFrame = player.GetFrame(frame);
+                if (replayFrame is null)
+                {
+                    return Task.FromResult<ReplayFrameSnapshot?>(null);
+                }
+
+                return Task.FromResult<ReplayFrameSnapshot?>(CreateFrameSnapshot(replayFrame));
+            }
+        }
+        catch
+        {
+            return Task.FromResult<ReplayFrameSnapshot?>(null);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<ReplayFrameSnapshot>> GetFrameRangeAsync(int startFrame, int count)
+    {
+        try
+        {
+            var results = new List<ReplayFrameSnapshot>();
+
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult<IReadOnlyList<ReplayFrameSnapshot>>(results);
+                }
+
+                for (var i = 0; i < count; i++)
+                {
+                    var frame = player.GetFrame(startFrame + i);
+                    if (frame is not null)
+                    {
+                        results.Add(CreateFrameSnapshot(frame));
+                    }
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<ReplayFrameSnapshot>>(results);
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<ReplayFrameSnapshot>>([]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<InputEventSnapshot>> GetInputsAsync(int startFrame, int endFrame)
+    {
+        try
+        {
+            var results = new List<InputEventSnapshot>();
+
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult<IReadOnlyList<InputEventSnapshot>>(results);
+                }
+
+                for (var i = startFrame; i <= endFrame; i++)
+                {
+                    var frame = player.GetFrame(i);
+                    if (frame is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var input in frame.InputEvents)
+                    {
+                        results.Add(CreateInputEventSnapshot(input, i));
+                    }
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<InputEventSnapshot>>(results);
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<InputEventSnapshot>>([]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<ReplayEventSnapshot>> GetEventsAsync(int startFrame, int endFrame)
+    {
+        try
+        {
+            var results = new List<ReplayEventSnapshot>();
+
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult<IReadOnlyList<ReplayEventSnapshot>>(results);
+                }
+
+                for (var i = startFrame; i <= endFrame; i++)
+                {
+                    var frame = player.GetFrame(i);
+                    if (frame is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var evt in frame.Events)
+                    {
+                        results.Add(CreateReplayEventSnapshot(evt, i));
+                    }
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<ReplayEventSnapshot>>(results);
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<ReplayEventSnapshot>>([]);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<SnapshotMarkerSnapshot>> GetSnapshotsAsync()
+    {
+        try
+        {
+            var results = new List<SnapshotMarkerSnapshot>();
+
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>(results);
+                }
+
+                var data = player.LoadedReplay;
+                if (data is null)
+                {
+                    return Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>(results);
+                }
+
+                for (var i = 0; i < data.Snapshots.Count; i++)
+                {
+                    var snapshot = data.Snapshots[i];
+                    results.Add(new SnapshotMarkerSnapshot
+                    {
+                        FrameNumber = snapshot.FrameNumber,
+                        ElapsedTimeSeconds = (float)snapshot.ElapsedTime.TotalSeconds,
+                        Checksum = snapshot.Checksum,
+                        Index = i
+                    });
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>(results);
+        }
+        catch
+        {
+            return Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>([]);
+        }
+    }
+
+    #endregion
+
+    #region Validation
+
+    /// <inheritdoc/>
+    public Task<ValidationResultSnapshot> ValidateAsync(string path)
+    {
+        try
+        {
+            var fileInfo = ReplayFileFormat.ValidateFile(path);
+            if (fileInfo is null)
+            {
+                return Task.FromResult(new ValidationResultSnapshot
+                {
+                    IsValid = false,
+                    Path = path,
+                    Errors = ["File is not a valid replay file or does not exist."]
+                });
+            }
+
+            var errors = new List<string>();
+            if (fileInfo.ValidationError is not null)
+            {
+                errors.Add(fileInfo.ValidationError);
+            }
+
+            return Task.FromResult(new ValidationResultSnapshot
+            {
+                IsValid = errors.Count == 0,
+                Path = path,
+                TotalFrames = fileInfo.FrameCount,
+                SnapshotCount = fileInfo.SnapshotCount,
+                DataVersion = fileInfo.DataVersion,
+                Errors = errors.Count > 0 ? errors : null
+            });
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new ValidationResultSnapshot
+            {
+                IsValid = false,
+                Path = path,
+                Errors = [ex.Message]
+            });
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<DeterminismResultSnapshot> CheckDeterminismAsync()
+    {
+        try
+        {
+            lock (syncLock)
+            {
+                if (!player.IsLoaded)
+                {
+                    return Task.FromResult(new DeterminismResultSnapshot
+                    {
+                        IsDeterministic = false,
+                        TotalFramesChecked = 0,
+                        FramesWithChecksums = 0,
+                        DesyncDetails = "No replay is loaded."
+                    });
+                }
+
+                // For now, we just check if checksums are consistent
+                // Full determinism check would require replaying with world
+                var data = player.LoadedReplay;
+                if (data is null)
+                {
+                    return Task.FromResult(new DeterminismResultSnapshot
+                    {
+                        IsDeterministic = false,
+                        TotalFramesChecked = 0,
+                        FramesWithChecksums = 0,
+                        DesyncDetails = "Failed to access replay data."
+                    });
+                }
+
+                var framesWithChecksums = data.Frames.Count(f => f.Checksum.HasValue);
+
+                return Task.FromResult(new DeterminismResultSnapshot
+                {
+                    IsDeterministic = true, // We can't validate without replaying
+                    TotalFramesChecked = data.FrameCount,
+                    FramesWithChecksums = framesWithChecksums,
+                    DesyncDetails = framesWithChecksums == 0
+                        ? "No checksums recorded in replay."
+                        : null
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new DeterminismResultSnapshot
+            {
+                IsDeterministic = false,
+                TotalFramesChecked = 0,
+                FramesWithChecksums = 0,
+                DesyncDetails = ex.Message
+            });
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private RecordingInfoSnapshot CreateRecordingInfo(ReplayRecorder recorder)
+    {
+        return new RecordingInfoSnapshot
+        {
+            IsRecording = recorder.IsRecording,
+            Name = null, // Not accessible from ReplayRecorder
+            FrameCount = recorder.RecordedFrameCount,
+            DurationSeconds = (float)recorder.ElapsedTime.TotalSeconds,
+            SnapshotCount = recorder.SnapshotCount,
+            StartedAt = null // Not accessible from ReplayRecorder
+        };
+    }
+
+    private PlaybackStateSnapshot CreatePlaybackState()
+    {
+        lock (syncLock)
+        {
+            var isLoaded = player.IsLoaded;
+            var totalFrames = isLoaded ? player.TotalFrames : 0;
+            var totalTime = isLoaded ? player.TotalDuration : TimeSpan.Zero;
+
+            return new PlaybackStateSnapshot
+            {
+                IsLoaded = isLoaded,
+                IsPlaying = player.State == PlaybackState.Playing,
+                IsPaused = player.State == PlaybackState.Paused,
+                IsStopped = player.State == PlaybackState.Stopped,
+                CurrentFrame = player.CurrentFrame,
+                TotalFrames = totalFrames,
+                CurrentTimeSeconds = (float)player.CurrentTime.TotalSeconds,
+                TotalTimeSeconds = (float)totalTime.TotalSeconds,
+                PlaybackSpeed = player.PlaybackSpeed,
+                ReplayName = player.LoadedReplay?.Name
+            };
+        }
+    }
+
+    private ReplayMetadataSnapshot? CreateMetadataFromPlayer()
+    {
+        lock (syncLock)
+        {
+            var data = player.LoadedReplay;
+            if (data is null)
+            {
+                return null;
+            }
+
+            return new ReplayMetadataSnapshot
+            {
+                Name = data.Name,
+                Description = data.Description,
+                RecordingStarted = data.RecordingStarted,
+                RecordingEnded = data.RecordingEnded,
+                DurationSeconds = (float)data.Duration.TotalSeconds,
+                FrameCount = data.FrameCount,
+                SnapshotCount = data.Snapshots.Count,
+                AverageFrameRate = (float)data.AverageFrameRate,
+                DataVersion = data.Version
+            };
+        }
+    }
+
+    private static ReplayMetadataSnapshot CreateMetadataFromFileInfo(ReplayFileInfo info)
+    {
+        return new ReplayMetadataSnapshot
+        {
+            Name = info.Name,
+            Description = info.Description,
+            RecordingStarted = info.RecordingStarted,
+            RecordingEnded = info.RecordingEnded,
+            DurationSeconds = (float)info.Duration.TotalSeconds,
+            FrameCount = info.FrameCount,
+            SnapshotCount = info.SnapshotCount,
+            AverageFrameRate = info.Duration.TotalSeconds > 0
+                ? (float)(info.FrameCount / info.Duration.TotalSeconds)
+                : 0f,
+            DataVersion = info.DataVersion,
+            FileSizeBytes = info.CompressedSize,
+            HasChecksum = info.Checksum is not null
+        };
+    }
+
+    private static ReplayFrameSnapshot CreateFrameSnapshot(ReplayFrame frame)
+    {
+        return new ReplayFrameSnapshot
+        {
+            FrameNumber = frame.FrameNumber,
+            DeltaTimeSeconds = (float)frame.DeltaTime.TotalSeconds,
+            ElapsedTimeSeconds = (float)frame.ElapsedTime.TotalSeconds,
+            InputEventCount = frame.InputEvents.Count,
+            EventCount = frame.Events.Count,
+            HasSnapshot = frame.PrecedingSnapshotIndex.HasValue,
+            Checksum = frame.Checksum
+        };
+    }
+
+    private static InputEventSnapshot CreateInputEventSnapshot(InputEvent input, int frame)
+    {
+        return new InputEventSnapshot
+        {
+            Type = input.Type.ToString(),
+            Frame = frame,
+            Key = input.Key,
+            Value = input.Value,
+            PositionX = input.Position.X,
+            PositionY = input.Position.Y,
+            CustomType = input.CustomType,
+            TimestampMs = (float)input.Timestamp.TotalMilliseconds
+        };
+    }
+
+    private static ReplayEventSnapshot CreateReplayEventSnapshot(ReplayEvent evt, int frame)
+    {
+        return new ReplayEventSnapshot
+        {
+            Type = evt.Type.ToString(),
+            Frame = frame,
+            TimestampMs = (float)evt.Timestamp.TotalMilliseconds,
+            EntityId = evt.EntityId,
+            ComponentTypeName = evt.ComponentTypeName,
+            SystemTypeName = evt.SystemTypeName,
+            CustomType = evt.CustomType
+        };
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/UIImpl/UIControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/UIImpl/UIControllerImpl.cs
@@ -1,0 +1,376 @@
+using System.Numerics;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.TestBridge.UI;
+using KeenEyes.UI;
+using KeenEyes.UI.Abstractions;
+
+namespace KeenEyes.TestBridge.UIImpl;
+
+/// <summary>
+/// In-process implementation of <see cref="IUIController"/>.
+/// </summary>
+internal sealed class UIControllerImpl(World world) : IUIController
+{
+    #region Statistics
+
+    /// <inheritdoc />
+    public Task<UIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<UIContext>(out var ui))
+        {
+            return Task.FromResult(new UIStatisticsSnapshot
+            {
+                TotalElementCount = 0,
+                VisibleElementCount = 0,
+                InteractableCount = 0,
+                FocusedElementId = null
+            });
+        }
+
+        var totalCount = 0;
+        var visibleCount = 0;
+        var interactableCount = 0;
+
+        foreach (var entity in world.Query<UIElement>())
+        {
+            totalCount++;
+
+            ref readonly var element = ref world.Get<UIElement>(entity);
+            if (element.Visible && !world.Has<UIHiddenTag>(entity))
+            {
+                visibleCount++;
+            }
+
+            if (world.Has<UIInteractable>(entity))
+            {
+                interactableCount++;
+            }
+        }
+
+        return Task.FromResult(new UIStatisticsSnapshot
+        {
+            TotalElementCount = totalCount,
+            VisibleElementCount = visibleCount,
+            InteractableCount = interactableCount,
+            FocusedElementId = ui.HasFocus ? ui.FocusedEntity.Id : null
+        });
+    }
+
+    #endregion
+
+    #region Focus Management
+
+    /// <inheritdoc />
+    public Task<int?> GetFocusedElementAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<UIContext>(out var ui))
+        {
+            return Task.FromResult<int?>(null);
+        }
+
+        return Task.FromResult<int?>(ui.HasFocus ? ui.FocusedEntity.Id : null);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetFocusAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<UIContext>(out var ui))
+        {
+            return Task.FromResult(false);
+        }
+
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!world.Has<UIInteractable>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ui.RequestFocus(entity);
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ClearFocusAsync(CancellationToken cancellationToken = default)
+    {
+        if (!world.TryGetExtension<UIContext>(out var ui))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!ui.HasFocus)
+        {
+            return Task.FromResult(false);
+        }
+
+        ui.ClearFocus();
+        return Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Element Inspection
+
+    /// <inheritdoc />
+    public Task<UIElementSnapshot?> GetElementAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UIElement>(entity))
+        {
+            return Task.FromResult<UIElementSnapshot?>(null);
+        }
+
+        ref readonly var element = ref world.Get<UIElement>(entity);
+
+        var name = world.GetName(entity);
+        var parent = world.GetParent(entity);
+        var children = world.GetChildren(entity).ToList();
+
+        return Task.FromResult<UIElementSnapshot?>(new UIElementSnapshot
+        {
+            EntityId = entityId,
+            Name = name,
+            IsVisible = element.Visible && !world.Has<UIHiddenTag>(entity),
+            IsRaycastTarget = element.RaycastTarget,
+            ParentId = parent.IsValid ? parent.Id : null,
+            ChildIds = children.Select(c => c.Id).ToList(),
+            HasInteractable = world.Has<UIInteractable>(entity),
+            HasText = world.Has<UIText>(entity),
+            HasStyle = world.Has<UIStyle>(entity)
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<UIElementSnapshot>> GetElementTreeAsync(int? rootEntityId = null, CancellationToken cancellationToken = default)
+    {
+        var elements = new List<UIElementSnapshot>();
+
+        if (rootEntityId.HasValue)
+        {
+            // Get tree starting from specific root
+            var rootEntity = new Entity(rootEntityId.Value, 0);
+            if (world.IsAlive(rootEntity) && world.Has<UIElement>(rootEntity))
+            {
+                CollectElementTree(rootEntity, elements);
+            }
+        }
+        else
+        {
+            // Get all root canvases
+            foreach (var rootEntity in world.Query<UIElement, UIRootTag>())
+            {
+                CollectElementTree(rootEntity, elements);
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<UIElementSnapshot>>(elements);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> GetRootElementsAsync(CancellationToken cancellationToken = default)
+    {
+        var roots = new List<int>();
+
+        foreach (var rootEntity in world.Query<UIElement, UIRootTag>())
+        {
+            roots.Add(rootEntity.Id);
+        }
+
+        return Task.FromResult<IReadOnlyList<int>>(roots);
+    }
+
+    /// <inheritdoc />
+    public Task<UIBoundsSnapshot?> GetElementBoundsAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UIRect>(entity))
+        {
+            return Task.FromResult<UIBoundsSnapshot?>(null);
+        }
+
+        ref readonly var rect = ref world.Get<UIRect>(entity);
+
+        return Task.FromResult<UIBoundsSnapshot?>(new UIBoundsSnapshot
+        {
+            X = rect.ComputedBounds.X,
+            Y = rect.ComputedBounds.Y,
+            Width = rect.ComputedBounds.Width,
+            Height = rect.ComputedBounds.Height,
+            LocalZIndex = rect.LocalZIndex
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<UIStyleSnapshot?> GetElementStyleAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UIStyle>(entity))
+        {
+            return Task.FromResult<UIStyleSnapshot?>(null);
+        }
+
+        ref readonly var style = ref world.Get<UIStyle>(entity);
+
+        return Task.FromResult<UIStyleSnapshot?>(new UIStyleSnapshot
+        {
+            BackgroundColorR = style.BackgroundColor.X,
+            BackgroundColorG = style.BackgroundColor.Y,
+            BackgroundColorB = style.BackgroundColor.Z,
+            BackgroundColorA = style.BackgroundColor.W,
+            BorderWidth = style.BorderWidth,
+            CornerRadius = style.CornerRadius,
+            PaddingLeft = style.Padding.Left,
+            PaddingRight = style.Padding.Right,
+            PaddingTop = style.Padding.Top,
+            PaddingBottom = style.Padding.Bottom
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<UIInteractionSnapshot?> GetInteractionStateAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UIInteractable>(entity))
+        {
+            return Task.FromResult<UIInteractionSnapshot?>(null);
+        }
+
+        ref readonly var interactable = ref world.Get<UIInteractable>(entity);
+
+        return Task.FromResult<UIInteractionSnapshot?>(new UIInteractionSnapshot
+        {
+            EntityId = entityId,
+            CanFocus = interactable.CanFocus,
+            CanClick = interactable.CanClick,
+            CanDrag = interactable.CanDrag,
+            IsHovered = interactable.IsHovered,
+            IsPressed = interactable.IsPressed,
+            IsFocused = interactable.IsFocused,
+            IsDragging = interactable.IsDragging
+        });
+    }
+
+    #endregion
+
+    #region Hit Testing
+
+    /// <inheritdoc />
+    public Task<int?> HitTestAsync(float x, float y, CancellationToken cancellationToken = default)
+    {
+        var hitTester = new UIHitTester(world);
+        var hit = hitTester.HitTest(new Vector2(x, y));
+
+        return Task.FromResult<int?>(hit.IsValid ? hit.Id : null);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<int>> HitTestAllAsync(float x, float y, CancellationToken cancellationToken = default)
+    {
+        var hitTester = new UIHitTester(world);
+        var hits = hitTester.HitTestAll(new Vector2(x, y));
+
+        return Task.FromResult<IReadOnlyList<int>>(hits.Select(e => e.Id).ToList());
+    }
+
+    #endregion
+
+    #region Element Search
+
+    /// <inheritdoc />
+    public Task<int?> FindElementByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        foreach (var entity in world.Query<UIElement>())
+        {
+            var entityName = world.GetName(entity);
+            if (string.Equals(entityName, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult<int?>(entity.Id);
+            }
+        }
+
+        return Task.FromResult<int?>(null);
+    }
+
+    #endregion
+
+    #region Interaction Simulation
+
+    /// <inheritdoc />
+    public Task<bool> SimulateClickAsync(int entityId, CancellationToken cancellationToken = default)
+    {
+        var entity = new Entity(entityId, 0);
+        if (!world.IsAlive(entity) || !world.Has<UIInteractable>(entity))
+        {
+            return Task.FromResult(false);
+        }
+
+        ref var interactable = ref world.Get<UIInteractable>(entity);
+
+        if (!interactable.CanClick)
+        {
+            return Task.FromResult(false);
+        }
+
+        // Simulate click by setting the pending event
+        interactable.PendingEvents |= UIEventType.Click;
+
+        // Get the element center position for the click event
+        var clickPosition = Vector2.Zero;
+        if (world.Has<UIRect>(entity))
+        {
+            ref readonly var rect = ref world.Get<UIRect>(entity);
+            clickPosition = rect.ComputedBounds.Center;
+        }
+
+        // Send click event
+        world.Send(new UIClickEvent(entity, clickPosition, MouseButton.Left));
+
+        return Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private void CollectElementTree(Entity entity, List<UIElementSnapshot> elements)
+    {
+        if (!world.Has<UIElement>(entity))
+        {
+            return;
+        }
+
+        ref readonly var element = ref world.Get<UIElement>(entity);
+
+        var name = world.GetName(entity);
+        var parent = world.GetParent(entity);
+        var children = world.GetChildren(entity).ToList();
+
+        elements.Add(new UIElementSnapshot
+        {
+            EntityId = entity.Id,
+            Name = name,
+            IsVisible = element.Visible && !world.Has<UIHiddenTag>(entity),
+            IsRaycastTarget = element.RaycastTarget,
+            ParentId = parent.IsValid ? parent.Id : null,
+            ChildIds = children.Select(c => c.Id).ToList(),
+            HasInteractable = world.Has<UIInteractable>(entity),
+            HasText = world.Has<UIText>(entity),
+            HasStyle = world.Has<UIStyle>(entity)
+        });
+
+        // Recursively collect children
+        foreach (var child in children)
+        {
+            if (world.Has<UIElement>(child))
+            {
+                CollectElementTree(child, elements);
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/KeenEyes.TestBridge/packages.lock.json
+++ b/src/KeenEyes.TestBridge/packages.lock.json
@@ -20,6 +20,11 @@
         "resolved": "1.16.7",
         "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.10",
+        "contentHash": "u7gAG7JgxF8VSJUGPSudAcPxOt+ymJKQCSxNRxiuKV+klCQbHljQR75SilpedCTfhPWDhtUwIJpnDVtspr9nMg=="
+      },
       "keeneyes.abstractions": {
         "type": "Project"
       },
@@ -31,6 +36,37 @@
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Navigation": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[1.16.0, )",
+          "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
       "keeneyes.common": {
@@ -66,6 +102,17 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[7.1.3, )"
+        }
+      },
       "keeneyes.logging": {
         "type": "Project",
         "dependencies": {
@@ -85,6 +132,13 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.network": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.network.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -92,6 +146,21 @@
         }
       },
       "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.physics": {
+        "type": "Project",
+        "dependencies": {
+          "BepuPhysics": "[2.4.0, )",
+          "BepuUtilities": "[2.4.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.replay": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
@@ -117,6 +186,86 @@
           "KeenEyes.Persistence": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "BepuPhysics": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "Ck/BJgSQrBqYrj0T9jGljDdHNILBP5kTPTylc7N/hCzR1XJJc7p6ORzwtjTfjgoYkkdajvLHxEQv6BRC8kaysQ==",
+        "dependencies": {
+          "BepuUtilities": "2.4.0"
+        }
+      },
+      "BepuUtilities": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "KNMxkzKLHAvV7jRtErxs3rPv71fHToqo/WN96HlT6iomWuwL97tohEbt0B1WA8A6sO5t6PP+qF08d4T9A8k2uA=="
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "go1/KHij1AB5K3nKiKKzSuSVIAKivgAnC3P6FAOOhB/WMg7y6lw9n95LCyABVuoewk4CNI8S0RZVvC6gkeTp7g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       }
     }
   }

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockCaptureController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockCaptureController.cs
@@ -80,4 +80,45 @@ internal sealed class MockCaptureController : ICaptureController
         IsRecording = false;
         return Task.FromResult<IReadOnlyList<FrameCapture>>(recordedFrames);
     }
+
+    public Task<FrameCapture> CaptureRegionAsync(int x, int y, int width, int height)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        var frame = new FrameCapture
+        {
+            Width = width,
+            Height = height,
+            Pixels = new byte[width * height * 4],
+            FrameNumber = 1,
+            Timestamp = TimeSpan.FromSeconds(1)
+        };
+
+        return Task.FromResult(frame);
+    }
+
+    public Task<byte[]> GetRegionScreenshotBytesAsync(int x, int y, int width, int height, ImageFormat format = ImageFormat.Png)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        // Return a minimal PNG stub
+        byte[] pngHeader = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        return Task.FromResult(pngHeader);
+    }
+
+    public Task<string> SaveRegionScreenshotAsync(int x, int y, int width, int height, string filePath, ImageFormat format = ImageFormat.Png)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        return Task.FromResult(filePath);
+    }
 }

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockExtendedControllers.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockExtendedControllers.cs
@@ -1,0 +1,575 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.Animation;
+using KeenEyes.TestBridge.Mutation;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.Physics;
+using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
+using KeenEyes.TestBridge.Snapshot;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.UI;
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IWindowController for testing.
+/// </summary>
+internal sealed class MockWindowController : IWindowController
+{
+    public bool IsAvailable { get; set; } = true;
+    public (int Width, int Height) Size { get; set; } = (1920, 1080);
+    public string Title { get; set; } = "Test Window";
+
+    public Task<WindowStateSnapshot> GetStateAsync() => Task.FromResult(new WindowStateSnapshot
+    {
+        Width = Size.Width,
+        Height = Size.Height,
+        Title = Title,
+        IsClosing = false,
+        IsFocused = true,
+        AspectRatio = (float)Size.Width / Size.Height
+    });
+
+    public Task<(int Width, int Height)> GetSizeAsync() => Task.FromResult(Size);
+    public Task<string> GetTitleAsync() => Task.FromResult(Title);
+    public Task<bool> IsClosingAsync() => Task.FromResult(false);
+    public Task<bool> IsFocusedAsync() => Task.FromResult(true);
+    public Task<float> GetAspectRatioAsync() => Task.FromResult((float)Size.Width / Size.Height);
+}
+
+/// <summary>
+/// Mock implementation of ITimeController for testing.
+/// </summary>
+internal sealed class MockTimeController : ITimeController
+{
+    public bool IsPaused { get; set; }
+    public float TimeScale { get; set; } = 1.0f;
+
+    public Task<TimeStateSnapshot> GetTimeStateAsync() => Task.FromResult(CreateSnapshot());
+    public Task<TimeStateSnapshot> PauseAsync() { IsPaused = true; return Task.FromResult(CreateSnapshot()); }
+    public Task<TimeStateSnapshot> ResumeAsync() { IsPaused = false; return Task.FromResult(CreateSnapshot()); }
+    public Task<TimeStateSnapshot> SetTimeScaleAsync(float scale) { TimeScale = scale; return Task.FromResult(CreateSnapshot()); }
+    public Task<TimeStateSnapshot> StepFrameAsync(int frames = 1) => Task.FromResult(CreateSnapshot());
+    public Task<TimeStateSnapshot> TogglePauseAsync() { IsPaused = !IsPaused; return Task.FromResult(CreateSnapshot()); }
+
+    private TimeStateSnapshot CreateSnapshot() => new()
+    {
+        IsPaused = IsPaused,
+        TimeScale = TimeScale,
+        TotalPausedTime = 0,
+        LastModifiedFrame = 0,
+        PendingStepFrames = 0
+    };
+}
+
+/// <summary>
+/// Mock implementation of ISystemController for testing.
+/// </summary>
+internal sealed class MockSystemController : ISystemController
+{
+    public List<SystemSnapshot> Systems { get; } = [];
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsAsync() => Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems);
+    public Task<int> GetCountAsync() => Task.FromResult(Systems.Count);
+    public Task<SystemSnapshot?> GetSystemAsync(string name) => Task.FromResult(Systems.FirstOrDefault(s => s.Name == name));
+
+    public Task<SystemSnapshot> EnableSystemAsync(string name) =>
+        Task.FromResult(Systems.First(s => s.Name == name));
+
+    public Task<SystemSnapshot> DisableSystemAsync(string name) =>
+        Task.FromResult(Systems.First(s => s.Name == name));
+
+    public Task<SystemSnapshot> ToggleSystemAsync(string name) =>
+        Task.FromResult(Systems.First(s => s.Name == name));
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsByPhaseAsync(string phase) =>
+        Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.Where(s => s.Phase == phase).ToList());
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetEnabledSystemsAsync() =>
+        Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.Where(s => s.Enabled).ToList());
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetDisabledSystemsAsync() =>
+        Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.Where(s => !s.Enabled).ToList());
+}
+
+/// <summary>
+/// Mock implementation of IMutationController for testing.
+/// </summary>
+internal sealed class MockMutationController : IMutationController
+{
+    public Task<EntityResult> SpawnAsync(string? name = null, IReadOnlyList<ComponentData>? components = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(new EntityResult { Success = true, EntityId = 1, EntityVersion = 1 });
+
+    public Task<bool> DespawnAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public Task<EntityResult> CloneAsync(int entityId, string? name = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(new EntityResult { Success = true, EntityId = 2, EntityVersion = 1 });
+
+    public Task<bool> SetNameAsync(int entityId, string name, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> ClearNameAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> SetParentAsync(int entityId, int? parentId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<IReadOnlyList<int>> GetRootEntitiesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<int>>([]);
+    public Task<bool> AddComponentAsync(int entityId, string componentType, JsonElement? data = null, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> RemoveComponentAsync(int entityId, string componentType, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> SetComponentAsync(int entityId, string componentType, JsonElement data, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> SetFieldAsync(int entityId, string componentType, string fieldName, JsonElement value, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> AddTagAsync(int entityId, string tag, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> RemoveTagAsync(int entityId, string tag, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<IReadOnlyList<string>> GetAllTagsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<string>>([]);
+}
+
+/// <summary>
+/// Mock implementation of IProfileController for testing.
+/// </summary>
+internal sealed class MockProfileController : IProfileController
+{
+    public Task<bool> IsDebugModeEnabledAsync() => Task.FromResult(false);
+    public Task EnableDebugModeAsync() => Task.CompletedTask;
+    public Task DisableDebugModeAsync() => Task.CompletedTask;
+    public Task<bool> IsProfilingAvailableAsync() => Task.FromResult(false);
+    public Task<SystemProfileSnapshot?> GetSystemProfileAsync(string systemName) => Task.FromResult<SystemProfileSnapshot?>(null);
+    public Task<IReadOnlyList<SystemProfileSnapshot>> GetAllSystemProfilesAsync() => Task.FromResult<IReadOnlyList<SystemProfileSnapshot>>([]);
+    public Task<IReadOnlyList<SystemProfileSnapshot>> GetSlowestSystemsAsync(int count = 10) => Task.FromResult<IReadOnlyList<SystemProfileSnapshot>>([]);
+    public Task ResetSystemProfilesAsync() => Task.CompletedTask;
+    public Task<bool> IsQueryProfilingAvailableAsync() => Task.FromResult(false);
+    public Task<QueryProfileSnapshot?> GetQueryProfileAsync(string queryName) => Task.FromResult<QueryProfileSnapshot?>(null);
+    public Task<IReadOnlyList<QueryProfileSnapshot>> GetAllQueryProfilesAsync() => Task.FromResult<IReadOnlyList<QueryProfileSnapshot>>([]);
+    public Task<IReadOnlyList<QueryProfileSnapshot>> GetSlowestQueriesAsync(int count = 10) => Task.FromResult<IReadOnlyList<QueryProfileSnapshot>>([]);
+
+    public Task<QueryCacheStatsSnapshot> GetQueryCacheStatsAsync() => Task.FromResult(new QueryCacheStatsSnapshot
+    {
+        CacheHits = 0,
+        CacheMisses = 0,
+        CachedQueryCount = 0,
+        HitRate = 0
+    });
+
+    public Task ResetQueryProfilesAsync() => Task.CompletedTask;
+    public Task<bool> IsGCTrackingAvailableAsync() => Task.FromResult(false);
+    public Task<AllocationProfileSnapshot?> GetAllocationProfileAsync(string systemName) => Task.FromResult<AllocationProfileSnapshot?>(null);
+    public Task<IReadOnlyList<AllocationProfileSnapshot>> GetAllAllocationProfilesAsync() => Task.FromResult<IReadOnlyList<AllocationProfileSnapshot>>([]);
+    public Task<IReadOnlyList<AllocationProfileSnapshot>> GetAllocationHotspotsAsync(int count = 10) => Task.FromResult<IReadOnlyList<AllocationProfileSnapshot>>([]);
+    public Task ResetAllocationProfilesAsync() => Task.CompletedTask;
+    public Task<bool> IsMemoryTrackingAvailableAsync() => Task.FromResult(false);
+
+    public Task<MemoryStatsSnapshot> GetMemoryStatsAsync() => Task.FromResult(new MemoryStatsSnapshot
+    {
+        EntitiesAllocated = 0,
+        EntitiesActive = 0,
+        EntitiesRecycled = 0,
+        EntityRecycleCount = 0,
+        ArchetypeCount = 0,
+        ComponentTypeCount = 0,
+        SystemCount = 0,
+        CachedQueryCount = 0,
+        QueryCacheHits = 0,
+        QueryCacheMisses = 0,
+        EstimatedComponentBytes = 0,
+        RecycleEfficiency = 0,
+        QueryCacheHitRate = 0
+    });
+
+    public Task<IReadOnlyList<ArchetypeStatsSnapshot>> GetArchetypeStatsAsync() => Task.FromResult<IReadOnlyList<ArchetypeStatsSnapshot>>([]);
+    public Task<bool> IsTimelineAvailableAsync() => Task.FromResult(false);
+
+    public Task<TimelineStatsSnapshot> GetTimelineStatsAsync() => Task.FromResult(new TimelineStatsSnapshot
+    {
+        IsRecording = false,
+        CurrentFrame = 0,
+        EntryCount = 0
+    });
+
+    public Task EnableTimelineRecordingAsync() => Task.CompletedTask;
+    public Task DisableTimelineRecordingAsync() => Task.CompletedTask;
+    public Task<IReadOnlyList<TimelineEntrySnapshot>> GetTimelineEntriesForFrameAsync(long frameNumber) => Task.FromResult<IReadOnlyList<TimelineEntrySnapshot>>([]);
+    public Task<IReadOnlyList<TimelineEntrySnapshot>> GetRecentTimelineEntriesAsync(int count = 100) => Task.FromResult<IReadOnlyList<TimelineEntrySnapshot>>([]);
+    public Task<IReadOnlyList<TimelineSystemStatsSnapshot>> GetTimelineSystemStatsAsync() => Task.FromResult<IReadOnlyList<TimelineSystemStatsSnapshot>>([]);
+    public Task ResetTimelineAsync() => Task.CompletedTask;
+}
+
+/// <summary>
+/// Mock implementation of ISnapshotController for testing.
+/// </summary>
+internal sealed class MockSnapshotController : ISnapshotController
+{
+    public Task<SnapshotResult> CreateAsync(string name) => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<SnapshotResult> RestoreAsync(string name) => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<bool> DeleteAsync(string name) => Task.FromResult(true);
+    public Task<IReadOnlyList<SnapshotInfo>> ListAsync() => Task.FromResult<IReadOnlyList<SnapshotInfo>>([]);
+    public Task<SnapshotInfo?> GetInfoAsync(string name) => Task.FromResult<SnapshotInfo?>(null);
+
+    public Task<SnapshotDiff> DiffAsync(string name1, string name2) => Task.FromResult(new SnapshotDiff
+    {
+        Snapshot1 = name1,
+        Snapshot2 = name2,
+        AddedEntities = [],
+        RemovedEntities = [],
+        ModifiedEntities = [],
+        TotalChanges = 0
+    });
+
+    public Task<SnapshotDiff> DiffCurrentAsync(string name) => Task.FromResult(new SnapshotDiff
+    {
+        Snapshot1 = name,
+        Snapshot2 = "current",
+        AddedEntities = [],
+        RemovedEntities = [],
+        ModifiedEntities = [],
+        TotalChanges = 0
+    });
+
+    public Task<SnapshotResult> SaveToFileAsync(string name, string path) => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<SnapshotResult> LoadFromFileAsync(string path, string? name = null) => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<string> ExportJsonAsync(string name) => Task.FromResult("{}");
+    public Task<SnapshotResult> ImportJsonAsync(string json, string name) => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<SnapshotResult> QuickSaveAsync() => Task.FromResult(new SnapshotResult { Success = true });
+    public Task<SnapshotResult> QuickLoadAsync() => Task.FromResult(new SnapshotResult { Success = true });
+}
+
+/// <summary>
+/// Mock implementation of IAIController for testing.
+/// </summary>
+internal sealed class MockAIController : IAIController
+{
+    public Task<AIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new AIStatisticsSnapshot
+        {
+            BehaviorTreeCount = 0,
+            StateMachineCount = 0,
+            UtilityAICount = 0,
+            ActiveBehaviorTreeCount = 0,
+            ActiveStateMachineCount = 0,
+            ActiveUtilityAICount = 0
+        });
+
+    public Task<IReadOnlyList<int>> GetBehaviorTreeEntitiesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<int>>([]);
+    public Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult<BehaviorTreeSnapshot?>(null);
+    public Task<bool> ResetBehaviorTreeAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<IReadOnlyList<int>> GetStateMachineEntitiesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<int>>([]);
+    public Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult<StateMachineSnapshot?>(null);
+    public Task<bool> ForceStateTransitionAsync(int entityId, int stateIndex, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<IReadOnlyList<int>> GetUtilityAIEntitiesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<int>>([]);
+    public Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult<UtilityAISnapshot?>(null);
+    public Task<IReadOnlyList<UtilityScoreSnapshot>> ScoreAllActionsAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
+    public Task<bool> ForceUtilityEvaluationAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<IReadOnlyList<BlackboardEntrySnapshot>> GetBlackboardAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
+    public Task<BlackboardEntrySnapshot?> GetBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default) => Task.FromResult<BlackboardEntrySnapshot?>(null);
+    public Task<bool> SetBlackboardValueAsync(int entityId, string key, JsonElement value, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> RemoveBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<bool> ClearBlackboardAsync(int entityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
+}
+
+/// <summary>
+/// Mock implementation of IReplayController for testing.
+/// </summary>
+internal sealed class MockReplayController : IReplayController
+{
+    public Task<ReplayOperationResult> StartRecordingAsync(string? name = null, int maxFrames = 36000, int snapshotIntervalMs = 5000)
+        => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> StopRecordingAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> CancelRecordingAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<bool> IsRecordingAsync() => Task.FromResult(false);
+    public Task<RecordingInfoSnapshot?> GetRecordingInfoAsync() => Task.FromResult<RecordingInfoSnapshot?>(null);
+    public Task<ReplayOperationResult> ForceSnapshotAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> SaveAsync(string path) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> LoadAsync(string path) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<IReadOnlyList<ReplayFileSnapshot>> ListAsync(string? directory = null) => Task.FromResult<IReadOnlyList<ReplayFileSnapshot>>([]);
+    public Task<bool> DeleteAsync(string path) => Task.FromResult(true);
+    public Task<ReplayMetadataSnapshot?> GetMetadataAsync(string path) => Task.FromResult<ReplayMetadataSnapshot?>(null);
+    public Task<ReplayOperationResult> PlayAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> PauseAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> StopPlaybackAsync() => Task.FromResult(new ReplayOperationResult { Success = true });
+
+    public Task<PlaybackStateSnapshot> GetPlaybackStateAsync() => Task.FromResult(new PlaybackStateSnapshot
+    {
+        IsLoaded = false,
+        IsPlaying = false,
+        IsPaused = false,
+        IsStopped = true,
+        CurrentFrame = 0,
+        TotalFrames = 0,
+        CurrentTimeSeconds = 0,
+        TotalTimeSeconds = 0,
+        PlaybackSpeed = 1.0f,
+        ReplayName = null
+    });
+
+    public Task<ReplayOperationResult> SetSpeedAsync(float speed) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> SeekFrameAsync(int frame) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> SeekTimeAsync(float seconds) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> StepForwardAsync(int frames = 1) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayOperationResult> StepBackwardAsync(int frames = 1) => Task.FromResult(new ReplayOperationResult { Success = true });
+    public Task<ReplayFrameSnapshot?> GetFrameAsync(int frame) => Task.FromResult<ReplayFrameSnapshot?>(null);
+    public Task<IReadOnlyList<ReplayFrameSnapshot>> GetFrameRangeAsync(int startFrame, int count) => Task.FromResult<IReadOnlyList<ReplayFrameSnapshot>>([]);
+    public Task<IReadOnlyList<InputEventSnapshot>> GetInputsAsync(int startFrame, int endFrame) => Task.FromResult<IReadOnlyList<InputEventSnapshot>>([]);
+    public Task<IReadOnlyList<ReplayEventSnapshot>> GetEventsAsync(int startFrame, int endFrame) => Task.FromResult<IReadOnlyList<ReplayEventSnapshot>>([]);
+    public Task<IReadOnlyList<SnapshotMarkerSnapshot>> GetSnapshotsAsync() => Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>([]);
+
+    public Task<ValidationResultSnapshot> ValidateAsync(string path) => Task.FromResult(new ValidationResultSnapshot
+    {
+        IsValid = true,
+        Path = path,
+        Errors = null
+    });
+
+    public Task<DeterminismResultSnapshot> CheckDeterminismAsync() => Task.FromResult(new DeterminismResultSnapshot
+    {
+        IsDeterministic = true,
+        TotalFramesChecked = 0,
+        FramesWithChecksums = 0
+    });
+}
+
+/// <summary>
+/// Mock implementation of IPhysicsController for testing.
+/// </summary>
+internal sealed class MockPhysicsController : IPhysicsController
+{
+    public Task<PhysicsStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new PhysicsStatisticsSnapshot
+        {
+            BodyCount = 0,
+            StaticCount = 0,
+            InterpolationAlpha = 0
+        });
+
+    public Task<RayHitSnapshot?> RaycastAsync(Vector3Snapshot origin, Vector3Snapshot direction, float maxDistance, CancellationToken cancellationToken = default)
+        => Task.FromResult<RayHitSnapshot?>(null);
+
+    public Task<IReadOnlyList<int>> OverlapSphereAsync(Vector3Snapshot center, float radius, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<IReadOnlyList<int>> OverlapBoxAsync(Vector3Snapshot center, Vector3Snapshot halfExtents, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<PhysicsBodySnapshot?> GetBodyStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<PhysicsBodySnapshot?>(null);
+
+    public Task<Vector3Snapshot?> GetVelocityAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<Vector3Snapshot?>(null);
+
+    public Task<bool> SetVelocityAsync(int entityId, Vector3Snapshot velocity, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool?> IsAwakeAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(true);
+
+    public Task<bool> WakeUpAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> ApplyForceAsync(int entityId, Vector3Snapshot force, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> ApplyImpulseAsync(int entityId, Vector3Snapshot impulse, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<Vector3Snapshot> GetGravityAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new Vector3Snapshot { X = 0, Y = -9.81f, Z = 0 });
+
+    public Task<bool> SetGravityAsync(Vector3Snapshot gravity, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+}
+
+/// <summary>
+/// Mock implementation of IAnimationController for testing.
+/// </summary>
+internal sealed class MockAnimationController : IAnimationController
+{
+    public Task<AnimationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new AnimationStatisticsSnapshot
+        {
+            ClipCount = 0,
+            ControllerCount = 0,
+            SpriteSheetCount = 0,
+            ActivePlayerCount = 0,
+            ActiveAnimatorCount = 0
+        });
+
+    public Task<IReadOnlyList<int>> GetAnimationPlayerEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<AnimationPlayerSnapshot?> GetAnimationPlayerStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<AnimationPlayerSnapshot?>(null);
+
+    public Task<bool> SetAnimationPlayerPlayingAsync(int entityId, bool isPlaying, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> SetAnimationPlayerTimeAsync(int entityId, float time, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> SetAnimationPlayerSpeedAsync(int entityId, float speed, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<IReadOnlyList<int>> GetAnimatorEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<AnimatorSnapshot?> GetAnimatorStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<AnimatorSnapshot?>(null);
+
+    public Task<bool> TriggerAnimatorStateAsync(int entityId, int stateHash, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> TriggerAnimatorStateByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<AnimationClipSnapshot?> GetClipInfoAsync(int clipId, CancellationToken cancellationToken = default)
+        => Task.FromResult<AnimationClipSnapshot?>(null);
+
+    public Task<IReadOnlyList<AnimationClipSnapshot>> ListClipsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<AnimationClipSnapshot>>([]);
+}
+
+/// <summary>
+/// Mock implementation of INavigationController for testing.
+/// </summary>
+internal sealed class MockNavigationController : INavigationController
+{
+    public Task<NavigationStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new NavigationStatisticsSnapshot
+        {
+            IsReady = true,
+            Strategy = "Mock",
+            ActiveAgentCount = 0,
+            PendingRequestCount = 0
+        });
+
+    public Task<bool> IsReadyAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<IReadOnlyList<int>> GetNavigationEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<NavAgentSnapshot?> GetAgentStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<NavAgentSnapshot?>(null);
+
+    public Task<NavPathSnapshot?> GetPathAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<NavPathSnapshot?>(null);
+
+    public Task<bool> SetDestinationAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> StopAgentAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> ResumeAgentAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> WarpAgentAsync(int entityId, float x, float y, float z, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<NavPathSnapshot?> FindPathAsync(float startX, float startY, float startZ, float endX, float endY, float endZ, CancellationToken cancellationToken = default)
+        => Task.FromResult<NavPathSnapshot?>(null);
+
+    public Task<bool> IsNavigableAsync(float x, float y, float z, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<NavPointSnapshot?> FindNearestPointAsync(float x, float y, float z, float searchRadius, CancellationToken cancellationToken = default)
+        => Task.FromResult<NavPointSnapshot?>(null);
+}
+
+/// <summary>
+/// Mock implementation of INetworkController for testing.
+/// </summary>
+internal sealed class MockNetworkController : INetworkController
+{
+    public Task<NetworkStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new NetworkStatisticsSnapshot
+        {
+            IsConnected = false,
+            IsServer = false,
+            IsClient = false,
+            CurrentTick = 0,
+            LocalClientId = 0,
+            ClientCount = 0,
+            NetworkedEntityCount = 0
+        });
+
+    public Task<bool> IsConnectedAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> IsServerAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<uint> GetCurrentTickAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(0u);
+
+    public Task<float> GetLatencyAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(0f);
+
+    public Task<ConnectionStatsSnapshot?> GetConnectionStatsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<ConnectionStatsSnapshot?>(null);
+
+    public Task<IReadOnlyList<ClientSnapshot>> GetConnectedClientsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ClientSnapshot>>([]);
+
+    public Task<IReadOnlyList<int>> GetNetworkedEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<uint?> GetNetworkIdAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<uint?>(null);
+
+    public Task<int?> GetOwnershipAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    public Task<ReplicationStateSnapshot?> GetReplicationStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ReplicationStateSnapshot?>(null);
+}
+
+/// <summary>
+/// Mock implementation of IUIController for testing.
+/// </summary>
+internal sealed class MockUIController : IUIController
+{
+    public Task<UIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new UIStatisticsSnapshot
+        {
+            TotalElementCount = 0,
+            VisibleElementCount = 0,
+            InteractableCount = 0,
+            FocusedElementId = null
+        });
+
+    public Task<int?> GetFocusedElementAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    public Task<bool> SetFocusAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> ClearFocusAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<UIElementSnapshot?> GetElementAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<UIElementSnapshot?>(null);
+
+    public Task<IReadOnlyList<UIElementSnapshot>> GetElementTreeAsync(int? rootEntityId = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<UIElementSnapshot>>([]);
+
+    public Task<IReadOnlyList<int>> GetRootElementsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<UIBoundsSnapshot?> GetElementBoundsAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<UIBoundsSnapshot?>(null);
+
+    public Task<UIStyleSnapshot?> GetElementStyleAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<UIStyleSnapshot?>(null);
+
+    public Task<UIInteractionSnapshot?> GetInteractionStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<UIInteractionSnapshot?>(null);
+
+    public Task<int?> HitTestAsync(float x, float y, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    public Task<IReadOnlyList<int>> HitTestAllAsync(float x, float y, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<int?> FindElementByNameAsync(string name, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    public Task<bool> SimulateClickAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTestBridge.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTestBridge.cs
@@ -1,10 +1,25 @@
+using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge;
+using KeenEyes.Testing.Input;
+using KeenEyes.TestBridge.AI;
+using KeenEyes.TestBridge.Animation;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
 using KeenEyes.TestBridge.Logging;
+using KeenEyes.TestBridge.Mutation;
+using KeenEyes.TestBridge.Navigation;
+using KeenEyes.TestBridge.Network;
+using KeenEyes.TestBridge.Physics;
 using KeenEyes.TestBridge.Process;
+using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
+using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.UI;
+using KeenEyes.TestBridge.Window;
 
 namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
 
@@ -14,17 +29,52 @@ namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
 internal sealed class MockTestBridge : ITestBridge
 {
     public bool IsConnected { get; set; } = true;
+
+    // Core controllers
     public MockInputController MockInput { get; } = new();
     public MockStateController MockState { get; } = new();
     public MockCaptureController MockCapture { get; } = new();
     public MockProcessController MockProcess { get; } = new();
     public MockLogController MockLogs { get; } = new();
 
+    // Extended controllers
+    public MockWindowController MockWindow { get; } = new();
+    public MockTimeController MockTime { get; } = new();
+    public MockSystemController MockSystems { get; } = new();
+    public MockMutationController MockMutation { get; } = new();
+    public MockProfileController MockProfile { get; } = new();
+    public MockSnapshotController MockSnapshot { get; } = new();
+    public MockAIController MockAI { get; } = new();
+    public MockReplayController MockReplay { get; } = new();
+    public MockPhysicsController MockPhysics { get; } = new();
+    public MockAnimationController MockAnimation { get; } = new();
+    public MockNavigationController MockNavigation { get; } = new();
+    public MockNetworkController MockNetwork { get; } = new();
+    public MockUIController MockUI { get; } = new();
+    public KeenEyes.Testing.Input.MockInputContext MockInputContext { get; } = new();
+
+    // Core interface implementations
     IInputController ITestBridge.Input => MockInput;
     ICaptureController ITestBridge.Capture => MockCapture;
     IStateController ITestBridge.State => MockState;
     IProcessController ITestBridge.Process => MockProcess;
     ILogController ITestBridge.Logs => MockLogs;
+
+    // Extended interface implementations
+    IWindowController ITestBridge.Window => MockWindow;
+    ITimeController ITestBridge.Time => MockTime;
+    ISystemController ITestBridge.Systems => MockSystems;
+    IMutationController ITestBridge.Mutation => MockMutation;
+    IProfileController ITestBridge.Profile => MockProfile;
+    ISnapshotController ITestBridge.Snapshot => MockSnapshot;
+    IAIController ITestBridge.AI => MockAI;
+    IReplayController ITestBridge.Replay => MockReplay;
+    IPhysicsController ITestBridge.Physics => MockPhysics;
+    IAnimationController ITestBridge.Animation => MockAnimation;
+    INavigationController ITestBridge.Navigation => MockNavigation;
+    INetworkController ITestBridge.Network => MockNetwork;
+    IUIController ITestBridge.UI => MockUI;
+    IInputContext ITestBridge.InputContext => MockInputContext;
 
     public Task<CommandResult> ExecuteAsync(ITestCommand command, CancellationToken cancellationToken = default)
     {

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/AnimationTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/AnimationTools.cs
@@ -1,0 +1,380 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Animation;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for animation debugging: animation players, animators, and animation clips.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose the AnimationPlugin debugging infrastructure via MCP, allowing inspection
+/// and manipulation of animation components in running games.
+/// </para>
+/// <para>
+/// Note: These tools require the AnimationPlugin to be installed in the target world.
+/// Entities must have the appropriate animation component (AnimationPlayer or Animator)
+/// for the operations to work.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class AnimationTools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "animation_get_statistics")]
+    [Description("Get overall animation statistics including clip count, controller count, and active animation instances.")]
+    public async Task<AnimationStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.Animation.GetStatisticsAsync();
+        return AnimationStatisticsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Animation Players
+
+    [McpServerTool(Name = "animation_player_list")]
+    [Description("List all entities that have an AnimationPlayer component.")]
+    public async Task<EntityListResult> GetAnimationPlayerEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.Animation.GetAnimationPlayerEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "animation_player_get")]
+    [Description("Get the current state of an entity's animation player.")]
+    public async Task<AnimationPlayerResult> GetAnimationPlayerState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Animation.GetAnimationPlayerStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new AnimationPlayerResult
+            {
+                Success = false,
+                Error = $"No animation player found on entity {entityId}"
+            };
+        }
+
+        return AnimationPlayerResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "animation_player_set_playing")]
+    [Description("Set whether an animation player is playing or paused.")]
+    public async Task<OperationResult> SetAnimationPlayerPlaying(
+        [Description("The entity ID to modify")]
+        int entityId,
+        [Description("Whether the animation should be playing")]
+        bool isPlaying)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Animation.SetAnimationPlayerPlayingAsync(entityId, isPlaying);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set playing state on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "animation_player_set_time")]
+    [Description("Set the playback time of an animation player.")]
+    public async Task<OperationResult> SetAnimationPlayerTime(
+        [Description("The entity ID to modify")]
+        int entityId,
+        [Description("The playback time in seconds")]
+        float time)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Animation.SetAnimationPlayerTimeAsync(entityId, time);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set time on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "animation_player_set_speed")]
+    [Description("Set the playback speed multiplier of an animation player.")]
+    public async Task<OperationResult> SetAnimationPlayerSpeed(
+        [Description("The entity ID to modify")]
+        int entityId,
+        [Description("The playback speed multiplier (1 = normal, 2 = double speed, -1 = reverse)")]
+        float speed)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Animation.SetAnimationPlayerSpeedAsync(entityId, speed);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set speed on entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Animators
+
+    [McpServerTool(Name = "animation_animator_list")]
+    [Description("List all entities that have an Animator component.")]
+    public async Task<EntityListResult> GetAnimatorEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.Animation.GetAnimatorEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "animation_animator_get")]
+    [Description("Get the current state of an entity's animator.")]
+    public async Task<AnimatorResult> GetAnimatorState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Animation.GetAnimatorStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new AnimatorResult
+            {
+                Success = false,
+                Error = $"No animator found on entity {entityId}"
+            };
+        }
+
+        return AnimatorResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "animation_animator_trigger_state")]
+    [Description("Trigger a state transition in an animator by state hash.")]
+    public async Task<OperationResult> TriggerAnimatorState(
+        [Description("The entity ID to transition")]
+        int entityId,
+        [Description("The hash of the target state")]
+        int stateHash)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Animation.TriggerAnimatorStateAsync(entityId, stateHash);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to trigger state transition on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "animation_animator_trigger_state_by_name")]
+    [Description("Trigger a state transition in an animator by state name.")]
+    public async Task<OperationResult> TriggerAnimatorStateByName(
+        [Description("The entity ID to transition")]
+        int entityId,
+        [Description("The name of the target state")]
+        string stateName)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Animation.TriggerAnimatorStateByNameAsync(entityId, stateName);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to trigger state '{stateName}' on entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Animation Clips
+
+    [McpServerTool(Name = "animation_clip_get")]
+    [Description("Get information about an animation clip by ID.")]
+    public async Task<AnimationClipResult> GetClipInfo(
+        [Description("The clip ID to query")]
+        int clipId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Animation.GetClipInfoAsync(clipId);
+
+        if (snapshot == null)
+        {
+            return new AnimationClipResult
+            {
+                Success = false,
+                Error = $"Clip {clipId} not found"
+            };
+        }
+
+        return AnimationClipResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "animation_clip_list")]
+    [Description("List all registered animation clips.")]
+    public async Task<AnimationClipListResult> ListClips()
+    {
+        var bridge = connection.GetBridge();
+        var clips = await bridge.Animation.ListClipsAsync();
+        return new AnimationClipListResult
+        {
+            Success = true,
+            Clips = clips,
+            Count = clips.Count
+        };
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for animation statistics query.
+/// </summary>
+public sealed class AnimationStatisticsResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int ClipCount { get; init; }
+    public int ControllerCount { get; init; }
+    public int SpriteSheetCount { get; init; }
+    public int ActivePlayerCount { get; init; }
+    public int ActiveAnimatorCount { get; init; }
+
+    public static AnimationStatisticsResult FromSnapshot(AnimationStatisticsSnapshot snapshot)
+    {
+        return new AnimationStatisticsResult
+        {
+            Success = true,
+            ClipCount = snapshot.ClipCount,
+            ControllerCount = snapshot.ControllerCount,
+            SpriteSheetCount = snapshot.SpriteSheetCount,
+            ActivePlayerCount = snapshot.ActivePlayerCount,
+            ActiveAnimatorCount = snapshot.ActiveAnimatorCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for animation player state query.
+/// </summary>
+public sealed class AnimationPlayerResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int EntityId { get; init; }
+    public int ClipId { get; init; }
+    public float Time { get; init; }
+    public float Speed { get; init; }
+    public bool IsPlaying { get; init; }
+    public bool IsComplete { get; init; }
+    public float Weight { get; init; }
+    public string? WrapModeOverride { get; init; }
+
+    public static AnimationPlayerResult FromSnapshot(AnimationPlayerSnapshot snapshot)
+    {
+        return new AnimationPlayerResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            ClipId = snapshot.ClipId,
+            Time = snapshot.Time,
+            Speed = snapshot.Speed,
+            IsPlaying = snapshot.IsPlaying,
+            IsComplete = snapshot.IsComplete,
+            Weight = snapshot.Weight,
+            WrapModeOverride = snapshot.WrapModeOverride
+        };
+    }
+}
+
+/// <summary>
+/// Result for animator state query.
+/// </summary>
+public sealed class AnimatorResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int EntityId { get; init; }
+    public int ControllerId { get; init; }
+    public int CurrentStateHash { get; init; }
+    public string? CurrentStateName { get; init; }
+    public float StateTime { get; init; }
+    public bool IsTransitioning { get; init; }
+    public float TransitionProgress { get; init; }
+    public float Speed { get; init; }
+    public bool Enabled { get; init; }
+    public int NextStateHash { get; init; }
+    public string? NextStateName { get; init; }
+
+    public static AnimatorResult FromSnapshot(AnimatorSnapshot snapshot)
+    {
+        return new AnimatorResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            ControllerId = snapshot.ControllerId,
+            CurrentStateHash = snapshot.CurrentStateHash,
+            CurrentStateName = snapshot.CurrentStateName,
+            StateTime = snapshot.StateTime,
+            IsTransitioning = snapshot.IsTransitioning,
+            TransitionProgress = snapshot.TransitionProgress,
+            Speed = snapshot.Speed,
+            Enabled = snapshot.Enabled,
+            NextStateHash = snapshot.NextStateHash,
+            NextStateName = snapshot.NextStateName
+        };
+    }
+}
+
+/// <summary>
+/// Result for animation clip query.
+/// </summary>
+public sealed class AnimationClipResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public int ClipId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public float Duration { get; init; }
+    public string WrapMode { get; init; } = string.Empty;
+    public int BoneTrackCount { get; init; }
+
+    public static AnimationClipResult FromSnapshot(AnimationClipSnapshot snapshot)
+    {
+        return new AnimationClipResult
+        {
+            Success = true,
+            ClipId = snapshot.ClipId,
+            Name = snapshot.Name,
+            Duration = snapshot.Duration,
+            WrapMode = snapshot.WrapMode,
+            BoneTrackCount = snapshot.BoneTrackCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for animation clip list query.
+/// </summary>
+public sealed class AnimationClipListResult
+{
+    public required bool Success { get; init; }
+    public string? Error { get; init; }
+    public IReadOnlyList<AnimationClipSnapshot> Clips { get; init; } = [];
+    public int Count { get; init; }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/NavigationTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/NavigationTools.cs
@@ -1,0 +1,498 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Navigation;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for navigation debugging: agents, paths, and navmesh queries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose the NavigationPlugin debugging infrastructure via MCP, allowing inspection
+/// and manipulation of navigation agents and pathfinding in running games.
+/// </para>
+/// <para>
+/// Note: These tools require the NavigationPlugin to be installed in the target world.
+/// Entities must have the NavMeshAgent component for agent operations to work.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class NavigationTools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "navigation_get_statistics")]
+    [Description("Get overall navigation statistics including agent count and navigation readiness.")]
+    public async Task<NavigationStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.Navigation.GetStatisticsAsync();
+        return NavigationStatisticsResult.FromSnapshot(stats);
+    }
+
+    [McpServerTool(Name = "navigation_is_ready")]
+    [Description("Check if the navigation system is ready and initialized.")]
+    public async Task<OperationResult> IsReady()
+    {
+        var bridge = connection.GetBridge();
+        var isReady = await bridge.Navigation.IsReadyAsync();
+        return new OperationResult
+        {
+            Success = isReady,
+            Error = isReady ? null : "Navigation system is not ready"
+        };
+    }
+
+    #endregion
+
+    #region Agent Operations
+
+    [McpServerTool(Name = "navigation_agent_list")]
+    [Description("List all entities that have a NavMeshAgent component.")]
+    public async Task<EntityListResult> GetNavigationEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.Navigation.GetNavigationEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "navigation_agent_get")]
+    [Description("Get the current state of a navigation agent, including path status and destination.")]
+    public async Task<NavAgentResult> GetAgentState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Navigation.GetAgentStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new NavAgentResult
+            {
+                Success = false,
+                Error = $"No navigation agent found on entity {entityId}"
+            };
+        }
+
+        return NavAgentResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "navigation_agent_get_path")]
+    [Description("Get the current path for a navigation agent, including all waypoints.")]
+    public async Task<NavPathResult> GetPath(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Navigation.GetPathAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new NavPathResult
+            {
+                Success = false,
+                Error = $"No path found for entity {entityId}"
+            };
+        }
+
+        return NavPathResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "navigation_agent_set_destination")]
+    [Description("Set a destination for a navigation agent, triggering pathfinding.")]
+    public async Task<OperationResult> SetDestination(
+        [Description("The entity ID")]
+        int entityId,
+        [Description("The destination X coordinate")]
+        float x,
+        [Description("The destination Y coordinate")]
+        float y,
+        [Description("The destination Z coordinate")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Navigation.SetDestinationAsync(entityId, x, y, z);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set destination for entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "navigation_agent_stop")]
+    [Description("Stop a navigation agent and clear its current path.")]
+    public async Task<OperationResult> StopAgent(
+        [Description("The entity ID to stop")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Navigation.StopAgentAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to stop agent on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "navigation_agent_resume")]
+    [Description("Resume navigation for a stopped agent.")]
+    public async Task<OperationResult> ResumeAgent(
+        [Description("The entity ID to resume")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Navigation.ResumeAgentAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to resume agent on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "navigation_agent_warp")]
+    [Description("Warp an agent to a position without pathfinding. Returns false if position is not on navmesh.")]
+    public async Task<OperationResult> WarpAgent(
+        [Description("The entity ID to warp")]
+        int entityId,
+        [Description("The destination X coordinate")]
+        float x,
+        [Description("The destination Y coordinate")]
+        float y,
+        [Description("The destination Z coordinate")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Navigation.WarpAgentAsync(entityId, x, y, z);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to warp agent on entity {entityId} (position may not be on navmesh)"
+        };
+    }
+
+    #endregion
+
+    #region Path Queries
+
+    [McpServerTool(Name = "navigation_find_path")]
+    [Description("Find a path between two positions using the navigation system.")]
+    public async Task<NavPathResult> FindPath(
+        [Description("The start X coordinate")]
+        float startX,
+        [Description("The start Y coordinate")]
+        float startY,
+        [Description("The start Z coordinate")]
+        float startZ,
+        [Description("The end X coordinate")]
+        float endX,
+        [Description("The end Y coordinate")]
+        float endY,
+        [Description("The end Z coordinate")]
+        float endZ)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Navigation.FindPathAsync(startX, startY, startZ, endX, endY, endZ);
+
+        if (snapshot == null)
+        {
+            return new NavPathResult
+            {
+                Success = false,
+                Error = "Failed to find path (navigation not ready or no path exists)"
+            };
+        }
+
+        return NavPathResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "navigation_is_navigable")]
+    [Description("Check if a position is on the navigation mesh and navigable.")]
+    public async Task<OperationResult> IsNavigable(
+        [Description("The X coordinate")]
+        float x,
+        [Description("The Y coordinate")]
+        float y,
+        [Description("The Z coordinate")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var isNavigable = await bridge.Navigation.IsNavigableAsync(x, y, z);
+        return new OperationResult
+        {
+            Success = isNavigable,
+            Error = isNavigable ? null : "Position is not navigable"
+        };
+    }
+
+    [McpServerTool(Name = "navigation_find_nearest_point")]
+    [Description("Find the nearest navigable point to a given position within a search radius.")]
+    public async Task<NavPointResult> FindNearestPoint(
+        [Description("The X coordinate")]
+        float x,
+        [Description("The Y coordinate")]
+        float y,
+        [Description("The Z coordinate")]
+        float z,
+        [Description("Maximum search radius in world units")]
+        float searchRadius = 10f)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Navigation.FindNearestPointAsync(x, y, z, searchRadius);
+
+        if (snapshot == null)
+        {
+            return new NavPointResult
+            {
+                Success = false,
+                Error = $"No navigable point found within {searchRadius} units"
+            };
+        }
+
+        return NavPointResult.FromSnapshot(snapshot);
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for navigation statistics.
+/// </summary>
+public sealed record NavigationStatisticsResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>
+    /// Gets whether the navigation system is ready and initialized.
+    /// </summary>
+    public bool IsReady { get; init; }
+
+    /// <summary>
+    /// Gets the current navigation strategy.
+    /// </summary>
+    public string Strategy { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the number of active navigation agents.
+    /// </summary>
+    public int ActiveAgentCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of pending path requests.
+    /// </summary>
+    public int PendingRequestCount { get; init; }
+
+    internal static NavigationStatisticsResult FromSnapshot(NavigationStatisticsSnapshot snapshot)
+    {
+        return new NavigationStatisticsResult
+        {
+            IsReady = snapshot.IsReady,
+            Strategy = snapshot.Strategy,
+            ActiveAgentCount = snapshot.ActiveAgentCount,
+            PendingRequestCount = snapshot.PendingRequestCount
+        };
+    }
+}
+
+/// <summary>
+/// Result for basic operations.
+/// </summary>
+public record OperationResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for navigation agent queries.
+/// </summary>
+public sealed record NavAgentResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the agent has a valid path.
+    /// </summary>
+    public bool HasPath { get; init; }
+
+    /// <summary>
+    /// Gets whether the agent is stopped.
+    /// </summary>
+    public bool IsStopped { get; init; }
+
+    /// <summary>
+    /// Gets whether a path request is pending.
+    /// </summary>
+    public bool PathPending { get; init; }
+
+    /// <summary>
+    /// Gets the current waypoint index in the path.
+    /// </summary>
+    public int CurrentWaypointIndex { get; init; }
+
+    /// <summary>
+    /// Gets the distance traveled along the current path.
+    /// </summary>
+    public float DistanceTraveled { get; init; }
+
+    /// <summary>
+    /// Gets the agent's movement speed.
+    /// </summary>
+    public float Speed { get; init; }
+
+    /// <summary>
+    /// Gets the agent's destination, if set.
+    /// </summary>
+    public NavPointSnapshot? Destination { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static NavAgentResult FromSnapshot(NavAgentSnapshot snapshot)
+    {
+        return new NavAgentResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            HasPath = snapshot.HasPath,
+            IsStopped = snapshot.IsStopped,
+            PathPending = snapshot.PathPending,
+            CurrentWaypointIndex = snapshot.CurrentWaypointIndex,
+            DistanceTraveled = snapshot.DistanceTraveled,
+            Speed = snapshot.Speed,
+            Destination = snapshot.Destination
+        };
+    }
+}
+
+/// <summary>
+/// Result for navigation path queries.
+/// </summary>
+public sealed record NavPathResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets whether this path is valid (has waypoints).
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets whether this path reaches the intended destination.
+    /// </summary>
+    public bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Gets the total traversal cost of the path.
+    /// </summary>
+    public float TotalCost { get; init; }
+
+    /// <summary>
+    /// Gets the total length of the path in world units.
+    /// </summary>
+    public float Length { get; init; }
+
+    /// <summary>
+    /// Gets the waypoints comprising the path.
+    /// </summary>
+    public IReadOnlyList<NavPointSnapshot>? Waypoints { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static NavPathResult FromSnapshot(NavPathSnapshot snapshot)
+    {
+        return new NavPathResult
+        {
+            Success = true,
+            IsValid = snapshot.IsValid,
+            IsComplete = snapshot.IsComplete,
+            TotalCost = snapshot.TotalCost,
+            Length = snapshot.Length,
+            Waypoints = snapshot.Waypoints
+        };
+    }
+}
+
+/// <summary>
+/// Result for navigation point queries.
+/// </summary>
+public sealed record NavPointResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the X coordinate.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y coordinate.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the Z coordinate.
+    /// </summary>
+    public float Z { get; init; }
+
+    /// <summary>
+    /// Gets the navigation area type at this point.
+    /// </summary>
+    public string AreaType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static NavPointResult FromSnapshot(NavPointSnapshot snapshot)
+    {
+        return new NavPointResult
+        {
+            Success = true,
+            X = snapshot.X,
+            Y = snapshot.Y,
+            Z = snapshot.Z,
+            AreaType = snapshot.AreaType
+        };
+    }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/NetworkTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/NetworkTools.cs
@@ -1,0 +1,388 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Network;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for network debugging: connection state, replication, and statistics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose network plugin debugging infrastructure via MCP, allowing inspection
+/// of networked entities, ownership, and replication state in running games.
+/// </para>
+/// <para>
+/// Note: These tools require either NetworkClientPlugin or NetworkServerPlugin to be installed
+/// in the target world.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class NetworkTools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "network_get_statistics")]
+    [Description("Get network statistics including connection state, tick, client count, and entity count.")]
+    public async Task<NetworkStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.Network.GetStatisticsAsync();
+        return NetworkStatisticsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Connection State
+
+    [McpServerTool(Name = "network_is_connected")]
+    [Description("Check if the network plugin is connected (client connected to server, or server listening).")]
+    public async Task<NetworkBoolResult> IsConnected()
+    {
+        var bridge = connection.GetBridge();
+        var isConnected = await bridge.Network.IsConnectedAsync();
+        return new NetworkBoolResult
+        {
+            Success = true,
+            Value = isConnected
+        };
+    }
+
+    [McpServerTool(Name = "network_is_server")]
+    [Description("Check if this is a server instance.")]
+    public async Task<NetworkBoolResult> IsServer()
+    {
+        var bridge = connection.GetBridge();
+        var isServer = await bridge.Network.IsServerAsync();
+        return new NetworkBoolResult
+        {
+            Success = true,
+            Value = isServer
+        };
+    }
+
+    [McpServerTool(Name = "network_get_tick")]
+    [Description("Get the current network tick.")]
+    public async Task<NetworkUIntResult> GetCurrentTick()
+    {
+        var bridge = connection.GetBridge();
+        var tick = await bridge.Network.GetCurrentTickAsync();
+        return new NetworkUIntResult
+        {
+            Success = true,
+            Value = tick
+        };
+    }
+
+    [McpServerTool(Name = "network_get_latency")]
+    [Description("Get the round-trip latency to the server in milliseconds (client only).")]
+    public async Task<NetworkFloatResult> GetLatency()
+    {
+        var bridge = connection.GetBridge();
+        var latency = await bridge.Network.GetLatencyAsync();
+        return new NetworkFloatResult
+        {
+            Success = true,
+            Value = latency
+        };
+    }
+
+    [McpServerTool(Name = "network_get_connection_stats")]
+    [Description("Get detailed connection statistics including RTT, packet loss, and bandwidth (client only).")]
+    public async Task<ConnectionStatsResult> GetConnectionStats()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.Network.GetConnectionStatsAsync();
+
+        if (stats == null)
+        {
+            return new ConnectionStatsResult
+            {
+                Success = false,
+                Error = "Not a client or not connected"
+            };
+        }
+
+        return ConnectionStatsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Server Operations
+
+    [McpServerTool(Name = "network_get_clients")]
+    [Description("Get all connected clients (server only).")]
+    public async Task<ConnectedClientsResult> GetConnectedClients()
+    {
+        var bridge = connection.GetBridge();
+        var clients = await bridge.Network.GetConnectedClientsAsync();
+        return ConnectedClientsResult.FromClients(clients);
+    }
+
+    #endregion
+
+    #region Entity Replication
+
+    [McpServerTool(Name = "network_list_networked_entities")]
+    [Description("List all entity IDs that have a NetworkId component.")]
+    public async Task<EntityListResult> GetNetworkedEntities()
+    {
+        var bridge = connection.GetBridge();
+        var entities = await bridge.Network.GetNetworkedEntitiesAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "network_get_network_id")]
+    [Description("Get the network ID assigned to an entity.")]
+    public async Task<NetworkUIntNullableResult> GetNetworkId(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var networkId = await bridge.Network.GetNetworkIdAsync(entityId);
+
+        if (networkId == null)
+        {
+            return new NetworkUIntNullableResult
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no network ID"
+            };
+        }
+
+        return new NetworkUIntNullableResult
+        {
+            Success = true,
+            Value = networkId
+        };
+    }
+
+    [McpServerTool(Name = "network_get_ownership")]
+    [Description("Get the owner client ID for a networked entity (0 for server-owned).")]
+    public async Task<NetworkIntNullableResult> GetOwnership(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var ownerId = await bridge.Network.GetOwnershipAsync(entityId);
+
+        if (ownerId == null)
+        {
+            return new NetworkIntNullableResult
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no network owner"
+            };
+        }
+
+        return new NetworkIntNullableResult
+        {
+            Success = true,
+            Value = ownerId
+        };
+    }
+
+    [McpServerTool(Name = "network_get_replication_state")]
+    [Description("Get the full replication state for a networked entity, including ownership, ticks, and prediction/interpolation flags.")]
+    public async Task<ReplicationStateResult> GetReplicationState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Network.GetReplicationStateAsync(entityId);
+
+        if (state == null)
+        {
+            return new ReplicationStateResult
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no replication state"
+            };
+        }
+
+        return ReplicationStateResult.FromSnapshot(state);
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for network statistics query.
+/// </summary>
+public sealed record NetworkStatisticsResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public bool IsConnected { get; init; }
+    public bool IsServer { get; init; }
+    public bool IsClient { get; init; }
+    public uint CurrentTick { get; init; }
+    public int LocalClientId { get; init; }
+    public int ClientCount { get; init; }
+    public int NetworkedEntityCount { get; init; }
+
+    public static NetworkStatisticsResult FromSnapshot(NetworkStatisticsSnapshot snapshot) => new()
+    {
+        Success = true,
+        IsConnected = snapshot.IsConnected,
+        IsServer = snapshot.IsServer,
+        IsClient = snapshot.IsClient,
+        CurrentTick = snapshot.CurrentTick,
+        LocalClientId = snapshot.LocalClientId,
+        ClientCount = snapshot.ClientCount,
+        NetworkedEntityCount = snapshot.NetworkedEntityCount
+    };
+}
+
+/// <summary>
+/// Result for connection statistics query.
+/// </summary>
+public sealed record ConnectionStatsResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public float RoundTripTimeMs { get; init; }
+    public float PacketLossPercent { get; init; }
+    public long BytesSent { get; init; }
+    public long BytesReceived { get; init; }
+    public long PacketsSent { get; init; }
+    public long PacketsReceived { get; init; }
+
+    public static ConnectionStatsResult FromSnapshot(ConnectionStatsSnapshot snapshot) => new()
+    {
+        Success = true,
+        RoundTripTimeMs = snapshot.RoundTripTimeMs,
+        PacketLossPercent = snapshot.PacketLossPercent,
+        BytesSent = snapshot.BytesSent,
+        BytesReceived = snapshot.BytesReceived,
+        PacketsSent = snapshot.PacketsSent,
+        PacketsReceived = snapshot.PacketsReceived
+    };
+}
+
+/// <summary>
+/// Result for connected clients query.
+/// </summary>
+public sealed record ConnectedClientsResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public IReadOnlyList<ClientInfo> Clients { get; init; } = [];
+    public int Count { get; init; }
+
+    public static ConnectedClientsResult FromClients(IReadOnlyList<ClientSnapshot> clients) => new()
+    {
+        Success = true,
+        Clients = clients.Select(c => new ClientInfo
+        {
+            ClientId = c.ClientId,
+            LastAckedTick = c.LastAckedTick,
+            NeedsFullSnapshot = c.NeedsFullSnapshot,
+            RoundTripTimeMs = c.RoundTripTimeMs
+        }).ToList(),
+        Count = clients.Count
+    };
+}
+
+/// <summary>
+/// Information about a connected client.
+/// </summary>
+public sealed record ClientInfo
+{
+    public int ClientId { get; init; }
+    public uint LastAckedTick { get; init; }
+    public bool NeedsFullSnapshot { get; init; }
+    public float RoundTripTimeMs { get; init; }
+}
+
+/// <summary>
+/// Result for replication state query.
+/// </summary>
+public sealed record ReplicationStateResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public uint NetworkId { get; init; }
+    public int OwnerId { get; init; }
+    public uint LastSentTick { get; init; }
+    public uint LastReceivedTick { get; init; }
+    public bool NeedsFullSync { get; init; }
+    public bool IsLocallyOwned { get; init; }
+    public bool IsRemotelyOwned { get; init; }
+    public bool IsPredicted { get; init; }
+    public bool IsInterpolated { get; init; }
+
+    public static ReplicationStateResult FromSnapshot(ReplicationStateSnapshot snapshot) => new()
+    {
+        Success = true,
+        NetworkId = snapshot.NetworkId,
+        OwnerId = snapshot.OwnerId,
+        LastSentTick = snapshot.LastSentTick,
+        LastReceivedTick = snapshot.LastReceivedTick,
+        NeedsFullSync = snapshot.NeedsFullSync,
+        IsLocallyOwned = snapshot.IsLocallyOwned,
+        IsRemotelyOwned = snapshot.IsRemotelyOwned,
+        IsPredicted = snapshot.IsPredicted,
+        IsInterpolated = snapshot.IsInterpolated
+    };
+}
+
+/// <summary>
+/// Result for boolean operations.
+/// </summary>
+public sealed record NetworkBoolResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public bool Value { get; init; }
+}
+
+/// <summary>
+/// Result for unsigned integer operations.
+/// </summary>
+public sealed record NetworkUIntResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public uint Value { get; init; }
+}
+
+/// <summary>
+/// Result for float operations.
+/// </summary>
+public sealed record NetworkFloatResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public float Value { get; init; }
+}
+
+/// <summary>
+/// Result for nullable unsigned integer operations.
+/// </summary>
+public sealed record NetworkUIntNullableResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public uint? Value { get; init; }
+}
+
+/// <summary>
+/// Result for nullable integer operations.
+/// </summary>
+public sealed record NetworkIntNullableResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public int? Value { get; init; }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/PhysicsTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/PhysicsTools.cs
@@ -1,0 +1,662 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Physics;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for physics debugging: raycasting, queries, body state, and force application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose the physics simulation debugging infrastructure via MCP, allowing
+/// inspection and manipulation of physics bodies in running games.
+/// </para>
+/// <para>
+/// Note: These tools require the PhysicsPlugin to be installed in the target world.
+/// Entities must have the appropriate physics components (RigidBody, PhysicsShape, Transform3D)
+/// for the operations to work.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class PhysicsTools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "physics_get_statistics")]
+    [Description("Get overall physics statistics including body counts and interpolation state.")]
+    public async Task<PhysicsStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.Physics.GetStatisticsAsync();
+        return PhysicsStatisticsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Raycasting
+
+    [McpServerTool(Name = "physics_raycast")]
+    [Description("Cast a ray and return the first hit. Returns null if nothing was hit.")]
+    public async Task<RaycastResult> Raycast(
+        [Description("Ray origin X coordinate")]
+        float originX,
+        [Description("Ray origin Y coordinate")]
+        float originY,
+        [Description("Ray origin Z coordinate")]
+        float originZ,
+        [Description("Ray direction X (normalized)")]
+        float directionX,
+        [Description("Ray direction Y (normalized)")]
+        float directionY,
+        [Description("Ray direction Z (normalized)")]
+        float directionZ,
+        [Description("Maximum distance to check for hits")]
+        float maxDistance)
+    {
+        var bridge = connection.GetBridge();
+        var origin = new Vector3Snapshot { X = originX, Y = originY, Z = originZ };
+        var direction = new Vector3Snapshot { X = directionX, Y = directionY, Z = directionZ };
+        var hit = await bridge.Physics.RaycastAsync(origin, direction, maxDistance);
+
+        if (hit == null)
+        {
+            return new RaycastResult
+            {
+                Success = true,
+                Hit = false
+            };
+        }
+
+        return new RaycastResult
+        {
+            Success = true,
+            Hit = true,
+            EntityId = hit.EntityId,
+            PositionX = hit.Position.X,
+            PositionY = hit.Position.Y,
+            PositionZ = hit.Position.Z,
+            NormalX = hit.Normal.X,
+            NormalY = hit.Normal.Y,
+            NormalZ = hit.Normal.Z,
+            Distance = hit.Distance
+        };
+    }
+
+    #endregion
+
+    #region Overlap Queries
+
+    [McpServerTool(Name = "physics_overlap_sphere")]
+    [Description("Find all entities within a sphere.")]
+    public async Task<OverlapResult> OverlapSphere(
+        [Description("Sphere center X coordinate")]
+        float centerX,
+        [Description("Sphere center Y coordinate")]
+        float centerY,
+        [Description("Sphere center Z coordinate")]
+        float centerZ,
+        [Description("Sphere radius")]
+        float radius)
+    {
+        var bridge = connection.GetBridge();
+        var center = new Vector3Snapshot { X = centerX, Y = centerY, Z = centerZ };
+        var entities = await bridge.Physics.OverlapSphereAsync(center, radius);
+
+        return new OverlapResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    [McpServerTool(Name = "physics_overlap_box")]
+    [Description("Find all entities within an axis-aligned box.")]
+    public async Task<OverlapResult> OverlapBox(
+        [Description("Box center X coordinate")]
+        float centerX,
+        [Description("Box center Y coordinate")]
+        float centerY,
+        [Description("Box center Z coordinate")]
+        float centerZ,
+        [Description("Box half-extent X (half-width)")]
+        float halfExtentX,
+        [Description("Box half-extent Y (half-height)")]
+        float halfExtentY,
+        [Description("Box half-extent Z (half-depth)")]
+        float halfExtentZ)
+    {
+        var bridge = connection.GetBridge();
+        var center = new Vector3Snapshot { X = centerX, Y = centerY, Z = centerZ };
+        var halfExtents = new Vector3Snapshot { X = halfExtentX, Y = halfExtentY, Z = halfExtentZ };
+        var entities = await bridge.Physics.OverlapBoxAsync(center, halfExtents);
+
+        return new OverlapResult
+        {
+            Success = true,
+            EntityIds = entities,
+            Count = entities.Count
+        };
+    }
+
+    #endregion
+
+    #region Body State
+
+    [McpServerTool(Name = "physics_get_body")]
+    [Description("Get the complete state of a physics body including position, rotation, velocities, and mass.")]
+    public async Task<PhysicsBodyResult> GetBodyState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var snapshot = await bridge.Physics.GetBodyStateAsync(entityId);
+
+        if (snapshot == null)
+        {
+            return new PhysicsBodyResult
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no physics body"
+            };
+        }
+
+        return PhysicsBodyResult.FromSnapshot(snapshot);
+    }
+
+    [McpServerTool(Name = "physics_get_velocity")]
+    [Description("Get the linear velocity of a physics body.")]
+    public async Task<Vector3Result> GetVelocity(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var velocity = await bridge.Physics.GetVelocityAsync(entityId);
+
+        if (velocity == null)
+        {
+            return new Vector3Result
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no physics body"
+            };
+        }
+
+        return new Vector3Result
+        {
+            Success = true,
+            X = velocity.X,
+            Y = velocity.Y,
+            Z = velocity.Z
+        };
+    }
+
+    [McpServerTool(Name = "physics_set_velocity")]
+    [Description("Set the linear velocity of a physics body.")]
+    public async Task<OperationResult> SetVelocity(
+        [Description("The entity ID to modify")]
+        int entityId,
+        [Description("Velocity X component")]
+        float x,
+        [Description("Velocity Y component")]
+        float y,
+        [Description("Velocity Z component")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var velocity = new Vector3Snapshot { X = x, Y = y, Z = z };
+        var success = await bridge.Physics.SetVelocityAsync(entityId, velocity);
+
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set velocity on entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "physics_is_awake")]
+    [Description("Check if a physics body is awake (not sleeping).")]
+    public async Task<BooleanResult> IsAwake(
+        [Description("The entity ID to check")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var isAwake = await bridge.Physics.IsAwakeAsync(entityId);
+
+        if (isAwake == null)
+        {
+            return new BooleanResult
+            {
+                Success = false,
+                Error = $"Entity {entityId} has no physics body"
+            };
+        }
+
+        return new BooleanResult
+        {
+            Success = true,
+            Value = isAwake.Value
+        };
+    }
+
+    [McpServerTool(Name = "physics_wake_up")]
+    [Description("Wake up a sleeping physics body.")]
+    public async Task<OperationResult> WakeUp(
+        [Description("The entity ID to wake")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.Physics.WakeUpAsync(entityId);
+
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to wake up entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Forces and Impulses
+
+    [McpServerTool(Name = "physics_apply_force")]
+    [Description("Apply a force to a physics body at its center of mass.")]
+    public async Task<OperationResult> ApplyForce(
+        [Description("The entity ID to apply force to")]
+        int entityId,
+        [Description("Force X component")]
+        float x,
+        [Description("Force Y component")]
+        float y,
+        [Description("Force Z component")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var force = new Vector3Snapshot { X = x, Y = y, Z = z };
+        var success = await bridge.Physics.ApplyForceAsync(entityId, force);
+
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to apply force to entity {entityId}"
+        };
+    }
+
+    [McpServerTool(Name = "physics_apply_impulse")]
+    [Description("Apply an impulse to a physics body at its center of mass.")]
+    public async Task<OperationResult> ApplyImpulse(
+        [Description("The entity ID to apply impulse to")]
+        int entityId,
+        [Description("Impulse X component")]
+        float x,
+        [Description("Impulse Y component")]
+        float y,
+        [Description("Impulse Z component")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var impulse = new Vector3Snapshot { X = x, Y = y, Z = z };
+        var success = await bridge.Physics.ApplyImpulseAsync(entityId, impulse);
+
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to apply impulse to entity {entityId}"
+        };
+    }
+
+    #endregion
+
+    #region Gravity
+
+    [McpServerTool(Name = "physics_get_gravity")]
+    [Description("Get the current gravity vector for the simulation.")]
+    public async Task<Vector3Result> GetGravity()
+    {
+        var bridge = connection.GetBridge();
+        var gravity = await bridge.Physics.GetGravityAsync();
+
+        return new Vector3Result
+        {
+            Success = true,
+            X = gravity.X,
+            Y = gravity.Y,
+            Z = gravity.Z
+        };
+    }
+
+    [McpServerTool(Name = "physics_set_gravity")]
+    [Description("Set the gravity vector for the simulation.")]
+    public async Task<OperationResult> SetGravity(
+        [Description("Gravity X component")]
+        float x,
+        [Description("Gravity Y component")]
+        float y,
+        [Description("Gravity Z component")]
+        float z)
+    {
+        var bridge = connection.GetBridge();
+        var gravity = new Vector3Snapshot { X = x, Y = y, Z = z };
+        var success = await bridge.Physics.SetGravityAsync(gravity);
+
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : "Failed to set gravity"
+        };
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for physics statistics.
+/// </summary>
+public sealed record PhysicsStatisticsResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>
+    /// Gets the total number of physics bodies (dynamic + kinematic).
+    /// </summary>
+    public int BodyCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of static bodies.
+    /// </summary>
+    public int StaticCount { get; init; }
+
+    /// <summary>
+    /// Gets the interpolation alpha for smooth rendering (0-1).
+    /// </summary>
+    public float InterpolationAlpha { get; init; }
+
+    /// <summary>
+    /// Gets the total count of all physics objects.
+    /// </summary>
+    public int TotalCount => BodyCount + StaticCount;
+
+    internal static PhysicsStatisticsResult FromSnapshot(PhysicsStatisticsSnapshot snapshot)
+    {
+        return new PhysicsStatisticsResult
+        {
+            BodyCount = snapshot.BodyCount,
+            StaticCount = snapshot.StaticCount,
+            InterpolationAlpha = snapshot.InterpolationAlpha
+        };
+    }
+}
+
+/// <summary>
+/// Result for raycast operations.
+/// </summary>
+public sealed record RaycastResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets whether something was hit.
+    /// </summary>
+    public bool Hit { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID that was hit.
+    /// </summary>
+    public int? EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the hit position X coordinate.
+    /// </summary>
+    public float? PositionX { get; init; }
+
+    /// <summary>
+    /// Gets the hit position Y coordinate.
+    /// </summary>
+    public float? PositionY { get; init; }
+
+    /// <summary>
+    /// Gets the hit position Z coordinate.
+    /// </summary>
+    public float? PositionZ { get; init; }
+
+    /// <summary>
+    /// Gets the surface normal X component.
+    /// </summary>
+    public float? NormalX { get; init; }
+
+    /// <summary>
+    /// Gets the surface normal Y component.
+    /// </summary>
+    public float? NormalY { get; init; }
+
+    /// <summary>
+    /// Gets the surface normal Z component.
+    /// </summary>
+    public float? NormalZ { get; init; }
+
+    /// <summary>
+    /// Gets the distance from the ray origin to the hit point.
+    /// </summary>
+    public float? Distance { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for overlap queries.
+/// </summary>
+public sealed record OverlapResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the list of entity IDs overlapping the query volume.
+    /// </summary>
+    public IReadOnlyList<int>? EntityIds { get; init; }
+
+    /// <summary>
+    /// Gets the count of entities.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for physics body queries.
+/// </summary>
+public sealed record PhysicsBodyResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the position X coordinate.
+    /// </summary>
+    public float PositionX { get; init; }
+
+    /// <summary>
+    /// Gets the position Y coordinate.
+    /// </summary>
+    public float PositionY { get; init; }
+
+    /// <summary>
+    /// Gets the position Z coordinate.
+    /// </summary>
+    public float PositionZ { get; init; }
+
+    /// <summary>
+    /// Gets the rotation quaternion X component.
+    /// </summary>
+    public float RotationX { get; init; }
+
+    /// <summary>
+    /// Gets the rotation quaternion Y component.
+    /// </summary>
+    public float RotationY { get; init; }
+
+    /// <summary>
+    /// Gets the rotation quaternion Z component.
+    /// </summary>
+    public float RotationZ { get; init; }
+
+    /// <summary>
+    /// Gets the rotation quaternion W component.
+    /// </summary>
+    public float RotationW { get; init; }
+
+    /// <summary>
+    /// Gets the linear velocity X component.
+    /// </summary>
+    public float LinearVelocityX { get; init; }
+
+    /// <summary>
+    /// Gets the linear velocity Y component.
+    /// </summary>
+    public float LinearVelocityY { get; init; }
+
+    /// <summary>
+    /// Gets the linear velocity Z component.
+    /// </summary>
+    public float LinearVelocityZ { get; init; }
+
+    /// <summary>
+    /// Gets the angular velocity X component.
+    /// </summary>
+    public float AngularVelocityX { get; init; }
+
+    /// <summary>
+    /// Gets the angular velocity Y component.
+    /// </summary>
+    public float AngularVelocityY { get; init; }
+
+    /// <summary>
+    /// Gets the angular velocity Z component.
+    /// </summary>
+    public float AngularVelocityZ { get; init; }
+
+    /// <summary>
+    /// Gets the mass in kilograms.
+    /// </summary>
+    public float Mass { get; init; }
+
+    /// <summary>
+    /// Gets the body type (Dynamic, Kinematic, Static).
+    /// </summary>
+    public string? BodyType { get; init; }
+
+    /// <summary>
+    /// Gets whether the body is currently awake (not sleeping).
+    /// </summary>
+    public bool IsAwake { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static PhysicsBodyResult FromSnapshot(PhysicsBodySnapshot snapshot)
+    {
+        return new PhysicsBodyResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            PositionX = snapshot.Position.X,
+            PositionY = snapshot.Position.Y,
+            PositionZ = snapshot.Position.Z,
+            RotationX = snapshot.Rotation.X,
+            RotationY = snapshot.Rotation.Y,
+            RotationZ = snapshot.Rotation.Z,
+            RotationW = snapshot.Rotation.W,
+            LinearVelocityX = snapshot.LinearVelocity.X,
+            LinearVelocityY = snapshot.LinearVelocity.Y,
+            LinearVelocityZ = snapshot.LinearVelocity.Z,
+            AngularVelocityX = snapshot.AngularVelocity.X,
+            AngularVelocityY = snapshot.AngularVelocity.Y,
+            AngularVelocityZ = snapshot.AngularVelocity.Z,
+            Mass = snapshot.Mass,
+            BodyType = snapshot.BodyType,
+            IsAwake = snapshot.IsAwake
+        };
+    }
+}
+
+/// <summary>
+/// Result for Vector3 queries.
+/// </summary>
+public sealed record Vector3Result
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the X component.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y component.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the Z component.
+    /// </summary>
+    public float Z { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for boolean queries.
+/// </summary>
+public sealed record BooleanResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the boolean value.
+    /// </summary>
+    public bool Value { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/ProfileTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/ProfileTools.cs
@@ -449,22 +449,6 @@ public sealed record AvailabilityResult
 }
 
 /// <summary>
-/// Generic operation result.
-/// </summary>
-public sealed record OperationResult
-{
-    /// <summary>
-    /// Gets whether the operation succeeded.
-    /// </summary>
-    public required bool Success { get; init; }
-
-    /// <summary>
-    /// Gets an optional error message.
-    /// </summary>
-    public string? Error { get; init; }
-}
-
-/// <summary>
 /// Result of a system profiling query.
 /// </summary>
 public sealed record SystemProfilingResult

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/ReplayTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/ReplayTools.cs
@@ -1,0 +1,1145 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.Replay;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for replay recording and playback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools allow recording gameplay sessions, saving/loading replay files,
+/// controlling playback with pause/seek/step operations, and validating replays.
+/// </para>
+/// <para>
+/// Recording requires the ReplayPlugin to be installed on the game world.
+/// Playback can be done independently using the built-in ReplayPlayer.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class ReplayTools(BridgeConnectionManager connection)
+{
+    #region Recording Control
+
+    [McpServerTool(Name = "replay_start_recording")]
+    [Description("Start recording gameplay. Requires ReplayPlugin to be installed on the world.")]
+    public async Task<ReplayOperationResultMcp> StartRecording(
+        [Description("Optional name for this recording")]
+        string? name = null,
+        [Description("Maximum frames to record (default: 36000 = 10 minutes at 60fps)")]
+        int maxFrames = 36000,
+        [Description("Interval in milliseconds between world state snapshots (default: 5000 = 5 seconds)")]
+        int snapshotIntervalMs = 5000)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.StartRecordingAsync(name, maxFrames, snapshotIntervalMs);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_stop_recording")]
+    [Description("Stop recording and keep the recording data in memory. Use replay_save to persist.")]
+    public async Task<ReplayOperationResultMcp> StopRecording()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.StopRecordingAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_cancel_recording")]
+    [Description("Cancel recording and discard all recorded data.")]
+    public async Task<ReplayOperationResultMcp> CancelRecording()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.CancelRecordingAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_is_recording")]
+    [Description("Check if recording is currently in progress.")]
+    public async Task<RecordingStatusResult> IsRecording()
+    {
+        var bridge = connection.GetBridge();
+        var isRecording = await bridge.Replay.IsRecordingAsync();
+        var info = await bridge.Replay.GetRecordingInfoAsync();
+
+        return new RecordingStatusResult
+        {
+            IsRecording = isRecording,
+            Info = info != null ? RecordingInfoResult.FromSnapshot(info) : null
+        };
+    }
+
+    [McpServerTool(Name = "replay_force_snapshot")]
+    [Description("Force a world state snapshot during recording.")]
+    public async Task<ReplayOperationResultMcp> ForceSnapshot()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.ForceSnapshotAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    #endregion
+
+    #region Recording Management
+
+    [McpServerTool(Name = "replay_save")]
+    [Description("Save the current recording to a file.")]
+    public async Task<ReplayOperationResultMcp> Save(
+        [Description("File path to save the replay to (with .kreplay extension)")]
+        string path)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.SaveAsync(path);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_load")]
+    [Description("Load a replay file for playback.")]
+    public async Task<ReplayOperationResultMcp> Load(
+        [Description("File path of the replay to load")]
+        string path)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.LoadAsync(path);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_list")]
+    [Description("List all replay files in a directory.")]
+    public async Task<ReplayFileListResult> List(
+        [Description("Directory to search for replay files (null = current directory)")]
+        string? directory = null)
+    {
+        var bridge = connection.GetBridge();
+        var files = await bridge.Replay.ListAsync(directory);
+        return new ReplayFileListResult
+        {
+            Count = files.Count,
+            Directory = directory ?? Environment.CurrentDirectory,
+            Files = files.Select(ReplayFileResult.FromSnapshot).ToList()
+        };
+    }
+
+    [McpServerTool(Name = "replay_delete")]
+    [Description("Delete a replay file.")]
+    public async Task<ReplayDeleteResult> Delete(
+        [Description("File path of the replay to delete")]
+        string path)
+    {
+        var bridge = connection.GetBridge();
+        var deleted = await bridge.Replay.DeleteAsync(path);
+        return new ReplayDeleteResult
+        {
+            Success = deleted,
+            Path = path,
+            Message = deleted ? $"Replay '{path}' deleted" : $"Replay '{path}' not found or could not be deleted"
+        };
+    }
+
+    [McpServerTool(Name = "replay_get_metadata")]
+    [Description("Get metadata from a replay file without loading it for playback.")]
+    public async Task<ReplayMetadataResult?> GetMetadata(
+        [Description("File path of the replay")]
+        string path)
+    {
+        var bridge = connection.GetBridge();
+        var metadata = await bridge.Replay.GetMetadataAsync(path);
+        return metadata != null ? ReplayMetadataResult.FromSnapshot(metadata) : null;
+    }
+
+    #endregion
+
+    #region Playback Control
+
+    [McpServerTool(Name = "replay_play")]
+    [Description("Start or resume playback of the loaded replay.")]
+    public async Task<ReplayOperationResultMcp> Play()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.PlayAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_pause")]
+    [Description("Pause playback.")]
+    public async Task<ReplayOperationResultMcp> Pause()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.PauseAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_stop")]
+    [Description("Stop playback and reset to the beginning.")]
+    public async Task<ReplayOperationResultMcp> Stop()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.StopPlaybackAsync();
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_get_playback_state")]
+    [Description("Get the current playback state.")]
+    public async Task<PlaybackStateResult> GetPlaybackState()
+    {
+        var bridge = connection.GetBridge();
+        var state = await bridge.Replay.GetPlaybackStateAsync();
+        return PlaybackStateResult.FromSnapshot(state);
+    }
+
+    [McpServerTool(Name = "replay_set_speed")]
+    [Description("Set the playback speed (0.25x to 4.0x).")]
+    public async Task<ReplayOperationResultMcp> SetSpeed(
+        [Description("Playback speed multiplier (0.25 to 4.0)")]
+        float speed)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.SetSpeedAsync(speed);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    #endregion
+
+    #region Playback Navigation
+
+    [McpServerTool(Name = "replay_seek_frame")]
+    [Description("Seek to a specific frame in the replay.")]
+    public async Task<ReplayOperationResultMcp> SeekFrame(
+        [Description("Frame number to seek to")]
+        int frame)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.SeekFrameAsync(frame);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_seek_time")]
+    [Description("Seek to a specific time in the replay.")]
+    public async Task<ReplayOperationResultMcp> SeekTime(
+        [Description("Time in seconds to seek to")]
+        float seconds)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.SeekTimeAsync(seconds);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_step_forward")]
+    [Description("Step forward by a number of frames (pauses if playing).")]
+    public async Task<ReplayOperationResultMcp> StepForward(
+        [Description("Number of frames to step forward")]
+        int frames = 1)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.StepForwardAsync(frames);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    [McpServerTool(Name = "replay_step_backward")]
+    [Description("Step backward by a number of frames (pauses if playing).")]
+    public async Task<ReplayOperationResultMcp> StepBackward(
+        [Description("Number of frames to step backward")]
+        int frames = 1)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.StepBackwardAsync(frames);
+        return ReplayOperationResultMcp.FromResult(result);
+    }
+
+    #endregion
+
+    #region Frame Inspection
+
+    [McpServerTool(Name = "replay_get_frame")]
+    [Description("Get details about a specific frame.")]
+    public async Task<ReplayFrameResult?> GetFrame(
+        [Description("Frame number to inspect")]
+        int frame)
+    {
+        var bridge = connection.GetBridge();
+        var frameData = await bridge.Replay.GetFrameAsync(frame);
+        return frameData != null ? ReplayFrameResult.FromSnapshot(frameData) : null;
+    }
+
+    [McpServerTool(Name = "replay_get_frame_range")]
+    [Description("Get details about a range of frames.")]
+    public async Task<FrameRangeResult> GetFrameRange(
+        [Description("Starting frame number")]
+        int startFrame,
+        [Description("Number of frames to retrieve")]
+        int count)
+    {
+        var bridge = connection.GetBridge();
+        var frames = await bridge.Replay.GetFrameRangeAsync(startFrame, count);
+        return new FrameRangeResult
+        {
+            StartFrame = startFrame,
+            Count = frames.Count,
+            Frames = frames.Select(ReplayFrameResult.FromSnapshot).ToList()
+        };
+    }
+
+    [McpServerTool(Name = "replay_get_inputs")]
+    [Description("Get input events for a range of frames.")]
+    public async Task<InputEventsResult> GetInputs(
+        [Description("Starting frame number")]
+        int startFrame,
+        [Description("Ending frame number")]
+        int endFrame)
+    {
+        var bridge = connection.GetBridge();
+        var inputs = await bridge.Replay.GetInputsAsync(startFrame, endFrame);
+        return new InputEventsResult
+        {
+            StartFrame = startFrame,
+            EndFrame = endFrame,
+            Count = inputs.Count,
+            Inputs = inputs.Select(InputEventResult.FromSnapshot).ToList()
+        };
+    }
+
+    [McpServerTool(Name = "replay_get_events")]
+    [Description("Get replay events (entity spawns, despawns, etc.) for a range of frames.")]
+    public async Task<ReplayEventsResult> GetEvents(
+        [Description("Starting frame number")]
+        int startFrame,
+        [Description("Ending frame number")]
+        int endFrame)
+    {
+        var bridge = connection.GetBridge();
+        var events = await bridge.Replay.GetEventsAsync(startFrame, endFrame);
+        return new ReplayEventsResult
+        {
+            StartFrame = startFrame,
+            EndFrame = endFrame,
+            Count = events.Count,
+            Events = events.Select(ReplayEventResult.FromSnapshot).ToList()
+        };
+    }
+
+    [McpServerTool(Name = "replay_get_snapshots")]
+    [Description("Get a list of all world state snapshots in the loaded replay.")]
+    public async Task<SnapshotMarkersResult> GetSnapshots()
+    {
+        var bridge = connection.GetBridge();
+        var snapshots = await bridge.Replay.GetSnapshotsAsync();
+        return new SnapshotMarkersResult
+        {
+            Count = snapshots.Count,
+            Snapshots = snapshots.Select(SnapshotMarkerResult.FromSnapshot).ToList()
+        };
+    }
+
+    #endregion
+
+    #region Validation
+
+    [McpServerTool(Name = "replay_validate")]
+    [Description("Validate a replay file for integrity and compatibility.")]
+    public async Task<ValidationResult> Validate(
+        [Description("File path of the replay to validate")]
+        string path)
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.ValidateAsync(path);
+        return ValidationResult.FromSnapshot(result);
+    }
+
+    [McpServerTool(Name = "replay_check_determinism")]
+    [Description("Check if the loaded replay has determinism issues (checksum mismatches).")]
+    public async Task<DeterminismResult> CheckDeterminism()
+    {
+        var bridge = connection.GetBridge();
+        var result = await bridge.Replay.CheckDeterminismAsync();
+        return DeterminismResult.FromSnapshot(result);
+    }
+
+    #endregion
+}
+
+#region Result Records
+
+/// <summary>
+/// Result of a replay operation.
+/// </summary>
+public sealed record ReplayOperationResultMcp
+{
+    /// <summary>
+    /// Gets whether the operation was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets recording info if available.
+    /// </summary>
+    public RecordingInfoResult? RecordingInfo { get; init; }
+
+    /// <summary>
+    /// Gets playback state if available.
+    /// </summary>
+    public PlaybackStateResult? PlaybackState { get; init; }
+
+    /// <summary>
+    /// Gets metadata if available.
+    /// </summary>
+    public ReplayMetadataResult? Metadata { get; init; }
+
+    /// <summary>
+    /// Creates from a ReplayOperationResult.
+    /// </summary>
+    public static ReplayOperationResultMcp FromResult(ReplayOperationResult result)
+    {
+        return new ReplayOperationResultMcp
+        {
+            Success = result.Success,
+            Error = result.Error,
+            RecordingInfo = result.RecordingInfo != null
+                ? RecordingInfoResult.FromSnapshot(result.RecordingInfo)
+                : null,
+            PlaybackState = result.PlaybackState != null
+                ? PlaybackStateResult.FromSnapshot(result.PlaybackState)
+                : null,
+            Metadata = result.Metadata != null
+                ? ReplayMetadataResult.FromSnapshot(result.Metadata)
+                : null
+        };
+    }
+}
+
+/// <summary>
+/// Recording status information.
+/// </summary>
+public sealed record RecordingStatusResult
+{
+    /// <summary>
+    /// Gets whether recording is in progress.
+    /// </summary>
+    public required bool IsRecording { get; init; }
+
+    /// <summary>
+    /// Gets recording info if recording.
+    /// </summary>
+    public RecordingInfoResult? Info { get; init; }
+}
+
+/// <summary>
+/// Recording information for MCP results.
+/// </summary>
+public sealed record RecordingInfoResult
+{
+    /// <summary>
+    /// Gets whether recording is in progress.
+    /// </summary>
+    public required bool IsRecording { get; init; }
+
+    /// <summary>
+    /// Gets the recording name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames recorded.
+    /// </summary>
+    public required int FrameCount { get; init; }
+
+    /// <summary>
+    /// Gets the recording duration in seconds.
+    /// </summary>
+    public required float DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the number of snapshots taken.
+    /// </summary>
+    public required int SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets when recording started.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>
+    /// Creates from a RecordingInfoSnapshot.
+    /// </summary>
+    public static RecordingInfoResult FromSnapshot(RecordingInfoSnapshot snapshot)
+    {
+        return new RecordingInfoResult
+        {
+            IsRecording = snapshot.IsRecording,
+            Name = snapshot.Name,
+            FrameCount = snapshot.FrameCount,
+            DurationSeconds = snapshot.DurationSeconds,
+            SnapshotCount = snapshot.SnapshotCount,
+            StartedAt = snapshot.StartedAt
+        };
+    }
+}
+
+/// <summary>
+/// Playback state for MCP results.
+/// </summary>
+public sealed record PlaybackStateResult
+{
+    /// <summary>
+    /// Gets whether a replay is loaded.
+    /// </summary>
+    public required bool IsLoaded { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is active.
+    /// </summary>
+    public required bool IsPlaying { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is paused.
+    /// </summary>
+    public required bool IsPaused { get; init; }
+
+    /// <summary>
+    /// Gets whether playback is stopped.
+    /// </summary>
+    public required bool IsStopped { get; init; }
+
+    /// <summary>
+    /// Gets the current frame number.
+    /// </summary>
+    public required int CurrentFrame { get; init; }
+
+    /// <summary>
+    /// Gets the total number of frames.
+    /// </summary>
+    public required int TotalFrames { get; init; }
+
+    /// <summary>
+    /// Gets the current time in seconds.
+    /// </summary>
+    public required float CurrentTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the total time in seconds.
+    /// </summary>
+    public required float TotalTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the playback speed multiplier.
+    /// </summary>
+    public required float PlaybackSpeed { get; init; }
+
+    /// <summary>
+    /// Gets the name of the loaded replay.
+    /// </summary>
+    public string? ReplayName { get; init; }
+
+    /// <summary>
+    /// Creates from a PlaybackStateSnapshot.
+    /// </summary>
+    public static PlaybackStateResult FromSnapshot(PlaybackStateSnapshot snapshot)
+    {
+        return new PlaybackStateResult
+        {
+            IsLoaded = snapshot.IsLoaded,
+            IsPlaying = snapshot.IsPlaying,
+            IsPaused = snapshot.IsPaused,
+            IsStopped = snapshot.IsStopped,
+            CurrentFrame = snapshot.CurrentFrame,
+            TotalFrames = snapshot.TotalFrames,
+            CurrentTimeSeconds = snapshot.CurrentTimeSeconds,
+            TotalTimeSeconds = snapshot.TotalTimeSeconds,
+            PlaybackSpeed = snapshot.PlaybackSpeed,
+            ReplayName = snapshot.ReplayName
+        };
+    }
+}
+
+/// <summary>
+/// Replay file list result.
+/// </summary>
+public sealed record ReplayFileListResult
+{
+    /// <summary>
+    /// Gets the number of files found.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets the directory that was searched.
+    /// </summary>
+    public required string Directory { get; init; }
+
+    /// <summary>
+    /// Gets the list of files.
+    /// </summary>
+    public required List<ReplayFileResult> Files { get; init; }
+}
+
+/// <summary>
+/// Replay file information for MCP results.
+/// </summary>
+public sealed record ReplayFileResult
+{
+    /// <summary>
+    /// Gets the file path.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the file name.
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public required long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets when the file was last modified.
+    /// </summary>
+    public required DateTimeOffset LastModified { get; init; }
+
+    /// <summary>
+    /// Gets the replay metadata, if available.
+    /// </summary>
+    public ReplayMetadataResult? Metadata { get; init; }
+
+    /// <summary>
+    /// Gets any validation error.
+    /// </summary>
+    public string? ValidationError { get; init; }
+
+    /// <summary>
+    /// Creates from a ReplayFileSnapshot.
+    /// </summary>
+    public static ReplayFileResult FromSnapshot(ReplayFileSnapshot snapshot)
+    {
+        return new ReplayFileResult
+        {
+            Path = snapshot.Path,
+            FileName = snapshot.FileName,
+            SizeBytes = snapshot.SizeBytes,
+            LastModified = snapshot.LastModified,
+            Metadata = snapshot.Metadata != null
+                ? ReplayMetadataResult.FromSnapshot(snapshot.Metadata)
+                : null,
+            ValidationError = snapshot.ValidationError
+        };
+    }
+}
+
+/// <summary>
+/// Replay metadata for MCP results.
+/// </summary>
+public sealed record ReplayMetadataResult
+{
+    /// <summary>
+    /// Gets the replay name.
+    /// </summary>
+    public required string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the replay description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets when recording started.
+    /// </summary>
+    public DateTimeOffset? RecordingStarted { get; init; }
+
+    /// <summary>
+    /// Gets when recording ended.
+    /// </summary>
+    public DateTimeOffset? RecordingEnded { get; init; }
+
+    /// <summary>
+    /// Gets the duration in seconds.
+    /// </summary>
+    public required float DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the total frame count.
+    /// </summary>
+    public required int FrameCount { get; init; }
+
+    /// <summary>
+    /// Gets the snapshot count.
+    /// </summary>
+    public required int SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets the average frame rate.
+    /// </summary>
+    public required float AverageFrameRate { get; init; }
+
+    /// <summary>
+    /// Gets the data version.
+    /// </summary>
+    public int? DataVersion { get; init; }
+
+    /// <summary>
+    /// Gets the file size in bytes.
+    /// </summary>
+    public long? FileSizeBytes { get; init; }
+
+    /// <summary>
+    /// Gets whether the file has a checksum.
+    /// </summary>
+    public bool? HasChecksum { get; init; }
+
+    /// <summary>
+    /// Creates from a ReplayMetadataSnapshot.
+    /// </summary>
+    public static ReplayMetadataResult FromSnapshot(ReplayMetadataSnapshot snapshot)
+    {
+        return new ReplayMetadataResult
+        {
+            Name = snapshot.Name,
+            Description = snapshot.Description,
+            RecordingStarted = snapshot.RecordingStarted,
+            RecordingEnded = snapshot.RecordingEnded,
+            DurationSeconds = snapshot.DurationSeconds,
+            FrameCount = snapshot.FrameCount,
+            SnapshotCount = snapshot.SnapshotCount,
+            AverageFrameRate = snapshot.AverageFrameRate,
+            DataVersion = snapshot.DataVersion,
+            FileSizeBytes = snapshot.FileSizeBytes,
+            HasChecksum = snapshot.HasChecksum
+        };
+    }
+}
+
+/// <summary>
+/// Replay delete result.
+/// </summary>
+public sealed record ReplayDeleteResult
+{
+    /// <summary>
+    /// Gets whether the delete was successful.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the path that was deleted.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets a message describing the result.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Replay frame information for MCP results.
+/// </summary>
+public sealed record ReplayFrameResult
+{
+    /// <summary>
+    /// Gets the frame number.
+    /// </summary>
+    public required int FrameNumber { get; init; }
+
+    /// <summary>
+    /// Gets the delta time in seconds.
+    /// </summary>
+    public required float DeltaTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed time in seconds.
+    /// </summary>
+    public required float ElapsedTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the number of input events in this frame.
+    /// </summary>
+    public required int InputEventCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of game events in this frame.
+    /// </summary>
+    public required int EventCount { get; init; }
+
+    /// <summary>
+    /// Gets whether this frame has a preceding snapshot.
+    /// </summary>
+    public required bool HasSnapshot { get; init; }
+
+    /// <summary>
+    /// Gets the frame checksum, if available.
+    /// </summary>
+    public uint? Checksum { get; init; }
+
+    /// <summary>
+    /// Creates from a ReplayFrameSnapshot.
+    /// </summary>
+    public static ReplayFrameResult FromSnapshot(ReplayFrameSnapshot snapshot)
+    {
+        return new ReplayFrameResult
+        {
+            FrameNumber = snapshot.FrameNumber,
+            DeltaTimeSeconds = snapshot.DeltaTimeSeconds,
+            ElapsedTimeSeconds = snapshot.ElapsedTimeSeconds,
+            InputEventCount = snapshot.InputEventCount,
+            EventCount = snapshot.EventCount,
+            HasSnapshot = snapshot.HasSnapshot,
+            Checksum = snapshot.Checksum
+        };
+    }
+}
+
+/// <summary>
+/// Frame range result.
+/// </summary>
+public sealed record FrameRangeResult
+{
+    /// <summary>
+    /// Gets the starting frame.
+    /// </summary>
+    public required int StartFrame { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames returned.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets the frame data.
+    /// </summary>
+    public required List<ReplayFrameResult> Frames { get; init; }
+}
+
+/// <summary>
+/// Input event for MCP results.
+/// </summary>
+public sealed record InputEventResult
+{
+    /// <summary>
+    /// Gets the input type.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the frame number.
+    /// </summary>
+    public required int Frame { get; init; }
+
+    /// <summary>
+    /// Gets the key name, if applicable.
+    /// </summary>
+    public string? Key { get; init; }
+
+    /// <summary>
+    /// Gets the value, if applicable.
+    /// </summary>
+    public float? Value { get; init; }
+
+    /// <summary>
+    /// Gets the X position, if applicable.
+    /// </summary>
+    public float? PositionX { get; init; }
+
+    /// <summary>
+    /// Gets the Y position, if applicable.
+    /// </summary>
+    public float? PositionY { get; init; }
+
+    /// <summary>
+    /// Gets the custom type name, if applicable.
+    /// </summary>
+    public string? CustomType { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp in milliseconds.
+    /// </summary>
+    public float? TimestampMs { get; init; }
+
+    /// <summary>
+    /// Creates from an InputEventSnapshot.
+    /// </summary>
+    public static InputEventResult FromSnapshot(InputEventSnapshot snapshot)
+    {
+        return new InputEventResult
+        {
+            Type = snapshot.Type,
+            Frame = snapshot.Frame,
+            Key = snapshot.Key,
+            Value = snapshot.Value,
+            PositionX = snapshot.PositionX,
+            PositionY = snapshot.PositionY,
+            CustomType = snapshot.CustomType,
+            TimestampMs = snapshot.TimestampMs
+        };
+    }
+}
+
+/// <summary>
+/// Input events result.
+/// </summary>
+public sealed record InputEventsResult
+{
+    /// <summary>
+    /// Gets the starting frame.
+    /// </summary>
+    public required int StartFrame { get; init; }
+
+    /// <summary>
+    /// Gets the ending frame.
+    /// </summary>
+    public required int EndFrame { get; init; }
+
+    /// <summary>
+    /// Gets the number of input events.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets the input events.
+    /// </summary>
+    public required List<InputEventResult> Inputs { get; init; }
+}
+
+/// <summary>
+/// Replay event for MCP results.
+/// </summary>
+public sealed record ReplayEventResult
+{
+    /// <summary>
+    /// Gets the event type.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the frame number.
+    /// </summary>
+    public required int Frame { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp in milliseconds.
+    /// </summary>
+    public required float TimestampMs { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID, if applicable.
+    /// </summary>
+    public int? EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the component type name, if applicable.
+    /// </summary>
+    public string? ComponentTypeName { get; init; }
+
+    /// <summary>
+    /// Gets the system type name, if applicable.
+    /// </summary>
+    public string? SystemTypeName { get; init; }
+
+    /// <summary>
+    /// Gets the custom type name, if applicable.
+    /// </summary>
+    public string? CustomType { get; init; }
+
+    /// <summary>
+    /// Creates from a ReplayEventSnapshot.
+    /// </summary>
+    public static ReplayEventResult FromSnapshot(ReplayEventSnapshot snapshot)
+    {
+        return new ReplayEventResult
+        {
+            Type = snapshot.Type,
+            Frame = snapshot.Frame,
+            TimestampMs = snapshot.TimestampMs,
+            EntityId = snapshot.EntityId,
+            ComponentTypeName = snapshot.ComponentTypeName,
+            SystemTypeName = snapshot.SystemTypeName,
+            CustomType = snapshot.CustomType
+        };
+    }
+}
+
+/// <summary>
+/// Replay events result.
+/// </summary>
+public sealed record ReplayEventsResult
+{
+    /// <summary>
+    /// Gets the starting frame.
+    /// </summary>
+    public required int StartFrame { get; init; }
+
+    /// <summary>
+    /// Gets the ending frame.
+    /// </summary>
+    public required int EndFrame { get; init; }
+
+    /// <summary>
+    /// Gets the number of events.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets the events.
+    /// </summary>
+    public required List<ReplayEventResult> Events { get; init; }
+}
+
+/// <summary>
+/// Snapshot marker for MCP results.
+/// </summary>
+public sealed record SnapshotMarkerResult
+{
+    /// <summary>
+    /// Gets the frame number where the snapshot was taken.
+    /// </summary>
+    public required int FrameNumber { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed time in seconds.
+    /// </summary>
+    public required float ElapsedTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the snapshot checksum, if available.
+    /// </summary>
+    public uint? Checksum { get; init; }
+
+    /// <summary>
+    /// Gets the snapshot index.
+    /// </summary>
+    public required int Index { get; init; }
+
+    /// <summary>
+    /// Creates from a SnapshotMarkerSnapshot.
+    /// </summary>
+    public static SnapshotMarkerResult FromSnapshot(SnapshotMarkerSnapshot snapshot)
+    {
+        return new SnapshotMarkerResult
+        {
+            FrameNumber = snapshot.FrameNumber,
+            ElapsedTimeSeconds = snapshot.ElapsedTimeSeconds,
+            Checksum = snapshot.Checksum,
+            Index = snapshot.Index
+        };
+    }
+}
+
+/// <summary>
+/// Snapshot markers result.
+/// </summary>
+public sealed record SnapshotMarkersResult
+{
+    /// <summary>
+    /// Gets the number of snapshots.
+    /// </summary>
+    public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets the snapshot markers.
+    /// </summary>
+    public required List<SnapshotMarkerResult> Snapshots { get; init; }
+}
+
+/// <summary>
+/// Validation result for MCP.
+/// </summary>
+public sealed record ValidationResult
+{
+    /// <summary>
+    /// Gets whether the file is valid.
+    /// </summary>
+    public required bool IsValid { get; init; }
+
+    /// <summary>
+    /// Gets the file path that was validated.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the total number of frames.
+    /// </summary>
+    public int? TotalFrames { get; init; }
+
+    /// <summary>
+    /// Gets the number of snapshots.
+    /// </summary>
+    public int? SnapshotCount { get; init; }
+
+    /// <summary>
+    /// Gets the data version.
+    /// </summary>
+    public int? DataVersion { get; init; }
+
+    /// <summary>
+    /// Gets any validation errors.
+    /// </summary>
+    public List<string>? Errors { get; init; }
+
+    /// <summary>
+    /// Creates from a ValidationResultSnapshot.
+    /// </summary>
+    public static ValidationResult FromSnapshot(ValidationResultSnapshot snapshot)
+    {
+        return new ValidationResult
+        {
+            IsValid = snapshot.IsValid,
+            Path = snapshot.Path,
+            TotalFrames = snapshot.TotalFrames,
+            SnapshotCount = snapshot.SnapshotCount,
+            DataVersion = snapshot.DataVersion,
+            Errors = snapshot.Errors?.ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Determinism check result for MCP.
+/// </summary>
+public sealed record DeterminismResult
+{
+    /// <summary>
+    /// Gets whether the replay is deterministic.
+    /// </summary>
+    public required bool IsDeterministic { get; init; }
+
+    /// <summary>
+    /// Gets the total frames checked.
+    /// </summary>
+    public required int TotalFramesChecked { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames with checksums.
+    /// </summary>
+    public required int FramesWithChecksums { get; init; }
+
+    /// <summary>
+    /// Gets the first frame where desync was detected.
+    /// </summary>
+    public int? FirstDesyncFrame { get; init; }
+
+    /// <summary>
+    /// Gets desync details, if any.
+    /// </summary>
+    public string? DesyncDetails { get; init; }
+
+    /// <summary>
+    /// Creates from a DeterminismResultSnapshot.
+    /// </summary>
+    public static DeterminismResult FromSnapshot(DeterminismResultSnapshot snapshot)
+    {
+        return new DeterminismResult
+        {
+            IsDeterministic = snapshot.IsDeterministic,
+            TotalFramesChecked = snapshot.TotalFramesChecked,
+            FramesWithChecksums = snapshot.FramesWithChecksums,
+            FirstDesyncFrame = snapshot.FirstDesyncFrame,
+            DesyncDetails = snapshot.DesyncDetails
+        };
+    }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/UITools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/UITools.cs
@@ -1,0 +1,777 @@
+using System.ComponentModel;
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.TestBridge.UI;
+using ModelContextProtocol.Server;
+
+namespace KeenEyes.Mcp.TestBridge.Tools;
+
+/// <summary>
+/// MCP tools for UI debugging: element inspection, focus management, hit testing, and interaction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tools expose the UIPlugin debugging infrastructure via MCP, allowing inspection
+/// and manipulation of UI elements in running games.
+/// </para>
+/// <para>
+/// Note: These tools require the UIPlugin to be installed in the target world.
+/// Entities must have UIElement component for the operations to work.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class UITools(BridgeConnectionManager connection)
+{
+    #region Statistics
+
+    [McpServerTool(Name = "ui_get_statistics")]
+    [Description("Get overall UI statistics including counts of total elements, visible elements, and interactable elements.")]
+    public async Task<UIStatisticsResult> GetStatistics()
+    {
+        var bridge = connection.GetBridge();
+        var stats = await bridge.UI.GetStatisticsAsync();
+        return UIStatisticsResult.FromSnapshot(stats);
+    }
+
+    #endregion
+
+    #region Focus Management
+
+    [McpServerTool(Name = "ui_get_focused")]
+    [Description("Get the currently focused UI element.")]
+    public async Task<FocusedElementResult> GetFocusedElement()
+    {
+        var bridge = connection.GetBridge();
+        var focusedId = await bridge.UI.GetFocusedElementAsync();
+
+        if (focusedId == null)
+        {
+            return new FocusedElementResult
+            {
+                Success = true,
+                EntityId = null
+            };
+        }
+
+        return new FocusedElementResult
+        {
+            Success = true,
+            EntityId = focusedId
+        };
+    }
+
+    [McpServerTool(Name = "ui_set_focus")]
+    [Description("Set keyboard focus to a specific UI element.")]
+    public async Task<OperationResult> SetFocus(
+        [Description("The entity ID to focus")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.UI.SetFocusAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to set focus on entity {entityId}. Entity may not exist or may not be focusable."
+        };
+    }
+
+    [McpServerTool(Name = "ui_clear_focus")]
+    [Description("Clear focus from the currently focused UI element.")]
+    public async Task<OperationResult> ClearFocus()
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.UI.ClearFocusAsync();
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : "No element is currently focused."
+        };
+    }
+
+    #endregion
+
+    #region Element Inspection
+
+    [McpServerTool(Name = "ui_get_element")]
+    [Description("Get detailed information about a specific UI element.")]
+    public async Task<UIElementResult> GetElement(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var element = await bridge.UI.GetElementAsync(entityId);
+
+        if (element == null)
+        {
+            return new UIElementResult
+            {
+                Success = false,
+                Error = $"No UI element found on entity {entityId}"
+            };
+        }
+
+        return UIElementResult.FromSnapshot(element);
+    }
+
+    [McpServerTool(Name = "ui_get_element_tree")]
+    [Description("Get the UI element hierarchy starting from a root (or all roots if not specified).")]
+    public async Task<UIElementTreeResult> GetElementTree(
+        [Description("The root entity ID, or null for all roots")]
+        int? rootEntityId = null)
+    {
+        var bridge = connection.GetBridge();
+        var elements = await bridge.UI.GetElementTreeAsync(rootEntityId);
+        return new UIElementTreeResult
+        {
+            Success = true,
+            Elements = elements,
+            Count = elements.Count
+        };
+    }
+
+    [McpServerTool(Name = "ui_get_roots")]
+    [Description("Get all root UI elements (canvases).")]
+    public async Task<EntityListResult> GetRootElements()
+    {
+        var bridge = connection.GetBridge();
+        var roots = await bridge.UI.GetRootElementsAsync();
+        return new EntityListResult
+        {
+            Success = true,
+            EntityIds = roots,
+            Count = roots.Count
+        };
+    }
+
+    [McpServerTool(Name = "ui_get_bounds")]
+    [Description("Get the screen-space bounds of a UI element.")]
+    public async Task<UIBoundsResult> GetElementBounds(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var bounds = await bridge.UI.GetElementBoundsAsync(entityId);
+
+        if (bounds == null)
+        {
+            return new UIBoundsResult
+            {
+                Success = false,
+                Error = $"No UIRect component found on entity {entityId}"
+            };
+        }
+
+        return UIBoundsResult.FromSnapshot(bounds);
+    }
+
+    [McpServerTool(Name = "ui_get_style")]
+    [Description("Get the visual style of a UI element (colors, borders, padding).")]
+    public async Task<UIStyleResult> GetElementStyle(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var style = await bridge.UI.GetElementStyleAsync(entityId);
+
+        if (style == null)
+        {
+            return new UIStyleResult
+            {
+                Success = false,
+                Error = $"No UIStyle component found on entity {entityId}"
+            };
+        }
+
+        return UIStyleResult.FromSnapshot(style);
+    }
+
+    [McpServerTool(Name = "ui_get_interaction")]
+    [Description("Get the interaction state of a UI element (hover, pressed, focused, dragging).")]
+    public async Task<UIInteractionResult> GetInteractionState(
+        [Description("The entity ID to query")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var interaction = await bridge.UI.GetInteractionStateAsync(entityId);
+
+        if (interaction == null)
+        {
+            return new UIInteractionResult
+            {
+                Success = false,
+                Error = $"No UIInteractable component found on entity {entityId}"
+            };
+        }
+
+        return UIInteractionResult.FromSnapshot(interaction);
+    }
+
+    #endregion
+
+    #region Hit Testing
+
+    [McpServerTool(Name = "ui_hit_test")]
+    [Description("Find the topmost UI element at a screen position.")]
+    public async Task<HitTestResult> HitTest(
+        [Description("The X screen coordinate")]
+        float x,
+        [Description("The Y screen coordinate")]
+        float y)
+    {
+        var bridge = connection.GetBridge();
+        var entityId = await bridge.UI.HitTestAsync(x, y);
+
+        return new HitTestResult
+        {
+            Success = true,
+            X = x,
+            Y = y,
+            EntityId = entityId
+        };
+    }
+
+    [McpServerTool(Name = "ui_hit_test_all")]
+    [Description("Find all UI elements at a screen position, sorted topmost first.")]
+    public async Task<HitTestAllResult> HitTestAll(
+        [Description("The X screen coordinate")]
+        float x,
+        [Description("The Y screen coordinate")]
+        float y)
+    {
+        var bridge = connection.GetBridge();
+        var entityIds = await bridge.UI.HitTestAllAsync(x, y);
+
+        return new HitTestAllResult
+        {
+            Success = true,
+            X = x,
+            Y = y,
+            EntityIds = entityIds,
+            Count = entityIds.Count
+        };
+    }
+
+    #endregion
+
+    #region Element Search
+
+    [McpServerTool(Name = "ui_find_by_name")]
+    [Description("Find a UI element by its name.")]
+    public async Task<FindElementResult> FindElementByName(
+        [Description("The element name to search for")]
+        string name)
+    {
+        var bridge = connection.GetBridge();
+        var entityId = await bridge.UI.FindElementByNameAsync(name);
+
+        if (entityId == null)
+        {
+            return new FindElementResult
+            {
+                Success = false,
+                Error = $"No UI element found with name '{name}'"
+            };
+        }
+
+        return new FindElementResult
+        {
+            Success = true,
+            Name = name,
+            EntityId = entityId.Value
+        };
+    }
+
+    #endregion
+
+    #region Interaction Simulation
+
+    [McpServerTool(Name = "ui_simulate_click")]
+    [Description("Simulate a click on a UI element.")]
+    public async Task<OperationResult> SimulateClick(
+        [Description("The entity ID to click")]
+        int entityId)
+    {
+        var bridge = connection.GetBridge();
+        var success = await bridge.UI.SimulateClickAsync(entityId);
+        return new OperationResult
+        {
+            Success = success,
+            Error = success ? null : $"Failed to simulate click on entity {entityId}. Entity may not exist or may not be clickable."
+        };
+    }
+
+    #endregion
+}
+
+#region Result Types
+
+/// <summary>
+/// Result for UI statistics.
+/// </summary>
+public sealed record UIStatisticsResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; } = true;
+
+    /// <summary>
+    /// Gets the total number of UI elements.
+    /// </summary>
+    public int TotalElementCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of visible UI elements.
+    /// </summary>
+    public int VisibleElementCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of interactable UI elements.
+    /// </summary>
+    public int InteractableCount { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID of the currently focused element, or null if none.
+    /// </summary>
+    public int? FocusedElementId { get; init; }
+
+    internal static UIStatisticsResult FromSnapshot(UIStatisticsSnapshot snapshot)
+    {
+        return new UIStatisticsResult
+        {
+            TotalElementCount = snapshot.TotalElementCount,
+            VisibleElementCount = snapshot.VisibleElementCount,
+            InteractableCount = snapshot.InteractableCount,
+            FocusedElementId = snapshot.FocusedElementId
+        };
+    }
+}
+
+/// <summary>
+/// Result for focused element query.
+/// </summary>
+public sealed record FocusedElementResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID of the focused element, or null if none.
+    /// </summary>
+    public int? EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for UI element query.
+/// </summary>
+public sealed record UIElementResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the element name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is visible.
+    /// </summary>
+    public bool IsVisible { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can receive pointer events.
+    /// </summary>
+    public bool IsRaycastTarget { get; init; }
+
+    /// <summary>
+    /// Gets the parent entity ID, or null if root.
+    /// </summary>
+    public int? ParentId { get; init; }
+
+    /// <summary>
+    /// Gets the child entity IDs.
+    /// </summary>
+    public IReadOnlyList<int>? ChildIds { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIInteractable component.
+    /// </summary>
+    public bool HasInteractable { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIText component.
+    /// </summary>
+    public bool HasText { get; init; }
+
+    /// <summary>
+    /// Gets whether the element has a UIStyle component.
+    /// </summary>
+    public bool HasStyle { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static UIElementResult FromSnapshot(UIElementSnapshot snapshot)
+    {
+        return new UIElementResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            Name = snapshot.Name,
+            IsVisible = snapshot.IsVisible,
+            IsRaycastTarget = snapshot.IsRaycastTarget,
+            ParentId = snapshot.ParentId,
+            ChildIds = snapshot.ChildIds,
+            HasInteractable = snapshot.HasInteractable,
+            HasText = snapshot.HasText,
+            HasStyle = snapshot.HasStyle
+        };
+    }
+}
+
+/// <summary>
+/// Result for UI element tree query.
+/// </summary>
+public sealed record UIElementTreeResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the UI elements in hierarchical order.
+    /// </summary>
+    public IReadOnlyList<UIElementSnapshot>? Elements { get; init; }
+
+    /// <summary>
+    /// Gets the count of elements.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for UI bounds query.
+/// </summary>
+public sealed record UIBoundsResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the X position in screen coordinates.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y position in screen coordinates.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the width in pixels.
+    /// </summary>
+    public float Width { get; init; }
+
+    /// <summary>
+    /// Gets the height in pixels.
+    /// </summary>
+    public float Height { get; init; }
+
+    /// <summary>
+    /// Gets the local Z-index for render ordering.
+    /// </summary>
+    public short LocalZIndex { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static UIBoundsResult FromSnapshot(UIBoundsSnapshot snapshot)
+    {
+        return new UIBoundsResult
+        {
+            Success = true,
+            X = snapshot.X,
+            Y = snapshot.Y,
+            Width = snapshot.Width,
+            Height = snapshot.Height,
+            LocalZIndex = snapshot.LocalZIndex
+        };
+    }
+}
+
+/// <summary>
+/// Result for UI style query.
+/// </summary>
+public sealed record UIStyleResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the background color red component (0-1).
+    /// </summary>
+    public float BackgroundColorR { get; init; }
+
+    /// <summary>
+    /// Gets the background color green component (0-1).
+    /// </summary>
+    public float BackgroundColorG { get; init; }
+
+    /// <summary>
+    /// Gets the background color blue component (0-1).
+    /// </summary>
+    public float BackgroundColorB { get; init; }
+
+    /// <summary>
+    /// Gets the background color alpha component (0-1).
+    /// </summary>
+    public float BackgroundColorA { get; init; }
+
+    /// <summary>
+    /// Gets the border width in pixels.
+    /// </summary>
+    public float BorderWidth { get; init; }
+
+    /// <summary>
+    /// Gets the corner radius for rounded rectangles.
+    /// </summary>
+    public float CornerRadius { get; init; }
+
+    /// <summary>
+    /// Gets the left padding in pixels.
+    /// </summary>
+    public float PaddingLeft { get; init; }
+
+    /// <summary>
+    /// Gets the right padding in pixels.
+    /// </summary>
+    public float PaddingRight { get; init; }
+
+    /// <summary>
+    /// Gets the top padding in pixels.
+    /// </summary>
+    public float PaddingTop { get; init; }
+
+    /// <summary>
+    /// Gets the bottom padding in pixels.
+    /// </summary>
+    public float PaddingBottom { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static UIStyleResult FromSnapshot(UIStyleSnapshot snapshot)
+    {
+        return new UIStyleResult
+        {
+            Success = true,
+            BackgroundColorR = snapshot.BackgroundColorR,
+            BackgroundColorG = snapshot.BackgroundColorG,
+            BackgroundColorB = snapshot.BackgroundColorB,
+            BackgroundColorA = snapshot.BackgroundColorA,
+            BorderWidth = snapshot.BorderWidth,
+            CornerRadius = snapshot.CornerRadius,
+            PaddingLeft = snapshot.PaddingLeft,
+            PaddingRight = snapshot.PaddingRight,
+            PaddingTop = snapshot.PaddingTop,
+            PaddingBottom = snapshot.PaddingBottom
+        };
+    }
+}
+
+/// <summary>
+/// Result for UI interaction state query.
+/// </summary>
+public sealed record UIInteractionResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can receive keyboard focus.
+    /// </summary>
+    public bool CanFocus { get; init; }
+
+    /// <summary>
+    /// Gets whether the element responds to click/tap events.
+    /// </summary>
+    public bool CanClick { get; init; }
+
+    /// <summary>
+    /// Gets whether the element can be dragged.
+    /// </summary>
+    public bool CanDrag { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is currently hovered.
+    /// </summary>
+    public bool IsHovered { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is currently pressed.
+    /// </summary>
+    public bool IsPressed { get; init; }
+
+    /// <summary>
+    /// Gets whether the element currently has focus.
+    /// </summary>
+    public bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Gets whether the element is being dragged.
+    /// </summary>
+    public bool IsDragging { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+
+    internal static UIInteractionResult FromSnapshot(UIInteractionSnapshot snapshot)
+    {
+        return new UIInteractionResult
+        {
+            Success = true,
+            EntityId = snapshot.EntityId,
+            CanFocus = snapshot.CanFocus,
+            CanClick = snapshot.CanClick,
+            CanDrag = snapshot.CanDrag,
+            IsHovered = snapshot.IsHovered,
+            IsPressed = snapshot.IsPressed,
+            IsFocused = snapshot.IsFocused,
+            IsDragging = snapshot.IsDragging
+        };
+    }
+}
+
+/// <summary>
+/// Result for hit test query.
+/// </summary>
+public sealed record HitTestResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the X screen coordinate tested.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y screen coordinate tested.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID at the position, or null if none.
+    /// </summary>
+    public int? EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for hit test all query.
+/// </summary>
+public sealed record HitTestAllResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the X screen coordinate tested.
+    /// </summary>
+    public float X { get; init; }
+
+    /// <summary>
+    /// Gets the Y screen coordinate tested.
+    /// </summary>
+    public float Y { get; init; }
+
+    /// <summary>
+    /// Gets the entity IDs at the position, sorted topmost first.
+    /// </summary>
+    public IReadOnlyList<int>? EntityIds { get; init; }
+
+    /// <summary>
+    /// Gets the count of entities found.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Result for element search by name.
+/// </summary>
+public sealed record FindElementResult
+{
+    /// <summary>
+    /// Gets whether the operation succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the name that was searched for.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the entity ID of the found element.
+    /// </summary>
+    public int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the error message if the operation failed.
+    /// </summary>
+    public string? Error { get; init; }
+}
+
+#endregion

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -277,6 +277,11 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.10",
+        "contentHash": "u7gAG7JgxF8VSJUGPSudAcPxOt+ymJKQCSxNRxiuKV+klCQbHljQR75SilpedCTfhPWDhtUwIJpnDVtspr9nMg=="
+      },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -320,6 +325,47 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[1.16.0, )",
+          "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -353,10 +399,41 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[7.1.3, )"
+        }
+      },
       "keeneyes.logging": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )"
         }
       },
       "keeneyes.network.abstractions": {
@@ -372,6 +449,14 @@
           "KeenEyes.Core": "[1.0.0, )"
         }
       },
+      "keeneyes.physics": {
+        "type": "Project",
+        "dependencies": {
+          "BepuPhysics": "[2.4.0, )",
+          "BepuUtilities": "[2.4.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
       "keeneyes.replay": {
         "type": "Project",
         "dependencies": {
@@ -382,13 +467,19 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Network": "[1.0.0, )",
+          "KeenEyes.Physics": "[1.0.0, )",
           "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
+          "KeenEyes.UI": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"
         }
       },
@@ -427,6 +518,86 @@
           "KeenEyes.Persistence": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "BepuPhysics": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "Ck/BJgSQrBqYrj0T9jGljDdHNILBP5kTPTylc7N/hCzR1XJJc7p6ORzwtjTfjgoYkkdajvLHxEQv6BRC8kaysQ==",
+        "dependencies": {
+          "BepuUtilities": "2.4.0"
+        }
+      },
+      "BepuUtilities": {
+        "type": "CentralTransitive",
+        "requested": "[2.4.0, )",
+        "resolved": "2.4.0",
+        "contentHash": "KNMxkzKLHAvV7jRtErxs3rPv71fHToqo/WN96HlT6iomWuwL97tohEbt0B1WA8A6sO5t6PP+qF08d4T9A8k2uA=="
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "go1/KHij1AB5K3nKiKKzSuSVIAKivgAnC3P6FAOOhB/WMg7y6lw9n95LCyABVuoewk4CNI8S0RZVvC6gkeTp7g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
       },
       "StbImageWriteSharp": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary
- Implements remaining Phase 6 subsystem-specific MCP debugging tools (#949, #950, #951, #953, #954)
- Adds complete 5-layer architecture for Physics, Navigation, Network, Animation, and UI debugging
- Enables Claude Code to inspect and debug game subsystem state during development

## Phase 6 Subsystems Implemented

### Physics Debugging (#950)
- Statistics (body count, static count, interpolation alpha)
- Raycast and overlap queries
- Body state inspection and velocity control
- Force/impulse application, gravity control

### Navigation Debugging (#951)
- Navigation system statistics
- Agent state inspection and path visualization
- Destination control, stop/resume/warp commands
- Path finding and navigability queries

### Network Debugging (#949)
- Network statistics (connection, tick, latency)
- Server/client state inspection
- Connected clients listing, replication state

### Animation Debugging (#953)
- Animation statistics (clips, controllers, sprite sheets)
- Animation player control (play/pause, time, speed)
- Animator state inspection and triggering

### UI Debugging (#954)
- UI statistics (element counts, focus state)
- Focus management, element tree inspection
- Bounds, style, interaction state queries
- Hit testing, click simulation

## Test plan
- [x] All 80 MCP TestBridge tests pass
- [x] All 247 TestBridge tests pass
- [x] Build succeeds with zero warnings
- [x] Code formatted per project standards

## Related Issues
Closes #949, closes #950, closes #951, closes #953, closes #954
Contributes to #948 (Phase 6 tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)