### PR TITLE
docs: per-tier XML-doc policy, stale-content fixes, csproj descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,12 +383,32 @@ public static class WorldPluginExtensions
 
 ```bash
 dotnet restore
-dotnet build
-dotnet test --max-parallel-test-modules 1
-dotnet format --verify-no-changes  # Check formatting
+dotnet build                                  # Zero warnings (TreatWarningsAsErrors)
+dotnet test --max-parallel-test-modules 1     # Full suite
+dotnet format --verify-no-changes             # Check formatting (auto-fix: dotnet format)
 ```
 
+The solution file is `KeenEyes.slnx` (not `.sln`). `dotnet build`/`test` with no argument operate on it.
+
 **Important:** Always use `--max-parallel-test-modules 1` when running tests. This prevents test assemblies from running in parallel, which causes ThreadPool contention and intermittent hangs in the Parallelism, Network, and Debugging test suites.
+
+### Running a Single Test or Project
+
+Tests use **xUnit.net v3 on Microsoft Testing Platform** (MTP), not VSTest — configured via `global.json` (`"runner": "Microsoft.Testing.Platform"`). MTP filter options are passed **after `--`**, not via VSTest's `--filter`:
+
+```bash
+# Run one test project (fastest inner loop)
+dotnet test tests/KeenEyes.Core.Tests --max-parallel-test-modules 1
+
+# Run a single test method (glob patterns supported)
+dotnet test tests/KeenEyes.Core.Tests -- --filter-method "*Spawn_CreatesEntity*"
+
+# Run all tests in a class / namespace
+dotnet test tests/KeenEyes.Core.Tests -- --filter-class "*WorldTests"
+dotnet test tests/KeenEyes.Core.Tests -- --filter-namespace "KeenEyes.Core.Tests.Queries"
+```
+
+`--filter-not-method`, `--filter-not-class`, etc. negate. Each test project lives in `tests/KeenEyes.<Area>.Tests` mirroring `src/`.
 
 ## Key Design Decisions
 
@@ -615,17 +635,19 @@ public ref T Get<T>(Entity entity) where T : struct, IComponent
 - Self-evident properties (e.g., `public int Count => items.Count;`)
 - Generated code (source generators handle this)
 
-### Validation
+### Enforcement (per tier)
 
-The build enforces documentation:
-```xml
-<PropertyGroup>
-  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Remove this to enforce -->
-</PropertyGroup>
-```
+XML documentation is enforced differently depending on where a project lives. `GenerateDocumentationFile` and `TreatWarningsAsErrors` are `true` repo-wide (root `Directory.Build.props`); the difference is whether `CS1591` ("missing XML comment for publicly visible type or member") is suppressed.
 
-Future goal: Enable CS1591 warning to require docs on all public members.
+| Tier | Location | CS1591 | Meaning |
+|------|----------|--------|---------|
+| **Runtime libraries** | `src/**` | **Enforced** (not suppressed) | A missing summary on any public/protected member is a build error. A green build proves the public API is documented. |
+| **Editor & build tooling** | `editor/**` | **Exempt** | `editor/Directory.Build.props` sets `GenerateDocumentationFile=false` and adds `CS1591` to `NoWarn`. App/prototype code — docs encouraged but not gated. |
+| **Standalone tools** | `tools/**` | **Enforced** | Same as `src/`. (Historically these suppressed CS1591 per-csproj; that was removed — do **not** re-add `CS1591` to `NoWarn` in a tool `.csproj`.) |
+
+Practical consequence: **"green CI" only proves documentation coverage for `src/` and `tools/`.** When adding a public member to a `src/` or `tools/` project, it must carry at least a `<summary>` or the build fails. `editor/` relies on convention, not the compiler.
+
+Note: CS1591 only fires on a *missing* comment. A member with a `<summary>` but no `<param>`/`<returns>`/`<typeparam>` still builds clean — tag completeness is a code-review concern (see the Style Guide above), not a build gate.
 
 ## Code Quality Requirements
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ keen-eye/
 ├── docs/                   # Documentation
 ├── Directory.Build.props   # Shared MSBuild properties
 ├── Directory.Packages.props # Centralized NuGet package versions
-└── KeenEyes.sln            # Solution file
+└── KeenEyes.slnx           # Solution file
 ```
 
 ## Getting Started

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -112,10 +112,15 @@ Disable automatic package references:
   <!-- Don't include KeenEyes.Generators -->
   <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
 
+  <!-- Don't include the KESL shader generator -->
+  <IncludeKeenEyesShaders>false</IncludeKeenEyesShaders>
+
   <!-- Plugin SDK only: Include KeenEyes.Common -->
   <IncludeKeenEyesCommon>true</IncludeKeenEyesCommon>
 </PropertyGroup>
 ```
+
+The Game SDK includes `KeenEyes.Core`, `KeenEyes.Generators`, and `KeenEyes.Shaders.Generator` by default.
 
 ### Adding Feature Packages
 
