### PR TITLE
docs: document Graph.Kesl node bases; drop obsolete compat shim

### DIFF
--- a/editor/KeenEyes.Graph.Kesl/Compiler/CompilationResult.cs
+++ b/editor/KeenEyes.Graph.Kesl/Compiler/CompilationResult.cs
@@ -67,12 +67,6 @@ public sealed class CompilationResult
     public FragmentDeclaration? FragmentDeclaration { get; }
 
     /// <summary>
-    /// Gets the compiled AST (for backwards compatibility - returns compute declaration).
-    /// </summary>
-    [Obsolete("Use ComputeDeclaration, VertexDeclaration, or FragmentDeclaration instead.")]
-    public ComputeDeclaration? Declaration => ComputeDeclaration;
-
-    /// <summary>
     /// Gets compilation errors.
     /// </summary>
     public IReadOnlyList<CompilationError> Errors { get; }

--- a/editor/KeenEyes.Graph.Kesl/Nodes/Math/MathNodeBase.cs
+++ b/editor/KeenEyes.Graph.Kesl/Nodes/Math/MathNodeBase.cs
@@ -19,13 +19,21 @@ public abstract class BinaryMathNodeBase : INodeTypeDefinition
         PortDefinition.Output("Result", PortTypeId.Float, 72.5f)
     ];
 
+    /// <inheritdoc />
     public abstract int TypeId { get; }
+    /// <inheritdoc />
     public abstract string Name { get; }
+    /// <inheritdoc />
     public string Category => "KESL/Math";
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> InputPorts => BinaryInputs;
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> OutputPorts => BinaryOutputs;
+    /// <inheritdoc />
     public bool IsCollapsible => true;
+    /// <inheritdoc />
     public void Initialize(Entity node, IWorld world) { }
+    /// <inheritdoc />
     public float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea) => 0f;
 }
 
@@ -44,13 +52,21 @@ public abstract class UnaryMathNodeBase : INodeTypeDefinition
         PortDefinition.Output("Result", PortTypeId.Float, 60f)
     ];
 
+    /// <inheritdoc />
     public abstract int TypeId { get; }
+    /// <inheritdoc />
     public abstract string Name { get; }
+    /// <inheritdoc />
     public string Category => "KESL/Math";
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> InputPorts => UnaryInputs;
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> OutputPorts => UnaryOutputs;
+    /// <inheritdoc />
     public bool IsCollapsible => true;
+    /// <inheritdoc />
     public void Initialize(Entity node, IWorld world) { }
+    /// <inheritdoc />
     public float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea) => 0f;
 }
 
@@ -71,12 +87,20 @@ public abstract class TernaryMathNodeBase : INodeTypeDefinition
         PortDefinition.Output("Result", PortTypeId.Float, 85f)
     ];
 
+    /// <inheritdoc />
     public abstract int TypeId { get; }
+    /// <inheritdoc />
     public abstract string Name { get; }
+    /// <inheritdoc />
     public string Category => "KESL/Math";
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> InputPorts => TernaryInputs;
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> OutputPorts => TernaryOutputs;
+    /// <inheritdoc />
     public bool IsCollapsible => true;
+    /// <inheritdoc />
     public void Initialize(Entity node, IWorld world) { }
+    /// <inheritdoc />
     public float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea) => 0f;
 }

--- a/editor/KeenEyes.Graph.Kesl/Nodes/Vector/VectorOperationNodes.cs
+++ b/editor/KeenEyes.Graph.Kesl/Nodes/Vector/VectorOperationNodes.cs
@@ -11,13 +11,21 @@ public abstract class UnaryVectorNodeBase : INodeTypeDefinition
         PortDefinition.Input("Vector", PortTypeId.Float3, 60f)
     ];
 
+    /// <inheritdoc />
     public abstract int TypeId { get; }
+    /// <inheritdoc />
     public abstract string Name { get; }
+    /// <inheritdoc />
     public string Category => "KESL/Vector";
+    /// <inheritdoc />
     public IReadOnlyList<PortDefinition> InputPorts => UnaryInputs;
+    /// <inheritdoc />
     public abstract IReadOnlyList<PortDefinition> OutputPorts { get; }
+    /// <inheritdoc />
     public bool IsCollapsible => true;
+    /// <inheritdoc />
     public void Initialize(Entity node, IWorld world) { }
+    /// <inheritdoc />
     public float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea) => 0f;
 }
 


### PR DESCRIPTION
## Summary
- Add `<inheritdoc />` to the `INodeTypeDefinition` members on the four abstract node bases (Binary/Unary/Ternary math + unary vector).
- Remove `CompilationResult.Declaration`, a dead `[Obsolete]` backwards-compatibility shim (used nowhere) that contradicted the repo's No-Backwards-Compatibility policy; callers use `ComputeDeclaration`/`VertexDeclaration`/`FragmentDeclaration`.

## Test plan
- [x] `dotnet build` (Debug) green for KeenEyes.Graph.Kesl
- [x] `dotnet format` clean
- [ ] CI green