### PR TITLE
docs: enforce XML docs on tools/ and document the public surface

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -222,6 +222,122 @@ Tools for screenshots and frame recording.
 
 Image formats: `png` (default), `jpeg`, `bmp`
 
+### Mutation Tools
+
+Tools for creating, modifying, and destroying entities at runtime.
+
+| Tool | Description |
+|------|-------------|
+| `mutation_spawn` | Spawn a new empty entity |
+| `mutation_spawn_with_components` | Spawn an entity with components |
+| `mutation_despawn` | Destroy an entity |
+| `mutation_clone` | Clone an existing entity |
+| `mutation_set_name` / `mutation_clear_name` | Set or clear an entity's name |
+| `mutation_set_parent` | Re-parent an entity |
+| `mutation_get_root_entities` | List entities with no parent |
+| `mutation_add_component` / `mutation_remove_component` / `mutation_set_component` | Add, remove, or replace a component |
+| `mutation_set_field` | Set a single field on a component |
+| `mutation_add_tag` / `mutation_remove_tag` / `mutation_get_all_tags` | Manage string tags |
+
+### System Tools
+
+Tools for inspecting and toggling registered systems.
+
+| Tool | Description |
+|------|-------------|
+| `system_list` / `system_get_count` / `system_get` | List systems, count them, or get one |
+| `system_enable` / `system_disable` / `system_toggle` | Change a system's enabled state |
+| `system_get_by_phase` | List systems in a given phase |
+| `system_get_enabled` / `system_get_disabled` | Filter systems by state |
+
+### Time Tools
+
+Tools for controlling simulation time.
+
+| Tool | Description |
+|------|-------------|
+| `time_get_state` | Get the current time/pause/scale state |
+| `time_pause` / `time_resume` / `time_toggle_pause` | Control pause state |
+| `time_set_scale` | Set the time scale (slow-mo / fast-forward) |
+| `time_step_frame` | Advance a single frame while paused |
+
+### Log Tools
+
+Tools for querying the in-game log ring buffer.
+
+| Tool | Description |
+|------|-------------|
+| `log_get_stats` / `log_get_count` | Aggregate log statistics and counts |
+| `log_get_recent` | Most recent entries |
+| `log_get_errors` | Error-level entries |
+| `log_get_by_level` / `log_get_by_category` | Filter by severity or category |
+| `log_search` / `log_query` | Text search and structured queries |
+| `log_clear` | Clear the buffer |
+
+### Window Tools
+
+Read-only tools for inspecting the game window.
+
+| Tool | Description |
+|------|-------------|
+| `window_is_available` | Check if a window is present |
+| `window_get_state` | Full window state |
+| `window_get_size` / `window_get_aspect_ratio` | Dimensions |
+| `window_get_title` | Window title |
+| `window_is_closing` / `window_is_focused` | Window lifecycle/focus flags |
+
+### AI Tools
+
+Tools for inspecting and steering `KeenEyes.AI` agents (behavior trees, state machines, utility AI, blackboards).
+
+| Tool | Description |
+|------|-------------|
+| `ai_get_statistics` | Aggregate AI agent statistics |
+| `ai_behavior_tree_list` / `ai_behavior_tree_get` / `ai_behavior_tree_reset` | Inspect and reset behavior trees |
+| `ai_state_machine_list` / `ai_state_machine_get` | Inspect FSM agents |
+| `ai_state_machine_force_state` / `ai_state_machine_force_state_by_name` | Force an FSM into a state |
+| `ai_utility_list` / `ai_utility_get` / `ai_utility_score_all` / `ai_utility_force_evaluation` | Inspect and drive utility AI scoring |
+| `ai_blackboard_get` / `ai_blackboard_get_value` / `ai_blackboard_set_value` / `ai_blackboard_remove_value` / `ai_blackboard_clear` | Read and mutate blackboard values |
+
+### Profiling & Memory Tools
+
+Tools for `KeenEyes.Debugging` profilers (system/query timing, GC, memory, timeline). Most require debug mode enabled.
+
+| Tool | Description |
+|------|-------------|
+| `profile_debug_mode_status` / `profile_debug_mode_enable` / `profile_debug_mode_disable` | Toggle debug/profiling mode |
+| `profile_system_*` | System timing: availability, get, list, slowest, reset |
+| `profile_query_*` | Query timing: get, list, slowest, cache stats, reset |
+| `profile_gc_*` | GC profiling: get, list, hotspots, reset |
+| `memory_available` / `memory_get_stats` / `memory_get_archetypes` | Memory and archetype statistics |
+| `timeline_*` | Frame timeline: start, stop, status, get frame/recent, per-system stats, reset |
+
+### Replay Tools
+
+Tools for `KeenEyes.Replay` recording, playback, and determinism validation.
+
+| Tool | Description |
+|------|-------------|
+| `replay_start_recording` / `replay_stop_recording` / `replay_cancel_recording` / `replay_is_recording` | Control recording |
+| `replay_force_snapshot` | Force a keyframe snapshot |
+| `replay_save` / `replay_load` / `replay_list` / `replay_delete` / `replay_get_metadata` | Manage saved replays |
+| `replay_play` / `replay_pause` / `replay_stop` / `replay_get_playback_state` / `replay_set_speed` | Control playback |
+| `replay_seek_frame` / `replay_seek_time` / `replay_step_forward` / `replay_step_backward` | Seek and step |
+| `replay_get_frame` / `replay_get_frame_range` / `replay_get_inputs` / `replay_get_events` / `replay_get_snapshots` | Inspect recorded data |
+| `replay_validate` / `replay_check_determinism` | Validate replays and check determinism |
+
+### Snapshot Tools
+
+Tools for saving, restoring, and diffing world snapshots (including quicksave/quickload).
+
+| Tool | Description |
+|------|-------------|
+| `snapshot_create` / `snapshot_restore` / `snapshot_delete` / `snapshot_list` / `snapshot_get_info` | Manage in-memory snapshots |
+| `snapshot_diff` / `snapshot_diff_current` | Diff two snapshots, or a snapshot against the live world |
+| `snapshot_save_file` / `snapshot_load_file` | Persist snapshots to disk |
+| `quicksave` / `quickload` | Convenience quicksave slot |
+| `snapshot_export_json` / `snapshot_import_json` | JSON import/export |
+
 ## Available Resources
 
 Resources provide read-only access to game state via URI templates.

--- a/tools/BenchmarkCompare/BenchmarkCompare.csproj
+++ b/tools/BenchmarkCompare/BenchmarkCompare.csproj
@@ -6,8 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Tool doesn't need XML docs -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Description>Command-line utility that compares KeenEyes benchmark result sets and reports performance regressions.</Description>
   </PropertyGroup>
 
 </Project>

--- a/tools/KeenEyes.Lsp.Kesl/KeenEyes.Lsp.Kesl.csproj
+++ b/tools/KeenEyes.Lsp.Kesl/KeenEyes.Lsp.Kesl.csproj
@@ -10,8 +10,8 @@
     <AssemblyName>KeenEyes.Lsp.Kesl</AssemblyName>
     <RootNamespace>KeenEyes.Lsp.Kesl</RootNamespace>
     <Description>Language Server Protocol implementation for KESL (KeenEyes Shader Language)</Description>
-    <!-- LSP protocol types don't need XML documentation -->
-    <NoWarn>$(NoWarn);CS1591;S2094</NoWarn>
+    <!-- S2094: empty marker/DTO classes are intentional in the LSP protocol layer -->
+    <NoWarn>$(NoWarn);S2094</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/KeenEyes.Lsp.Kesl/KeslLanguageServer.cs
+++ b/tools/KeenEyes.Lsp.Kesl/KeslLanguageServer.cs
@@ -20,6 +20,11 @@ public sealed class KeslLanguageServer
 
     private bool shutdown;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeslLanguageServer"/> class.
+    /// </summary>
+    /// <param name="input">The stream from which incoming LSP messages are read.</param>
+    /// <param name="output">The stream to which outgoing LSP messages are written.</param>
     public KeslLanguageServer(Stream input, Stream output)
     {
         framing = new MessageFraming(input, output);

--- a/tools/KeenEyes.Lsp.Kesl/Protocol/LspMessages.cs
+++ b/tools/KeenEyes.Lsp.Kesl/Protocol/LspMessages.cs
@@ -89,18 +89,29 @@ public sealed record LspError
 public static class LspErrorCodes
 {
     // JSON-RPC standard errors
+    /// <summary>The JSON sent to the server could not be parsed.</summary>
     public const int ParseError = -32700;
+    /// <summary>The JSON sent is not a valid request object.</summary>
     public const int InvalidRequest = -32600;
+    /// <summary>The requested method does not exist or is not available.</summary>
     public const int MethodNotFound = -32601;
+    /// <summary>One or more method parameters are invalid.</summary>
     public const int InvalidParams = -32602;
+    /// <summary>An internal JSON-RPC error occurred while processing the request.</summary>
     public const int InternalError = -32603;
 
     // LSP-specific errors
+    /// <summary>A request was received before the server has finished initializing.</summary>
     public const int ServerNotInitialized = -32002;
+    /// <summary>An unknown error occurred that does not map to a more specific code.</summary>
     public const int UnknownErrorCode = -32001;
+    /// <summary>The request failed but was otherwise properly formed and delivered.</summary>
     public const int RequestFailed = -32803;
+    /// <summary>The server cancelled the request; the client should resend it if appropriate.</summary>
     public const int ServerCancelled = -32802;
+    /// <summary>The result of the request is stale because its content was modified since the request started.</summary>
     public const int ContentModified = -32801;
+    /// <summary>The client cancelled the request and does not expect a response.</summary>
     public const int RequestCancelled = -32800;
 }
 

--- a/tools/KeenEyes.Lsp.Kesl/Protocol/LspTypes.cs
+++ b/tools/KeenEyes.Lsp.Kesl/Protocol/LspTypes.cs
@@ -7,8 +7,11 @@ namespace KeenEyes.Lsp.Kesl.Protocol;
 /// </summary>
 public static class LspHeaders
 {
+    /// <summary>The name of the header that specifies the length, in bytes, of the message content.</summary>
     public const string ContentLength = "Content-Length";
+    /// <summary>The name of the header that specifies the MIME type and encoding of the message content.</summary>
     public const string ContentType = "Content-Type";
+    /// <summary>The JSON-RPC protocol version used by LSP messages.</summary>
     public const string JsonRpc = "2.0";
 }
 
@@ -115,9 +118,13 @@ public record TextDocumentPositionParams
 /// </summary>
 public enum LspDiagnosticSeverity
 {
+    /// <summary>Reports an error.</summary>
     Error = 1,
+    /// <summary>Reports a warning.</summary>
     Warning = 2,
+    /// <summary>Reports an informational message.</summary>
     Information = 3,
+    /// <summary>Reports a hint.</summary>
     Hint = 4
 }
 
@@ -201,30 +208,55 @@ public enum TextDocumentSyncKind
 /// </summary>
 public enum CompletionItemKind
 {
+    /// <summary>A plain text completion item.</summary>
     Text = 1,
+    /// <summary>A method completion item.</summary>
     Method = 2,
+    /// <summary>A function completion item.</summary>
     Function = 3,
+    /// <summary>A constructor completion item.</summary>
     Constructor = 4,
+    /// <summary>A field completion item.</summary>
     Field = 5,
+    /// <summary>A variable completion item.</summary>
     Variable = 6,
+    /// <summary>A class completion item.</summary>
     Class = 7,
+    /// <summary>An interface completion item.</summary>
     Interface = 8,
+    /// <summary>A module completion item.</summary>
     Module = 9,
+    /// <summary>A property completion item.</summary>
     Property = 10,
+    /// <summary>A unit completion item.</summary>
     Unit = 11,
+    /// <summary>A value completion item.</summary>
     Value = 12,
+    /// <summary>An enum completion item.</summary>
     Enum = 13,
+    /// <summary>A keyword completion item.</summary>
     Keyword = 14,
+    /// <summary>A snippet completion item.</summary>
     Snippet = 15,
+    /// <summary>A color completion item.</summary>
     Color = 16,
+    /// <summary>A file completion item.</summary>
     File = 17,
+    /// <summary>A reference completion item.</summary>
     Reference = 18,
+    /// <summary>A folder completion item.</summary>
     Folder = 19,
+    /// <summary>An enum member completion item.</summary>
     EnumMember = 20,
+    /// <summary>A constant completion item.</summary>
     Constant = 21,
+    /// <summary>A struct completion item.</summary>
     Struct = 22,
+    /// <summary>An event completion item.</summary>
     Event = 23,
+    /// <summary>An operator completion item.</summary>
     Operator = 24,
+    /// <summary>A type parameter completion item.</summary>
     TypeParameter = 25
 }
 
@@ -295,6 +327,12 @@ public sealed record MarkupContent
     [JsonPropertyName("value")]
     public required string Value { get; init; }
 
+    /// <summary>Creates a <see cref="MarkupContent"/> whose value is interpreted as plain text.</summary>
+    /// <param name="text">The plain text content.</param>
+    /// <returns>A <see cref="MarkupContent"/> with kind set to "plaintext".</returns>
     public static MarkupContent PlainText(string text) => new() { Kind = "plaintext", Value = text };
+    /// <summary>Creates a <see cref="MarkupContent"/> whose value is interpreted as Markdown.</summary>
+    /// <param name="markdown">The Markdown content.</param>
+    /// <returns>A <see cref="MarkupContent"/> with kind set to "markdown".</returns>
     public static MarkupContent Markdown(string markdown) => new() { Kind = "markdown", Value = markdown };
 }

