### PR TITLE
docs: complete XML-doc tags on high-traffic src APIs

### DIFF
--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -190,6 +190,9 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets a reference to a component for the entity at the specified global index.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="globalIndex">The global index of the entity within this archetype.</param>
+    /// <returns>A reference to the component data.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T Get<T>(int globalIndex) where T : struct, IComponent
     {
@@ -200,6 +203,9 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets a reference to a component for an entity.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="entity">The entity to get the component for.</param>
+    /// <returns>A reference to the component data.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T GetByEntity<T>(Entity entity) where T : struct, IComponent
     {
@@ -210,6 +216,9 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets a readonly reference to a component.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="globalIndex">The global index of the entity within this archetype.</param>
+    /// <returns>A readonly reference to the component data.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref readonly T GetReadonly<T>(int globalIndex) where T : struct, IComponent
     {
@@ -220,6 +229,9 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Sets a component value at the specified global index.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="globalIndex">The global index of the entity within this archetype.</param>
+    /// <param name="component">The component value to set.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Set<T>(int globalIndex, in T component) where T : struct, IComponent
     {
@@ -260,6 +272,9 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets a readonly span of components from a specific chunk.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="chunkIndex">The chunk index.</param>
+    /// <returns>A readonly span over component values in that chunk.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<T> GetChunkReadOnlySpan<T>(int chunkIndex) where T : struct, IComponent
     {
@@ -271,6 +286,8 @@ public sealed class Archetype : IDisposable
     /// Note: With chunked storage, this only returns the first chunk's span.
     /// For full iteration, use chunk-based methods.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>A span over component values in the first chunk.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Obsolete("Use GetChunkSpan for chunked archetypes. This method only returns the first chunk. Will be removed in v1.0.")]
     public Span<T> GetSpan<T>() where T : struct, IComponent
@@ -286,6 +303,8 @@ public sealed class Archetype : IDisposable
     /// Gets a readonly span of components.
     /// Note: With chunked storage, this only returns the first chunk's span.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>A readonly span over component values in the first chunk.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Obsolete("Use GetChunkReadOnlySpan for chunked archetypes. This method only returns the first chunk. Will be removed in v1.0.")]
     public ReadOnlySpan<T> GetReadOnlySpan<T>() where T : struct, IComponent
@@ -300,6 +319,8 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Checks if this archetype contains a specific component type.
     /// </summary>
+    /// <typeparam name="T">The component type to check for.</typeparam>
+    /// <returns><see langword="true"/> if the archetype contains the component type; otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has<T>() where T : struct, IComponent
     {
@@ -309,6 +330,8 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Checks if this archetype contains a specific component type.
     /// </summary>
+    /// <param name="type">The component type to check for.</param>
+    /// <returns><see langword="true"/> if the archetype contains the component type; otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has(Type type)
     {
@@ -343,6 +366,8 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets the global index of an entity in this archetype.
     /// </summary>
+    /// <param name="entity">The entity to locate.</param>
+    /// <returns>The global index of the entity, or -1 if the entity is not found in this archetype.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetEntityIndex(Entity entity)
     {
@@ -356,6 +381,8 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets the entity location (chunk index and index within chunk).
     /// </summary>
+    /// <param name="entity">The entity to locate.</param>
+    /// <returns>A tuple containing the chunk index and index within the chunk, or (-1, -1) if the entity is not found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public (int ChunkIndex, int IndexInChunk) GetEntityLocation(Entity entity)
     {
@@ -365,6 +392,8 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets the entity at the specified global index.
     /// </summary>
+    /// <param name="globalIndex">The global index within this archetype.</param>
+    /// <returns>The entity at the specified index.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Entity GetEntity(int globalIndex)
     {

--- a/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
@@ -179,6 +179,9 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets a reference to a component for the entity at the specified index.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="index">The index of the entity within the chunk.</param>
+    /// <returns>A reference to the component data.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T Get<T>(int index) where T : struct, IComponent
     {
@@ -188,6 +191,9 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets a readonly reference to a component.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="index">The index of the entity within the chunk.</param>
+    /// <returns>A readonly reference to the component data.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref readonly T GetReadonly<T>(int index) where T : struct, IComponent
     {
@@ -197,6 +203,9 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Sets a component value at the specified index.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="index">The index of the entity within the chunk.</param>
+    /// <param name="component">The component value to set.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Set<T>(int index, in T component) where T : struct, IComponent
     {
@@ -229,6 +238,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets a span of components for efficient iteration.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>A span over all component values of type <typeparamref name="T"/> in this chunk.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<T> GetSpan<T>() where T : struct, IComponent
     {
@@ -238,6 +249,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets a readonly span of components.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>A readonly span over all component values of type <typeparamref name="T"/> in this chunk.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<T> GetReadOnlySpan<T>() where T : struct, IComponent
     {
@@ -247,6 +260,7 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets a span of all entities in this chunk.
     /// </summary>
+    /// <returns>A readonly span over all entities currently stored in this chunk.</returns>
     public ReadOnlySpan<Entity> GetEntities()
     {
         return new ReadOnlySpan<Entity>(entities, 0, count);
@@ -255,6 +269,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets the entity at the specified index.
     /// </summary>
+    /// <param name="index">The index of the entity within the chunk.</param>
+    /// <returns>The entity stored at the specified index.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Entity GetEntity(int index)
     {
@@ -264,6 +280,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Gets the index of an entity in this chunk.
     /// </summary>
+    /// <param name="entity">The entity to locate.</param>
+    /// <returns>The index of the entity within the chunk, or -1 if it is not present.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetEntityIndex(Entity entity)
     {
@@ -273,6 +291,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Checks if this chunk contains the specified entity.
     /// </summary>
+    /// <param name="entity">The entity to check for.</param>
+    /// <returns><see langword="true"/> if the entity is present in this chunk; otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Contains(Entity entity)
     {
@@ -282,6 +302,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Checks if this chunk has a specific component type.
     /// </summary>
+    /// <typeparam name="T">The component type to check for.</typeparam>
+    /// <returns><see langword="true"/> if this chunk stores components of type <typeparamref name="T"/>; otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has<T>() where T : struct, IComponent
     {
@@ -291,6 +313,8 @@ public sealed class ArchetypeChunk : IDisposable
     /// <summary>
     /// Checks if this chunk has a specific component type.
     /// </summary>
+    /// <param name="type">The component type to check for.</param>
+    /// <returns><see langword="true"/> if this chunk stores components of the specified type; otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has(Type type)
     {

--- a/src/KeenEyes.Core/Components/ComponentRegistry.cs
+++ b/src/KeenEyes.Core/Components/ComponentRegistry.cs
@@ -139,6 +139,8 @@ public sealed class ComponentRegistry : IComponentRegistry
     /// <summary>
     /// Gets the component info for a type, or null if not registered.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns>The component info for the type, or <c>null</c> if not registered.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ComponentInfo? Get<T>() where T : struct, IComponent
     {
@@ -151,6 +153,8 @@ public sealed class ComponentRegistry : IComponentRegistry
     /// <summary>
     /// Gets the component info for a type, or null if not registered.
     /// </summary>
+    /// <param name="type">The component type to look up.</param>
+    /// <returns>The component info for the type, or <c>null</c> if not registered.</returns>
     public ComponentInfo? Get(Type type)
     {
         lock (syncRoot)
@@ -167,6 +171,9 @@ public sealed class ComponentRegistry : IComponentRegistry
     /// <summary>
     /// Gets or registers a component type.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="isTag">Whether this is a tag component.</param>
+    /// <returns>The component info for this type.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ComponentInfo GetOrRegister<T>(bool isTag = false) where T : struct, IComponent
     {
@@ -177,6 +184,8 @@ public sealed class ComponentRegistry : IComponentRegistry
     /// <summary>
     /// Checks if a component type is registered.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <returns><c>true</c> if the component type is registered; otherwise, <c>false</c>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsRegistered<T>() where T : struct, IComponent
     {

--- a/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
+++ b/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
@@ -164,6 +164,11 @@ public static class ParallelQueryExtensions
     /// <summary>
     /// Processes all matching entities in parallel with readonly component access.
     /// </summary>
+    /// <typeparam name="T1">First component type.</typeparam>
+    /// <typeparam name="T2">Second component type.</typeparam>
+    /// <param name="query">The query builder.</param>
+    /// <param name="action">The action to execute for each entity.</param>
+    /// <param name="minEntityCount">Minimum entity count to enable parallelization.</param>
     public static void ForEachParallelReadOnly<T1, T2>(
         this QueryBuilder query,
         EntityActionReadOnly<T1, T2> action,
@@ -253,6 +258,12 @@ public static class ParallelQueryExtensions
     /// <summary>
     /// Processes all matching entities in parallel with readonly component access.
     /// </summary>
+    /// <typeparam name="T1">First component type.</typeparam>
+    /// <typeparam name="T2">Second component type.</typeparam>
+    /// <typeparam name="T3">Third component type.</typeparam>
+    /// <param name="query">The query builder.</param>
+    /// <param name="action">The action to execute for each entity.</param>
+    /// <param name="minEntityCount">Minimum entity count to enable parallelization.</param>
     public static void ForEachParallelReadOnly<T1, T2, T3>(
         this QueryBuilder query,
         EntityActionReadOnly<T1, T2, T3> action,
@@ -349,6 +360,13 @@ public static class ParallelQueryExtensions
     /// <summary>
     /// Processes all matching entities in parallel with readonly component access.
     /// </summary>
+    /// <typeparam name="T1">First component type.</typeparam>
+    /// <typeparam name="T2">Second component type.</typeparam>
+    /// <typeparam name="T3">Third component type.</typeparam>
+    /// <typeparam name="T4">Fourth component type.</typeparam>
+    /// <param name="query">The query builder.</param>
+    /// <param name="action">The action to execute for each entity.</param>
+    /// <param name="minEntityCount">Minimum entity count to enable parallelization.</param>
     public static void ForEachParallelReadOnly<T1, T2, T3, T4>(
         this QueryBuilder query,
         EntityActionReadOnly<T1, T2, T3, T4> action,
@@ -428,18 +446,29 @@ public static class ParallelQueryExtensions
 /// <summary>
 /// Delegate for processing an entity with one component.
 /// </summary>
+/// <typeparam name="T1">The component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A reference to the component instance.</param>
 public delegate void EntityAction<T1>(Entity entity, ref T1 c1)
     where T1 : struct, IComponent;
 
 /// <summary>
 /// Delegate for processing an entity with one readonly component.
 /// </summary>
+/// <typeparam name="T1">The component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A read-only reference to the component instance.</param>
 public delegate void EntityActionReadOnly<T1>(Entity entity, in T1 c1)
     where T1 : struct, IComponent;
 
 /// <summary>
 /// Delegate for processing an entity with two components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A reference to the first component instance.</param>
+/// <param name="c2">A reference to the second component instance.</param>
 public delegate void EntityAction<T1, T2>(Entity entity, ref T1 c1, ref T2 c2)
     where T1 : struct, IComponent
     where T2 : struct, IComponent;
@@ -447,6 +476,11 @@ public delegate void EntityAction<T1, T2>(Entity entity, ref T1 c1, ref T2 c2)
 /// <summary>
 /// Delegate for processing an entity with two readonly components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A read-only reference to the first component instance.</param>
+/// <param name="c2">A read-only reference to the second component instance.</param>
 public delegate void EntityActionReadOnly<T1, T2>(Entity entity, in T1 c1, in T2 c2)
     where T1 : struct, IComponent
     where T2 : struct, IComponent;
@@ -454,6 +488,13 @@ public delegate void EntityActionReadOnly<T1, T2>(Entity entity, in T1 c1, in T2
 /// <summary>
 /// Delegate for processing an entity with three components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <typeparam name="T3">Third component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A reference to the first component instance.</param>
+/// <param name="c2">A reference to the second component instance.</param>
+/// <param name="c3">A reference to the third component instance.</param>
 public delegate void EntityAction<T1, T2, T3>(Entity entity, ref T1 c1, ref T2 c2, ref T3 c3)
     where T1 : struct, IComponent
     where T2 : struct, IComponent
@@ -462,6 +503,13 @@ public delegate void EntityAction<T1, T2, T3>(Entity entity, ref T1 c1, ref T2 c
 /// <summary>
 /// Delegate for processing an entity with three readonly components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <typeparam name="T3">Third component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A read-only reference to the first component instance.</param>
+/// <param name="c2">A read-only reference to the second component instance.</param>
+/// <param name="c3">A read-only reference to the third component instance.</param>
 public delegate void EntityActionReadOnly<T1, T2, T3>(Entity entity, in T1 c1, in T2 c2, in T3 c3)
     where T1 : struct, IComponent
     where T2 : struct, IComponent
@@ -470,6 +518,15 @@ public delegate void EntityActionReadOnly<T1, T2, T3>(Entity entity, in T1 c1, i
 /// <summary>
 /// Delegate for processing an entity with four components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <typeparam name="T3">Third component type.</typeparam>
+/// <typeparam name="T4">Fourth component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A reference to the first component instance.</param>
+/// <param name="c2">A reference to the second component instance.</param>
+/// <param name="c3">A reference to the third component instance.</param>
+/// <param name="c4">A reference to the fourth component instance.</param>
 public delegate void EntityAction<T1, T2, T3, T4>(Entity entity, ref T1 c1, ref T2 c2, ref T3 c3, ref T4 c4)
     where T1 : struct, IComponent
     where T2 : struct, IComponent
@@ -479,6 +536,15 @@ public delegate void EntityAction<T1, T2, T3, T4>(Entity entity, ref T1 c1, ref 
 /// <summary>
 /// Delegate for processing an entity with four readonly components.
 /// </summary>
+/// <typeparam name="T1">First component type.</typeparam>
+/// <typeparam name="T2">Second component type.</typeparam>
+/// <typeparam name="T3">Third component type.</typeparam>
+/// <typeparam name="T4">Fourth component type.</typeparam>
+/// <param name="entity">The entity being processed.</param>
+/// <param name="c1">A read-only reference to the first component instance.</param>
+/// <param name="c2">A read-only reference to the second component instance.</param>
+/// <param name="c3">A read-only reference to the third component instance.</param>
+/// <param name="c4">A read-only reference to the fourth component instance.</param>
 public delegate void EntityActionReadOnly<T1, T2, T3, T4>(Entity entity, in T1 c1, in T2 c2, in T3 c3, in T4 c4)
     where T1 : struct, IComponent
     where T2 : struct, IComponent

--- a/src/KeenEyes.Core/Queries/QueryBuilder.cs
+++ b/src/KeenEyes.Core/Queries/QueryBuilder.cs
@@ -123,6 +123,8 @@ public sealed class QueryDescription
     /// <summary>
     /// Checks if an entity with the given components matches this query.
     /// </summary>
+    /// <param name="entityComponents">The component types present on the entity.</param>
+    /// <returns><c>true</c> if the entity has all required components and none of the excluded components; otherwise, <c>false</c>.</returns>
     public bool Matches(IEnumerable<Type> entityComponents)
     {
         var componentSet = entityComponents.ToHashSet();
@@ -181,6 +183,8 @@ public readonly struct QueryBuilder : IQueryBuilder
     }
 
     /// <summary>Requires the entity to have this component (filter only, not accessed).</summary>
+    /// <typeparam name="TWith">The component type that must be present.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     public QueryBuilder With<TWith>() where TWith : struct, IComponent
     {
         description.AddWith<TWith>();
@@ -188,6 +192,8 @@ public readonly struct QueryBuilder : IQueryBuilder
     }
 
     /// <summary>Excludes entities that have this component.</summary>
+    /// <typeparam name="TWithout">The component type that must not be present.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     public QueryBuilder Without<TWithout>() where TWithout : struct, IComponent
     {
         description.AddWithout<TWithout>();
@@ -196,6 +202,7 @@ public readonly struct QueryBuilder : IQueryBuilder
 
     /// <summary>Requires the entity to have this string tag.</summary>
     /// <param name="tag">The string tag that must be present.</param>
+    /// <returns>This builder for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="tag"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="tag"/> is empty or whitespace.</exception>
     public QueryBuilder WithTag(string tag)
@@ -207,6 +214,7 @@ public readonly struct QueryBuilder : IQueryBuilder
 
     /// <summary>Excludes entities that have this string tag.</summary>
     /// <param name="tag">The string tag that must NOT be present.</param>
+    /// <returns>This builder for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="tag"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="tag"/> is empty or whitespace.</exception>
     public QueryBuilder WithoutTag(string tag)
@@ -223,6 +231,7 @@ public readonly struct QueryBuilder : IQueryBuilder
     public World World => world;
 
     /// <summary>Gets an enumerator for iterating over matching entities.</summary>
+    /// <returns>An enumerator over the entities matching this query.</returns>
     public QueryEnumerator GetEnumerator() => new(world, description);
     IEnumerator<Entity> IEnumerable<Entity>.GetEnumerator() => GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/KeenEyes.Core/World.Queries.cs
+++ b/src/KeenEyes.Core/World.Queries.cs
@@ -7,6 +7,8 @@ public sealed partial class World
     /// <summary>
     /// Creates a query for entities with the specified component.
     /// </summary>
+    /// <typeparam name="T1">The required component type.</typeparam>
+    /// <returns>A query builder for filtering and enumerating entities.</returns>
     public QueryBuilder Query<T1>()
         where T1 : struct, IComponent
     {
@@ -16,6 +18,9 @@ public sealed partial class World
     /// <summary>
     /// Creates a query for entities with the specified components.
     /// </summary>
+    /// <typeparam name="T1">The first required component type.</typeparam>
+    /// <typeparam name="T2">The second required component type.</typeparam>
+    /// <returns>A query builder for filtering and enumerating entities.</returns>
     public QueryBuilder Query<T1, T2>()
         where T1 : struct, IComponent
         where T2 : struct, IComponent
@@ -26,6 +31,10 @@ public sealed partial class World
     /// <summary>
     /// Creates a query for entities with the specified components.
     /// </summary>
+    /// <typeparam name="T1">The first required component type.</typeparam>
+    /// <typeparam name="T2">The second required component type.</typeparam>
+    /// <typeparam name="T3">The third required component type.</typeparam>
+    /// <returns>A query builder for filtering and enumerating entities.</returns>
     public QueryBuilder Query<T1, T2, T3>()
         where T1 : struct, IComponent
         where T2 : struct, IComponent
@@ -37,6 +46,11 @@ public sealed partial class World
     /// <summary>
     /// Creates a query for entities with the specified components.
     /// </summary>
+    /// <typeparam name="T1">The first required component type.</typeparam>
+    /// <typeparam name="T2">The second required component type.</typeparam>
+    /// <typeparam name="T3">The third required component type.</typeparam>
+    /// <typeparam name="T4">The fourth required component type.</typeparam>
+    /// <returns>A query builder for filtering and enumerating entities.</returns>
     public QueryBuilder Query<T1, T2, T3, T4>()
         where T1 : struct, IComponent
         where T2 : struct, IComponent

--- a/src/KeenEyes.Testing/Fixtures/CommonComponents.cs
+++ b/src/KeenEyes.Testing/Fixtures/CommonComponents.cs
@@ -26,6 +26,9 @@ public partial struct TestPosition
     /// <summary>
     /// Creates a new position with the specified coordinates.
     /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
+    /// <returns>A new <see cref="TestPosition"/> with the specified coordinates.</returns>
     public static TestPosition Create(float x, float y) => new() { X = x, Y = y };
 
     /// <summary>
@@ -55,6 +58,10 @@ public partial struct TestPosition3D
     /// <summary>
     /// Creates a new position with the specified coordinates.
     /// </summary>
+    /// <param name="x">The X coordinate.</param>
+    /// <param name="y">The Y coordinate.</param>
+    /// <param name="z">The Z coordinate.</param>
+    /// <returns>A new <see cref="TestPosition3D"/> with the specified coordinates.</returns>
     public static TestPosition3D Create(float x, float y, float z) => new() { X = x, Y = y, Z = z };
 
     /// <summary>
@@ -81,6 +88,9 @@ public partial struct TestVelocity
     /// <summary>
     /// Creates a new velocity with the specified values.
     /// </summary>
+    /// <param name="vx">The X velocity.</param>
+    /// <param name="vy">The Y velocity.</param>
+    /// <returns>A new <see cref="TestVelocity"/> with the specified values.</returns>
     public static TestVelocity Create(float vx, float vy) => new() { VX = vx, VY = vy };
 
     /// <summary>
@@ -107,11 +117,16 @@ public partial struct TestHealth
     /// <summary>
     /// Creates a new health component with the specified values.
     /// </summary>
+    /// <param name="current">The current health value.</param>
+    /// <param name="max">The maximum health value.</param>
+    /// <returns>A new <see cref="TestHealth"/> with the specified values.</returns>
     public static TestHealth Create(int current, int max) => new() { Current = current, Max = max };
 
     /// <summary>
     /// Creates a full health component with the specified maximum.
     /// </summary>
+    /// <param name="max">The maximum health value, also used as the current health value.</param>
+    /// <returns>A new <see cref="TestHealth"/> whose current value equals its maximum.</returns>
     public static TestHealth Full(int max) => new() { Current = max, Max = max };
 
     /// <summary>
@@ -140,6 +155,8 @@ public partial struct TestDamage
     /// <summary>
     /// Creates a new damage component with the specified amount.
     /// </summary>
+    /// <param name="amount">The damage amount.</param>
+    /// <returns>A new <see cref="TestDamage"/> with the specified amount.</returns>
     public static TestDamage Create(int amount) => new() { Amount = amount };
 
     /// <inheritdoc/>
@@ -158,6 +175,8 @@ public partial struct TestSpeed
     /// <summary>
     /// Creates a new speed component with the specified value.
     /// </summary>
+    /// <param name="value">The movement speed.</param>
+    /// <returns>A new <see cref="TestSpeed"/> with the specified value.</returns>
     public static TestSpeed Create(float value) => new() { Value = value };
 
     /// <inheritdoc/>
@@ -176,6 +195,8 @@ public partial struct TestRotation
     /// <summary>
     /// Creates a new rotation component with the specified angle.
     /// </summary>
+    /// <param name="angle">The rotation angle in degrees.</param>
+    /// <returns>A new <see cref="TestRotation"/> with the specified angle.</returns>
     public static TestRotation Create(float angle) => new() { Angle = angle };
 
     /// <inheritdoc/>
@@ -194,6 +215,8 @@ public partial struct TestScale
     /// <summary>
     /// Creates a new scale component with the specified value.
     /// </summary>
+    /// <param name="value">The scale value.</param>
+    /// <returns>A new <see cref="TestScale"/> with the specified value.</returns>
     public static TestScale Create(float value) => new() { Value = value };
 
     /// <summary>
@@ -217,6 +240,8 @@ public partial struct TestLifetime
     /// <summary>
     /// Creates a new lifetime component with the specified duration.
     /// </summary>
+    /// <param name="seconds">The remaining lifetime in seconds.</param>
+    /// <returns>A new <see cref="TestLifetime"/> with the specified duration.</returns>
     public static TestLifetime Create(float seconds) => new() { Remaining = seconds };
 
     /// <summary>
@@ -240,6 +265,8 @@ public partial struct TestTeam
     /// <summary>
     /// Creates a new team component with the specified ID.
     /// </summary>
+    /// <param name="id">The team identifier.</param>
+    /// <returns>A new <see cref="TestTeam"/> with the specified ID.</returns>
     public static TestTeam Create(int id) => new() { Id = id };
 
     /// <inheritdoc/>
@@ -258,6 +285,8 @@ public partial struct TestCounter
     /// <summary>
     /// Creates a new counter with the specified initial value.
     /// </summary>
+    /// <param name="value">The current count.</param>
+    /// <returns>A new <see cref="TestCounter"/> with the specified initial value.</returns>
     public static TestCounter Create(int value) => new() { Value = value };
 
     /// <inheritdoc/>

--- a/src/KeenEyes.Testing/Fixtures/EntityPresets.cs
+++ b/src/KeenEyes.Testing/Fixtures/EntityPresets.cs
@@ -160,6 +160,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity name.
     /// </summary>
+    /// <param name="name">The name to assign to the entity.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithName(string name)
     {
         this.name = name;
@@ -169,6 +171,9 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity position.
     /// </summary>
+    /// <param name="x">The X coordinate of the position.</param>
+    /// <param name="y">The Y coordinate of the position.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder AtPosition(float x, float y)
     {
         posX = x;
@@ -179,6 +184,9 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity velocity.
     /// </summary>
+    /// <param name="vx">The velocity component along the X axis.</param>
+    /// <param name="vy">The velocity component along the Y axis.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithVelocity(float vx, float vy)
     {
         velX = vx;
@@ -190,6 +198,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity health (both current and max).
     /// </summary>
+    /// <param name="value">The current and maximum health value to assign.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithHealth(int value)
     {
         health = value;
@@ -200,6 +210,9 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity health with different current and max values.
     /// </summary>
+    /// <param name="current">The current health value.</param>
+    /// <param name="max">The maximum health value.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithHealth(int current, int max)
     {
         health = current;
@@ -210,6 +223,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity damage.
     /// </summary>
+    /// <param name="value">The damage value to assign.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithDamage(int value)
     {
         damage = value;
@@ -219,6 +234,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity speed.
     /// </summary>
+    /// <param name="value">The speed value to assign.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithSpeed(float value)
     {
         speed = value;
@@ -228,6 +245,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity lifetime.
     /// </summary>
+    /// <param name="seconds">The lifetime duration, in seconds.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithLifetime(float seconds)
     {
         lifetime = seconds;
@@ -237,6 +256,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Sets the entity team.
     /// </summary>
+    /// <param name="teamId">The team identifier to assign.</param>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder OnTeam(int teamId)
     {
         team = teamId;
@@ -246,6 +267,8 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Adds a tag component to the entity.
     /// </summary>
+    /// <typeparam name="T">The tag component type.</typeparam>
+    /// <returns>This builder, for chaining.</returns>
     public EntityPresetBuilder WithTag<T>() where T : struct, ITagComponent
     {
         tagActions.Add(builder => builder.WithTag<T>());
@@ -255,6 +278,7 @@ public sealed class EntityPresetBuilder
     /// <summary>
     /// Builds and returns the entity.
     /// </summary>
+    /// <returns>The constructed entity.</returns>
     public Entity Build()
     {
         var builder = name != null
@@ -329,6 +353,8 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Applies a modification to each entity based on its index.
     /// </summary>
+    /// <param name="modifier">The action to apply to each entity's builder, given the entity's index.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithModifier(Action<EntityPresetBuilder, int> modifier)
     {
         modifiers.Add(modifier);
@@ -338,6 +364,8 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Sets all entities to have the specified health.
     /// </summary>
+    /// <param name="value">The current and maximum health value to assign to each entity.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithHealth(int value)
     {
         return WithModifier((b, _) => b.WithHealth(value));
@@ -346,6 +374,8 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Sets all entities to have the specified damage.
     /// </summary>
+    /// <param name="value">The damage value to assign to each entity.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithDamage(int value)
     {
         return WithModifier((b, _) => b.WithDamage(value));
@@ -354,6 +384,8 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Sets all entities to have the specified speed.
     /// </summary>
+    /// <param name="value">The speed value to assign to each entity.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithSpeed(float value)
     {
         return WithModifier((b, _) => b.WithSpeed(value));
@@ -362,6 +394,9 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Positions entities in a grid pattern.
     /// </summary>
+    /// <param name="columns">The number of columns in the grid.</param>
+    /// <param name="spacing">The distance between adjacent entities.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder InGrid(int columns, float spacing)
     {
         return WithModifier((b, i) =>
@@ -375,6 +410,9 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Positions entities in a line.
     /// </summary>
+    /// <param name="spacing">The distance between adjacent entities.</param>
+    /// <param name="horizontal">Whether to lay out entities along the X axis (<see langword="true"/>) or the Y axis (<see langword="false"/>).</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder InLine(float spacing, bool horizontal = true)
     {
         return WithModifier((b, i) =>
@@ -393,6 +431,7 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Assigns sequential team IDs to entities.
     /// </summary>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithSequentialTeams()
     {
         return WithModifier((b, i) => b.OnTeam(i));
@@ -401,6 +440,9 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Assigns entities to alternating teams.
     /// </summary>
+    /// <param name="teamA">The team identifier assigned to entities at even indices.</param>
+    /// <param name="teamB">The team identifier assigned to entities at odd indices.</param>
+    /// <returns>This builder, for chaining.</returns>
     public BatchEntityBuilder WithAlternatingTeams(int teamA, int teamB)
     {
         return WithModifier((b, i) => b.OnTeam(i % 2 == 0 ? teamA : teamB));
@@ -409,6 +451,7 @@ public sealed class BatchEntityBuilder
     /// <summary>
     /// Builds and returns all entities.
     /// </summary>
+    /// <returns>An array containing the constructed entities.</returns>
     public Entity[] Build()
     {
         var entities = new Entity[count];

--- a/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
@@ -313,6 +313,8 @@ public sealed class UIColorPickerSystem : SystemBase
     /// <summary>
     /// Converts RGB color to hue (0-360).
     /// </summary>
+    /// <param name="color">The RGBA color to convert.</param>
+    /// <returns>The hue component in degrees (0-360).</returns>
     public static float RgbToHue(Vector4 color)
     {
         float r = color.X;
@@ -353,6 +355,8 @@ public sealed class UIColorPickerSystem : SystemBase
     /// <summary>
     /// Converts RGB color to saturation (0-1).
     /// </summary>
+    /// <param name="color">The RGBA color to convert.</param>
+    /// <returns>The saturation component (0-1).</returns>
     public static float RgbToSaturation(Vector4 color)
     {
         float max = MathF.Max(color.X, MathF.Max(color.Y, color.Z));
@@ -369,6 +373,8 @@ public sealed class UIColorPickerSystem : SystemBase
     /// <summary>
     /// Converts RGB color to value/brightness (0-1).
     /// </summary>
+    /// <param name="color">The RGBA color to convert.</param>
+    /// <returns>The value/brightness component (0-1).</returns>
     public static float RgbToValue(Vector4 color)
     {
         return MathF.Max(color.X, MathF.Max(color.Y, color.Z));

--- a/src/KeenEyes.UI/Widgets/WidgetConfig.cs
+++ b/src/KeenEyes.UI/Widgets/WidgetConfig.cs
@@ -969,6 +969,7 @@ public sealed record MenuItemDef(
     /// <summary>
     /// Creates a separator item.
     /// </summary>
+    /// <returns>A menu item definition representing a separator line.</returns>
     public static MenuItemDef Separator() => new("", IsSeparator: true);
 }
 
@@ -1198,6 +1199,7 @@ public abstract record ToolbarItemDef
     /// <summary>
     /// Creates a button item.
     /// </summary>
+    /// <param name="Definition">The toolbar button definition.</param>
     public sealed record Button(ToolbarButtonDef Definition) : ToolbarItemDef;
 
     /// <summary>
@@ -1986,24 +1988,40 @@ public sealed record ToastConfig(
     /// <summary>
     /// Creates an info toast configuration.
     /// </summary>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">Optional title displayed above the message.</param>
+    /// <param name="duration">How long the toast displays in seconds (0 = indefinite).</param>
+    /// <returns>A toast configuration styled for informational messages.</returns>
     public static ToastConfig Info(string message, string? title = null, float duration = 3f) =>
         new(message, title, ToastType.Info, duration);
 
     /// <summary>
     /// Creates a success toast configuration.
     /// </summary>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">Optional title displayed above the message.</param>
+    /// <param name="duration">How long the toast displays in seconds (0 = indefinite).</param>
+    /// <returns>A toast configuration styled for success messages.</returns>
     public static ToastConfig Success(string message, string? title = null, float duration = 3f) =>
         new(message, title, ToastType.Success, duration);
 
     /// <summary>
     /// Creates a warning toast configuration.
     /// </summary>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">Optional title displayed above the message.</param>
+    /// <param name="duration">How long the toast displays in seconds (0 = indefinite).</param>
+    /// <returns>A toast configuration styled for warning messages.</returns>
     public static ToastConfig Warning(string message, string? title = null, float duration = 5f) =>
         new(message, title, ToastType.Warning, duration);
 
     /// <summary>
     /// Creates an error toast configuration.
     /// </summary>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">Optional title displayed above the message.</param>
+    /// <param name="duration">How long the toast displays in seconds (0 = indefinite).</param>
+    /// <returns>A toast configuration styled for error messages.</returns>
     public static ToastConfig Error(string message, string? title = null, float duration = 0f) =>
         new(message, title, ToastType.Error, duration);
 
@@ -2053,24 +2071,32 @@ public sealed record ToastContainerConfig(
     /// <summary>
     /// Creates a top-right positioned container.
     /// </summary>
+    /// <param name="maxVisible">Maximum number of visible toasts.</param>
+    /// <returns>A toast container configuration anchored to the top-right corner.</returns>
     public static ToastContainerConfig TopRight(int maxVisible = 5) =>
         new(ToastPosition.TopRight, maxVisible);
 
     /// <summary>
     /// Creates a bottom-right positioned container.
     /// </summary>
+    /// <param name="maxVisible">Maximum number of visible toasts.</param>
+    /// <returns>A toast container configuration anchored to the bottom-right corner.</returns>
     public static ToastContainerConfig BottomRight(int maxVisible = 5) =>
         new(ToastPosition.BottomRight, maxVisible);
 
     /// <summary>
     /// Creates a top-center positioned container.
     /// </summary>
+    /// <param name="maxVisible">Maximum number of visible toasts.</param>
+    /// <returns>A toast container configuration anchored to the top-center of the screen.</returns>
     public static ToastContainerConfig TopCenter(int maxVisible = 3) =>
         new(ToastPosition.TopCenter, maxVisible);
 
     /// <summary>
     /// Creates a bottom-center positioned container.
     /// </summary>
+    /// <param name="maxVisible">Maximum number of visible toasts.</param>
+    /// <returns>A toast container configuration anchored to the bottom-center of the screen.</returns>
     public static ToastContainerConfig BottomCenter(int maxVisible = 3) =>
         new(ToastPosition.BottomCenter, maxVisible);
 }
@@ -2102,30 +2128,43 @@ public sealed record SpinnerConfig(
     /// <summary>
     /// Creates a small spinner (24px).
     /// </summary>
+    /// <param name="color">The spinner color.</param>
+    /// <returns>A spinner configuration sized for small UI elements.</returns>
     public static SpinnerConfig Small(Vector4? color = null) =>
         new(Size: 24f, Color: color, Thickness: 2f);
 
     /// <summary>
     /// Creates a medium spinner (40px).
     /// </summary>
+    /// <param name="color">The spinner color.</param>
+    /// <returns>A spinner configuration sized for typical loading indicators.</returns>
     public static SpinnerConfig Medium(Vector4? color = null) =>
         new(Size: 40f, Color: color);
 
     /// <summary>
     /// Creates a large spinner (64px).
     /// </summary>
+    /// <param name="color">The spinner color.</param>
+    /// <returns>A spinner configuration sized for prominent loading states.</returns>
     public static SpinnerConfig Large(Vector4? color = null) =>
         new(Size: 64f, Color: color, Thickness: 4f);
 
     /// <summary>
     /// Creates a dot-style spinner.
     /// </summary>
+    /// <param name="size">The size of the spinner in pixels.</param>
+    /// <param name="dotCount">Number of dot elements in the spinner.</param>
+    /// <param name="color">The spinner color.</param>
+    /// <returns>A spinner configuration using the dots animation style.</returns>
     public static SpinnerConfig Dots(float size = 40f, int dotCount = 8, Vector4? color = null) =>
         new(Style: SpinnerStyle.Dots, Size: size, ElementCount: dotCount, Color: color);
 
     /// <summary>
     /// Creates a bar-style spinner (indeterminate progress).
     /// </summary>
+    /// <param name="width">The width of the spinner bar in pixels.</param>
+    /// <param name="color">The spinner color.</param>
+    /// <returns>A spinner configuration using the indeterminate progress bar style.</returns>
     public static SpinnerConfig Bar(float width = 200f, Vector4? color = null) =>
         new(Style: SpinnerStyle.Bar, Size: width, Color: color);
 
@@ -2169,24 +2208,34 @@ public sealed record ColorPickerConfig(
     /// <summary>
     /// Creates an HSV color picker configuration.
     /// </summary>
+    /// <param name="initialColor">The initial color in RGBA format (0-1 range).</param>
+    /// <param name="showAlpha">Whether to show the alpha slider.</param>
+    /// <returns>A color picker configuration using HSV mode.</returns>
     public static ColorPickerConfig HSV(Vector4? initialColor = null, bool showAlpha = true) =>
         new(InitialColor: initialColor, Mode: ColorPickerMode.HSV, ShowAlpha: showAlpha);
 
     /// <summary>
     /// Creates an RGB color picker configuration.
     /// </summary>
+    /// <param name="initialColor">The initial color in RGBA format (0-1 range).</param>
+    /// <param name="showAlpha">Whether to show the alpha slider.</param>
+    /// <returns>A color picker configuration using RGB mode.</returns>
     public static ColorPickerConfig RGB(Vector4? initialColor = null, bool showAlpha = true) =>
         new(InitialColor: initialColor, Mode: ColorPickerMode.RGB, ShowAlpha: showAlpha);
 
     /// <summary>
     /// Creates a compact color picker (no hex input, smaller size).
     /// </summary>
+    /// <param name="initialColor">The initial color in RGBA format (0-1 range).</param>
+    /// <returns>A color picker configuration with a reduced footprint.</returns>
     public static ColorPickerConfig Compact(Vector4? initialColor = null) =>
         new(InitialColor: initialColor, ShowHexInput: false, Width: 200f, Height: 220f);
 
     /// <summary>
     /// Creates a color picker without alpha slider.
     /// </summary>
+    /// <param name="initialColor">The initial color in RGBA format (0-1 range).</param>
+    /// <returns>A color picker configuration with the alpha slider disabled.</returns>
     public static ColorPickerConfig Opaque(Vector4? initialColor = null) =>
         new(InitialColor: initialColor, ShowAlpha: false);
 
@@ -2234,36 +2283,52 @@ public sealed record DatePickerConfig(
     /// <summary>
     /// Creates a date-only picker configuration.
     /// </summary>
+    /// <param name="initialValue">The initial date/time value.</param>
+    /// <returns>A date picker configuration restricted to date selection.</returns>
     public static DatePickerConfig DateOnly(DateTime? initialValue = null) =>
         new(InitialValue: initialValue, Mode: DatePickerMode.Date);
 
     /// <summary>
     /// Creates a time-only picker configuration.
     /// </summary>
+    /// <param name="initialValue">The initial date/time value.</param>
+    /// <param name="format">The time format (12-hour or 24-hour).</param>
+    /// <returns>A date picker configuration restricted to time selection.</returns>
     public static DatePickerConfig TimeOnly(DateTime? initialValue = null, TimeFormat format = TimeFormat.Hour24) =>
         new(InitialValue: initialValue, Mode: DatePickerMode.Time, TimeFormat: format, Height: 100f);
 
     /// <summary>
     /// Creates a date and time picker configuration.
     /// </summary>
+    /// <param name="initialValue">The initial date/time value.</param>
+    /// <param name="format">The time format (12-hour or 24-hour).</param>
+    /// <returns>A date picker configuration that selects both date and time.</returns>
     public static DatePickerConfig DateAndTime(DateTime? initialValue = null, TimeFormat format = TimeFormat.Hour24) =>
         new(InitialValue: initialValue, Mode: DatePickerMode.DateTime, TimeFormat: format, Height: 380f);
 
     /// <summary>
     /// Creates a date picker with a date range constraint.
     /// </summary>
+    /// <param name="minDate">The minimum selectable date.</param>
+    /// <param name="maxDate">The maximum selectable date.</param>
+    /// <param name="initialValue">The initial date/time value.</param>
+    /// <returns>A date picker configuration restricted to the given date range.</returns>
     public static DatePickerConfig WithRange(DateTime minDate, DateTime maxDate, DateTime? initialValue = null) =>
         new(InitialValue: initialValue, MinDate: minDate, MaxDate: maxDate);
 
     /// <summary>
     /// Creates a date picker that only allows future dates.
     /// </summary>
+    /// <param name="initialValue">The initial date/time value (defaults to today).</param>
+    /// <returns>A date picker configuration with today as the minimum selectable date.</returns>
     public static DatePickerConfig FutureOnly(DateTime? initialValue = null) =>
         new(InitialValue: initialValue ?? DateTime.Today, MinDate: DateTime.Today);
 
     /// <summary>
     /// Creates a date picker that only allows past dates.
     /// </summary>
+    /// <param name="initialValue">The initial date/time value (defaults to today).</param>
+    /// <returns>A date picker configuration with today as the maximum selectable date.</returns>
     public static DatePickerConfig PastOnly(DateTime? initialValue = null) =>
         new(InitialValue: initialValue ?? DateTime.Today, MaxDate: DateTime.Today);
 
@@ -2317,18 +2382,24 @@ public sealed record DataGridConfig(
     /// <summary>
     /// Creates a default data grid configuration with specified columns.
     /// </summary>
+    /// <param name="columns">The column definitions.</param>
+    /// <returns>A data grid configuration using the specified columns.</returns>
     public static DataGridConfig WithColumns(params DataGridColumnDef[] columns) =>
         new(Columns: columns);
 
     /// <summary>
     /// Creates a data grid with simple string column headers.
     /// </summary>
+    /// <param name="headers">The column header text for each column.</param>
+    /// <returns>A data grid configuration with a column generated for each header.</returns>
     public static DataGridConfig WithHeaders(params string[] headers) =>
         new(Columns: headers.Select(h => new DataGridColumnDef(h)).ToArray());
 
     /// <summary>
     /// Creates a read-only data grid (no selection, no sorting, no resize).
     /// </summary>
+    /// <param name="columns">The column definitions.</param>
+    /// <returns>A data grid configuration with selection, sorting, and column resize disabled.</returns>
     public static DataGridConfig ReadOnly(params DataGridColumnDef[] columns) =>
         new(
             Columns: columns,
@@ -2339,6 +2410,8 @@ public sealed record DataGridConfig(
     /// <summary>
     /// Creates a data grid that allows multiple row selection.
     /// </summary>
+    /// <param name="columns">The column definitions.</param>
+    /// <returns>A data grid configuration with multi-row selection enabled.</returns>
     public static DataGridConfig MultiSelect(params DataGridColumnDef[] columns) =>
         new(
             Columns: columns,

--- a/src/KeenEyes.UI/Widgets/WidgetFactory.Toast.cs
+++ b/src/KeenEyes.UI/Widgets/WidgetFactory.Toast.cs
@@ -280,24 +280,48 @@ public static partial class WidgetFactory
     /// <summary>
     /// Creates an info toast.
     /// </summary>
+    /// <param name="world">The world to create the toast in.</param>
+    /// <param name="container">The toast container entity.</param>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">The optional toast title.</param>
+    /// <param name="duration">The duration, in seconds, the toast remains visible before dismissing.</param>
+    /// <returns>The toast entity.</returns>
     public static Entity ShowInfoToast(IWorld world, Entity container, string message, string? title = null, float duration = 3f) =>
         ShowToast(world, container, ToastConfig.Info(message, title, duration));
 
     /// <summary>
     /// Creates a success toast.
     /// </summary>
+    /// <param name="world">The world to create the toast in.</param>
+    /// <param name="container">The toast container entity.</param>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">The optional toast title.</param>
+    /// <param name="duration">The duration, in seconds, the toast remains visible before dismissing.</param>
+    /// <returns>The toast entity.</returns>
     public static Entity ShowSuccessToast(IWorld world, Entity container, string message, string? title = null, float duration = 3f) =>
         ShowToast(world, container, ToastConfig.Success(message, title, duration));
 
     /// <summary>
     /// Creates a warning toast.
     /// </summary>
+    /// <param name="world">The world to create the toast in.</param>
+    /// <param name="container">The toast container entity.</param>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">The optional toast title.</param>
+    /// <param name="duration">The duration, in seconds, the toast remains visible before dismissing.</param>
+    /// <returns>The toast entity.</returns>
     public static Entity ShowWarningToast(IWorld world, Entity container, string message, string? title = null, float duration = 5f) =>
         ShowToast(world, container, ToastConfig.Warning(message, title, duration));
 
     /// <summary>
     /// Creates an error toast.
     /// </summary>
+    /// <param name="world">The world to create the toast in.</param>
+    /// <param name="container">The toast container entity.</param>
+    /// <param name="message">The toast message text.</param>
+    /// <param name="title">The optional toast title.</param>
+    /// <param name="duration">The duration, in seconds, the toast remains visible before dismissing. A value of zero means the toast does not auto-dismiss.</param>
+    /// <returns>The toast entity.</returns>
     public static Entity ShowErrorToast(IWorld world, Entity container, string message, string? title = null, float duration = 0f) =>
         ShowToast(world, container, ToastConfig.Error(message, title, duration));
 


### PR DESCRIPTION
## Summary
Coverage was already 100% (CS1591 clean); this fills in the missing `<param>`/`<returns>`/`<typeparam>` tags on public members that carried only a one-line `<summary>`, matching the fully-tagged style of the `World` facade.
- **KeenEyes.Core**: `World.Query<T1..T4>()`, the `Archetype`/`ArchetypeChunk` accessors, `ComponentRegistry`, `QueryBuilder`, and the `ParallelQueryExtensions` delegates.
- **KeenEyes.Testing**: `CommonComponents` factories and the EntityPreset/Batch builders.
- **KeenEyes.UI**: `RgbTo*` helpers and ~29 Toast/Spinner/ColorPicker/DatePicker/DataGrid config presets.

## Test plan
- [x] `dotnet build` (Debug) green for Core/Testing/UI with CS1591 enforced (no CS1573/CS1712 from partial tags)
- [x] `dotnet format` clean
- [ ] CI green