@@ -172,6 +177,41 @@ World files define initial world setup:
 <ItemGroup>
   <KeenEyesWorld Include="Worlds/**/*.keworld" />
 </ItemGroup>
+```
+
+### Shaders
+
+Shader files written in KESL (KeenEyes Shader Language) are compiled at build time:
+
+```xml
+<ItemGroup>
+  <KeenEyesShader Include="Shaders/**/*.kesl" />
+</ItemGroup>
+```
+
+## Shader Compilation (KESL)
+
+When `IncludeKeenEyesShaders` is `true` (the default for the Game SDK), the SDK references `KeenEyes.Shaders.Generator` as an analyzer and auto-detects every `**/*.kesl` file in the project, registering it as both an `AdditionalFiles` entry and a `<KeenEyesShader>` item. The source generator compiles each shader to GLSL plus strongly-typed C# bindings during the build — no manual wiring or runtime shader parsing required. Set `IncludeKeenEyesShaders=false` to opt out (see [Opting Out](#opting-out)).
+
+## Asset Constants Generation
+
+The SDK can generate type-safe, compile-time-validated constants for your asset paths so a typo in a texture or audio path becomes a build error rather than a runtime failure. It is **off by default**; enable it with `GenerateAssetConstants`:
+
+```xml
+<PropertyGroup>
+  <GenerateAssetConstants>true</GenerateAssetConstants>
+  <!-- Optional overrides (defaults shown) -->
+  <AssetConstantsNamespace>$(RootNamespace)</AssetConstantsNamespace>
+  <AssetConstantsClassName>Assets</AssetConstantsClassName>
+  <AssetConstantsRootPath>$(MSBuildProjectDirectory)/Assets</AssetConstantsRootPath>
+</PropertyGroup>
+```
+
+When enabled, asset files under `AssetConstantsRootPath` (images, audio, fonts, `.json`, `.atlas`, `.keanim`, `.glb`/`.gltf`, and more) are passed to the generator, which emits a static class (default name `Assets`) of path constants:
+
+```csharp
+// Generated — usage
+var texture = assetManager.Load<Texture>(Assets.Sprites.Player);
 ```
 
 ## Version Information

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,7 +24,6 @@ With `KeenEyes.Testing`, you can test in isolation:
 
 ```csharp
 // With KeenEyes.Testing - focused, fast tests
-var mockWorld = new MockWorld();
 var mockContext = new MockPluginContext("Test");
 
 var plugin = new MyPlugin();
@@ -275,23 +274,24 @@ public void MovementSystem_UpdatesPositions()
 }
 ```
 
-### Unit Test with MockWorld
+### Unit Test with TestWorld
+
+Build an isolated world with `TestWorldBuilder`, opting into only the mocks the test needs. `TestWorld.Step()` advances the manual clock and runs one update; the mock renderer records every draw call it received:
 
 ```csharp
 [Fact]
-public void RenderSystem_SkipsInvisibleEntities()
+public void RenderSystem_RecordsDrawCommands()
 {
-    var mockWorld = new MockWorld();
-    var renderer = new MockRenderer();
+    using var test = new TestWorldBuilder()
+        .WithManualTime()
+        .WithMock2DRenderer()
+        .Build();
 
-    // Set up test entity as invisible
-    mockWorld.SetupEntity(entity, visible: false);
+    // Arrange entities in test.World and register your render system here...
 
-    var system = new RenderSystem(renderer);
-    system.Initialize(mockWorld);
-    system.Update(0.016f);
+    test.Step(); // advance one frame at the manual clock's fps
 
-    Assert.Empty(renderer.RenderedEntities);
+    Assert.NotEmpty(test.Mock2DRenderer!.Commands);
 }
 ```
 

--- a/editor/KeenEyes.Cli/KeenEyes.Cli.csproj
+++ b/editor/KeenEyes.Cli/KeenEyes.Cli.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>KeenEyes.Cli</RootNamespace>
     <AssemblyName>keeneyes</AssemblyName>
+    <Description>Command-line interface for the KeenEyes ECS framework — project migrations, plugin management, and package source configuration.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/editor/KeenEyes.Editor/KeenEyes.Editor.csproj
+++ b/editor/KeenEyes.Editor/KeenEyes.Editor.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>KeenEyes.Editor</RootNamespace>
     <AssemblyName>KeenEyes.Editor</AssemblyName>
+    <Description>Visual editor application for the KeenEyes ECS framework — scene editing, entity inspectors, play mode, and a NuGet-based plugin marketplace.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/editor/KeenEyes.Sdk/README.md
+++ b/editor/KeenEyes.Sdk/README.md
@@ -34,6 +34,8 @@ That's it! The SDK automatically:
 | AOT Compatible | `true` | Set `<IsAotCompatible>` |
 | KeenEyes.Core | Included | Set `<IncludeKeenEyesCore>false</IncludeKeenEyesCore>` |
 | KeenEyes.Generators | Included | Set `<IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>` |
+| KeenEyes.Shaders.Generator (KESL) | Included | Set `<IncludeKeenEyesShaders>false</IncludeKeenEyesShaders>` |
+| Asset path constants | Off | Set `<GenerateAssetConstants>true</GenerateAssetConstants>` |
 
 ## Custom Item Types
 
@@ -72,6 +74,24 @@ Assets are automatically copied to the output directory.
   <KeenEyesWorld Include="Worlds\**\*.keworld" />
 </ItemGroup>
 ```
+
+### Shaders (`.kesl`)
+
+```xml
+<ItemGroup>
+  <KeenEyesShader Include="Shaders\**\*.kesl" />
+</ItemGroup>
+```
+
+`.kesl` files are auto-detected and compiled to GLSL + C# bindings by `KeenEyes.Shaders.Generator` during build (unless `IncludeKeenEyesShaders` is `false`).
+
+## Shader Compilation (KESL)
+
+The Game SDK references the KESL source generator and passes every `**/*.kesl` file to it automatically, producing GLSL and strongly-typed C# shader bindings at build time. Opt out with `<IncludeKeenEyesShaders>false</IncludeKeenEyesShaders>`.
+
+## Asset Constants Generation
+
+Enable `<GenerateAssetConstants>true</GenerateAssetConstants>` to generate a type-safe `Assets` class of compile-time-validated asset paths from the files under `AssetConstantsRootPath` (default: `Assets/`). Override `AssetConstantsNamespace`, `AssetConstantsClassName`, and `AssetConstantsRootPath` as needed.
 
 ## Version Properties
 

--- a/src/KeenEyes.AI/FSM/State.cs
+++ b/src/KeenEyes.AI/FSM/State.cs
@@ -19,14 +19,13 @@ namespace KeenEyes.AI.FSM;
 /// var patrolState = new State
 /// {
 ///     Name = "Patrol",
-///     OnUpdateActions = [new PatrolAction { WaypointTag = "PatrolPoint" }]
+///     OnUpdateActions = [new PatrolAction { Waypoints = waypoints, Loop = true }]
 /// };
 ///
 /// var chaseState = new State
 /// {
 ///     Name = "Chase",
-///     OnEnterActions = [new PlaySoundAction { Sound = "alert" }],
-///     OnUpdateActions = [new ChaseAction { Speed = 5f }]
+///     OnUpdateActions = [new ChaseAction { Target = player, CatchDistance = 1.5f }]
 /// };
 /// </code>
 /// </example>

--- a/src/KeenEyes.Testing/Network/INetworkContext.cs
+++ b/src/KeenEyes.Testing/Network/INetworkContext.cs
@@ -30,21 +30,20 @@ public readonly record struct NetworkConnectionEventArgs(string Endpoint, string
 /// <item>Event-driven data reception</item>
 /// </list>
 /// <para>
-/// This is an interface-only design. A mock implementation (MockNetworkContext) will be
-/// provided in a future update for testing networked game code without actual network connections.
+/// <see cref="MockNetworkContext"/> is the in-memory implementation used to test networked
+/// game code without real network connections.
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
-/// // Future usage with MockNetworkContext
 /// var network = new MockNetworkContext();
-/// network.SetLatency(50); // Simulate 50ms latency
-/// network.SetPacketLoss(0.01f); // Simulate 1% packet loss
+/// network.SimulateLatency(50);      // Simulate 50ms latency
+/// network.SimulatePacketLoss(0.01f); // Simulate 1% packet loss
 ///
 /// network.Connect("localhost:7777");
 /// network.Send(new PlayerMoveMessage { X = 10, Y = 20 });
 ///
-/// while (network.TryReceive(out var message))
+/// while (network.TryReceive&lt;PlayerMoveMessage&gt;(out var message))
 /// {
 ///     ProcessMessage(message);
 /// }


### PR DESCRIPTION
## Summary
- Replace CLAUDE.md's outdated "CS1591 future goal" note with the **real per-tier enforcement policy** (`src/` + `tools/` enforced, `editor/` exempt).
- Fix stale / non-compiling XML-doc + guide content: the `KeenEyes.AI` FSM `<example>` (removed nonexistent `PatrolAction.WaypointTag`/`ChaseAction.Speed`/`PlaySoundAction`), the `KeenEyes.Testing` `INetworkContext` example + stale remark, `docs/testing.md`'s nonexistent `MockWorld` (→ `TestWorld`/`TestWorldBuilder`), and `docs/sdk.md` + the SDK README (added the shipped KESL pipeline & Asset Constants Generator).
- Add missing `<Description>` to `KeenEyes.Cli` and `KeenEyes.Editor`; plus the `/init` single-test docs and `KeenEyes.slnx` filename fix.

## Test plan
- [x] Changes are docs/comments/metadata only — no compilation impact
- [x] `dotnet format` clean
- [ ] CI green

Part of the repo-wide documentation audit (2026-07-20). Sibling PRs cover tools enforcement, the src tag sweep, Graph.Kesl, and the conceptual pages.