--- a/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
+++ b/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
@@ -6,8 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Tool doesn't need XML docs -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!-- MCP server name -->
     <AssemblyTitle>KeenEyes MCP TestBridge Server</AssemblyTitle>
     <Description>MCP server bridging LLM clients to KeenEyes games via TestBridge IPC</Description>

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/CaptureResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/CaptureResources.cs
@@ -8,6 +8,7 @@ namespace KeenEyes.Mcp.TestBridge.Resources;
 /// <summary>
 /// MCP resources for capture and screenshot access.
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerResourceType]
 public sealed class CaptureResources(BridgeConnectionManager connection)
 {
@@ -16,6 +17,11 @@ public sealed class CaptureResources(BridgeConnectionManager connection)
     private const string ScreenshotUri = "keeneyes://capture/screenshot";
 #pragma warning restore S1075
 
+    /// <summary>
+    /// Captures the current screenshot and returns it as a PNG blob resource.
+    /// </summary>
+    /// <returns>A <see cref="BlobResourceContents"/> containing the base64-encoded PNG screenshot data.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when screenshot capture is not available on the connected bridge.</exception>
     [McpServerResource(
         UriTemplate = ScreenshotUri,
         Name = "screenshot",

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/ConnectionResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/ConnectionResources.cs
@@ -8,6 +8,7 @@ namespace KeenEyes.Mcp.TestBridge.Resources;
 /// <summary>
 /// MCP resources for connection status information.
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerResourceType]
 public sealed class ConnectionResources(BridgeConnectionManager connection)
 {
@@ -16,6 +17,10 @@ public sealed class ConnectionResources(BridgeConnectionManager connection)
     private const string ConnectionStatusUri = "keeneyes://connection/status";
 #pragma warning restore S1075
 
+    /// <summary>
+    /// Gets the current connection status as a JSON text resource.
+    /// </summary>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized connection status.</returns>
     [McpServerResource(
         UriTemplate = ConnectionStatusUri,
         Name = "connection-status",

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/ExtensionResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/ExtensionResources.cs
@@ -9,6 +9,7 @@ namespace KeenEyes.Mcp.TestBridge.Resources;
 /// <summary>
 /// MCP resources for world extensions (singletons).
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerResourceType]
 public sealed class ExtensionResources(BridgeConnectionManager connection)
 {
@@ -17,6 +18,11 @@ public sealed class ExtensionResources(BridgeConnectionManager connection)
     private const string ExtensionUriTemplate = "keeneyes://extension/{typeName}";
 #pragma warning restore S1075
 
+    /// <summary>
+    /// Gets a world extension (singleton) by type name as a JSON text resource.
+    /// </summary>
+    /// <param name="typeName">Extension type name.</param>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized extension, or an error payload if no extension of that type is registered.</returns>
     [McpServerResource(
         UriTemplate = ExtensionUriTemplate,
         Name = "extension",

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/LogResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/LogResources.cs
@@ -20,6 +20,10 @@ public sealed class LogResources(BridgeConnectionManager connection)
     private const string LogByCategoryUriTemplate = "keeneyes://logs/category/{pattern}";
 #pragma warning restore S1075
 
+    /// <summary>
+    /// Retrieves aggregate log statistics as a JSON resource.
+    /// </summary>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized log statistics.</returns>
     [McpServerResource(
         UriTemplate = LogStatsUri,
         Name = "log-stats",
@@ -38,6 +42,11 @@ public sealed class LogResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Retrieves the most recent log entries as a JSON resource.
+    /// </summary>
+    /// <param name="count">Maximum number of entries to return (default: 100).</param>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized log entries.</returns>
     [McpServerResource(
         UriTemplate = LogRecentUri,
         Name = "log-recent",
@@ -57,6 +66,12 @@ public sealed class LogResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Retrieves log entries filtered by severity level as a JSON resource.
+    /// </summary>
+    /// <param name="level">The log level to filter by (0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=Fatal).</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 1000).</param>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized log entries.</returns>
     [McpServerResource(
         UriTemplate = LogByLevelUriTemplate,
         Name = "log-by-level",
@@ -78,6 +93,12 @@ public sealed class LogResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Retrieves log entries filtered by category pattern as a JSON resource.
+    /// </summary>
+    /// <param name="pattern">Category pattern supporting wildcards (<c>*</c> and <c>?</c>).</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 1000).</param>
+    /// <returns>A <see cref="TextResourceContents"/> containing the serialized log entries.</returns>
     [McpServerResource(
         UriTemplate = LogByCategoryUriTemplate,
         Name = "log-by-category",

--- a/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Resources/WorldResources.cs
@@ -9,6 +9,7 @@ namespace KeenEyes.Mcp.TestBridge.Resources;
 /// <summary>
 /// MCP resources for world and entity state information.
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerResourceType]
 public sealed class WorldResources(BridgeConnectionManager connection)
 {
@@ -22,6 +23,10 @@ public sealed class WorldResources(BridgeConnectionManager connection)
     private const string EntityComponentUriTemplate = "keeneyes://entity/{id}/component/{type}";
 #pragma warning restore S1075
 
+    /// <summary>
+    /// Gets aggregate statistics about the current world state.
+    /// </summary>
+    /// <returns>A JSON text resource containing the world statistics.</returns>
     [McpServerResource(
         UriTemplate = WorldStatsUri,
         Name = "world-stats",
@@ -40,6 +45,11 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets detailed information about an entity by its ID.
+    /// </summary>
+    /// <param name="id">Entity ID.</param>
+    /// <returns>A JSON text resource containing the entity snapshot, or an error payload if no such entity exists.</returns>
     [McpServerResource(
         UriTemplate = EntityByIdUriTemplate,
         Name = "entity-by-id",
@@ -71,6 +81,11 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Finds the first entity with the given name.
+    /// </summary>
+    /// <param name="name">Entity name.</param>
+    /// <returns>A JSON text resource containing the entity snapshot, or an error payload if none is found.</returns>
     [McpServerResource(
         UriTemplate = EntityByNameUriTemplate,
         Name = "entity-by-name",
@@ -102,6 +117,12 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets a single component's data from an entity.
+    /// </summary>
+    /// <param name="id">Entity ID.</param>
+    /// <param name="type">Component type name.</param>
+    /// <returns>A JSON text resource containing the component data, or an error payload if the component is not found on the entity.</returns>
     [McpServerResource(
         UriTemplate = EntityComponentUriTemplate,
         Name = "entity-component",
@@ -134,6 +155,10 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the list of systems registered in the world, including their timing information.
+    /// </summary>
+    /// <returns>A JSON text resource containing the world's systems.</returns>
     [McpServerResource(
         UriTemplate = WorldSystemsUri,
         Name = "world-systems",
@@ -152,6 +177,11 @@ public sealed class WorldResources(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets performance metrics for the world, such as FPS and frame timing.
+    /// </summary>
+    /// <param name="frameCount">Number of frames to analyze (default: 60).</param>
+    /// <returns>A JSON text resource containing the performance metrics.</returns>
     [McpServerResource(
         UriTemplate = WorldPerformanceUri,
         Name = "world-performance",

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/AITools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/AITools.cs
@@ -25,6 +25,10 @@ public sealed class AITools(BridgeConnectionManager connection)
 {
     #region Statistics
 
+    /// <summary>
+    /// Gets overall AI statistics, including counts of behavior trees, state machines, and utility AI instances.
+    /// </summary>
+    /// <returns>The aggregated <see cref="AIStatisticsResult"/>.</returns>
     [McpServerTool(Name = "ai_get_statistics")]
     [Description("Get overall AI statistics including counts of behavior trees, state machines, and utility AI instances.")]
     public async Task<AIStatisticsResult> GetStatistics()
@@ -38,6 +42,10 @@ public sealed class AITools(BridgeConnectionManager connection)
 
     #region Behavior Trees
 
+    /// <summary>
+    /// Lists all entities that have a <c>BehaviorTreeComponent</c>.
+    /// </summary>
+    /// <returns>The list of matching entity IDs.</returns>
     [McpServerTool(Name = "ai_behavior_tree_list")]
     [Description("List all entities that have a BehaviorTreeComponent.")]
     public async Task<EntityListResult> GetBehaviorTreeEntities()
@@ -52,6 +60,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current state of an entity's behavior tree.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <returns>The behavior tree state, or an error result if the entity has no behavior tree.</returns>
     [McpServerTool(Name = "ai_behavior_tree_get")]
     [Description("Get the current state of an entity's behavior tree.")]
     public async Task<BehaviorTreeResult> GetBehaviorTreeState(
@@ -73,6 +86,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         return BehaviorTreeResult.FromSnapshot(snapshot);
     }
 
+    /// <summary>
+    /// Resets an entity's behavior tree to its initial state.
+    /// </summary>
+    /// <param name="entityId">The entity ID to reset.</param>
+    /// <returns>The result of the reset operation.</returns>
     [McpServerTool(Name = "ai_behavior_tree_reset")]
     [Description("Reset an entity's behavior tree to its initial state.")]
     public async Task<OperationResult> ResetBehaviorTree(
@@ -92,6 +110,10 @@ public sealed class AITools(BridgeConnectionManager connection)
 
     #region State Machines
 
+    /// <summary>
+    /// Lists all entities that have a <c>StateMachineComponent</c>.
+    /// </summary>
+    /// <returns>The list of matching entity IDs.</returns>
     [McpServerTool(Name = "ai_state_machine_list")]
     [Description("List all entities that have a StateMachineComponent.")]
     public async Task<EntityListResult> GetStateMachineEntities()
@@ -106,6 +128,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current state of an entity's state machine, including all states and transitions.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <returns>The state machine state, or an error result if the entity has no state machine.</returns>
     [McpServerTool(Name = "ai_state_machine_get")]
     [Description("Get the current state of an entity's state machine, including all states and transitions.")]
     public async Task<StateMachineResult> GetStateMachineState(
@@ -127,6 +154,12 @@ public sealed class AITools(BridgeConnectionManager connection)
         return StateMachineResult.FromSnapshot(snapshot);
     }
 
+    /// <summary>
+    /// Forces a state machine to transition to a specific state by index.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <param name="stateIndex">The state index to transition to.</param>
+    /// <returns>The result of the transition operation.</returns>
     [McpServerTool(Name = "ai_state_machine_force_state")]
     [Description("Force a state machine to transition to a specific state by index.")]
     public async Task<OperationResult> ForceStateTransition(
@@ -144,6 +177,12 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Forces a state machine to transition to a specific state by name.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <param name="stateName">The state name to transition to.</param>
+    /// <returns>The result of the transition operation.</returns>
     [McpServerTool(Name = "ai_state_machine_force_state_by_name")]
     [Description("Force a state machine to transition to a specific state by name.")]
     public async Task<OperationResult> ForceStateTransitionByName(
@@ -165,6 +204,10 @@ public sealed class AITools(BridgeConnectionManager connection)
 
     #region Utility AI
 
+    /// <summary>
+    /// Lists all entities that have a <c>UtilityComponent</c>.
+    /// </summary>
+    /// <returns>The list of matching entity IDs.</returns>
     [McpServerTool(Name = "ai_utility_list")]
     [Description("List all entities that have a UtilityComponent.")]
     public async Task<EntityListResult> GetUtilityAIEntities()
@@ -179,6 +222,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current state of an entity's utility AI, including the current action and evaluation settings.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <returns>The utility AI state, or an error result if the entity has no utility AI.</returns>
     [McpServerTool(Name = "ai_utility_get")]
     [Description("Get the current state of an entity's utility AI, including current action and evaluation settings.")]
     public async Task<UtilityAIResult> GetUtilityAIState(
@@ -200,6 +248,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         return UtilityAIResult.FromSnapshot(snapshot);
     }
 
+    /// <summary>
+    /// Evaluates and returns scores for all available actions on a utility AI entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID to score.</param>
+    /// <returns>The scores for all evaluated actions.</returns>
     [McpServerTool(Name = "ai_utility_score_all")]
     [Description("Evaluate and return scores for all available actions on a utility AI entity.")]
     public async Task<UtilityScoresResult> ScoreAllActions(
@@ -217,6 +270,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Forces an immediate utility AI evaluation, bypassing the normal evaluation interval.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <returns>The result of the evaluation operation.</returns>
     [McpServerTool(Name = "ai_utility_force_evaluation")]
     [Description("Force an immediate utility AI evaluation, bypassing the normal evaluation interval.")]
     public async Task<OperationResult> ForceUtilityEvaluation(
@@ -236,6 +294,11 @@ public sealed class AITools(BridgeConnectionManager connection)
 
     #region Blackboard
 
+    /// <summary>
+    /// Gets all entries in an entity's AI blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <returns>The blackboard entries for the entity.</returns>
     [McpServerTool(Name = "ai_blackboard_get")]
     [Description("Get all entries in an entity's AI blackboard.")]
     public async Task<BlackboardResult> GetBlackboard(
@@ -253,6 +316,12 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets a specific value from an entity's AI blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID to query.</param>
+    /// <param name="key">The blackboard key.</param>
+    /// <returns>The blackboard value, or an error result if the key is not found.</returns>
     [McpServerTool(Name = "ai_blackboard_get_value")]
     [Description("Get a specific value from an entity's AI blackboard.")]
     public async Task<BlackboardValueResult> GetBlackboardValue(
@@ -281,6 +350,13 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Sets a value in an entity's AI blackboard. Supports strings, numbers, booleans, and null.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <param name="key">The blackboard key.</param>
+    /// <param name="value">The value to set, as JSON.</param>
+    /// <returns>The result of the set operation.</returns>
     [McpServerTool(Name = "ai_blackboard_set_value")]
     [Description("Set a value in an entity's AI blackboard. Supports strings, numbers, booleans, and null.")]
     public async Task<OperationResult> SetBlackboardValue(
@@ -300,6 +376,12 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Removes a value from an entity's AI blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <param name="key">The blackboard key to remove.</param>
+    /// <returns>The result of the remove operation.</returns>
     [McpServerTool(Name = "ai_blackboard_remove_value")]
     [Description("Remove a value from an entity's AI blackboard.")]
     public async Task<OperationResult> RemoveBlackboardValue(
@@ -317,6 +399,11 @@ public sealed class AITools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Clears all entries from an entity's AI blackboard.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <returns>The result of the clear operation.</returns>
     [McpServerTool(Name = "ai_blackboard_clear")]
     [Description("Clear all entries from an entity's AI blackboard.")]
     public async Task<OperationResult> ClearBlackboard(

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/CaptureTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/CaptureTools.cs
@@ -13,6 +13,10 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
 {
     #region Screenshots
 
+    /// <summary>
+    /// Checks whether screenshot capture is available on the connected bridge.
+    /// </summary>
+    /// <returns>A <see cref="CaptureAvailabilityResult"/> indicating whether capture is available.</returns>
     [McpServerTool(Name = "capture_is_available")]
     [Description("Check if screenshot capture is available. Capture may be unavailable in headless mode.")]
     public CaptureAvailabilityResult CaptureIsAvailable()
@@ -21,6 +25,11 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         return new CaptureAvailabilityResult { IsAvailable = bridge.Capture.IsAvailable };
     }
 
+    /// <summary>
+    /// Captures a screenshot and returns it as base64-encoded image data.
+    /// </summary>
+    /// <param name="format">The image format: 'png' (default), 'jpeg', or 'bmp'.</param>
+    /// <returns>A <see cref="ScreenshotResult"/> containing the encoded image data, or an error if capture failed.</returns>
     [McpServerTool(Name = "capture_screenshot")]
     [Description("Capture a screenshot and return it as base64-encoded image data. Formats: 'png' (default), 'jpeg', 'bmp'.")]
     public async Task<ScreenshotResult> CaptureScreenshot(
@@ -64,6 +73,12 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         }
     }
 
+    /// <summary>
+    /// Captures a screenshot and saves it to a file.
+    /// </summary>
+    /// <param name="filePath">The file path to save the screenshot to.</param>
+    /// <param name="format">The image format: 'png' (default), 'jpeg', or 'bmp'.</param>
+    /// <returns>A <see cref="ScreenshotFileResult"/> containing the full saved file path, or an error if capture failed.</returns>
     [McpServerTool(Name = "capture_screenshot_to_file")]
     [Description("Capture a screenshot and save it to a file. Returns the full file path.")]
     public async Task<ScreenshotFileResult> CaptureScreenshotToFile(
@@ -105,6 +120,15 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         }
     }
 
+    /// <summary>
+    /// Captures a region of the screen and returns it as base64-encoded image data.
+    /// </summary>
+    /// <param name="x">The left edge X coordinate (0-based).</param>
+    /// <param name="y">The top edge Y coordinate (0-based).</param>
+    /// <param name="width">The region width in pixels.</param>
+    /// <param name="height">The region height in pixels.</param>
+    /// <param name="format">The image format: 'png' (default), 'jpeg', or 'bmp'.</param>
+    /// <returns>A <see cref="ScreenshotResult"/> containing the encoded image data, or an error if capture failed.</returns>
     [McpServerTool(Name = "capture_screenshot_region")]
     [Description("Capture a region of the screen and return it as base64-encoded image data.")]
     public async Task<ScreenshotResult> CaptureScreenshotRegion(
@@ -163,6 +187,16 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         }
     }
 
+    /// <summary>
+    /// Captures a region of the screen and saves it to a file.
+    /// </summary>
+    /// <param name="x">The left edge X coordinate (0-based).</param>
+    /// <param name="y">The top edge Y coordinate (0-based).</param>
+    /// <param name="width">The region width in pixels.</param>
+    /// <param name="height">The region height in pixels.</param>
+    /// <param name="filePath">The file path to save the screenshot to.</param>
+    /// <param name="format">The image format: 'png' (default), 'jpeg', or 'bmp'.</param>
+    /// <returns>A <see cref="ScreenshotFileResult"/> containing the full saved file path, or an error if capture failed.</returns>
     [McpServerTool(Name = "capture_screenshot_region_to_file")]
     [Description("Capture a region of the screen and save it to a file.")]
     public async Task<ScreenshotFileResult> CaptureScreenshotRegionToFile(
@@ -224,6 +258,11 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
 
     #region Recording
 
+    /// <summary>
+    /// Starts recording frames, storing them in memory on the game side.
+    /// </summary>
+    /// <param name="maxFrames">The maximum number of frames to record before the oldest are discarded (default: 300).</param>
+    /// <returns>A <see cref="RecordingResult"/> indicating whether recording was started.</returns>
     [McpServerTool(Name = "capture_start_recording")]
     [Description("Start recording frames. Frames are stored in memory on the game side.")]
     public async Task<RecordingResult> CaptureStartRecording(
@@ -259,6 +298,10 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Stops recording and returns the number of frames captured.
+    /// </summary>
+    /// <returns>A <see cref="RecordingResult"/> containing the number of recorded frames.</returns>
     [McpServerTool(Name = "capture_stop_recording")]
     [Description("Stop recording and return the number of frames captured.")]
     public async Task<RecordingResult> CaptureStopRecording()
@@ -284,6 +327,10 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Checks whether frame recording is currently active.
+    /// </summary>
+    /// <returns>A <see cref="RecordingStateResult"/> describing the current recording state.</returns>
     [McpServerTool(Name = "capture_is_recording")]
     [Description("Check if frame recording is currently active.")]
     public RecordingStateResult CaptureIsRecording()
@@ -297,6 +344,10 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the number of frames recorded so far.
+    /// </summary>
+    /// <returns>A <see cref="RecordedCountResult"/> containing the recorded frame count and recording state.</returns>
     [McpServerTool(Name = "capture_get_recorded_count")]
     [Description("Get the number of frames recorded so far.")]
     public RecordedCountResult CaptureGetRecordedCount()
@@ -344,6 +395,9 @@ public sealed class CaptureTools(BridgeConnectionManager connection)
 /// </summary>
 public sealed record CaptureAvailabilityResult
 {
+    /// <summary>
+    /// Gets whether screenshot capture is available.
+    /// </summary>
     public required bool IsAvailable { get; init; }
 }
 
@@ -352,11 +406,34 @@ public sealed record CaptureAvailabilityResult
 /// </summary>
 public sealed record ScreenshotResult
 {
+    /// <summary>
+    /// Gets whether the screenshot capture succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the base64-encoded image data, or <c>null</c> if capture failed.
+    /// </summary>
     public string? Data { get; init; }
+
+    /// <summary>
+    /// Gets the MIME type of the captured image, or <c>null</c> if capture failed.
+    /// </summary>
     public string? MimeType { get; init; }
+
+    /// <summary>
+    /// Gets the width of the captured image in pixels.
+    /// </summary>
     public int Width { get; init; }
+
+    /// <summary>
+    /// Gets the height of the captured image in pixels.
+    /// </summary>
     public int Height { get; init; }
+
+    /// <summary>
+    /// Gets the error message, or <c>null</c> if capture succeeded.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -365,9 +442,24 @@ public sealed record ScreenshotResult
 /// </summary>
 public sealed record ScreenshotFileResult
 {
+    /// <summary>
+    /// Gets whether the screenshot capture succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the full path the screenshot was saved to, or <c>null</c> if capture failed.
+    /// </summary>
     public string? FilePath { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable message describing the outcome, or <c>null</c> if capture failed.
+    /// </summary>
     public string? Message { get; init; }
+
+    /// <summary>
+    /// Gets the error message, or <c>null</c> if capture succeeded.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -376,8 +468,19 @@ public sealed record ScreenshotFileResult
 /// </summary>
 public sealed record RecordingResult
 {
+    /// <summary>
+    /// Gets whether the recording operation succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable message describing the outcome.
+    /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames captured, or <c>null</c> if not applicable.
+    /// </summary>
     public int? FrameCount { get; init; }
 }
 
@@ -386,7 +489,14 @@ public sealed record RecordingResult
 /// </summary>
 public sealed record RecordingStateResult
 {
+    /// <summary>
+    /// Gets whether frame recording is currently active.
+    /// </summary>
     public required bool IsRecording { get; init; }
+
+    /// <summary>
+    /// Gets the number of frames recorded so far.
+    /// </summary>
     public required int RecordedFrameCount { get; init; }
 }
 
@@ -395,7 +505,14 @@ public sealed record RecordingStateResult
 /// </summary>
 public sealed record RecordedCountResult
 {
+    /// <summary>
+    /// Gets the number of frames recorded so far.
+    /// </summary>
     public required int Count { get; init; }
+
+    /// <summary>
+    /// Gets whether frame recording is currently active.
+    /// </summary>
     public required bool IsRecording { get; init; }
 }
 

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/GameTools.cs
@@ -12,6 +12,14 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 [McpServerToolType]
 public sealed class GameTools(BridgeConnectionManager connection, McpServer server)
 {
+    /// <summary>
+    /// Connects to a running KeenEyes game over the configured transport. Must be called before using other tools.
+    /// </summary>
+    /// <param name="pipeName">Named pipe name (default: from KEENEYES_PIPE_NAME env var or 'KeenEyes.TestBridge').</param>
+    /// <param name="host">TCP host for network connection (default: '127.0.0.1').</param>
+    /// <param name="port">TCP port for network connection (default: 19283).</param>
+    /// <param name="transport">Transport mode: 'pipe' or 'tcp' (default: 'pipe').</param>
+    /// <returns>The resulting connection status.</returns>
     [McpServerTool(Name = "game_connect")]
     [Description("Connect to a running KeenEyes game. Must be called before using other tools. Returns connection status.")]
     public async Task<ConnectionResult> GameConnect(
@@ -64,6 +72,10 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
         }
     }
 
+    /// <summary>
+    /// Disconnects from the currently connected game.
+    /// </summary>
+    /// <returns>The resulting connection status.</returns>
     [McpServerTool(Name = "game_disconnect")]
     [Description("Disconnect from the game.")]
     public async Task<ConnectionResult> GameDisconnect()
@@ -90,6 +102,10 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
         };
     }
 
+    /// <summary>
+    /// Gets detailed connection status including latency and uptime.
+    /// </summary>
+    /// <returns>The current <see cref="ConnectionStatus"/>.</returns>
     [McpServerTool(Name = "game_status")]
     [Description("Get detailed connection status including latency and uptime.")]
     public ConnectionStatus GameStatus()
@@ -97,6 +113,10 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
         return connection.GetStatus();
     }
 
+    /// <summary>
+    /// Gets the current game window dimensions in pixels.
+    /// </summary>
+    /// <returns>The window width and height.</returns>
     [McpServerTool(Name = "game_get_screen_size")]
     [Description("Get the current game window dimensions in pixels.")]
     public async Task<ScreenSizeResult> GameGetScreenSize()
@@ -111,6 +131,15 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
         };
     }
 
+    /// <summary>
+    /// Waits for a game state condition to become true. Useful for waiting after input before checking state.
+    /// </summary>
+    /// <param name="condition">Condition: 'entity_exists', 'entity_gone', 'component_exists', 'component_gone'.</param>
+    /// <param name="timeoutMs">Timeout in milliseconds (default: 5000).</param>
+    /// <param name="entityId">Entity ID to check (use this or <paramref name="entityName"/>).</param>
+    /// <param name="entityName">Entity name to check (use this or <paramref name="entityId"/>).</param>
+    /// <param name="componentType">Component type name (for component conditions).</param>
+    /// <returns>Whether the condition was met before the timeout elapsed, and how long it took.</returns>
     [McpServerTool(Name = "game_wait_for_condition")]
     [Description("Wait for a game state condition. Useful for waiting after input before checking state.")]
     public async Task<WaitResult> GameWaitForCondition(
@@ -234,11 +263,34 @@ public sealed class GameTools(BridgeConnectionManager connection, McpServer serv
 /// </summary>
 public sealed record ConnectionResult
 {
+    /// <summary>
+    /// Gets whether the connection operation succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable description of the connection outcome.
+    /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Gets the named pipe used for the connection, when applicable.
+    /// </summary>
     public string? PipeName { get; init; }
+
+    /// <summary>
+    /// Gets the TCP host used for the connection, when applicable.
+    /// </summary>
     public string? Host { get; init; }
+
+    /// <summary>
+    /// Gets the TCP port used for the connection, when applicable.
+    /// </summary>
     public int? Port { get; init; }
+
+    /// <summary>
+    /// Gets the transport mode used for the connection.
+    /// </summary>
     public string? Transport { get; init; }
 }
 
@@ -247,7 +299,14 @@ public sealed record ConnectionResult
 /// </summary>
 public sealed record ScreenSizeResult
 {
+    /// <summary>
+    /// Gets the window width in pixels.
+    /// </summary>
     public required int Width { get; init; }
+
+    /// <summary>
+    /// Gets the window height in pixels.
+    /// </summary>
     public required int Height { get; init; }
 }
 
@@ -256,7 +315,18 @@ public sealed record ScreenSizeResult
 /// </summary>
 public sealed record WaitResult
 {
+    /// <summary>
+    /// Gets whether the condition was met before the timeout elapsed.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable description of the wait outcome.
+    /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Gets the elapsed time, in milliseconds, spent waiting for the condition.
+    /// </summary>
     public required int ElapsedMs { get; init; }
 }

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/InputTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/InputTools.cs
@@ -8,11 +8,19 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// <summary>
 /// MCP tools for simulating keyboard, mouse, and gamepad input.
 /// </summary>
+/// <param name="connection">The connection manager used to access the active test bridge.</param>
 [McpServerToolType]
 public sealed class InputTools(BridgeConnectionManager connection)
 {
     #region Keyboard
 
+    /// <summary>
+    /// Presses and releases a keyboard key, optionally with modifiers and a hold duration.
+    /// </summary>
+    /// <param name="key">The key to press (e.g., 'Space', 'Enter', 'W', 'Escape').</param>
+    /// <param name="modifiers">Modifier keys to hold while pressing, as a comma-separated list: 'Shift', 'Ctrl', 'Alt', 'Super'.</param>
+    /// <param name="holdMs">How long to hold the key in milliseconds, defaulting to a single frame.</param>
+    /// <returns>The result of the key press operation.</returns>
     [McpServerTool(Name = "input_key_press")]
     [Description("Press and release a keyboard key. Common keys: Space, Enter, Escape, Tab, Backspace, W, A, S, D, Up, Down, Left, Right, F1-F12.")]
     public async Task<InputResult> InputKeyPress(
@@ -33,6 +41,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Pressed key: {key}" };
     }
 
+    /// <summary>
+    /// Holds a keyboard key down until released with <see cref="InputKeyUp"/>.
+    /// </summary>
+    /// <param name="key">The key to hold down.</param>
+    /// <param name="modifiers">Modifier keys to hold, as a comma-separated list: 'Shift', 'Ctrl', 'Alt', 'Super'.</param>
+    /// <returns>The result of the key-down operation.</returns>
     [McpServerTool(Name = "input_key_down")]
     [Description("Hold a keyboard key down. Use input_key_up to release. Common keys: Space, Enter, W, A, S, D, Up, Down, Left, Right.")]
     public async Task<InputResult> InputKeyDown(
@@ -50,6 +64,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Key down: {key}" };
     }
 
+    /// <summary>
+    /// Releases a keyboard key previously held down with <see cref="InputKeyDown"/>.
+    /// </summary>
+    /// <param name="key">The key to release.</param>
+    /// <param name="modifiers">Modifier keys to release, as a comma-separated list: 'Shift', 'Ctrl', 'Alt', 'Super'.</param>
+    /// <returns>The result of the key-up operation.</returns>
     [McpServerTool(Name = "input_key_up")]
     [Description("Release a held keyboard key.")]
     public async Task<InputResult> InputKeyUp(
@@ -67,6 +87,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Key up: {key}" };
     }
 
+    /// <summary>
+    /// Types a string of text as text input events, such as entry into a text field.
+    /// </summary>
+    /// <param name="text">The text to type.</param>
+    /// <param name="delayMs">The delay between characters in milliseconds, defaulting to no delay.</param>
+    /// <returns>The result of the type-text operation.</returns>
     [McpServerTool(Name = "input_type_text")]
     [Description("Type a string of text as text input events. Use for text entry like typing in a text field.")]
     public async Task<InputResult> InputTypeText(
@@ -83,6 +109,11 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Typed: \"{text}\"" };
     }
 
+    /// <summary>
+    /// Checks whether a keyboard key is currently pressed.
+    /// </summary>
+    /// <param name="key">The key to check.</param>
+    /// <returns>The current pressed state of the key.</returns>
     [McpServerTool(Name = "input_is_key_down")]
     [Description("Check if a keyboard key is currently pressed.")]
     public KeyStateResult InputIsKeyDown(
@@ -100,6 +131,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
 
     #region Mouse
 
+    /// <summary>
+    /// Moves the mouse to an absolute screen position.
+    /// </summary>
+    /// <param name="x">The X coordinate to move to.</param>
+    /// <param name="y">The Y coordinate to move to.</param>
+    /// <returns>The result of the mouse-move operation.</returns>
     [McpServerTool(Name = "input_mouse_move")]
     [Description("Move the mouse to an absolute screen position.")]
     public async Task<InputResult> InputMouseMove(
@@ -114,6 +151,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Moved mouse to ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Moves the mouse by a relative delta from its current position.
+    /// </summary>
+    /// <param name="deltaX">The X delta to move by (positive = right, negative = left).</param>
+    /// <param name="deltaY">The Y delta to move by (positive = down, negative = up).</param>
+    /// <returns>The result of the relative mouse-move operation.</returns>
     [McpServerTool(Name = "input_mouse_move_relative")]
     [Description("Move the mouse by a relative delta from its current position.")]
     public async Task<InputResult> InputMouseMoveRelative(
@@ -128,6 +171,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Moved mouse by ({deltaX}, {deltaY})" };
     }
 
+    /// <summary>
+    /// Clicks the mouse at a position.
+    /// </summary>
+    /// <param name="x">The X coordinate to click at.</param>
+    /// <param name="y">The Y coordinate to click at.</param>
+    /// <param name="button">The mouse button to click: 'Left', 'Right', 'Middle' (default: Left).</param>
+    /// <returns>The result of the mouse-click operation.</returns>
     [McpServerTool(Name = "input_mouse_click")]
     [Description("Click the mouse at a position. Buttons: Left, Right, Middle, Button4, Button5.")]
     public async Task<InputResult> InputMouseClick(
@@ -145,6 +195,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Clicked {btn} at ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Double-clicks the mouse at a position.
+    /// </summary>
+    /// <param name="x">The X coordinate to click at.</param>
+    /// <param name="y">The Y coordinate to click at.</param>
+    /// <param name="button">The mouse button to click: 'Left', 'Right', 'Middle' (default: Left).</param>
+    /// <returns>The result of the double-click operation.</returns>
     [McpServerTool(Name = "input_mouse_double_click")]
     [Description("Double-click the mouse at a position.")]
     public async Task<InputResult> InputMouseDoubleClick(
@@ -162,6 +219,11 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Double-clicked {btn} at ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Presses a mouse button down until released with <see cref="InputMouseUp"/>.
+    /// </summary>
+    /// <param name="button">The mouse button to press: 'Left', 'Right', 'Middle' (default: Left).</param>
+    /// <returns>The result of the mouse-down operation.</returns>
     [McpServerTool(Name = "input_mouse_down")]
     [Description("Press a mouse button down. Use input_mouse_up to release.")]
     public async Task<InputResult> InputMouseDown(
@@ -175,6 +237,11 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Mouse button down: {btn}" };
     }
 
+    /// <summary>
+    /// Releases a mouse button previously pressed with <see cref="InputMouseDown"/>.
+    /// </summary>
+    /// <param name="button">The mouse button to release: 'Left', 'Right', 'Middle' (default: Left).</param>
+    /// <returns>The result of the mouse-up operation.</returns>
     [McpServerTool(Name = "input_mouse_up")]
     [Description("Release a pressed mouse button.")]
     public async Task<InputResult> InputMouseUp(
@@ -188,6 +255,15 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Mouse button up: {btn}" };
     }
 
+    /// <summary>
+    /// Drags the mouse from one position to another while holding a button.
+    /// </summary>
+    /// <param name="startX">The starting X coordinate.</param>
+    /// <param name="startY">The starting Y coordinate.</param>
+    /// <param name="endX">The ending X coordinate.</param>
+    /// <param name="endY">The ending Y coordinate.</param>
+    /// <param name="button">The mouse button to hold while dragging: 'Left', 'Right', 'Middle' (default: Left).</param>
+    /// <returns>The result of the mouse-drag operation.</returns>
     [McpServerTool(Name = "input_mouse_drag")]
     [Description("Drag the mouse from one position to another while holding a button.")]
     public async Task<InputResult> InputMouseDrag(
@@ -209,6 +285,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Dragged from ({startX}, {startY}) to ({endX}, {endY})" };
     }
 
+    /// <summary>
+    /// Scrolls the mouse wheel.
+    /// </summary>
+    /// <param name="deltaY">The vertical scroll amount (positive = up, negative = down).</param>
+    /// <param name="deltaX">The horizontal scroll amount (positive = right, negative = left).</param>
+    /// <returns>The result of the scroll operation.</returns>
     [McpServerTool(Name = "input_mouse_scroll")]
     [Description("Scroll the mouse wheel. Positive deltaY scrolls up, negative scrolls down.")]
     public async Task<InputResult> InputMouseScroll(
@@ -223,6 +305,10 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Scrolled ({deltaX}, {deltaY})" };
     }
 
+    /// <summary>
+    /// Gets the current mouse position.
+    /// </summary>
+    /// <returns>The current mouse position.</returns>
     [McpServerTool(Name = "input_get_mouse_position")]
     [Description("Get the current mouse position.")]
     public MousePositionResult InputGetMousePosition()
@@ -237,6 +323,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
 
     #region Gamepad
 
+    /// <summary>
+    /// Presses a gamepad button down until released with <see cref="InputGamepadButtonUp"/>.
+    /// </summary>
+    /// <param name="button">The gamepad button name.</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the gamepad button-down operation.</returns>
     [McpServerTool(Name = "input_gamepad_button_down")]
     [Description("Press a gamepad button down. Buttons: A, B, X, Y, LeftBumper, RightBumper, Back, Start, Home, LeftStick, RightStick, DPadUp, DPadDown, DPadLeft, DPadRight.")]
     public async Task<InputResult> InputGamepadButtonDown(
@@ -252,6 +344,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} button down: {button}" };
     }
 
+    /// <summary>
+    /// Releases a gamepad button previously pressed with <see cref="InputGamepadButtonDown"/>.
+    /// </summary>
+    /// <param name="button">The gamepad button name.</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the gamepad button-up operation.</returns>
     [McpServerTool(Name = "input_gamepad_button_up")]
     [Description("Release a pressed gamepad button.")]
     public async Task<InputResult> InputGamepadButtonUp(
@@ -267,6 +365,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} button up: {button}" };
     }
 
+    /// <summary>
+    /// Presses and releases a gamepad button.
+    /// </summary>
+    /// <param name="button">The gamepad button name.</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <param name="holdMs">How long to hold the button in milliseconds (default: 50ms).</param>
+    /// <returns>The result of the gamepad button-press operation.</returns>
     [McpServerTool(Name = "input_gamepad_button_press")]
     [Description("Press and release a gamepad button.")]
     public async Task<InputResult> InputGamepadButtonPress(
@@ -287,6 +392,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} pressed: {button}" };
     }
 
+    /// <summary>
+    /// Sets the left analog stick position.
+    /// </summary>
+    /// <param name="x">The X position (-1 = left, 1 = right).</param>
+    /// <param name="y">The Y position (-1 = up, 1 = down).</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the left-stick operation.</returns>
     [McpServerTool(Name = "input_gamepad_left_stick")]
     [Description("Set the left analog stick position. Values range from -1 to 1 for each axis.")]
     public async Task<InputResult> InputGamepadLeftStick(
@@ -303,6 +415,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} left stick: ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Sets the right analog stick position.
+    /// </summary>
+    /// <param name="x">The X position (-1 = left, 1 = right).</param>
+    /// <param name="y">The Y position (-1 = up, 1 = down).</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the right-stick operation.</returns>
     [McpServerTool(Name = "input_gamepad_right_stick")]
     [Description("Set the right analog stick position. Values range from -1 to 1 for each axis.")]
     public async Task<InputResult> InputGamepadRightStick(
@@ -319,6 +438,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} right stick: ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Sets a gamepad trigger value.
+    /// </summary>
+    /// <param name="trigger">The trigger to set: 'Left' or 'Right'.</param>
+    /// <param name="value">The trigger value (0 to 1).</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the trigger operation.</returns>
     [McpServerTool(Name = "input_gamepad_trigger")]
     [Description("Set a trigger value. Values range from 0 (not pressed) to 1 (fully pressed).")]
     public async Task<InputResult> InputGamepadTrigger(
@@ -336,6 +462,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Gamepad {playerIndex} {trigger} trigger: {value}" };
     }
 
+    /// <summary>
+    /// Connects or disconnects a virtual gamepad.
+    /// </summary>
+    /// <param name="connected">Whether the gamepad should be connected.</param>
+    /// <param name="playerIndex">The player/gamepad index (default: 0).</param>
+    /// <returns>The result of the connect/disconnect operation.</returns>
     [McpServerTool(Name = "input_gamepad_connect")]
     [Description("Connect or disconnect a virtual gamepad.")]
     public async Task<InputResult> InputGamepadConnect(
@@ -355,6 +487,11 @@ public sealed class InputTools(BridgeConnectionManager connection)
 
     #region Input Actions
 
+    /// <summary>
+    /// Triggers a named input action directly, bypassing normal input bindings.
+    /// </summary>
+    /// <param name="actionName">The name of the input action to trigger.</param>
+    /// <returns>The result of the trigger-action operation.</returns>
     [McpServerTool(Name = "input_trigger_action")]
     [Description("Trigger a named input action directly, bypassing normal input bindings.")]
     public async Task<InputResult> InputTriggerAction(
@@ -367,6 +504,12 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Triggered action: {actionName}" };
     }
 
+    /// <summary>
+    /// Sets the value of an axis-based input action.
+    /// </summary>
+    /// <param name="actionName">The name of the input action.</param>
+    /// <param name="value">The axis value (-1 to 1 for most axes, 0 to 1 for triggers).</param>
+    /// <returns>The result of the set-action-value operation.</returns>
     [McpServerTool(Name = "input_set_action_value")]
     [Description("Set the value of an axis-based input action.")]
     public async Task<InputResult> InputSetActionValue(
@@ -381,6 +524,13 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Set action '{actionName}' to {value}" };
     }
 
+    /// <summary>
+    /// Sets the value of a 2D axis input action, such as movement.
+    /// </summary>
+    /// <param name="actionName">The name of the input action.</param>
+    /// <param name="x">The X axis value.</param>
+    /// <param name="y">The Y axis value.</param>
+    /// <returns>The result of the set-action-vector2 operation.</returns>
     [McpServerTool(Name = "input_set_action_vector2")]
     [Description("Set the value of a 2D axis input action (like movement).")]
     public async Task<InputResult> InputSetActionVector2(
@@ -397,6 +547,10 @@ public sealed class InputTools(BridgeConnectionManager connection)
         return new InputResult { Success = true, Message = $"Set action '{actionName}' to ({x}, {y})" };
     }
 
+    /// <summary>
+    /// Resets all input state to default (all keys up, mouse at origin, sticks centered).
+    /// </summary>
+    /// <returns>The result of the reset operation.</returns>
     [McpServerTool(Name = "input_reset")]
     [Description("Reset all input state to default (all keys up, mouse at origin, sticks centered).")]
     public async Task<InputResult> InputReset()
@@ -482,7 +636,14 @@ public sealed class InputTools(BridgeConnectionManager connection)
 /// </summary>
 public sealed record InputResult
 {
+    /// <summary>
+    /// Gets whether the input operation succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets a message describing the outcome of the input operation.
+    /// </summary>
     public required string Message { get; init; }
 }
 
@@ -491,7 +652,14 @@ public sealed record InputResult
 /// </summary>
 public sealed record MousePositionResult
 {
+    /// <summary>
+    /// Gets the current mouse X coordinate.
+    /// </summary>
     public required float X { get; init; }
+
+    /// <summary>
+    /// Gets the current mouse Y coordinate.
+    /// </summary>
     public required float Y { get; init; }
 }
 
@@ -500,6 +668,13 @@ public sealed record MousePositionResult
 /// </summary>
 public sealed record KeyStateResult
 {
+    /// <summary>
+    /// Gets the key that was checked.
+    /// </summary>
     public required string Key { get; init; }
+
+    /// <summary>
+    /// Gets whether the key is currently pressed.
+    /// </summary>
     public required bool IsDown { get; init; }
 }

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/LogTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/LogTools.cs
@@ -13,6 +13,10 @@ public sealed class LogTools(BridgeConnectionManager connection)
 {
     #region Statistics
 
+    /// <summary>
+    /// Gets log statistics including counts per level, timestamps, and capacity.
+    /// </summary>
+    /// <returns>The aggregated log statistics.</returns>
     [McpServerTool(Name = "log_get_stats")]
     [Description("Get log statistics including counts per level, timestamps, and capacity.")]
     public async Task<LogStatsResult> GetStats()
@@ -35,6 +39,10 @@ public sealed class LogTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the total number of log entries currently stored.
+    /// </summary>
+    /// <returns>The current log entry count.</returns>
     [McpServerTool(Name = "log_get_count")]
     [Description("Get the total number of log entries currently stored.")]
     public async Task<LogCountResult> GetCount()
@@ -48,6 +56,11 @@ public sealed class LogTools(BridgeConnectionManager connection)
 
     #region Retrieval
 
+    /// <summary>
+    /// Gets the most recent log entries, newest first.
+    /// </summary>
+    /// <param name="count">Maximum number of entries to return (default: 100, max: 1000).</param>
+    /// <returns>The most recent log entries.</returns>
     [McpServerTool(Name = "log_get_recent")]
     [Description("Get the most recent log entries. Returns newest first.")]
     public async Task<LogEntriesResult> GetRecent(
@@ -65,6 +78,11 @@ public sealed class LogTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets only error and fatal log entries, useful for debugging issues.
+    /// </summary>
+    /// <param name="maxResults">Maximum number of entries to return (default: 100).</param>
+    /// <returns>The matching error and fatal log entries, newest first.</returns>
     [McpServerTool(Name = "log_get_errors")]
     [Description("Get only error and fatal log entries. Useful for debugging issues.")]
     public async Task<LogEntriesResult> GetErrors(
@@ -90,6 +108,12 @@ public sealed class LogTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets log entries at a specific level.
+    /// </summary>
+    /// <param name="level">Log level (0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=Fatal).</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 100).</param>
+    /// <returns>The log entries matching the specified level.</returns>
     [McpServerTool(Name = "log_get_by_level")]
     [Description("Get log entries at a specific level. Level values: 0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=Fatal.")]
     public async Task<LogEntriesResult> GetByLevel(
@@ -108,6 +132,12 @@ public sealed class LogTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets log entries matching a category pattern. Supports wildcards (* for any, ? for a single character).
+    /// </summary>
+    /// <param name="categoryPattern">Category pattern (e.g., 'Physics.*' or 'AI.Pathfinding').</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 100).</param>
+    /// <returns>The log entries whose category matches the pattern.</returns>
     [McpServerTool(Name = "log_get_by_category")]
     [Description("Get log entries matching a category pattern. Supports wildcards (* for any, ? for single character).")]
     public async Task<LogEntriesResult> GetByCategory(
@@ -130,6 +160,12 @@ public sealed class LogTools(BridgeConnectionManager connection)
 
     #region Search
 
+    /// <summary>
+    /// Searches log messages for specific text using a case-insensitive substring match.
+    /// </summary>
+    /// <param name="searchText">Text to search for in log messages.</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 100).</param>
+    /// <returns>The log entries whose message contains the search text.</returns>
     [McpServerTool(Name = "log_search")]
     [Description("Search log messages for specific text. Case-insensitive substring search.")]
     public async Task<LogEntriesResult> Search(
@@ -148,6 +184,18 @@ public sealed class LogTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Queries logs with multiple optional filters, combined with AND logic.
+    /// </summary>
+    /// <param name="minLevel">Minimum log level (0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=Fatal).</param>
+    /// <param name="maxLevel">Maximum log level (0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=Fatal).</param>
+    /// <param name="categoryPattern">Category pattern (supports wildcards: *, ?).</param>
+    /// <param name="messageContains">Text to search for in log messages.</param>
+    /// <param name="after">Only include entries after this ISO 8601 timestamp.</param>
+    /// <param name="before">Only include entries before this ISO 8601 timestamp.</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 100).</param>
+    /// <param name="skip">Number of entries to skip, for pagination.</param>
+    /// <returns>The log entries matching all specified filters.</returns>
     [McpServerTool(Name = "log_query")]
     [Description("Query logs with multiple filters. All filters are optional and combined with AND logic.")]
     public async Task<LogEntriesResult> Query(
@@ -195,6 +243,10 @@ public sealed class LogTools(BridgeConnectionManager connection)
 
     #region Management
 
+    /// <summary>
+    /// Clears all log entries. This action cannot be undone.
+    /// </summary>
+    /// <returns>The result of the clear operation, including how many entries were removed.</returns>
     [McpServerTool(Name = "log_clear")]
     [Description("Clear all log entries. This action cannot be undone.")]
     public async Task<LogClearResult> Clear()
@@ -220,16 +272,59 @@ public sealed class LogTools(BridgeConnectionManager connection)
 /// </summary>
 public sealed record LogStatsResult
 {
+    /// <summary>
+    /// Gets whether the statistics were retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the total number of log entries currently stored.
+    /// </summary>
     public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Trace level.
+    /// </summary>
     public int TraceCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Debug level.
+    /// </summary>
     public int DebugCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Info level.
+    /// </summary>
     public int InfoCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Warning level.
+    /// </summary>
     public int WarningCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Error level.
+    /// </summary>
     public int ErrorCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of stored entries at the Fatal level.
+    /// </summary>
     public int FatalCount { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp of the oldest stored log entry, if any entries exist.
+    /// </summary>
     public DateTime? OldestTimestamp { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp of the newest stored log entry, if any entries exist.
+    /// </summary>
     public DateTime? NewestTimestamp { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of log entries the store can hold, if bounded.
+    /// </summary>
     public int? Capacity { get; init; }
 }
 
@@ -238,6 +333,9 @@ public sealed record LogStatsResult
 /// </summary>
 public sealed record LogCountResult
 {
+    /// <summary>
+    /// Gets the total number of log entries currently stored.
+    /// </summary>
     public required int Count { get; init; }
 }
 
@@ -246,8 +344,19 @@ public sealed record LogCountResult
 /// </summary>
 public sealed record LogEntriesResult
 {
+    /// <summary>
+    /// Gets whether the query was executed successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the log entries returned by the query.
+    /// </summary>
     public IReadOnlyList<LogEntrySnapshot> Entries { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of entries in <see cref="Entries"/>.
+    /// </summary>
     public int Count { get; init; }
 }
 
@@ -256,8 +365,19 @@ public sealed record LogEntriesResult
 /// </summary>
 public sealed record LogClearResult
 {
+    /// <summary>
+    /// Gets whether the clear operation completed successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the number of log entries that were removed.
+    /// </summary>
     public int ClearedCount { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable summary of the clear operation.
+    /// </summary>
     public required string Message { get; init; }
 }
 

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/MutationTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/MutationTools.cs
@@ -20,6 +20,11 @@ public sealed class MutationTools(BridgeConnectionManager connection)
 {
     #region Entity Management
 
+    /// <summary>
+    /// Spawns a new entity with an optional name.
+    /// </summary>
+    /// <param name="name">Optional name for the entity.</param>
+    /// <returns>The result of the spawn operation, including the new entity's ID and version.</returns>
     [McpServerTool(Name = "mutation_spawn")]
     [Description("Spawn a new entity with an optional name and components.")]
     public async Task<MutationEntityResult> Spawn(
@@ -31,6 +36,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         return MutationEntityResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Spawns a new entity with the specified components.
+    /// </summary>
+    /// <param name="name">Optional name for the entity.</param>
+    /// <param name="componentsJson">JSON array of components. Each component has 'type' (component type name) and optional 'data' (JSON object with field values).</param>
+    /// <returns>The result of the spawn operation, including the new entity's ID and version, or an error if the component JSON is invalid.</returns>
     [McpServerTool(Name = "mutation_spawn_with_components")]
     [Description("Spawn a new entity with specified components. Component data is JSON.")]
     public async Task<MutationEntityResult> SpawnWithComponents(
@@ -79,6 +90,11 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         return MutationEntityResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Despawns (destroys) an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to despawn.</param>
+    /// <returns>The result of the despawn operation.</returns>
     [McpServerTool(Name = "mutation_despawn")]
     [Description("Despawn (destroy) an entity.")]
     public async Task<MutationBoolResult> Despawn(
@@ -94,6 +110,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Clones an existing entity, duplicating all its components and tags.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to clone.</param>
+    /// <param name="name">Optional name for the cloned entity.</param>
+    /// <returns>The result of the clone operation, including the new entity's ID and version.</returns>
     [McpServerTool(Name = "mutation_clone")]
     [Description("Clone an existing entity, duplicating all its components and tags.")]
     public async Task<MutationEntityResult> Clone(
@@ -107,6 +129,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         return MutationEntityResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Sets the name of an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to rename.</param>
+    /// <param name="name">The new name for the entity.</param>
+    /// <returns>The result of the rename operation.</returns>
     [McpServerTool(Name = "mutation_set_name")]
     [Description("Set the name of an entity.")]
     public async Task<MutationBoolResult> SetName(
@@ -124,6 +152,11 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Clears (removes) the name from an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to clear the name from.</param>
+    /// <returns>The result of the clear operation.</returns>
     [McpServerTool(Name = "mutation_clear_name")]
     [Description("Clear (remove) the name from an entity.")]
     public async Task<MutationBoolResult> ClearName(
@@ -143,6 +176,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
 
     #region Hierarchy
 
+    /// <summary>
+    /// Sets the parent of an entity, or makes it a root entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to reparent.</param>
+    /// <param name="parentId">The parent entity ID, or null to make this a root entity.</param>
+    /// <returns>The result of the reparent operation.</returns>
     [McpServerTool(Name = "mutation_set_parent")]
     [Description("Set the parent of an entity, or make it a root entity.")]
     public async Task<MutationBoolResult> SetParent(
@@ -160,6 +199,10 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets all root entities (entities without parents).
+    /// </summary>
+    /// <returns>The result containing the IDs of all root entities.</returns>
     [McpServerTool(Name = "mutation_get_root_entities")]
     [Description("Get all root entities (entities without parents).")]
     public async Task<MutationRootEntitiesResult> GetRootEntities()
@@ -177,6 +220,13 @@ public sealed class MutationTools(BridgeConnectionManager connection)
 
     #region Components
 
+    /// <summary>
+    /// Adds a component to an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to add the component to.</param>
+    /// <param name="componentType">The component type name (e.g., 'Position', 'Velocity').</param>
+    /// <param name="dataJson">Optional JSON object with field values for the component.</param>
+    /// <returns>The result of the add operation, or an error if the data JSON is invalid.</returns>
     [McpServerTool(Name = "mutation_add_component")]
     [Description("Add a component to an entity.")]
     public async Task<MutationBoolResult> AddComponent(
@@ -214,6 +264,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Removes a component from an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to remove the component from.</param>
+    /// <param name="componentType">The component type name (e.g., 'Position', 'Velocity').</param>
+    /// <returns>The result of the remove operation.</returns>
     [McpServerTool(Name = "mutation_remove_component")]
     [Description("Remove a component from an entity.")]
     public async Task<MutationBoolResult> RemoveComponent(
@@ -231,6 +287,13 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Sets all fields of a component on an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity.</param>
+    /// <param name="componentType">The component type name (e.g., 'Position', 'Velocity').</param>
+    /// <param name="dataJson">JSON object with field values for the component.</param>
+    /// <returns>The result of the set operation, or an error if the data JSON is invalid.</returns>
     [McpServerTool(Name = "mutation_set_component")]
     [Description("Set all fields of a component on an entity.")]
     public async Task<MutationBoolResult> SetComponent(
@@ -265,6 +328,14 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Sets a single field of a component on an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity.</param>
+    /// <param name="componentType">The component type name (e.g., 'Position', 'Velocity').</param>
+    /// <param name="fieldName">The name of the field to set.</param>
+    /// <param name="valueJson">JSON value for the field (can be a number, string, boolean, or object).</param>
+    /// <returns>The result of the set operation, or an error if the value JSON is invalid.</returns>
     [McpServerTool(Name = "mutation_set_field")]
     [Description("Set a single field of a component on an entity.")]
     public async Task<MutationBoolResult> SetField(
@@ -305,6 +376,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
 
     #region Tags
 
+    /// <summary>
+    /// Adds a string tag to an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to add the tag to.</param>
+    /// <param name="tag">The tag to add.</param>
+    /// <returns>The result of the add operation.</returns>
     [McpServerTool(Name = "mutation_add_tag")]
     [Description("Add a string tag to an entity.")]
     public async Task<MutationBoolResult> AddTag(
@@ -322,6 +399,12 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Removes a string tag from an entity.
+    /// </summary>
+    /// <param name="entityId">The ID of the entity to remove the tag from.</param>
+    /// <param name="tag">The tag to remove.</param>
+    /// <returns>The result of the remove operation.</returns>
     [McpServerTool(Name = "mutation_remove_tag")]
     [Description("Remove a string tag from an entity.")]
     public async Task<MutationBoolResult> RemoveTag(
@@ -339,6 +422,10 @@ public sealed class MutationTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets all unique tags currently in use across all entities.
+    /// </summary>
+    /// <returns>The result containing all unique tags in use.</returns>
     [McpServerTool(Name = "mutation_get_all_tags")]
     [Description("Get all unique tags currently in use across all entities.")]
     public async Task<MutationTagsResult> GetAllTags()

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/ProfileTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/ProfileTools.cs
@@ -19,11 +19,16 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// target world. If not installed, availability checks will return false.
 /// </para>
 /// </remarks>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerToolType]
 public sealed class ProfileTools(BridgeConnectionManager connection)
 {
     #region Debug Mode
 
+    /// <summary>
+    /// Checks whether debug mode is currently enabled.
+    /// </summary>
+    /// <returns>A <see cref="DebugModeResult"/> reporting the current debug mode state.</returns>
     [McpServerTool(Name = "profile_debug_mode_status")]
     [Description("Check if debug mode is currently enabled.")]
     public async Task<DebugModeResult> GetDebugModeStatus()
@@ -33,6 +38,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new DebugModeResult { Enabled = enabled };
     }
 
+    /// <summary>
+    /// Enables debug mode for enhanced diagnostics.
+    /// </summary>
+    /// <returns>A <see cref="DebugModeResult"/> confirming debug mode is enabled.</returns>
     [McpServerTool(Name = "profile_debug_mode_enable")]
     [Description("Enable debug mode for enhanced diagnostics.")]
     public async Task<DebugModeResult> EnableDebugMode()
@@ -42,6 +51,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new DebugModeResult { Enabled = true };
     }
 
+    /// <summary>
+    /// Disables debug mode.
+    /// </summary>
+    /// <returns>A <see cref="DebugModeResult"/> confirming debug mode is disabled.</returns>
     [McpServerTool(Name = "profile_debug_mode_disable")]
     [Description("Disable debug mode.")]
     public async Task<DebugModeResult> DisableDebugMode()
@@ -55,6 +68,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
 
     #region System Profiling
 
+    /// <summary>
+    /// Checks whether system profiling is available.
+    /// </summary>
+    /// <returns>An <see cref="AvailabilityResult"/> indicating whether the DebugPlugin is installed and system profiling is available.</returns>
     [McpServerTool(Name = "profile_system_available")]
     [Description("Check if system profiling is available. Requires DebugPlugin to be installed.")]
     public async Task<AvailabilityResult> IsSystemProfilingAvailable()
@@ -64,6 +81,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new AvailabilityResult { Available = available };
     }
 
+    /// <summary>
+    /// Gets profiling data for a specific system.
+    /// </summary>
+    /// <param name="name">The system name (e.g., 'MovementSystem').</param>
+    /// <returns>A <see cref="SystemProfilingResult"/> containing the system's profiling data, or an error if no profile was found.</returns>
     [McpServerTool(Name = "profile_system_get")]
     [Description("Get profiling data for a specific system.")]
     public async Task<SystemProfilingResult> GetSystemProfile(
@@ -85,6 +107,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return SystemProfilingResult.FromSnapshot(profile);
     }
 
+    /// <summary>
+    /// Gets profiling data for all systems.
+    /// </summary>
+    /// <returns>A <see cref="SystemProfilingListResult"/> containing profiling data for every profiled system.</returns>
     [McpServerTool(Name = "profile_system_list")]
     [Description("Get profiling data for all systems.")]
     public async Task<SystemProfilingListResult> GetAllSystemProfiles()
@@ -99,6 +125,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the slowest systems by average execution time.
+    /// </summary>
+    /// <param name="count">The maximum number of systems to return (default: 10).</param>
+    /// <returns>A <see cref="SystemProfilingListResult"/> containing the slowest systems, ordered by average execution time.</returns>
     [McpServerTool(Name = "profile_system_slowest")]
     [Description("Get the slowest systems by average execution time.")]
     public async Task<SystemProfilingListResult> GetSlowestSystems(
@@ -115,6 +146,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Resets all system profiling data.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating the reset succeeded.</returns>
     [McpServerTool(Name = "profile_system_reset")]
     [Description("Reset all system profiling data.")]
     public async Task<OperationResult> ResetSystemProfiles()
@@ -128,6 +163,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
 
     #region Query Profiling
 
+    /// <summary>
+    /// Checks whether query profiling is available.
+    /// </summary>
+    /// <returns>An <see cref="AvailabilityResult"/> indicating whether the DebugPlugin has query profiling enabled.</returns>
     [McpServerTool(Name = "profile_query_available")]
     [Description("Check if query profiling is available. Requires DebugPlugin with query profiling enabled.")]
     public async Task<AvailabilityResult> IsQueryProfilingAvailable()
@@ -137,6 +176,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new AvailabilityResult { Available = available };
     }
 
+    /// <summary>
+    /// Gets profiling data for a specific named query.
+    /// </summary>
+    /// <param name="name">The query name, as passed to BeginQuery/EndQuery.</param>
+    /// <returns>A <see cref="QueryProfilingResult"/> containing the query's profiling data, or an error if no profile was found.</returns>
     [McpServerTool(Name = "profile_query_get")]
     [Description("Get profiling data for a specific named query.")]
     public async Task<QueryProfilingResult> GetQueryProfile(
@@ -158,6 +202,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return QueryProfilingResult.FromSnapshot(profile);
     }
 
+    /// <summary>
+    /// Gets profiling data for all queries.
+    /// </summary>
+    /// <returns>A <see cref="QueryProfilingListResult"/> containing profiling data for every profiled query.</returns>
     [McpServerTool(Name = "profile_query_list")]
     [Description("Get profiling data for all queries.")]
     public async Task<QueryProfilingListResult> GetAllQueryProfiles()
@@ -172,6 +220,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the slowest queries by average execution time.
+    /// </summary>
+    /// <param name="count">The maximum number of queries to return (default: 10).</param>
+    /// <returns>A <see cref="QueryProfilingListResult"/> containing the slowest queries, ordered by average execution time.</returns>
     [McpServerTool(Name = "profile_query_slowest")]
     [Description("Get the slowest queries by average execution time.")]
     public async Task<QueryProfilingListResult> GetSlowestQueries(
@@ -188,6 +241,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets query cache hit/miss statistics.
+    /// </summary>
+    /// <returns>A <see cref="QueryCacheResult"/> containing cache hit, miss, and hit-rate statistics.</returns>
     [McpServerTool(Name = "profile_query_cache_stats")]
     [Description("Get query cache hit/miss statistics.")]
     public async Task<QueryCacheResult> GetQueryCacheStats()
@@ -203,6 +260,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Resets all query profiling data.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating the reset succeeded.</returns>
     [McpServerTool(Name = "profile_query_reset")]
     [Description("Reset all query profiling data.")]
     public async Task<OperationResult> ResetQueryProfiles()
@@ -216,6 +277,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
 
     #region GC/Allocation Profiling
 
+    /// <summary>
+    /// Checks whether GC/allocation tracking is available.
+    /// </summary>
+    /// <returns>An <see cref="AvailabilityResult"/> indicating whether the DebugPlugin has GC tracking enabled.</returns>
     [McpServerTool(Name = "profile_gc_available")]
     [Description("Check if GC/allocation tracking is available. Requires DebugPlugin with GC tracking enabled.")]
     public async Task<AvailabilityResult> IsGCTrackingAvailable()
@@ -225,6 +290,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new AvailabilityResult { Available = available };
     }
 
+    /// <summary>
+    /// Gets allocation data for a specific system.
+    /// </summary>
+    /// <param name="name">The system name (e.g., 'RenderSystem').</param>
+    /// <returns>An <see cref="AllocationResult"/> containing the system's allocation data, or an error if no profile was found.</returns>
     [McpServerTool(Name = "profile_gc_get")]
     [Description("Get allocation data for a specific system.")]
     public async Task<AllocationResult> GetAllocationProfile(
@@ -246,6 +316,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return AllocationResult.FromSnapshot(profile);
     }
 
+    /// <summary>
+    /// Gets allocation data for all systems.
+    /// </summary>
+    /// <returns>An <see cref="AllocationListResult"/> containing allocation data for every tracked system.</returns>
     [McpServerTool(Name = "profile_gc_list")]
     [Description("Get allocation data for all systems.")]
     public async Task<AllocationListResult> GetAllAllocationProfiles()
@@ -260,6 +334,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the systems with the highest total allocations.
+    /// </summary>
+    /// <param name="count">The maximum number of systems to return (default: 10).</param>
+    /// <returns>An <see cref="AllocationListResult"/> containing the systems with the highest total allocations.</returns>
     [McpServerTool(Name = "profile_gc_hotspots")]
     [Description("Get the systems with the highest total allocations.")]
     public async Task<AllocationListResult> GetAllocationHotspots(
@@ -276,6 +355,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Resets all allocation tracking data.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating the reset succeeded.</returns>
     [McpServerTool(Name = "profile_gc_reset")]
     [Description("Reset all allocation tracking data.")]
     public async Task<OperationResult> ResetAllocationProfiles()
@@ -289,6 +372,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
 
     #region Memory Stats
 
+    /// <summary>
+    /// Checks whether memory tracking is available.
+    /// </summary>
+    /// <returns>An <see cref="AvailabilityResult"/> indicating whether memory tracking is available.</returns>
     [McpServerTool(Name = "memory_available")]
     [Description("Check if memory tracking is available.")]
     public async Task<AvailabilityResult> IsMemoryTrackingAvailable()
@@ -298,6 +385,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new AvailabilityResult { Available = available };
     }
 
+    /// <summary>
+    /// Gets world memory statistics including entity counts, archetypes, and estimated memory usage.
+    /// </summary>
+    /// <returns>A <see cref="MemoryResult"/> containing the world's memory statistics.</returns>
     [McpServerTool(Name = "memory_get_stats")]
     [Description("Get world memory statistics including entity counts, archetypes, and estimated memory usage.")]
     public async Task<MemoryResult> GetMemoryStats()
@@ -307,6 +398,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return MemoryResult.FromSnapshot(stats);
     }
 
+    /// <summary>
+    /// Gets detailed statistics for all archetypes including entity distribution and memory usage.
+    /// </summary>
+    /// <returns>An <see cref="ArchetypeListResult"/> containing statistics for every archetype.</returns>
     [McpServerTool(Name = "memory_get_archetypes")]
     [Description("Get detailed statistics for all archetypes including entity distribution and memory usage.")]
     public async Task<ArchetypeListResult> GetArchetypeStats()
@@ -325,6 +420,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
 
     #region Timeline Recording
 
+    /// <summary>
+    /// Checks whether timeline recording is available.
+    /// </summary>
+    /// <returns>An <see cref="AvailabilityResult"/> indicating whether the DebugPlugin has timeline recording enabled.</returns>
     [McpServerTool(Name = "timeline_available")]
     [Description("Check if timeline recording is available. Requires DebugPlugin with timeline enabled.")]
     public async Task<AvailabilityResult> IsTimelineAvailable()
@@ -334,6 +433,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new AvailabilityResult { Available = available };
     }
 
+    /// <summary>
+    /// Gets the current timeline recording status.
+    /// </summary>
+    /// <returns>A <see cref="TimelineStatusResult"/> describing whether recording is active and the current frame and entry count.</returns>
     [McpServerTool(Name = "timeline_status")]
     [Description("Get the current timeline recording status.")]
     public async Task<TimelineStatusResult> GetTimelineStatus()
@@ -348,6 +451,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Enables timeline recording.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating recording was enabled.</returns>
     [McpServerTool(Name = "timeline_start")]
     [Description("Enable timeline recording.")]
     public async Task<OperationResult> StartTimelineRecording()
@@ -357,6 +464,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new OperationResult { Success = true };
     }
 
+    /// <summary>
+    /// Disables timeline recording.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating recording was disabled.</returns>
     [McpServerTool(Name = "timeline_stop")]
     [Description("Disable timeline recording.")]
     public async Task<OperationResult> StopTimelineRecording()
@@ -366,6 +477,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         return new OperationResult { Success = true };
     }
 
+    /// <summary>
+    /// Gets timeline entries for a specific frame.
+    /// </summary>
+    /// <param name="frameNumber">The frame number to query.</param>
+    /// <returns>A <see cref="TimelineEntriesResult"/> containing the timeline entries recorded for the frame.</returns>
     [McpServerTool(Name = "timeline_get_frame")]
     [Description("Get timeline entries for a specific frame.")]
     public async Task<TimelineEntriesResult> GetTimelineEntriesForFrame(
@@ -382,6 +498,11 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the most recent timeline entries.
+    /// </summary>
+    /// <param name="count">The maximum number of entries to return (default: 100).</param>
+    /// <returns>A <see cref="TimelineEntriesResult"/> containing the most recently recorded timeline entries.</returns>
     [McpServerTool(Name = "timeline_get_recent")]
     [Description("Get the most recent timeline entries.")]
     public async Task<TimelineEntriesResult> GetRecentTimelineEntries(
@@ -398,6 +519,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets aggregated timeline statistics per system.
+    /// </summary>
+    /// <returns>A <see cref="TimelineSystemStatsResult"/> containing per-system aggregated timeline statistics.</returns>
     [McpServerTool(Name = "timeline_system_stats")]
     [Description("Get aggregated timeline statistics per system.")]
     public async Task<TimelineSystemStatsResult> GetTimelineSystemStats()
@@ -412,6 +537,10 @@ public sealed class ProfileTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Clears all timeline data and resets the frame counter.
+    /// </summary>
+    /// <returns>An <see cref="OperationResult"/> indicating the timeline was reset.</returns>
     [McpServerTool(Name = "timeline_reset")]
     [Description("Clear all timeline data and reset the frame counter.")]
     public async Task<OperationResult> ResetTimeline()
@@ -469,15 +598,51 @@ public sealed record OperationResult
 /// </summary>
 public sealed record SystemProfilingResult
 {
+    /// <summary>
+    /// Gets whether a profile was found for the requested system.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the name of the profiled system.
+    /// </summary>
     public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the total execution time, in milliseconds, accumulated across all calls.
+    /// </summary>
     public double TotalTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the number of times the system has executed.
+    /// </summary>
     public int CallCount { get; init; }
+
+    /// <summary>
+    /// Gets the average execution time, in milliseconds, per call.
+    /// </summary>
     public double AverageTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the minimum recorded execution time, in milliseconds.
+    /// </summary>
     public double MinTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the maximum recorded execution time, in milliseconds.
+    /// </summary>
     public double MaxTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 
+    /// <summary>
+    /// Creates a <see cref="SystemProfilingResult"/> from a <see cref="SystemProfileSnapshot"/>.
+    /// </summary>
+    /// <param name="snapshot">The system profile snapshot to convert.</param>
+    /// <returns>A successful <see cref="SystemProfilingResult"/> populated from the snapshot.</returns>
     public static SystemProfilingResult FromSnapshot(SystemProfileSnapshot snapshot) => new()
     {
         Success = true,
@@ -495,9 +660,24 @@ public sealed record SystemProfilingResult
 /// </summary>
 public sealed record SystemProfilingListResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the profiling snapshots for the returned systems.
+    /// </summary>
     public IReadOnlyList<SystemProfileSnapshot> Profiles { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of profiles in <see cref="Profiles"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -506,19 +686,71 @@ public sealed record SystemProfilingListResult
 /// </summary>
 public sealed record QueryProfilingResult
 {
+    /// <summary>
+    /// Gets whether a profile was found for the requested query.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the name of the profiled query.
+    /// </summary>
     public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the total execution time, in milliseconds, accumulated across all calls.
+    /// </summary>
     public double TotalTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the number of times the query has executed.
+    /// </summary>
     public int CallCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of entities matched across all calls.
+    /// </summary>
     public long TotalEntities { get; init; }
+
+    /// <summary>
+    /// Gets the average execution time, in milliseconds, per call.
+    /// </summary>
     public double AverageTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the average number of entities matched per call.
+    /// </summary>
     public long AverageEntities { get; init; }
+
+    /// <summary>
+    /// Gets the minimum recorded execution time, in milliseconds.
+    /// </summary>
     public double MinTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the maximum recorded execution time, in milliseconds.
+    /// </summary>
     public double MaxTimeMs { get; init; }
+
+    /// <summary>
+    /// Gets the minimum number of entities matched in a single call.
+    /// </summary>
     public int MinEntities { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of entities matched in a single call.
+    /// </summary>
     public int MaxEntities { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 
+    /// <summary>
+    /// Creates a <see cref="QueryProfilingResult"/> from a <see cref="QueryProfileSnapshot"/>.
+    /// </summary>
+    /// <param name="snapshot">The query profile snapshot to convert.</param>
+    /// <returns>A successful <see cref="QueryProfilingResult"/> populated from the snapshot.</returns>
     public static QueryProfilingResult FromSnapshot(QueryProfileSnapshot snapshot) => new()
     {
         Success = true,
@@ -540,9 +772,24 @@ public sealed record QueryProfilingResult
 /// </summary>
 public sealed record QueryProfilingListResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the profiling snapshots for the returned queries.
+    /// </summary>
     public IReadOnlyList<QueryProfileSnapshot> Profiles { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of profiles in <see cref="Profiles"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -551,9 +798,24 @@ public sealed record QueryProfilingListResult
 /// </summary>
 public sealed record QueryCacheResult
 {
+    /// <summary>
+    /// Gets the number of query cache hits.
+    /// </summary>
     public required long CacheHits { get; init; }
+
+    /// <summary>
+    /// Gets the number of query cache misses.
+    /// </summary>
     public required long CacheMisses { get; init; }
+
+    /// <summary>
+    /// Gets the number of queries currently cached.
+    /// </summary>
     public required int CachedQueryCount { get; init; }
+
+    /// <summary>
+    /// Gets the cache hit rate, as a fraction between 0 and 1.
+    /// </summary>
     public required double HitRate { get; init; }
 }
 
@@ -562,15 +824,51 @@ public sealed record QueryCacheResult
 /// </summary>
 public sealed record AllocationResult
 {
+    /// <summary>
+    /// Gets whether an allocation profile was found for the requested system.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the name of the profiled system.
+    /// </summary>
     public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the total number of bytes allocated across all calls.
+    /// </summary>
     public long TotalBytes { get; init; }
+
+    /// <summary>
+    /// Gets the number of times the system has executed.
+    /// </summary>
     public int CallCount { get; init; }
+
+    /// <summary>
+    /// Gets the average number of bytes allocated per call.
+    /// </summary>
     public long AverageBytes { get; init; }
+
+    /// <summary>
+    /// Gets the minimum number of bytes allocated in a single call.
+    /// </summary>
     public long MinBytes { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of bytes allocated in a single call.
+    /// </summary>
     public long MaxBytes { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 
+    /// <summary>
+    /// Creates an <see cref="AllocationResult"/> from an <see cref="AllocationProfileSnapshot"/>.
+    /// </summary>
+    /// <param name="snapshot">The allocation profile snapshot to convert.</param>
+    /// <returns>A successful <see cref="AllocationResult"/> populated from the snapshot.</returns>
     public static AllocationResult FromSnapshot(AllocationProfileSnapshot snapshot) => new()
     {
         Success = true,
@@ -588,9 +886,24 @@ public sealed record AllocationResult
 /// </summary>
 public sealed record AllocationListResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the allocation profiling snapshots for the returned systems.
+    /// </summary>
     public IReadOnlyList<AllocationProfileSnapshot> Profiles { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of profiles in <see cref="Profiles"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -599,20 +912,76 @@ public sealed record AllocationListResult
 /// </summary>
 public sealed record MemoryResult
 {
+    /// <summary>
+    /// Gets the total number of entity slots ever allocated.
+    /// </summary>
     public int EntitiesAllocated { get; init; }
+
+    /// <summary>
+    /// Gets the number of entities currently active in the world.
+    /// </summary>
     public int EntitiesActive { get; init; }
+
+    /// <summary>
+    /// Gets the number of entity slots currently available for recycling.
+    /// </summary>
     public int EntitiesRecycled { get; init; }
+
+    /// <summary>
+    /// Gets the total number of times an entity slot has been recycled.
+    /// </summary>
     public long EntityRecycleCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of distinct archetypes in the world.
+    /// </summary>
     public int ArchetypeCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of registered component types.
+    /// </summary>
     public int ComponentTypeCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of registered systems.
+    /// </summary>
     public int SystemCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of queries currently cached.
+    /// </summary>
     public int CachedQueryCount { get; init; }
+
+    /// <summary>
+    /// Gets the number of query cache hits.
+    /// </summary>
     public long QueryCacheHits { get; init; }
+
+    /// <summary>
+    /// Gets the number of query cache misses.
+    /// </summary>
     public long QueryCacheMisses { get; init; }
+
+    /// <summary>
+    /// Gets the estimated number of bytes used by component storage.
+    /// </summary>
     public long EstimatedComponentBytes { get; init; }
+
+    /// <summary>
+    /// Gets the entity recycling efficiency, as a fraction between 0 and 1.
+    /// </summary>
     public double RecycleEfficiency { get; init; }
+
+    /// <summary>
+    /// Gets the query cache hit rate, as a fraction between 0 and 1.
+    /// </summary>
     public double QueryCacheHitRate { get; init; }
 
+    /// <summary>
+    /// Creates a <see cref="MemoryResult"/> from a <see cref="MemoryStatsSnapshot"/>.
+    /// </summary>
+    /// <param name="snapshot">The memory statistics snapshot to convert.</param>
+    /// <returns>A <see cref="MemoryResult"/> populated from the snapshot.</returns>
     public static MemoryResult FromSnapshot(MemoryStatsSnapshot snapshot) => new()
     {
         EntitiesAllocated = snapshot.EntitiesAllocated,
@@ -636,9 +1005,24 @@ public sealed record MemoryResult
 /// </summary>
 public sealed record ArchetypeListResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the statistics for each archetype in the world.
+    /// </summary>
     public IReadOnlyList<ArchetypeStatsSnapshot> Archetypes { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of archetypes in <see cref="Archetypes"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -647,8 +1031,19 @@ public sealed record ArchetypeListResult
 /// </summary>
 public sealed record TimelineStatusResult
 {
+    /// <summary>
+    /// Gets whether timeline recording is currently active.
+    /// </summary>
     public required bool IsRecording { get; init; }
+
+    /// <summary>
+    /// Gets the current frame number.
+    /// </summary>
     public required long CurrentFrame { get; init; }
+
+    /// <summary>
+    /// Gets the total number of entries currently recorded in the timeline.
+    /// </summary>
     public required int EntryCount { get; init; }
 }
 
@@ -657,9 +1052,24 @@ public sealed record TimelineStatusResult
 /// </summary>
 public sealed record TimelineEntriesResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the recorded timeline entries.
+    /// </summary>
     public IReadOnlyList<TimelineEntrySnapshot> Entries { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of entries in <see cref="Entries"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 
@@ -668,9 +1078,24 @@ public sealed record TimelineEntriesResult
 /// </summary>
 public sealed record TimelineSystemStatsResult
 {
+    /// <summary>
+    /// Gets whether the query succeeded.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the aggregated timeline statistics for each system.
+    /// </summary>
     public IReadOnlyList<TimelineSystemStatsSnapshot> Stats { get; init; } = [];
+
+    /// <summary>
+    /// Gets the number of entries in <see cref="Stats"/>.
+    /// </summary>
     public int Count { get; init; }
+
+    /// <summary>
+    /// Gets an error message if the query failed.
+    /// </summary>
     public string? Error { get; init; }
 }
 

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/ReplayTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/ReplayTools.cs
@@ -18,11 +18,19 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// Playback can be done independently using the built-in ReplayPlayer.
 /// </para>
 /// </remarks>
+/// <param name="connection">The connection manager used to reach the active bridge.</param>
 [McpServerToolType]
 public sealed class ReplayTools(BridgeConnectionManager connection)
 {
     #region Recording Control
 
+    /// <summary>
+    /// Starts recording gameplay, requiring the ReplayPlugin to be installed on the world.
+    /// </summary>
+    /// <param name="name">Optional name for this recording.</param>
+    /// <param name="maxFrames">Maximum frames to record (default: 36000 = 10 minutes at 60fps).</param>
+    /// <param name="snapshotIntervalMs">Interval in milliseconds between world state snapshots (default: 5000 = 5 seconds).</param>
+    /// <returns>The result of the start-recording operation.</returns>
     [McpServerTool(Name = "replay_start_recording")]
     [Description("Start recording gameplay. Requires ReplayPlugin to be installed on the world.")]
     public async Task<ReplayOperationResultMcp> StartRecording(
@@ -38,6 +46,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Stops recording and keeps the recorded data in memory; use replay_save to persist it.
+    /// </summary>
+    /// <returns>The result of the stop-recording operation.</returns>
     [McpServerTool(Name = "replay_stop_recording")]
     [Description("Stop recording and keep the recording data in memory. Use replay_save to persist.")]
     public async Task<ReplayOperationResultMcp> StopRecording()
@@ -47,6 +59,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Cancels recording and discards all recorded data.
+    /// </summary>
+    /// <returns>The result of the cancel-recording operation.</returns>
     [McpServerTool(Name = "replay_cancel_recording")]
     [Description("Cancel recording and discard all recorded data.")]
     public async Task<ReplayOperationResultMcp> CancelRecording()
@@ -56,6 +72,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Checks whether recording is currently in progress.
+    /// </summary>
+    /// <returns>The current recording status, including recording info when active.</returns>
     [McpServerTool(Name = "replay_is_recording")]
     [Description("Check if recording is currently in progress.")]
     public async Task<RecordingStatusResult> IsRecording()
@@ -71,6 +91,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Forces a world state snapshot to be taken during recording.
+    /// </summary>
+    /// <returns>The result of the force-snapshot operation.</returns>
     [McpServerTool(Name = "replay_force_snapshot")]
     [Description("Force a world state snapshot during recording.")]
     public async Task<ReplayOperationResultMcp> ForceSnapshot()
@@ -84,6 +108,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
 
     #region Recording Management
 
+    /// <summary>
+    /// Saves the current recording to a file.
+    /// </summary>
+    /// <param name="path">File path to save the replay to (with .kreplay extension).</param>
+    /// <returns>The result of the save operation.</returns>
     [McpServerTool(Name = "replay_save")]
     [Description("Save the current recording to a file.")]
     public async Task<ReplayOperationResultMcp> Save(
@@ -95,6 +124,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Loads a replay file for playback.
+    /// </summary>
+    /// <param name="path">File path of the replay to load.</param>
+    /// <returns>The result of the load operation.</returns>
     [McpServerTool(Name = "replay_load")]
     [Description("Load a replay file for playback.")]
     public async Task<ReplayOperationResultMcp> Load(
@@ -106,6 +140,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Lists all replay files in a directory.
+    /// </summary>
+    /// <param name="directory">Directory to search for replay files (null = current directory).</param>
+    /// <returns>The list of replay files found in the directory.</returns>
     [McpServerTool(Name = "replay_list")]
     [Description("List all replay files in a directory.")]
     public async Task<ReplayFileListResult> List(
@@ -122,6 +161,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Deletes a replay file.
+    /// </summary>
+    /// <param name="path">File path of the replay to delete.</param>
+    /// <returns>The result of the delete operation.</returns>
     [McpServerTool(Name = "replay_delete")]
     [Description("Delete a replay file.")]
     public async Task<ReplayDeleteResult> Delete(
@@ -138,6 +182,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets metadata from a replay file without loading it for playback.
+    /// </summary>
+    /// <param name="path">File path of the replay.</param>
+    /// <returns>The replay metadata, or <see langword="null"/> if the file could not be read.</returns>
     [McpServerTool(Name = "replay_get_metadata")]
     [Description("Get metadata from a replay file without loading it for playback.")]
     public async Task<ReplayMetadataResult?> GetMetadata(
@@ -153,6 +202,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
 
     #region Playback Control
 
+    /// <summary>
+    /// Starts or resumes playback of the loaded replay.
+    /// </summary>
+    /// <returns>The result of the play operation.</returns>
     [McpServerTool(Name = "replay_play")]
     [Description("Start or resume playback of the loaded replay.")]
     public async Task<ReplayOperationResultMcp> Play()
@@ -162,6 +215,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Pauses playback.
+    /// </summary>
+    /// <returns>The result of the pause operation.</returns>
     [McpServerTool(Name = "replay_pause")]
     [Description("Pause playback.")]
     public async Task<ReplayOperationResultMcp> Pause()
@@ -171,6 +228,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Stops playback and resets to the beginning.
+    /// </summary>
+    /// <returns>The result of the stop operation.</returns>
     [McpServerTool(Name = "replay_stop")]
     [Description("Stop playback and reset to the beginning.")]
     public async Task<ReplayOperationResultMcp> Stop()
@@ -180,6 +241,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Gets the current playback state.
+    /// </summary>
+    /// <returns>The current playback state.</returns>
     [McpServerTool(Name = "replay_get_playback_state")]
     [Description("Get the current playback state.")]
     public async Task<PlaybackStateResult> GetPlaybackState()
@@ -189,6 +254,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return PlaybackStateResult.FromSnapshot(state);
     }
 
+    /// <summary>
+    /// Sets the playback speed.
+    /// </summary>
+    /// <param name="speed">Playback speed multiplier (0.25 to 4.0).</param>
+    /// <returns>The result of the set-speed operation.</returns>
     [McpServerTool(Name = "replay_set_speed")]
     [Description("Set the playback speed (0.25x to 4.0x).")]
     public async Task<ReplayOperationResultMcp> SetSpeed(
@@ -204,6 +274,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
 
     #region Playback Navigation
 
+    /// <summary>
+    /// Seeks to a specific frame in the replay.
+    /// </summary>
+    /// <param name="frame">Frame number to seek to.</param>
+    /// <returns>The result of the seek operation.</returns>
     [McpServerTool(Name = "replay_seek_frame")]
     [Description("Seek to a specific frame in the replay.")]
     public async Task<ReplayOperationResultMcp> SeekFrame(
@@ -215,6 +290,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Seeks to a specific time in the replay.
+    /// </summary>
+    /// <param name="seconds">Time in seconds to seek to.</param>
+    /// <returns>The result of the seek operation.</returns>
     [McpServerTool(Name = "replay_seek_time")]
     [Description("Seek to a specific time in the replay.")]
     public async Task<ReplayOperationResultMcp> SeekTime(
@@ -226,6 +306,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Steps forward by a number of frames, pausing playback if it is currently playing.
+    /// </summary>
+    /// <param name="frames">Number of frames to step forward.</param>
+    /// <returns>The result of the step-forward operation.</returns>
     [McpServerTool(Name = "replay_step_forward")]
     [Description("Step forward by a number of frames (pauses if playing).")]
     public async Task<ReplayOperationResultMcp> StepForward(
@@ -237,6 +322,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ReplayOperationResultMcp.FromResult(result);
     }
 
+    /// <summary>
+    /// Steps backward by a number of frames, pausing playback if it is currently playing.
+    /// </summary>
+    /// <param name="frames">Number of frames to step backward.</param>
+    /// <returns>The result of the step-backward operation.</returns>
     [McpServerTool(Name = "replay_step_backward")]
     [Description("Step backward by a number of frames (pauses if playing).")]
     public async Task<ReplayOperationResultMcp> StepBackward(
@@ -252,6 +342,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
 
     #region Frame Inspection
 
+    /// <summary>
+    /// Gets details about a specific frame.
+    /// </summary>
+    /// <param name="frame">Frame number to inspect.</param>
+    /// <returns>The frame details, or <see langword="null"/> if the frame does not exist.</returns>
     [McpServerTool(Name = "replay_get_frame")]
     [Description("Get details about a specific frame.")]
     public async Task<ReplayFrameResult?> GetFrame(
@@ -263,6 +358,12 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return frameData != null ? ReplayFrameResult.FromSnapshot(frameData) : null;
     }
 
+    /// <summary>
+    /// Gets details about a range of frames.
+    /// </summary>
+    /// <param name="startFrame">Starting frame number.</param>
+    /// <param name="count">Number of frames to retrieve.</param>
+    /// <returns>The requested range of frame details.</returns>
     [McpServerTool(Name = "replay_get_frame_range")]
     [Description("Get details about a range of frames.")]
     public async Task<FrameRangeResult> GetFrameRange(
@@ -281,6 +382,12 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets input events for a range of frames.
+    /// </summary>
+    /// <param name="startFrame">Starting frame number.</param>
+    /// <param name="endFrame">Ending frame number.</param>
+    /// <returns>The input events recorded within the given frame range.</returns>
     [McpServerTool(Name = "replay_get_inputs")]
     [Description("Get input events for a range of frames.")]
     public async Task<InputEventsResult> GetInputs(
@@ -300,6 +407,12 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets replay events, such as entity spawns and despawns, for a range of frames.
+    /// </summary>
+    /// <param name="startFrame">Starting frame number.</param>
+    /// <param name="endFrame">Ending frame number.</param>
+    /// <returns>The replay events recorded within the given frame range.</returns>
     [McpServerTool(Name = "replay_get_events")]
     [Description("Get replay events (entity spawns, despawns, etc.) for a range of frames.")]
     public async Task<ReplayEventsResult> GetEvents(
@@ -319,6 +432,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets a list of all world state snapshots in the loaded replay.
+    /// </summary>
+    /// <returns>The snapshot markers contained in the loaded replay.</returns>
     [McpServerTool(Name = "replay_get_snapshots")]
     [Description("Get a list of all world state snapshots in the loaded replay.")]
     public async Task<SnapshotMarkersResult> GetSnapshots()
@@ -336,6 +453,11 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
 
     #region Validation
 
+    /// <summary>
+    /// Validates a replay file for integrity and compatibility.
+    /// </summary>
+    /// <param name="path">File path of the replay to validate.</param>
+    /// <returns>The validation result.</returns>
     [McpServerTool(Name = "replay_validate")]
     [Description("Validate a replay file for integrity and compatibility.")]
     public async Task<ValidationResult> Validate(
@@ -347,6 +469,10 @@ public sealed class ReplayTools(BridgeConnectionManager connection)
         return ValidationResult.FromSnapshot(result);
     }
 
+    /// <summary>
+    /// Checks whether the loaded replay has determinism issues, such as checksum mismatches.
+    /// </summary>
+    /// <returns>The determinism check result.</returns>
     [McpServerTool(Name = "replay_check_determinism")]
     [Description("Check if the loaded replay has determinism issues (checksum mismatches).")]
     public async Task<DeterminismResult> CheckDeterminism()

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/SnapshotTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/SnapshotTools.cs
@@ -15,11 +15,17 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// entities and components at a point in time.
 /// </para>
 /// </remarks>
+/// <param name="connection">The bridge connection manager used to reach the active game or editor session.</param>
 [McpServerToolType]
 public sealed class SnapshotTools(BridgeConnectionManager connection)
 {
     #region Create/Restore
 
+    /// <summary>
+    /// Creates a named in-memory snapshot of the current world state.
+    /// </summary>
+    /// <param name="name">Unique name for this snapshot.</param>
+    /// <returns>The result of the create operation.</returns>
     [McpServerTool(Name = "snapshot_create")]
     [Description("Create a named in-memory snapshot of the current world state.")]
     public async Task<SnapshotOperationResult> Create(
@@ -31,6 +37,11 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         return SnapshotOperationResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Restores the world state from a named snapshot, clearing the current world and recreating all entities.
+    /// </summary>
+    /// <param name="name">Name of the snapshot to restore.</param>
+    /// <returns>The result of the restore operation.</returns>
     [McpServerTool(Name = "snapshot_restore")]
     [Description("Restore the world state from a named snapshot. This clears the current world and recreates all entities.")]
     public async Task<SnapshotOperationResult> Restore(
@@ -42,6 +53,11 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         return SnapshotOperationResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Deletes a named snapshot from memory.
+    /// </summary>
+    /// <param name="name">Name of the snapshot to delete.</param>
+    /// <returns>The result of the delete operation.</returns>
     [McpServerTool(Name = "snapshot_delete")]
     [Description("Delete a named snapshot from memory.")]
     public async Task<SnapshotDeleteResult> Delete(
@@ -62,6 +78,10 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
 
     #region List/Info
 
+    /// <summary>
+    /// Lists all available snapshots with their metadata.
+    /// </summary>
+    /// <returns>A result containing the count and metadata of all available snapshots.</returns>
     [McpServerTool(Name = "snapshot_list")]
     [Description("List all available snapshots with their metadata.")]
     public async Task<SnapshotListResult> List()
@@ -75,6 +95,11 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets detailed information about a specific snapshot.
+    /// </summary>
+    /// <param name="name">Name of the snapshot.</param>
+    /// <returns>The snapshot metadata, or <see langword="null"/> if no snapshot with that name exists.</returns>
     [McpServerTool(Name = "snapshot_get_info")]
     [Description("Get detailed information about a specific snapshot.")]
     public async Task<SnapshotInfoResult?> GetInfo(
@@ -90,6 +115,12 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
 
     #region Diff
 
+    /// <summary>
+    /// Compares two named snapshots and reports the differences between them.
+    /// </summary>
+    /// <param name="name1">Name of the first (baseline) snapshot.</param>
+    /// <param name="name2">Name of the second snapshot to compare.</param>
+    /// <returns>The differences between the two snapshots.</returns>
     [McpServerTool(Name = "snapshot_diff")]
     [Description("Compare two named snapshots and show the differences.")]
     public async Task<SnapshotDiffResult> Diff(
@@ -103,6 +134,11 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         return SnapshotDiffResult.FromDiff(diff);
     }
 
+    /// <summary>
+    /// Compares a snapshot with the current world state.
+    /// </summary>
+    /// <param name="name">Name of the snapshot to compare against the current state.</param>
+    /// <returns>The differences between the snapshot and the current world state.</returns>
     [McpServerTool(Name = "snapshot_diff_current")]
     [Description("Compare a snapshot with the current world state.")]
     public async Task<SnapshotDiffResult> DiffCurrent(
@@ -118,6 +154,12 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
 
     #region File Operations
 
+    /// <summary>
+    /// Saves a snapshot to a file on disk.
+    /// </summary>
+    /// <param name="name">Name of the snapshot to save.</param>
+    /// <param name="path">File path to save the snapshot to.</param>
+    /// <returns>The result of the save operation.</returns>
     [McpServerTool(Name = "snapshot_save_file")]
     [Description("Save a snapshot to a file on disk.")]
     public async Task<SnapshotOperationResult> SaveToFile(
@@ -131,6 +173,12 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         return SnapshotOperationResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Loads a snapshot from a file on disk.
+    /// </summary>
+    /// <param name="path">File path to load the snapshot from.</param>
+    /// <param name="name">Optional name for the loaded snapshot; defaults to the filename when omitted.</param>
+    /// <returns>The result of the load operation.</returns>
     [McpServerTool(Name = "snapshot_load_file")]
     [Description("Load a snapshot from a file on disk.")]
     public async Task<SnapshotOperationResult> LoadFromFile(
@@ -148,6 +196,10 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
 
     #region Quick Save/Load
 
+    /// <summary>
+    /// Creates a quicksave snapshot for rapid iteration. Only one quicksave can exist at a time.
+    /// </summary>
+    /// <returns>The result of the quicksave operation.</returns>
     [McpServerTool(Name = "quicksave")]
     [Description("Create a quicksave snapshot for rapid iteration. Only one quicksave can exist at a time.")]
     public async Task<SnapshotOperationResult> QuickSave()
@@ -157,6 +209,10 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         return SnapshotOperationResult.FromResult(result);
     }
 
+    /// <summary>
+    /// Restores the world state from the quicksave snapshot.
+    /// </summary>
+    /// <returns>The result of the quickload operation.</returns>
     [McpServerTool(Name = "quickload")]
     [Description("Restore from the quicksave snapshot.")]
     public async Task<SnapshotOperationResult> QuickLoad()
@@ -170,6 +226,11 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
 
     #region Export/Import
 
+    /// <summary>
+    /// Exports a snapshot as a JSON string.
+    /// </summary>
+    /// <param name="name">Name of the snapshot to export.</param>
+    /// <returns>The result of the export operation, including the JSON payload when successful.</returns>
     [McpServerTool(Name = "snapshot_export_json")]
     [Description("Export a snapshot as a JSON string.")]
     public async Task<SnapshotExportResult> ExportJson(
@@ -187,6 +248,12 @@ public sealed class SnapshotTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Imports a snapshot from a JSON string.
+    /// </summary>
+    /// <param name="json">JSON string containing snapshot data.</param>
+    /// <param name="name">Name to assign to the imported snapshot.</param>
+    /// <returns>The result of the import operation.</returns>
     [McpServerTool(Name = "snapshot_import_json")]
     [Description("Import a snapshot from a JSON string.")]
     public async Task<SnapshotOperationResult> ImportJson(

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/StateTools.cs
@@ -9,11 +9,16 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// <summary>
 /// MCP tools for querying game state (entities, components, systems, performance).
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerToolType]
 public sealed class StateTools(BridgeConnectionManager connection)
 {
     #region Entity Queries
 
+    /// <summary>
+    /// Gets the total number of entities currently in the world.
+    /// </summary>
+    /// <returns>The entity count.</returns>
     [McpServerTool(Name = "state_get_entity_count")]
     [Description("Get the total number of entities in the world.")]
     public async Task<EntityCountResult> StateGetEntityCount()
@@ -24,6 +29,17 @@ public sealed class StateTools(BridgeConnectionManager connection)
         return new EntityCountResult { Count = count };
     }
 
+    /// <summary>
+    /// Queries entities matching the given filters and returns their snapshots.
+    /// </summary>
+    /// <param name="withComponents">Component types entities must have (e.g., ['Position', 'Velocity']).</param>
+    /// <param name="withoutComponents">Component types entities must NOT have.</param>
+    /// <param name="withTags">Tags entities must have.</param>
+    /// <param name="namePattern">Name pattern to match (supports * and ? wildcards).</param>
+    /// <param name="parentId">Parent entity ID to filter by.</param>
+    /// <param name="maxResults">The maximum number of results to return.</param>
+    /// <param name="includeComponentData">Whether to include full component data in the results.</param>
+    /// <returns>The entity snapshots matching the criteria.</returns>
     [McpServerTool(Name = "state_query_entities")]
     [Description("Query entities with filters. Returns entity snapshots matching the criteria.")]
     public async Task<IReadOnlyList<EntitySnapshot>> StateQueryEntities(
@@ -58,6 +74,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
         return await bridge.State.QueryEntitiesAsync(query);
     }
 
+    /// <summary>
+    /// Gets detailed information about an entity by its ID.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <returns>The entity snapshot, or <see langword="null"/> if no such entity exists.</returns>
     [McpServerTool(Name = "state_get_entity")]
     [Description("Get detailed information about an entity by its ID.")]
     public async Task<EntitySnapshot?> StateGetEntity(
@@ -68,6 +89,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
         return await bridge.State.GetEntityAsync(entityId);
     }
 
+    /// <summary>
+    /// Finds the first entity with the given name.
+    /// </summary>
+    /// <param name="name">The entity name to search for.</param>
+    /// <returns>The matching entity snapshot, or <see langword="null"/> if none is found.</returns>
     [McpServerTool(Name = "state_get_entity_by_name")]
     [Description("Find an entity by its name. Returns the first entity with the given name.")]
     public async Task<EntitySnapshot?> StateGetEntityByName(
@@ -82,6 +108,12 @@ public sealed class StateTools(BridgeConnectionManager connection)
 
     #region Components
 
+    /// <summary>
+    /// Gets component data from an entity as field names and values.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <param name="componentType">The component type name (e.g., 'Position', 'Health').</param>
+    /// <returns>The component data lookup result.</returns>
     [McpServerTool(Name = "state_get_component")]
     [Description("Get component data from an entity. Returns field names and values.")]
     public async Task<ComponentDataResult> StateGetComponent(
@@ -129,6 +161,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
 
     #region Hierarchy
 
+    /// <summary>
+    /// Gets the child entity IDs of an entity.
+    /// </summary>
+    /// <param name="entityId">The parent entity ID.</param>
+    /// <returns>The child entity IDs.</returns>
     [McpServerTool(Name = "state_get_children")]
     [Description("Get the child entity IDs of an entity.")]
     public async Task<ChildrenResult> StateGetChildren(
@@ -146,6 +183,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the parent entity ID of an entity.
+    /// </summary>
+    /// <param name="entityId">The entity ID.</param>
+    /// <returns>The parent lookup result; <see cref="ParentResult.HasParent"/> is <see langword="false"/> if the entity has no parent.</returns>
     [McpServerTool(Name = "state_get_parent")]
     [Description("Get the parent entity ID of an entity. Returns null if entity has no parent.")]
     public async Task<ParentResult> StateGetParent(
@@ -163,6 +205,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Finds all entity IDs that have a specific tag.
+    /// </summary>
+    /// <param name="tag">The tag name to search for.</param>
+    /// <returns>The matching entity IDs.</returns>
     [McpServerTool(Name = "state_get_entities_with_tag")]
     [Description("Find all entity IDs that have a specific tag.")]
     public async Task<TagQueryResult> StateGetEntitiesWithTag(
@@ -184,6 +231,10 @@ public sealed class StateTools(BridgeConnectionManager connection)
 
     #region World Info
 
+    /// <summary>
+    /// Gets statistics about the world, including entity count, archetype count, and memory usage.
+    /// </summary>
+    /// <returns>The world statistics.</returns>
     [McpServerTool(Name = "state_get_world_stats")]
     [Description("Get statistics about the world: entity count, archetype count, memory usage, etc.")]
     public async Task<WorldStats> StateGetWorldStats()
@@ -192,6 +243,10 @@ public sealed class StateTools(BridgeConnectionManager connection)
         return await bridge.State.GetWorldStatsAsync();
     }
 
+    /// <summary>
+    /// Lists all registered systems with their phase, order, and execution stats.
+    /// </summary>
+    /// <returns>The registered systems' information.</returns>
     [McpServerTool(Name = "state_get_systems")]
     [Description("List all registered systems with their phase, order, and execution stats.")]
     public async Task<IReadOnlyList<SystemInfo>> StateGetSystems()
@@ -200,6 +255,11 @@ public sealed class StateTools(BridgeConnectionManager connection)
         return await bridge.State.GetSystemsAsync();
     }
 
+    /// <summary>
+    /// Gets performance metrics such as FPS, frame times, and per-system timing.
+    /// </summary>
+    /// <param name="frameCount">The number of frames to analyze.</param>
+    /// <returns>The performance metrics.</returns>
     [McpServerTool(Name = "state_get_performance")]
     [Description("Get performance metrics: FPS, frame times, per-system timing.")]
     public async Task<PerformanceMetrics> StateGetPerformance(
@@ -220,6 +280,9 @@ public sealed class StateTools(BridgeConnectionManager connection)
 /// </summary>
 public sealed record EntityCountResult
 {
+    /// <summary>
+    /// Gets the total number of entities in the world.
+    /// </summary>
     public required int Count { get; init; }
 }
 
@@ -228,8 +291,19 @@ public sealed record EntityCountResult
 /// </summary>
 public sealed record ChildrenResult
 {
+    /// <summary>
+    /// Gets the ID of the entity whose children were queried.
+    /// </summary>
     public required int ParentId { get; init; }
+
+    /// <summary>
+    /// Gets the child entity IDs.
+    /// </summary>
     public required int[] ChildIds { get; init; }
+
+    /// <summary>
+    /// Gets the number of child entities.
+    /// </summary>
     public required int Count { get; init; }
 }
 
@@ -238,8 +312,19 @@ public sealed record ChildrenResult
 /// </summary>
 public sealed record ParentResult
 {
+    /// <summary>
+    /// Gets the ID of the entity whose parent was queried.
+    /// </summary>
     public required int EntityId { get; init; }
+
+    /// <summary>
+    /// Gets the parent entity ID, or <see langword="null"/> if the entity has no parent.
+    /// </summary>
     public int? ParentId { get; init; }
+
+    /// <summary>
+    /// Gets whether the entity has a parent.
+    /// </summary>
     public required bool HasParent { get; init; }
 }
 
@@ -248,8 +333,19 @@ public sealed record ParentResult
 /// </summary>
 public sealed record TagQueryResult
 {
+    /// <summary>
+    /// Gets the tag name that was queried.
+    /// </summary>
     public required string Tag { get; init; }
+
+    /// <summary>
+    /// Gets the IDs of entities that have the tag.
+    /// </summary>
     public required int[] EntityIds { get; init; }
+
+    /// <summary>
+    /// Gets the number of matching entities.
+    /// </summary>
     public required int Count { get; init; }
 }
 

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/SystemTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/SystemTools.cs
@@ -20,6 +20,10 @@ public sealed class SystemTools(BridgeConnectionManager connection)
 {
     #region Listing
 
+    /// <summary>
+    /// Lists all registered ECS systems along with their state and metadata.
+    /// </summary>
+    /// <returns>A <see cref="SystemListResult"/> containing the systems and their count.</returns>
     [McpServerTool(Name = "system_list")]
     [Description("List all registered ECS systems with their state and metadata.")]
     public async Task<SystemListResult> List()
@@ -34,6 +38,10 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the total number of registered systems.
+    /// </summary>
+    /// <returns>A <see cref="SystemCountResult"/> containing the system count.</returns>
     [McpServerTool(Name = "system_get_count")]
     [Description("Get the total number of registered systems.")]
     public async Task<SystemCountResult> GetCount()
@@ -43,6 +51,11 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         return new SystemCountResult { Count = count };
     }
 
+    /// <summary>
+    /// Gets detailed information about a specific system by name.
+    /// </summary>
+    /// <param name="name">The system name (e.g., 'MovementSystem', 'PhysicsSystem').</param>
+    /// <returns>A <see cref="SystemResult"/> describing the system, or a failed result if the system was not found.</returns>
     [McpServerTool(Name = "system_get")]
     [Description("Get detailed information about a specific system by name.")]
     public async Task<SystemResult> Get(
@@ -68,6 +81,11 @@ public sealed class SystemTools(BridgeConnectionManager connection)
 
     #region Enable/Disable
 
+    /// <summary>
+    /// Enables a system so that it is executed during world updates.
+    /// </summary>
+    /// <param name="name">The name of the system to enable.</param>
+    /// <returns>A <see cref="SystemResult"/> describing the updated system, or a failed result if the system was not found.</returns>
     [McpServerTool(Name = "system_enable")]
     [Description("Enable a system so it will be executed during world updates.")]
     public async Task<SystemResult> Enable(
@@ -90,6 +108,11 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         }
     }
 
+    /// <summary>
+    /// Disables a system so that it is skipped during world updates.
+    /// </summary>
+    /// <param name="name">The name of the system to disable.</param>
+    /// <returns>A <see cref="SystemResult"/> describing the updated system, or a failed result if the system was not found.</returns>
     [McpServerTool(Name = "system_disable")]
     [Description("Disable a system so it will be skipped during world updates.")]
     public async Task<SystemResult> Disable(
@@ -112,6 +135,11 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         }
     }
 
+    /// <summary>
+    /// Toggles a system's enabled state.
+    /// </summary>
+    /// <param name="name">The name of the system to toggle.</param>
+    /// <returns>A <see cref="SystemResult"/> describing the updated system, or a failed result if the system was not found.</returns>
     [McpServerTool(Name = "system_toggle")]
     [Description("Toggle a system's enabled state.")]
     public async Task<SystemResult> Toggle(
@@ -138,6 +166,11 @@ public sealed class SystemTools(BridgeConnectionManager connection)
 
     #region Filtering
 
+    /// <summary>
+    /// Gets all systems in a specific execution phase.
+    /// </summary>
+    /// <param name="phase">The phase name (e.g., 'Update', 'FixedUpdate', 'LateUpdate', 'Render').</param>
+    /// <returns>A <see cref="SystemListResult"/> containing the matching systems and their count.</returns>
     [McpServerTool(Name = "system_get_by_phase")]
     [Description("Get all systems in a specific execution phase.")]
     public async Task<SystemListResult> GetByPhase(
@@ -154,6 +187,10 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets all currently enabled systems.
+    /// </summary>
+    /// <returns>A <see cref="SystemListResult"/> containing the enabled systems and their count.</returns>
     [McpServerTool(Name = "system_get_enabled")]
     [Description("Get all currently enabled systems.")]
     public async Task<SystemListResult> GetEnabled()
@@ -168,6 +205,10 @@ public sealed class SystemTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets all currently disabled systems.
+    /// </summary>
+    /// <returns>A <see cref="SystemListResult"/> containing the disabled systems and their count.</returns>
     [McpServerTool(Name = "system_get_disabled")]
     [Description("Get all currently disabled systems.")]
     public async Task<SystemListResult> GetDisabled()

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/TimeTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/TimeTools.cs
@@ -20,6 +20,10 @@ public sealed class TimeTools(BridgeConnectionManager connection)
 {
     #region State
 
+    /// <summary>
+    /// Gets the current time control state, including pause status, time scale, and frame information.
+    /// </summary>
+    /// <returns>The current time control state.</returns>
     [McpServerTool(Name = "time_get_state")]
     [Description("Get the current time control state including pause status, time scale, and frame information.")]
     public async Task<TimeStateResult> GetState()
@@ -33,6 +37,10 @@ public sealed class TimeTools(BridgeConnectionManager connection)
 
     #region Pause Control
 
+    /// <summary>
+    /// Pauses game execution. The game stops updating until resumed.
+    /// </summary>
+    /// <returns>The updated time control state after pausing.</returns>
     [McpServerTool(Name = "time_pause")]
     [Description("Pause game execution. The game will stop updating until resumed.")]
     public async Task<TimeStateResult> Pause()
@@ -42,6 +50,10 @@ public sealed class TimeTools(BridgeConnectionManager connection)
         return TimeStateResult.FromSnapshot(state);
     }
 
+    /// <summary>
+    /// Resumes game execution after being paused.
+    /// </summary>
+    /// <returns>The updated time control state after resuming.</returns>
     [McpServerTool(Name = "time_resume")]
     [Description("Resume game execution after being paused.")]
     public async Task<TimeStateResult> Resume()
@@ -51,6 +63,10 @@ public sealed class TimeTools(BridgeConnectionManager connection)
         return TimeStateResult.FromSnapshot(state);
     }
 
+    /// <summary>
+    /// Toggles between paused and running states.
+    /// </summary>
+    /// <returns>The updated time control state after toggling.</returns>
     [McpServerTool(Name = "time_toggle_pause")]
     [Description("Toggle between paused and running states.")]
     public async Task<TimeStateResult> TogglePause()
@@ -64,6 +80,12 @@ public sealed class TimeTools(BridgeConnectionManager connection)
 
     #region Time Scale
 
+    /// <summary>
+    /// Sets the time scale multiplier. Use 1.0 for normal speed, values below 1.0 for slow motion,
+    /// and values above 1.0 for fast forward.
+    /// </summary>
+    /// <param name="scale">The time scale multiplier (0.0 = frozen, 0.5 = half speed, 1.0 = normal, 2.0 = double speed).</param>
+    /// <returns>The updated time control state, or a failed result if <paramref name="scale"/> is negative.</returns>
     [McpServerTool(Name = "time_set_scale")]
     [Description("Set the time scale multiplier. Use 1.0 for normal speed, <1.0 for slow motion, >1.0 for fast forward.")]
     public async Task<TimeStateResult> SetScale(
@@ -88,6 +110,11 @@ public sealed class TimeTools(BridgeConnectionManager connection)
 
     #region Frame Stepping
 
+    /// <summary>
+    /// Steps forward a specified number of frames while paused. Useful for frame-by-frame debugging.
+    /// </summary>
+    /// <param name="frames">The number of frames to step forward (default: 1).</param>
+    /// <returns>The updated time control state, or a failed result if <paramref name="frames"/> is less than 1.</returns>
     [McpServerTool(Name = "time_step_frame")]
     [Description("Step forward a specified number of frames while paused. Useful for frame-by-frame debugging.")]
     public async Task<TimeStateResult> StepFrame(

--- a/tools/KeenEyes.Mcp.TestBridge/Tools/WindowTools.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Tools/WindowTools.cs
@@ -8,9 +8,14 @@ namespace KeenEyes.Mcp.TestBridge.Tools;
 /// <summary>
 /// MCP tools for window state queries.
 /// </summary>
+/// <param name="connection">The connection manager used to reach the active test bridge.</param>
 [McpServerToolType]
 public sealed class WindowTools(BridgeConnectionManager connection)
 {
+    /// <summary>
+    /// Checks whether window state queries are available.
+    /// </summary>
+    /// <returns>The availability result; <see cref="WindowAvailableResult.Available"/> is <see langword="false"/> if the game is running headless.</returns>
     [McpServerTool(Name = "window_is_available")]
     [Description("Check if window state queries are available. Returns false if the game is running headless.")]
     public WindowAvailableResult WindowIsAvailable()
@@ -22,6 +27,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the complete window state, including size, title, focus state, and closing status.
+    /// </summary>
+    /// <returns>The window state result.</returns>
     [McpServerTool(Name = "window_get_state")]
     [Description("Get complete window state including size, title, focus state, and closing status.")]
     public async Task<WindowStateResult> WindowGetState()
@@ -50,6 +59,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current window dimensions in pixels.
+    /// </summary>
+    /// <returns>The window size result.</returns>
     [McpServerTool(Name = "window_get_size")]
     [Description("Get the current window dimensions in pixels.")]
     public async Task<WindowSizeResultMcp> WindowGetSize()
@@ -74,6 +87,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current window title.
+    /// </summary>
+    /// <returns>The window title result.</returns>
     [McpServerTool(Name = "window_get_title")]
     [Description("Get the current window title.")]
     public async Task<WindowTitleResult> WindowGetTitle()
@@ -97,6 +114,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Checks whether the window is in the process of closing.
+    /// </summary>
+    /// <returns>The window closing state result.</returns>
     [McpServerTool(Name = "window_is_closing")]
     [Description("Check if the window is in the process of closing.")]
     public async Task<WindowClosingResult> WindowIsClosing()
@@ -120,6 +141,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Checks whether the window currently has focus.
+    /// </summary>
+    /// <returns>The window focus state result.</returns>
     [McpServerTool(Name = "window_is_focused")]
     [Description("Check if the window currently has focus.")]
     public async Task<WindowFocusedResult> WindowIsFocused()
@@ -143,6 +168,10 @@ public sealed class WindowTools(BridgeConnectionManager connection)
         };
     }
 
+    /// <summary>
+    /// Gets the current window aspect ratio (width divided by height).
+    /// </summary>
+    /// <returns>The window aspect ratio result.</returns>
     [McpServerTool(Name = "window_get_aspect_ratio")]
     [Description("Get the current window aspect ratio (width / height).")]
     public async Task<WindowAspectRatioResult> WindowGetAspectRatio()
@@ -172,6 +201,9 @@ public sealed class WindowTools(BridgeConnectionManager connection)
 /// </summary>
 public sealed record WindowAvailableResult
 {
+    /// <summary>
+    /// Gets whether window state queries are available.
+    /// </summary>
     public required bool Available { get; init; }
 }
 
@@ -180,13 +212,44 @@ public sealed record WindowAvailableResult
 /// </summary>
 public sealed record WindowStateResult
 {
+    /// <summary>
+    /// Gets whether the window state was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets the window width in pixels.
+    /// </summary>
     public int Width { get; init; }
+
+    /// <summary>
+    /// Gets the window height in pixels.
+    /// </summary>
     public int Height { get; init; }
+
+    /// <summary>
+    /// Gets the window title.
+    /// </summary>
     public string? Title { get; init; }
+
+    /// <summary>
+    /// Gets whether the window is in the process of closing.
+    /// </summary>
     public bool IsClosing { get; init; }
+
+    /// <summary>
+    /// Gets whether the window currently has focus.
+    /// </summary>
     public bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Gets the window aspect ratio (width divided by height).
+    /// </summary>
     public float AspectRatio { get; init; }
 }
 
@@ -195,9 +258,24 @@ public sealed record WindowStateResult
 /// </summary>
 public sealed record WindowSizeResultMcp
 {
+    /// <summary>
+    /// Gets whether the window size was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets the window width in pixels.
+    /// </summary>
     public int Width { get; init; }
+
+    /// <summary>
+    /// Gets the window height in pixels.
+    /// </summary>
     public int Height { get; init; }
 }
 
@@ -206,8 +284,19 @@ public sealed record WindowSizeResultMcp
 /// </summary>
 public sealed record WindowTitleResult
 {
+    /// <summary>
+    /// Gets whether the window title was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets the window title.
+    /// </summary>
     public string? Title { get; init; }
 }
 
@@ -216,8 +305,19 @@ public sealed record WindowTitleResult
 /// </summary>
 public sealed record WindowClosingResult
 {
+    /// <summary>
+    /// Gets whether the window closing state was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets whether the window is in the process of closing.
+    /// </summary>
     public bool IsClosing { get; init; }
 }
 
@@ -226,8 +326,19 @@ public sealed record WindowClosingResult
 /// </summary>
 public sealed record WindowFocusedResult
 {
+    /// <summary>
+    /// Gets whether the window focus state was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets whether the window currently has focus.
+    /// </summary>
     public bool IsFocused { get; init; }
 }
 
@@ -236,7 +347,18 @@ public sealed record WindowFocusedResult
 /// </summary>
 public sealed record WindowAspectRatioResult
 {
+    /// <summary>
+    /// Gets whether the window aspect ratio was retrieved successfully.
+    /// </summary>
     public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the error message when the query failed; <see langword="null"/> otherwise.
+    /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>
+    /// Gets the window aspect ratio (width divided by height).
+    /// </summary>
     public float AspectRatio { get; init; }
 }


### PR DESCRIPTION
## Summary
- Remove the per-csproj `CS1591` suppressions from the three `tools/` projects, bringing them in line with `src/` enforcement.
- Document the entire previously-undocumented public surface so they build green with CS1591 as an error: **KeenEyes.Mcp.TestBridge** (~359 members across the 13 `Tools/` + `Resources/` classes) and **KeenEyes.Lsp.Kesl** (45: LSP enum members, JSON-RPC error/header consts, `MarkupContent` factories, server entry points). `BenchmarkCompare` (no public API) also drops the opt-out and gains a `<Description>`.
- Refresh `docs/mcp-server.md` with the 9 previously-missing tool categories (mutation/system/time/log/window/ai/profile/replay/snapshot).

## Test plan
- [x] `dotnet build` (Debug) green for all three tool projects **with CS1591 enforced** — this is the real gate
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI green

Resolves the only grade-C project from the doc audit. `KeenEyes.Lsp.Kesl` keeps its unrelated `S2094` suppression.