### PR TITLE
docs: add subsystem conceptual guides + editor/CLI/plugin references

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -1,0 +1,231 @@
+# Animation
+
+The `KeenEyes.Animation` library provides ECS-native animation support: skeletal keyframe playback, animator state machines, sprite sheet animation, and property tweening. Animation assets (clips, sprite sheets, controllers) are plain data registered with a manager and referenced from components by integer ID, keeping components pure data per ECS principles.
+
+## Overview
+
+Animation state in KeenEyes always follows the same split:
+
+- **Assets** (`AnimationClip`, `SpriteSheet`, `AnimatorController`) are shared, immutable-ish data owned by `AnimationManager`.
+- **Components** (`AnimationPlayer`, `Animator`, `SpriteAnimator`, tween components) hold per-entity playback state and reference an asset by its integer ID (`ClipId`, `SheetId`, `ControllerId`).
+- **Systems** advance playback time each frame, sample curves, and write results (bone transforms, sprite source rectangles, tween values).
+
+This means multiple entities can share one `AnimationClip` or `SpriteSheet` while each tracks its own time, speed, and weight independently.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Animation;
+
+using var world = new World();
+
+// Install with default configuration
+world.InstallPlugin(new AnimationPlugin());
+```
+
+`AnimationPlugin.Install` registers the following components:
+
+- `AnimationPlayer`, `Animator`, `SpriteAnimator`, `BoneReference`
+- `TweenFloat`, `TweenVector2`, `TweenVector3`, `TweenVector4`
+
+and the following systems, all in `SystemPhase.Update` (order matters, since later systems depend on earlier ones having run):
+
+| Order | System | Responsibility |
+|-------|--------|-----------------|
+| 50 | `AnimatorSystem` | Advances state-machine time and resolves transitions/crossfades |
+| 51 | `AnimationPlayerSystem` | Advances `AnimationPlayer` time and handles wrap modes |
+| 52 | `SpriteAnimationSystem` | Advances `SpriteAnimator` time and resolves the current frame |
+| 53 | `AnimationEventSystem` | Detects and publishes clip events crossed this frame |
+| 55 | `SkeletonPoseSystem` | Samples clips and writes pose data to bone `Transform3D`s |
+| 60 | `TweenSystem` | Advances all tween components and computes `CurrentValue` |
+
+It also creates an `AnimationManager` and exposes it as a world extension via `context.SetExtension`.
+
+> `SkinnedMeshBoneSystem` (GPU bone matrix computation for `SkinnedMesh` entities) exists in `KeenEyes.Animation.Systems` but is **not** registered by `AnimationPlugin`; add it explicitly with `world.AddSystem<SkinnedMeshBoneSystem>(...)` if you render skinned meshes. Similarly, the IK components (`IKRig`, `IKChainReference`, `IKConstraint`, `IKTarget`) and `LookAtTarget` are not registered by the plugin and have no bundled solver systems yet — see [IK Rigs](#ik-rigs-unwired) below.
+
+### Registering Assets
+
+Access the manager through the world extension and register assets before referencing them from components:
+
+```csharp
+var animations = world.GetExtension<AnimationManager>();
+
+var walkClip = new AnimationClip { Name = "Walk", WrapMode = WrapMode.Loop };
+// ... populate walkClip.AddBoneTrack(...) ...
+var walkClipId = animations.RegisterClip(walkClip);
+
+var runSheet = new SpriteSheet { Name = "Run" };
+runSheet.AddGridFrames(columns: 8, rows: 1, frameCount: 8, frameDuration: 0.1f);
+var runSheetId = animations.RegisterSpriteSheet(runSheet);
+```
+
+`AnimationManager` also exposes `GetClip`/`TryGetClip`, `GetSpriteSheet`/`TryGetSpriteSheet`, `GetController`/`TryGetController`, matching `Unregister*` methods, and `ClipCount`/`SpriteSheetCount`/`ControllerCount` counters.
+
+### Your First Animated Entity
+
+```csharp
+using KeenEyes.Animation.Components;
+
+var character = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(AnimationPlayer.ForClip(walkClipId))
+    .Build();
+
+var sprite = world.Spawn()
+    .With(new Transform2D(position, 0, Vector2.One))
+    .With(SpriteAnimator.ForSheet(runSheetId))
+    .Build();
+
+var fading = world.Spawn()
+    .With(TweenFloat.Create(1f, 0f, 2f, EaseType.QuadOut))
+    .Build();
+```
+
+## Core Concepts
+
+### AnimationPlayer
+
+`AnimationPlayer` provides basic single-clip playback: it stores `ClipId`, `Time`, `Speed`, `IsPlaying`, an optional `WrapModeOverride`, a blend `Weight`, and a system-managed `IsComplete` flag. Use the static factories `AnimationPlayer.Default` and `AnimationPlayer.ForClip(clipId, autoPlay)` to construct one. For state-machine-driven playback with multiple clips and transitions, use `Animator` instead.
+
+```csharp
+var entity = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(new AnimationPlayer { ClipId = walkClipId, IsPlaying = true })
+    .Build();
+```
+
+`AnimationPlayerSystem` advances `Time` each frame by `deltaTime * Speed * clip.Speed` and applies the clip's `WrapMode` (`Once`, `Loop`, `PingPong`, `ClampForever`).
+
+### Animator and AnimatorController
+
+`Animator` is the state-machine component: it references an `AnimatorController` by `ControllerId` and tracks `CurrentStateHash`, `StateTime`, and in-progress transition data (`NextStateHash`, `TransitionProgress`, `TransitionDuration`, `NextStateTime`). Because components must stay pure data, you trigger a transition by setting `TriggerStateHash` directly — `AnimatorSystem` clears it after processing. `Animator.GetStateHash(string)` converts a state name to the hash the component expects.
+
+```csharp
+var entity = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(new Animator { ControllerId = humanoidControllerId })
+    .Build();
+
+ref var animator = ref world.Get<Animator>(entity);
+animator.TriggerStateHash = Animator.GetStateHash("Jump");
+```
+
+An `AnimatorController` is built from `AnimatorState` entries (each with a `ClipId` and `Speed`) connected by `AnimatorTransition`s (`TargetStateHash`, crossfade `Duration`, optional normalized `ExitTime`, and an `EaseType`):
+
+```csharp
+var controller = new AnimatorController { Name = "Humanoid" };
+
+var idle = new AnimatorState { Name = "Idle", ClipId = idleClipId };
+idle.AddTransition("Jump", duration: 0.15f);
+
+var jump = new AnimatorState { Name = "Jump", ClipId = jumpClipId };
+jump.AddTransition("Idle", duration: 0.2f, exitTime: 0.9f);
+
+controller.AddState(idle, isDefault: true);
+controller.AddState(jump);
+
+var controllerId = animations.RegisterController(controller);
+```
+
+`AnimatorSystem` advances `StateTime`, resolves a triggered or exit-time transition into a crossfade, and blends `TransitionProgress` toward 1 before completing the switch. `SkeletonPoseSystem` reads that state, samples both the current and (if transitioning) next clip's bone tracks, and blends them with `Vector3.Lerp`/`Quaternion.Slerp`.
+
+### Skeletal Animation: BoneReference and AnimationClip
+
+Skeleton bones are ordinary entities marked with `BoneReference { BoneName, SkeletonRootId }` and a `Transform3D`, parented under the skeleton root (the entity carrying `AnimationPlayer` or `Animator`):
+
+```csharp
+var hip = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(new BoneReference { BoneName = "Hip", SkeletonRootId = characterEntity.Id })
+    .Build();
+```
+
+An `AnimationClip` holds one `BoneTrack` per animated bone (added with `AddBoneTrack`), each with optional `PositionCurve`/`RotationCurve`/`ScaleCurve` and a `Sample(time, out position, out rotation, out scale)` method. `SkeletonPoseSystem` queries all `BoneReference` + `Transform3D` entities each frame, looks up the sampled pose for their `SkeletonRootId`, and writes `Position`/`Rotation`/`Scale` onto the bone's `Transform3D`.
+
+`SkeletonFactory.InstantiateSkeleton(world, bones, rootEntity)` is a helper for building a bone hierarchy from `BoneSetupData[]` (bone name, parent index, bind-pose matrix) in one call, returning the bone entity IDs in skeleton order; `SkeletonFactory.DespawnSkeleton` and `SkeletonFactory.FindBoneByName` round out cleanup and lookup.
+
+### Skinned Mesh Rendering
+
+`SkinnedMesh` marks a mesh entity for GPU skinning: it carries `MeshAssetId`, `BoneEntityIds` (in skeleton order), `InverseBindMatrices`, and a `Generation` counter. `SkinnedMeshBoneSystem` (not auto-registered — see above) walks each bone entity's world transform, multiplies by its inverse bind matrix, and stores the result in a `BoneMatrixBuffer`, which tracks per-bone generations so only changed matrices need re-uploading to the GPU.
+
+```csharp
+var character = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(SkinnedMesh.Create(meshAssetId, boneEntityIds, inverseBindMatrices))
+    .Build();
+```
+
+### Sprite Animation
+
+`SpriteAnimator` drives frame-based 2D animation against a `SpriteSheet` asset: `SheetId`, `Time`, `Speed`, `IsPlaying`, an optional `WrapModeOverride`, and system-managed `CurrentFrame`/`SourceRect`/`IsComplete` outputs. Build a sheet with `AddFrame` (one frame at a time) or `AddGridFrames` (uniform grid layout), then reference it by ID:
+
+```csharp
+var runSheet = new SpriteSheet { Name = "Run", WrapMode = WrapMode.Loop };
+runSheet.AddGridFrames(columns: 8, rows: 1, frameCount: 8, frameDuration: 0.1f);
+var runSheetId = animations.RegisterSpriteSheet(runSheet);
+
+var entity = world.Spawn()
+    .With(new Transform2D(position, 0, Vector2.One))
+    .With(new SpriteAnimator { SheetId = runSheetId, IsPlaying = true })
+    .Build();
+```
+
+`SpriteAnimationSystem` advances `Time`, resolves the wrap mode, and calls `sheet.GetFrameAtTime` to update `CurrentFrame` and `SourceRect` — the latter can be fed directly to `I2DRenderer.DrawTextureRegion`.
+
+### Animation Events
+
+`AnimationClip.Events` is an `AnimationEventTrack` of named, timed `AnimationEvent`s (`Time`, `EventName`, optional `Parameter`), added with `AddEvent`. Each frame, `AnimationEventSystem` compares each playing `AnimationPlayer`'s `PreviousTime`/`Time` against the clip's events and publishes an `AnimationEventTriggeredEvent` (`Entity`, `EventName`, `Parameter`, `Time`, `ClipId`) for every event crossed:
+
+```csharp
+walkClip.Events.AddEvent(0.3f, "footstep");
+
+world.Events.Subscribe<AnimationEventTriggeredEvent>(e =>
+{
+    if (e.EventName == "footstep")
+    {
+        PlayFootstepSound(e.Entity, e.Parameter);
+    }
+});
+```
+
+Event dispatch can be disabled via `AnimationConfig.EnableEvents` if you don't need it.
+
+### Property Tweening
+
+`TweenFloat`, `TweenVector2`, `TweenVector3`, and `TweenVector4` interpolate a value from `StartValue` to `EndValue` over `Duration` seconds, with an `EaseType`, and optional `Loop`/`PingPong`. Each exposes a static `Create(start, end, duration, ease)` factory and writes its result to `CurrentValue` (also tracking `ElapsedTime` and `IsComplete`):
+
+```csharp
+using KeenEyes.Animation.Tweening;
+
+var fading = world.Spawn()
+    .With(TweenFloat.Create(1f, 0f, 2f, EaseType.QuadOut))
+    .Build();
+
+// Later, in a user system, read CurrentValue and apply it to whatever it drives:
+ref readonly var tween = ref world.Get<TweenFloat>(fading);
+var alpha = tween.CurrentValue;
+```
+
+`TweenSystem` advances all four tween component types every frame and evaluates the easing curve via `Easing.Evaluate(EaseType, t)`. `EaseType` covers linear plus in/out/in-out variants of quadratic, cubic, quartic, quintic, sine, exponential, circular, elastic, back, and bounce curves. `AnimationConfig.MaxTweensPerEntity` documents an intended per-entity cap (default 16) but is not currently enforced by `TweenSystem`.
+
+### IK Rigs (unwired)
+
+`KeenEyes.Animation.IK` and the `IKManager` class provide the data model for inverse-kinematics rigs: `IKRigDefinition` (a named collection of `IKChainDefinition`s, built with `AddTwoBoneChain`/`AddFABRIKChain`), `IKChainDefinition` (bone names root-to-tip, `IKSolverType` — `TwoBone`, `FABRIK`, `CCD`, or `LookAt` — iteration/tolerance settings), and the `IKRig`, `IKChainReference`, `IKConstraint`, and `IKTarget` components that would attach a rig to a skeleton entity. `IKManager` registers rigs/chains and looks up solver instances by `IKSolverType` via `RegisterSolver`/`GetSolver`/`GetSolverForType`.
+
+As of this writing, **`AnimationPlugin` does not register the IK components, does not create/expose an `IKManager` extension, and ships no `IIKSolver` implementations or IK system** — the types exist as a foundation for a future feature. If you want to use them today, construct your own `IKManager`, register solver implementations of `IIKSolver`, register the IK components with `world.Components.Register<T>()`, and drive solving from a custom system.
+
+## Performance
+
+- **Per-frame caching:** `SkeletonPoseSystem` builds a per-frame `Dictionary` cache of active `AnimationPlayer`/`Animator` states before iterating bones, so sampling cost for a skeleton's clip is paid once regardless of bone count.
+- **Dirty-tracked GPU uploads:** `BoneMatrixBuffer` only marks itself dirty when a bone's generation counter advances, and `GetDirtyBoneIndices`/`GetDirtyBoneCount` let a render system upload only the bones that actually changed.
+- **Shared assets:** Because clips, sprite sheets, and controllers are registered once in `AnimationManager` and referenced by ID, many entities can share the same animation data without duplicating curve or frame data per entity.
+- **Disable unused features:** Set `AnimationConfig.EnableEvents = false` if you don't use animation events, to skip event-range checks in `AnimationEventSystem`.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How plugins work
+- [Systems Guide](systems.md) - System design patterns
+- [Components Guide](components.md) - Component registration and builders
+- [Animation System Design](research/animation-system.md) - Original design document (aspirational; the shipped implementation differs in several details, e.g. ID-based asset references rather than direct object references)

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,243 @@
+# Asset Management
+
+The `KeenEyes.Assets` library provides loading, caching, and lifecycle management for game resources such as textures, audio clips, meshes, and fonts. It integrates with a `World` as a plugin, so asset resolution can be driven directly from ECS components.
+
+## Overview
+
+`KeenEyes.Assets` is built around a few core pieces:
+
+- **`AssetManager`** - the central API for loading, caching, and unloading assets. Assets are identified by file path and loaded through registered `IAssetLoader<T>` implementations.
+- **`AssetHandle<T>`** - a type-safe, reference-counted handle to a loaded asset, returned from `AssetManager.Load<T>`/`LoadAsync<T>`.
+- **`AssetRef<T>`** - a serializable struct for use inside components, holding just a path. The `AssetResolutionSystem` resolves it to a loaded asset automatically.
+- **`AssetsPlugin`** - the `IWorldPlugin` that wires an `AssetManager` and the resolution system into a `World`, auto-registering built-in loaders based on what other plugins (graphics, audio) are installed.
+
+Assets are cached by path, reference-counted, and unloaded according to a configurable `CachePolicy`. Loading can happen synchronously (`Load<T>`) or asynchronously (`LoadAsync<T>`) without blocking the calling thread.
+
+## Quick Start
+
+### Installation
+
+Install `AssetsPlugin` on a `World`. If graphics or audio plugins are installed first, `AssetsPlugin` automatically registers the loaders that depend on them:
+
+```csharp
+using KeenEyes.Assets;
+
+using var world = new World();
+
+// Install graphics and audio first (optional - enables texture/audio loaders)
+world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
+world.InstallPlugin(new SilkAudioPlugin());
+
+// Install assets plugin
+world.InstallPlugin(new AssetsPlugin(new AssetsConfig
+{
+    RootPath = "Assets",
+    EnableHotReload = true // Development mode
+}));
+
+// Now load assets
+var assets = world.GetExtension<AssetManager>();
+using var texture = assets.Load<TextureAsset>("textures/player.png");
+```
+
+During `Install`, `AssetsPlugin`:
+
+- Creates an `AssetManager` from the supplied `AssetsConfig` (or `AssetsConfig.Default` if none is passed) and registers it as a world extension (`context.SetExtension(assetManager)`), retrievable via `world.GetExtension<AssetManager>()`.
+- Registers built-in loaders based on available dependencies:
+  - `TextureLoader`, `DdsTextureLoader`, `SpriteAtlasLoader`, `AnimationLoader` - if an `IGraphicsContext` extension is present.
+  - `FontLoader` - if the graphics context also implements `IFontManagerProvider`.
+  - `AudioClipLoader` - if an `IAudioContext` extension is present.
+  - `MeshLoader` and `RawLoader` - always, since they have no external dependencies.
+- Registers `AssetResolutionSystem` in the `SystemPhase.EarlyUpdate` phase with `order: -100`.
+- If `AssetsConfig.EnableHotReload` is `true` and `AssetsConfig.RootPath` exists, creates a `ReloadManager` that watches the root path for file changes.
+
+On `Uninstall`, the plugin disposes the `ReloadManager` (if any), removes the `AssetManager` extension, and disposes the `AssetManager` (which unloads all cached assets).
+
+### Configuration
+
+`AssetsConfig` is a record with the following settings:
+
+| Property | Default | Description |
+|---|---|---|
+| `RootPath` | `"Assets"` | Root directory that all asset paths are relative to. |
+| `MaxCacheBytes` | 512 MB | Cache size at which eviction may occur, subject to `CachePolicy`. |
+| `CachePolicy` | `CachePolicy.LRU` | Eviction strategy - see below. |
+| `MaxConcurrentLoads` | `4` | Maximum number of concurrent async load operations. |
+| `EnableHotReload` | `false` | Watches `RootPath` for changes and reloads modified assets. Development only. |
+| `DefaultPriority` | `LoadPriority.Normal` | Default priority for async loads. |
+| `Services` | `null` | Optional `IServiceProvider` passed to loaders via `AssetLoadContext`. |
+| `OnLoadError` | `null` | Callback invoked with `(path, exception)` when an async load triggered by `AssetResolutionSystem` fails. |
+
+`AssetsConfig.Default` returns production-friendly defaults; `AssetsConfig.Development` enables hot reload and switches to `CachePolicy.Aggressive`.
+
+```csharp
+var config = new AssetsConfig
+{
+    RootPath = "Assets",
+    MaxCacheBytes = 1024 * 1024 * 1024, // 1 GB
+    CachePolicy = CachePolicy.LRU,
+    EnableHotReload = true
+};
+
+world.InstallPlugin(new AssetsPlugin(config));
+```
+
+## Loading Assets Directly
+
+`AssetManager` exposes both synchronous and asynchronous loading. Both return an `AssetHandle<T>`, which is `IDisposable` and reference-counted:
+
+```csharp
+var manager = world.GetExtension<AssetManager>();
+
+// Synchronous load - blocks until the file is read and parsed
+using var texture = manager.Load<TextureAsset>("textures/player.png");
+
+// Asynchronous load - does not block the calling thread
+using var clip = await manager.LoadAsync<AudioClipAsset>(
+    "audio/music.ogg",
+    priority: LoadPriority.Normal);
+
+if (texture.IsLoaded)
+{
+    var asset = texture.Asset!; // TextureAsset
+}
+```
+
+Key `AssetHandle<T>` members:
+
+- `IsValid` - refers to a tracked asset (may still be loading).
+- `State` - the current `AssetState` (`Invalid`, `Pending`, `Loading`, `Loaded`, `Failed`, `Unloaded`).
+- `IsLoaded`, `IsLoading`, `IsFailed` - convenience checks over `State`.
+- `Asset` - the loaded `T`, or `null` if not yet loaded.
+- `Acquire()` - takes an additional reference, returning a new handle that must also be disposed.
+- `Dispose()` - releases this handle's reference; the asset becomes eligible for eviction once all references are released.
+
+Repeated calls to `Load<T>`/`LoadAsync<T>` for the same path return handles to the same cached entry rather than reloading from disk.
+
+Requesting the same asset with two different type parameters (e.g. `Load<TextureAsset>` and `Load<RawAsset>` for the same path) is not supported - each cache entry is keyed by path and a single asset type.
+
+### Built-in Asset Types
+
+The loaders registered by `AssetsPlugin` produce these asset types, all `sealed class`, all `IDisposable`:
+
+- `TextureAsset` - wraps a `TextureHandle` plus `Width`, `Height`, `Format` (`TextureFormat`), and estimated `SizeBytes`.
+- `AudioClipAsset` - wraps an `AudioClipHandle` plus `Duration`, `Channels`, `SampleRate`, `BitsPerSample`.
+- `MeshAsset` - holds `Vertices` (`MeshVertex[]`), `Indices` (`uint[]`), `Submeshes`, and bounds (`BoundsMin`/`BoundsMax`). Use `MeshAsset.Create(name, vertices, indices)` to build one with computed bounds.
+- `RawAsset` - unprocessed file bytes, exposed via `Data`, `AsSpan()`, `AsMemory()`, and `CreateStream()`.
+
+Other asset types exist for specialized loaders (`FontAsset`, `SpriteAtlasAsset`, `AnimationAsset`, `SkeletonAsset`, `SkeletalAnimationAsset`, `ModelAsset`) - see the `KeenEyes.Assets.Assets` namespace for details.
+
+### Custom Loaders
+
+Add support for a new asset type by implementing `IAssetLoader<T>` and registering it with `AssetManager.RegisterLoader<T>`:
+
+```csharp
+public sealed class MyFormatLoader : IAssetLoader<MyAsset>
+{
+    public IReadOnlyList<string> Extensions => [".myf"];
+
+    public MyAsset Load(Stream stream, AssetLoadContext context)
+    {
+        // Parse the stream and return the asset
+        return new MyAsset(stream);
+    }
+
+    public async Task<MyAsset> LoadAsync(
+        Stream stream, AssetLoadContext context, CancellationToken cancellationToken = default)
+    {
+        return await Task.Run(() => Load(stream, context), cancellationToken);
+    }
+}
+
+manager.RegisterLoader(new MyFormatLoader());
+```
+
+`AssetLoadContext` (a `readonly record struct`) carries `Path`, the owning `Manager`, and the optional `Services` provider configured on `AssetsConfig`. Loaders that need to load a dependent asset (e.g. a model referencing textures) can call `AssetManager.LoadDependency<T>(parentPath, dependencyPath)` or its async counterpart; the dependency's reference count is then tied to the parent and released automatically when the parent is released.
+
+## Resolving Assets from Components with `AssetRef<T>`
+
+`AssetRef<T>` is an `IComponent` that stores just a path, suitable for serializing with entity data. Add it as a component field and let `AssetResolutionSystem` resolve it:
+
+```csharp
+[Component]
+public partial struct SpriteRenderer
+{
+    public AssetRef<TextureAsset> Texture;
+    public Vector4 Color;
+}
+
+world.Spawn()
+    .With(new SpriteRenderer
+    {
+        Texture = AssetRef<TextureAsset>.FromPath("textures/player.png"),
+        Color = Vector4.One
+    })
+    .Build();
+```
+
+`AssetResolutionSystem` runs every `EarlyUpdate` (registered at `order: -100` by `AssetsPlugin`) and, for every entity with an unresolved `AssetRef<T>`, starts an async load at `LoadPriority.Normal`. It currently resolves `AssetRef<TextureAsset>`, `AssetRef<AudioClipAsset>`, `AssetRef<MeshAsset>`, and `AssetRef<RawAsset>` components each tick. Check `AssetRef<T>.IsResolved` (true once `HandleId` is set) before relying on the referenced asset being available. If a load fails, the `AssetsConfig.OnLoadError` callback (if configured) is invoked with the path and exception. Call `Invalidate()` on the ref after changing its `Path` to force re-resolution.
+
+## Caching and Eviction
+
+`AssetManager.CachePolicy` controls eviction behavior, all subject to reference counting - assets with active `AssetHandle<T>` references are never evicted:
+
+- `CachePolicy.LRU` (default) - evicts zero-reference assets by least-recently-used order once the cache exceeds `MaxCacheBytes`.
+- `CachePolicy.Manual` - never auto-evicts; call `Unload(path)` or `UnloadAll()` explicitly.
+- `CachePolicy.Aggressive` - unloads an asset as soon as its reference count reaches zero; no caching benefit, useful for development/memory-constrained scenarios.
+
+```csharp
+var stats = manager.GetCacheStats(); // CacheStats
+Console.WriteLine($"{stats.LoadedAssets}/{stats.TotalAssets} loaded, hit ratio {stats.HitRatio:P0}");
+
+manager.TrimCache(targetBytes: 256 * 1024 * 1024);
+```
+
+`CacheStats` reports `TotalAssets`, `LoadedAssets`, `PendingAssets`, `FailedAssets`, `TotalSizeBytes`, `MaxSizeBytes`, `CacheHits`, `CacheMisses`, plus computed `HitRatio` and `UtilizationRatio`.
+
+## Streaming and Hot Reload
+
+`StreamingManager` preloads a batch of assets in the background at `LoadPriority.Streaming`, useful for level transitions:
+
+```csharp
+var streaming = new StreamingManager(manager);
+
+streaming.Queue<TextureAsset>("levels/forest/ground.png");
+streaming.Queue<MeshAsset>("levels/forest/trees.glb");
+streaming.Start();
+
+await streaming.WaitForCompletionAsync();
+```
+
+`Progress` reports completion as a `0`-`1` float, and `OnAssetStreamed`/`OnStreamingComplete`/`OnStreamingError` events report per-asset and overall status.
+
+When `AssetsConfig.EnableHotReload` is `true`, `AssetsPlugin` creates a `ReloadManager` that watches `RootPath` (via `FileSystemWatcher`) and calls `AssetManager.ReloadAsync(path)` for loaded assets when their backing file changes, after a short debounce. This works for any type with a registered loader, without additional configuration. Hot reload is intended for development only.
+
+## Asset Manifests
+
+`AssetManifest` describes build-time asset metadata (path, type, size, hash, dependencies) without needing filesystem scanning at runtime - useful for preloading and validating packaged builds:
+
+```csharp
+var manifest = AssetManifest.Load("Assets/manifest.json");
+
+if (manifest.Exists("textures/player.png"))
+{
+    var info = manifest.GetInfo("textures/player.png"); // AssetInfo?
+}
+```
+
+Build one programmatically with `AssetManifest.CreateBuilder()` (returns an `AssetManifestBuilder`), chaining `AddAsset(path, type, size, hash, dependencies)` calls and finishing with `Build()`.
+
+## Performance
+
+- Prefer `LoadAsync<T>` over `Load<T>` on hot paths (e.g. gameplay code running each frame) - `Load<T>` blocks the calling thread until the file is read and parsed.
+- Dispose every `AssetHandle<T>` you acquire. Cache policies other than `Manual` can only evict assets with zero active references, so undisposed handles keep assets resident indefinitely.
+- `AssetsConfig.MaxConcurrentLoads` bounds concurrent disk/parse work; raise it cautiously since higher values use more threads and I/O bandwidth simultaneously.
+- Use `CachePolicy.Aggressive` only for development or memory-constrained targets - it reloads from disk on every access with no caching benefit.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - how `IWorldPlugin` installation and extensions work in general
+- [Systems Guide](systems.md) - system phases and ordering, as used by `AssetResolutionSystem`
+- [Components Guide](components.md) - defining components like `AssetRef<T>` fields with `[Component]`
+- [Asset Management Design](research/asset-management.md) - original design document (aspirational; verify details against source before relying on them)
+- [Asset Loading Design](research/asset-loading.md) - original loading pipeline design document

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,0 +1,166 @@
+# Audio
+
+The `KeenEyes.Audio` library provides ECS components and systems for sound playback, while `KeenEyes.Audio.Silk` supplies a Silk.NET/OpenAL backend that you install into a `World` as a plugin.
+
+## Overview
+
+Audio in KeenEyes is split across three packages:
+
+- **`KeenEyes.Audio.Abstractions`** - Backend-agnostic contracts: `IAudioContext` (high-level playback API), `IAudioDevice` (low-level backend operations), handles (`AudioClipHandle`, `SoundHandle`), and value types (`PlaybackOptions`, `AudioClipInfo`, `AudioConfig`).
+- **`KeenEyes.Audio`** - ECS integration: the `AudioSource` and `AudioListener` components, plus `AudioSourceSystem`, `AudioListenerSystem`, and `AudioUpdateSystem` that synchronize those components with whichever `IAudioContext` is installed.
+- **`KeenEyes.Audio.Silk`** - A concrete backend, `SilkAudioPlugin`, that implements `IAudioContext` on top of OpenAL via Silk.NET and wires up the ECS systems automatically.
+
+Two usage styles are supported and can be mixed freely:
+
+1. **Fire-and-forget** - call `IAudioContext.Play`/`PlayAt` directly for one-shot sounds (UI clicks, hit reactions).
+2. **ECS-driven** - attach an `AudioSource` component to an entity for sounds whose playback state and 3D position should track that entity across frames.
+
+## Quick Start
+
+### Installation
+
+`SilkAudioPlugin` requires a Silk window plugin to already be installed, since it shares the window's OpenAL lifecycle:
+
+```csharp
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Audio.Silk;
+using KeenEyes.Platform.Silk;
+
+using var world = new World();
+
+// Window plugin must be installed first
+world.InstallPlugin(new SilkWindowPlugin(new WindowConfig
+{
+    Title = "My Game",
+    Width = 1920,
+    Height = 1080
+}));
+
+// Then install audio
+world.InstallPlugin(new SilkAudioPlugin(new SilkAudioConfig
+{
+    MaxOneShotSources = 64,
+    InitialMasterVolume = 0.8f
+}));
+```
+
+Installing `SilkAudioPlugin` registers:
+
+- The `IAudioContext` extension (backed by `SilkAudioContext`), retrievable via `world.GetExtension<IAudioContext>()`.
+- The `AudioSource` and `AudioListener` components.
+- Three systems in the `SystemPhase.Update` phase: `AudioUpdateSystem` (order 0, recycles pooled sources), `AudioListenerSystem` (order 5, syncs the active listener), and `AudioSourceSystem` (order 10, syncs sources and playback state).
+
+If the window plugin was not installed first, `Install` throws an `InvalidOperationException`.
+
+### Playing a One-Shot Sound
+
+```csharp
+var audio = world.GetExtension<IAudioContext>();
+
+var explosion = audio.LoadClip("assets/sounds/explosion.wav");
+audio.Play(explosion, volume: 0.8f);
+```
+
+`Play` and `PlayAt` also accept a `PlaybackOptions` value for control over pitch, looping, and mixer channel:
+
+```csharp
+audio.Play(explosion, new PlaybackOptions
+{
+    Volume = 0.5f,
+    Pitch = 1f,
+    Loop = false,
+    Channel = AudioChannel.SFX
+});
+```
+
+Both `Play` overloads return a `SoundHandle` that can be used with `Stop`, `Pause`, `Resume`, `SetVolume`, `SetPitch`, `SetPosition`, and `IsPlaying`.
+
+## Core Concepts
+
+### `AudioClipHandle` and `SoundHandle`
+
+`IAudioContext` deals in two opaque handle types instead of exposing backend resource types directly:
+
+- `AudioClipHandle` identifies loaded audio data (returned by `LoadClip`/`CreateClip`).
+- `SoundHandle` identifies a specific playing instance. A single clip can have many concurrent sound handles.
+
+Both are `readonly record struct` types with a static `Invalid` value and an `IsValid` property.
+
+### `IAudioContext`
+
+`IAudioContext` is the application-facing API. Beyond clip loading and playback, it exposes:
+
+- `MasterVolume` (get/set, 0.0-1.0) for global volume.
+- `GetChannelVolume(AudioChannel)` / `SetChannelVolume(AudioChannel, float)` for per-category mixing across `AudioChannel.Master`, `Music`, `SFX`, `Voice`, and `Ambient`.
+- `SetListenerPosition`, `SetListenerOrientation`, and `SetListenerVelocity` as convenience wrappers around the device - for ECS-driven games, prefer the `AudioListener` component instead.
+- `StopAll`, `PauseAll`, and `ResumeAll` for bulk control.
+- `Update()`, which the `AudioUpdateSystem` calls once per frame to recycle finished sources back into the pool.
+
+### `AudioSource` Component
+
+Attach `AudioSource` to an entity to have `AudioSourceSystem` manage a backend source on its behalf:
+
+```csharp
+using System.Numerics;
+using KeenEyes.Audio;
+using KeenEyes.Common;
+
+var enemy = world.Spawn()
+    .With(new Transform3D(new Vector3(10, 0, 0), Quaternion.Identity, Vector3.One))
+    .With(AudioSource.Default with
+    {
+        Clip = explosion,
+        Spatial = true,
+        PlayOnAwake = true,
+        MinDistance = 2f,
+        MaxDistance = 50f
+    })
+    .Build();
+```
+
+Key fields on `AudioSource`:
+
+- `Clip` (`AudioClipHandle`) - the clip to play.
+- `Volume`, `Pitch`, `Loop`, `Channel` - playback parameters, mirroring `PlaybackOptions`.
+- `PlayOnAwake` - starts playback the first time the system sees the component; the flag is consumed (set back to `false`) afterward.
+- `Spatial` - when `true`, `AudioSourceSystem` reads the entity's `Transform3D` (and `Velocity3D`, if present, for Doppler) each frame to update the backend source's position/velocity. When `false`, the sound plays without distance attenuation.
+- `MinDistance`, `MaxDistance`, `RolloffMode` - 3D distance attenuation settings, used only when `Spatial` is `true`.
+- `State` (`AudioPlayState`) - set to `AudioPlayState.Playing` or `AudioPlayState.Stopped` to request playback changes; the system updates it to reflect what actually happened (e.g. a non-looping sound naturally finishing sets it back to `Stopped`).
+- `CurrentSound` (`SoundHandle`) - the handle for the actively playing sound, so you can still call `IAudioContext` methods like `SetVolume` on it directly.
+
+`AudioSourceSystem` creates the backend source lazily (only once `State` becomes `Playing`), and cleans it up when the component is removed or the entity is destroyed - `SilkAudioPlugin` wires both of those lifecycle events automatically.
+
+### `AudioListener` Component
+
+`AudioListener` marks the entity that acts as the "ears" for 3D spatial audio - typically the player or camera:
+
+```csharp
+var player = world.Spawn()
+    .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+    .With(AudioListener.Active)
+    .Build();
+```
+
+`AudioListenerSystem` reads the listener entity's `Transform3D` each frame to update the backend listener's position and orientation, derives velocity from the position delta for Doppler calculations, and applies `AudioListener.VolumeMultiplier`, `DopplerFactor`, and `SpeedOfSound`. Only one active listener is honored; if several entities have `IsActive = true`, the first one encountered by the query wins.
+
+Use `AudioListener.Active` or `AudioListener.Inactive` to get an instance with sensible defaults (`DopplerFactor = 1`, `VolumeMultiplier = 1`, `SpeedOfSound = 343`).
+
+### Channels and Playback Options
+
+`AudioChannel` provides five mixer groups - `Master`, `Music`, `SFX`, `Voice`, `Ambient` - so a UI can, for example, mute music while keeping sound effects audible via `SetChannelVolume`. `PlaybackOptions` (a `readonly record struct`) bundles `Volume`, `Pitch`, `Loop`, and `Channel` for a single `Play`/`PlayAt` call; use `PlaybackOptions.Default` or `with` expressions to tweak individual fields.
+
+### Distance Attenuation
+
+`AudioRolloffMode` controls how spatial sound volume falls off with distance: `Linear`, `Logarithmic` (the default used by both `AudioConfig` and `AudioSource.Default`), `Exponential`, or `Custom` (where the application computes gain manually - the backend applies no automatic attenuation in that mode).
+
+## Performance
+
+- One-shot sounds played through `IAudioContext.Play`/`PlayAt` draw from an internal source pool sized by `SilkAudioConfig.MaxOneShotSources` (default 32); `AudioUpdateSystem` must run every frame to recycle finished sources back into that pool, or it will eventually be exhausted.
+- `AudioSourceSystem` only allocates a backend source for an `AudioSource` once its `State` becomes `Playing`, so idle sources with no clip assigned cost nothing.
+- Spatial position/velocity updates are only issued for entities with `Spatial = true`, avoiding unnecessary device calls for 2D/UI sounds.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How plugins like `SilkAudioPlugin` install extensions and systems
+- [Systems Guide](systems.md) - System phases, ordering, and lifecycle
+- [Audio System Design](research/audio-system.md) - Original design document

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,94 @@
+# Command-Line Interface (`keeneyes`)
+
+The `keeneyes` command-line tool (`KeenEyes.Cli`) manages editor plugins, configures the NuGet package sources they are installed from, and batch-upgrades save files to the latest component versions. It shares its plugin/source infrastructure with the [KeenEyes Editor](editor.md), so plugins installed from the CLI are available in the editor and vice versa.
+
+## Running
+
+The tool builds to an executable named `keeneyes`:
+
+```bash
+# From a build of this repo
+dotnet run --project editor/KeenEyes.Cli -- <command> [options]
+
+# Or, once published / installed on PATH
+keeneyes <command> [options]
+```
+
+Running `keeneyes` with no command (or `--help`) prints the command list; `keeneyes <command> --help` prints help for a specific command.
+
+### Global options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Show help information |
+| `-v`, `--version` | Show version information |
+| `--verbose` | Show verbose output (includes stack traces on error) |
+| `-q`, `--quiet` | Suppress non-essential output |
+
+The process exit code is `0` on success, `1` on error, and `130` if cancelled with `Ctrl+C`.
+
+## Plugin management
+
+`keeneyes plugin <subcommand>` manages editor plugins installed from NuGet.
+
+| Subcommand | Description | Usage |
+|------------|-------------|-------|
+| `install` | Install a plugin from NuGet | `plugin install <package-id> [--version <ver>] [--source <url>]` |
+| `list` | List installed plugins | `plugin list [--all \| --enabled \| --disabled]` |
+| `search` | Search for plugins on NuGet | `plugin search <query> [--source <url>] [--take <n>]` |
+| `uninstall` | Uninstall a plugin | `plugin uninstall <package-id>` |
+| `update` | Update installed plugins | `plugin update [<package-id>] [--all]` |
+
+```bash
+# Find and install a plugin
+keeneyes plugin search physics
+keeneyes plugin install Acme.KeenEyes.Physics --version 1.2.0
+
+# Review what's installed, then update everything
+keeneyes plugin list --all
+keeneyes plugin update --all
+```
+
+## Package sources
+
+`keeneyes sources <subcommand>` configures the NuGet feeds that `plugin install`/`search` resolve against. (`sources` is an alias for `plugin sources`.)
+
+| Subcommand | Description | Usage |
+|------------|-------------|-------|
+| `add` | Add a NuGet package source | `sources add <name> <url> [--default]` |
+| `list` | List configured NuGet sources | `sources list` |
+| `remove` | Remove a NuGet package source | `sources remove <name>` |
+
+```bash
+keeneyes sources add studio-feed https://nuget.example.com/v3/index.json --default
+keeneyes sources list
+keeneyes sources remove studio-feed
+```
+
+## Migrating save files
+
+`keeneyes migrate` batch-upgrades saved worlds to the latest component schema versions — the offline, bulk counterpart to the runtime migration system described in the [Migrations guide](migrations.md).
+
+**Usage:** `migrate --path <dir> [--pattern <glob>] [--dry-run] [--backup] [--output <dir>] [--verbose] [--continue-on-error]`
+
+| Option | Description |
+|--------|-------------|
+| `--path <dir>` | Directory of save files to process (required) |
+| `--pattern <glob>` | Filename glob to match (e.g. `*.kesave`) |
+| `--dry-run` | Report what would change without writing |
+| `--backup` | Write a backup copy before upgrading each file |
+| `--output <dir>` | Write upgraded files to a separate directory |
+| `--continue-on-error` | Keep going if an individual file fails |
+
+```bash
+# Preview upgrades, then apply them with backups
+keeneyes migrate --path ./saves --pattern "*.kesave" --dry-run
+keeneyes migrate --path ./saves --pattern "*.kesave" --backup
+```
+
+## Next Steps
+
+- [KeenEyes Editor](editor.md) - The editor that consumes these plugins
+- [Migrations](migrations.md) - How component schema migrations work at runtime
+- [Editor Plugin Dependencies](editor-plugin-dependencies.md) - How plugin dependencies resolve
+- [SDK](sdk.md) - Building plugins that the CLI can install

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,332 @@
+# Debugging & Profiling
+
+The `KeenEyes.Debugging` library provides system profiling, GC allocation tracking, query
+diagnostics, entity inspection, log capture, and execution timeline recording for a KeenEyes
+`World`. It ships as a single plugin, `DebugPlugin`, that wires these tools together using
+`SystemHooks` and the world's capability interfaces.
+
+> **Note:** An earlier example in [Plugins Guide](plugins.md) shows a hand-rolled
+> `DebugPlugin` used purely to illustrate the `IWorldPlugin` interface. That example is not the
+> library described here — this page documents the real `KeenEyes.Debugging.DebugPlugin`.
+
+## What is KeenEyes.Debugging?
+
+`KeenEyes.Debugging` bundles several independent diagnostic extensions:
+
+1. **`DebugController`** - a central toggle for "debug mode" that other systems can query.
+2. **`Profiler`** - per-system execution timing (total, average, min, max).
+3. **`GCTracker`** - per-system GC allocation tracking.
+4. **`QueryProfiler`** - manual query timing plus automatic query-cache statistics.
+5. **`MemoryTracker`** - world and archetype memory statistics and formatted reports.
+6. **`EntityInspector`** - runtime inspection of an entity's components, name, and hierarchy.
+7. **`LogCapture`** - buffers log entries from an `ILogQueryable` provider during a debug session.
+8. **`TimelineRecorder`** / **`TimelineExporter`** (in `KeenEyes.Debugging.Timeline`) - frame-by-frame
+   execution history with JSON/CSV export.
+
+Each of these is installed as a `World` extension and retrieved with `IWorld.GetExtension<T>`.
+`DebugPlugin` only installs the extensions whose prerequisites are met and whose feature flag
+is enabled, so unused tools have zero footprint.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Debugging;
+
+using var world = new World();
+
+// Install with default options (profiling, GC tracking, and query profiling enabled)
+world.InstallPlugin(new DebugPlugin());
+```
+
+`DebugPlugin`'s constructor takes an optional `DebugOptions` record:
+
+```csharp
+using KeenEyes.Debugging;
+
+var options = new DebugOptions
+{
+    InitialDebugMode = false,
+    EnableProfiling = true,
+    EnableGCTracking = true,
+    EnableQueryProfiling = true,
+    EnableTimeline = false,
+    TimelineMaxFrames = 300,
+    EnableLogCapture = false
+};
+
+using var world = new World();
+world.InstallPlugin(new DebugPlugin(options));
+```
+
+During `Install`, `DebugPlugin`:
+
+- Always installs `DebugController`, seeded with `DebugOptions.InitialDebugMode`.
+- Installs `EntityInspector` only if the world exposes `IInspectionCapability` (it also picks up
+  `IHierarchyCapability` when available, for parent/child lookups).
+- Installs `MemoryTracker` (and `QueryProfiler`, if `EnableQueryProfiling` is true) only if the
+  world exposes `IStatisticsCapability`.
+- Installs `Profiler`, `GCTracker`, and `TimelineRecorder` via `SystemHooks`, obtained from
+  `ISystemHookCapability`. If any of `EnableProfiling`, `EnableGCTracking`, or `EnableTimeline` is
+  true and the world does not support system hooks, `Install` throws `InvalidOperationException`.
+- Installs `LogCapture` only if `EnableLogCapture` is true, using the `ILogQueryable` passed as
+  `DebugOptions.LogQueryable`.
+
+Retrieve the tools you need through the world's extension API:
+
+```csharp
+var profiler = world.GetExtension<Profiler>();
+var gcTracker = world.GetExtension<GCTracker>();
+var memoryTracker = world.GetExtension<MemoryTracker>();
+var queryProfiler = world.GetExtension<QueryProfiler>();
+var inspector = world.GetExtension<EntityInspector>();
+var controller = world.GetExtension<DebugController>();
+```
+
+## Core Concepts
+
+### Debug Mode
+
+`DebugController` is a lightweight, always-installed switch that other code can query before
+doing expensive diagnostic work. It raises `DebugModeChanged` whenever `IsDebugMode` changes,
+tracks a `ToggleCount` and `LastToggleTime`, and offers a couple of convenience helpers:
+
+```csharp
+var controller = world.GetExtension<DebugController>();
+
+controller.DebugModeChanged += (_, enabled) =>
+{
+    Console.WriteLine(enabled ? "Debug mode ON" : "Debug mode OFF");
+};
+
+controller.Enable();
+controller.Toggle();
+
+// Only run expensive validation when debug mode is active
+controller.WhenDebug(() => ValidateAllEntityReferences());
+
+// Pick a value based on debug mode without an if/else
+var resolution = controller.Select(
+    debugValue: TimeSpan.FromMicroseconds(1),
+    releaseValue: TimeSpan.FromMilliseconds(1));
+```
+
+`DebugOptions.OnDebugModeChanged` lets you wire the toggle straight into another system (for
+example, adjusting a `LogManager.MinimumLevel`) without subscribing to the event yourself.
+
+### System Profiling
+
+`Profiler` is driven by a pair of `SystemHooks` that `DebugPlugin` registers automatically when
+`EnableProfiling` is true. Each system's execution is bracketed with `BeginSample`/`EndSample`,
+keyed by the system's type name:
+
+```csharp
+var profiler = world.GetExtension<Profiler>();
+
+world.Update(0.016f);
+
+foreach (var profile in profiler.GetAllSystemProfiles())
+{
+    Console.WriteLine(
+        $"{profile.Name}: avg {profile.AverageTime.TotalMilliseconds:F2}ms " +
+        $"(min {profile.MinTime.TotalMilliseconds:F2}ms, max {profile.MaxTime.TotalMilliseconds:F2}ms, " +
+        $"calls {profile.CallCount})");
+}
+
+profiler.Reset();
+```
+
+`SystemProfile` (a `readonly record struct`) exposes `Name`, `TotalTime`, `CallCount`,
+`AverageTime`, `MinTime`, and `MaxTime`. `DebugOptions.ProfilingPhase` restricts profiling to a
+single `SystemPhase` when set; leaving it `null` profiles every phase.
+
+### GC Allocation Tracking
+
+`GCTracker` uses `GC.GetAllocatedBytesForCurrentThread()` around each system's execution to spot
+allocation hotspots, following the same `BeginTracking`/`EndTracking` pairing driven by
+`SystemHooks`:
+
+```csharp
+var gcTracker = world.GetExtension<GCTracker>();
+
+foreach (var profile in gcTracker.GetAllAllocationProfiles())
+{
+    if (profile.TotalBytes > 1024)
+    {
+        Console.WriteLine($"{profile.Name} allocated {profile.TotalBytes} bytes over {profile.CallCount} calls");
+    }
+}
+
+// Formatted report of every tracked system, sorted by total bytes
+Console.WriteLine(gcTracker.GetAllocationReport());
+```
+
+Because it only measures allocations on the thread where systems execute, allocations made on
+worker threads in multi-threaded scenarios are not captured. `DebugOptions.GCTrackingPhase` filters
+tracking to a single phase, just like profiling.
+
+### Query Profiling
+
+Unlike system execution, queries run inline inside system code with no automatic hook point, so
+`QueryProfiler` requires manual instrumentation with `BeginQuery`/`EndQuery` around the query you
+want to measure:
+
+```csharp
+var queryProfiler = world.GetExtension<QueryProfiler>();
+
+queryProfiler.BeginQuery("MovementQuery");
+var count = 0;
+foreach (var entity in world.Query<Position, Velocity>())
+{
+    count++;
+    // process entity
+}
+queryProfiler.EndQuery("MovementQuery", entityCount: count);
+
+var profile = queryProfiler.GetQueryProfile("MovementQuery");
+Console.WriteLine($"Avg: {profile.AverageTime.TotalMicroseconds:F2}us over {profile.AverageEntities} entities");
+```
+
+`QueryProfiler` also surfaces cache statistics automatically, with no instrumentation required,
+via `IStatisticsCapability`:
+
+```csharp
+var cacheStats = queryProfiler.GetCacheStatistics();
+Console.WriteLine($"Cache hit rate: {cacheStats.HitRate:F1}% ({cacheStats.CachedQueryCount} cached queries)");
+
+// Slowest 10 queries by average time, plus cache stats, as a formatted report
+Console.WriteLine(queryProfiler.GetQueryReport());
+```
+
+### Memory & Archetype Statistics
+
+`MemoryTracker` wraps `IStatisticsCapability` with formatted reporting:
+
+```csharp
+var memoryTracker = world.GetExtension<MemoryTracker>();
+
+var stats = memoryTracker.GetMemoryStats();
+Console.WriteLine($"Active entities: {stats.EntitiesActive}, archetypes: {stats.ArchetypeCount}");
+
+Console.WriteLine(memoryTracker.GetMemoryReport());
+Console.WriteLine(memoryTracker.GetArchetypeReport());
+```
+
+`GetArchetypeStats()` returns `ArchetypeStatistics` for every archetype currently in use,
+including `EntityCount`, `ChunkCount`, `EstimatedMemoryBytes`, and `ComponentTypeNames`, which
+`GetArchetypeReport()` renders as a table sorted by entity count.
+
+### Entity Inspection
+
+`EntityInspector` is only installed when the world supports `IInspectionCapability`. Call
+`Inspect` to snapshot an entity's name, components, and (if `IHierarchyCapability` is also
+available) parent/children:
+
+```csharp
+var inspector = world.GetExtension<EntityInspector>();
+var info = inspector.Inspect(entity);
+
+Console.WriteLine($"Entity {info.Entity.Id} ({info.Name ?? "unnamed"})");
+foreach (var component in info.Components)
+{
+    Console.WriteLine($"  - {component.TypeName} ({component.SizeInBytes} bytes)");
+}
+```
+
+`Inspect` throws `InvalidOperationException` if the entity is dead or invalid. `EntityInspector`
+also exposes `GetAllEntities()` and `HasComponent`/`HasComponent<T>` for lighter-weight checks
+without a full inspection.
+
+### Timeline Recording
+
+`TimelineRecorder` (in `KeenEyes.Debugging.Timeline`) captures per-system, per-frame execution
+history when `DebugOptions.EnableTimeline` is true. It is driven by the same `SystemHooks`
+mechanism as `Profiler` and `GCTracker`, and keeps only a rolling window of frames
+(`DebugOptions.TimelineMaxFrames`, default 300):
+
+```csharp
+var recorder = world.GetExtension<TimelineRecorder>();
+
+// Recent history and per-frame slices
+var recent = recorder.GetRecentEntries(100);
+var frame = recorder.GetEntriesForFrame(recorder.CurrentFrame);
+
+// Aggregate stats per system
+var stats = recorder.GetSystemStats();
+```
+
+Each `TimelineEntry` records `FrameNumber`, `SystemName`, `Phase`, `StartTicks`, `Duration`, and
+`DeltaTime`. `TimelineExporter` turns recorded entries or `TimelineSystemStats` into JSON or CSV
+for external visualization tools, or a quick human-readable report:
+
+```csharp
+using KeenEyes.Debugging.Timeline;
+
+var json = TimelineExporter.ToJson(recorder.GetAllEntries());
+var csv = TimelineExporter.ToCsv(recorder.GetAllEntries());
+
+Console.WriteLine(TimelineExporter.GenerateReport(recorder));
+```
+
+Note that `TimelineRecorder` does not advance its own frame counter automatically - call
+`AdvanceFrame()` once per frame (for example, right after `world.Update(deltaTime)`) so entries
+are correctly bucketed and old frames are trimmed.
+
+### Log Capture
+
+`LogCapture` bridges `KeenEyes.Logging` into a debug session by subscribing to an
+`ILogQueryable` provider's `LogAdded` event while capturing is active:
+
+```csharp
+using KeenEyes.Debugging;
+
+var options = new DebugOptions
+{
+    EnableLogCapture = true,
+    LogQueryable = ringBufferLogProvider, // an ILogQueryable, e.g. a ring-buffer provider
+    LogCaptureMaxEntries = 5_000,
+    AutoStartLogCaptureOnDebugMode = true
+};
+
+world.InstallPlugin(new DebugPlugin(options));
+
+var logCapture = world.GetExtension<LogCapture>();
+logCapture.StartCapture();
+
+world.Update(0.016f);
+
+logCapture.StopCapture();
+foreach (var entry in logCapture.GetCapturedEntries(LogLevel.Warning))
+{
+    Console.WriteLine($"[{entry.Timestamp}] {entry.Level}: {entry.Message}");
+}
+```
+
+When `AutoStartLogCaptureOnDebugMode` is true (the default), `DebugPlugin` starts and stops
+`LogCapture` automatically whenever `DebugController.IsDebugMode` changes, so you don't need to
+call `StartCapture`/`StopCapture` yourself in that mode. `GetCapturedEntries` also accepts a
+category wildcard pattern (`*`/`?`) for filtering by category instead of level.
+
+## Performance
+
+- Disabled features carry no runtime cost: `DebugPlugin` only registers the `SystemHooks` or
+  extensions for features whose `DebugOptions` flag is enabled.
+- `Profiler` and `GCTracker` add one hook invocation before and after every system; keep this in
+  mind if you also register your own `SystemHooks` for other cross-cutting concerns, since hook
+  overhead scales with the total number of registered hooks.
+- `QueryProfiler`'s manual timing (`BeginQuery`/`EndQuery`) only costs what you instrument -
+  cache statistics from `IStatisticsCapability` are effectively free since the ECS already tracks
+  them.
+- `TimelineRecorder` trims frames older than `TimelineMaxFrames` on every `AdvanceFrame()` call,
+  bounding memory growth; raise the limit for longer replay windows at the cost of more retained
+  entries.
+- `LogCapture` bounds its buffer at `LogCaptureMaxEntries`, discarding the oldest entry once the
+  limit is reached.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How the plugin/capability system that `DebugPlugin` builds on works
+- [System Hooks](systems.md) - The `SystemHooks` mechanism used for profiling, GC tracking, and timeline recording
+- [Logging](logging.md) - `KeenEyes.Logging` providers and `ILogQueryable` for use with `LogCapture`
+- [TestBridge Architecture Guide](testbridge.md) - External tooling that can query similar world state over MCP

--- a/docs/editor-plugin-development.md
+++ b/docs/editor-plugin-development.md
@@ -1,0 +1,184 @@
+# Editor Plugin Development
+
+This is a reference for authoring editor plugins against `KeenEyes.Editor.Abstractions`. It assumes you've read the [Editor](editor.md) overview (launching, panels, install flow); this page goes one level deeper into the lifecycle interfaces, capabilities, and extension points a plugin actually codes against.
+
+Types that make up the surface area:
+
+- **Lifecycle**: `IEditorPlugin`, `EditorPluginBase`, `IEditorContext`, `IStatefulPlugin`, `IEditorCapability`, `PluginPermission`, `PermissionDeniedException`.
+- **Capabilities** (obtained from `IEditorContext`): `IPanelCapability` / `IExtendedPanelCapability`, `IInspectorCapability`, `IMenuCapability`, `IShortcutCapability`, `IToolCapability`, `IViewportCapability`, `IAssetCapability`, `INotificationCapability`.
+- **Extension points** (types you implement): `IEditorPanel`, `EditorToolBase` / `IEditorTool`, `IComponentInspector`, `PropertyDrawer` (via `IPropertyDrawerRegistry`), `IGizmoRenderer` / `IGizmoDrawer`, `IEditorCommand`, and classes marked `[EditorExtension]`.
+
+All of these live under the `KeenEyes.Editor.Abstractions` namespace, with the capability interfaces specifically in `KeenEyes.Editor.Abstractions.Capabilities` and drawer/inspector types in `KeenEyes.Editor.Abstractions.Inspector`.
+
+## Plugin Lifecycle
+
+### IEditorPlugin
+
+`IEditorPlugin` is the contract every editor plugin implements: `Name`, `Version`, `Description` (nullable), `Initialize(IEditorContext context)`, and `Shutdown()`. Per its documented lifecycle, a plugin is instantiated by the editor, `Initialize` is called with the editor context, the plugin registers its extensions through capabilities obtained from that context, it stays active until editor shutdown, and `Shutdown` is called to release resources. Resources registered through capabilities during `Initialize` are tracked and cleaned up automatically when the plugin is uninstalled — `Shutdown` is for any *additional* custom cleanup.
+
+### EditorPluginBase
+
+`EditorPluginBase` is an abstract base implementing `IEditorPlugin` with sensible defaults: `Version` defaults to `"1.0.0"` and `Description` defaults to `null` (both `virtual`, override to change). It exposes a protected `Context` property (`IEditorContext?`) that's set when `Initialize` runs and cleared when `Shutdown` runs — so it's `null` outside that window. `Initialize`/`Shutdown` themselves are plain (non-virtual) methods that set/clear `Context` and delegate — you don't override them directly. Instead, override the protected `OnInitialize(IEditorContext context)` (abstract) and `OnShutdown()` (virtual, no-op by default).
+
+### IEditorContext
+
+`IEditorContext` is what `Initialize`/`OnInitialize` receives, and it groups into four areas:
+
+- **Core services** — properties for the pieces of editor state a plugin most commonly needs: `Worlds` (`IEditorWorldManager`), `Selection` (`ISelectionManager`), `UndoRedo` (`IUndoRedoManager`), `Assets` (`IAssetDatabase`), `EditorWorld` (`IWorld`, the world backing the editor's own UI, distinct from the scene being edited), and `Log` (`ILogQueryable?`, null if no queryable log provider is configured — see [Logging](logging.md#querying-log-history)).
+- **Extension storage** — `SetExtension<T>(T extension)`, `T GetExtension<T>()` (throws `InvalidOperationException` if unregistered), `bool TryGetExtension<T>(out T? extension)`, and `bool RemoveExtension<T>()`. This is the same pattern used for `IWorld` extensions, applied to the editor itself, and lets one plugin expose an API surface that other plugins can consume.
+- **Capability access** — `T GetCapability<T>()` (throws `InvalidOperationException` if unavailable), `bool TryGetCapability<T>(out T? capability)`, and `bool HasCapability<T>()`, all constrained to `T : class, IEditorCapability`.
+- **Event subscriptions** — `OnSceneOpened(Action<IWorld>)`, `OnSceneClosed(Action)`, `OnSelectionChanged(Action<IReadOnlyList<Entity>>)`, and `OnPlayModeChanged(Action<EditorPlayState>)`. Each returns an `EventSubscription`; dispose it to unsubscribe. `EditorPlayState` is an enum: `Editing`, `Playing`, `Paused`.
+
+### Capabilities and permissions
+
+`IEditorCapability` is an empty marker interface every capability interface implements, so `GetCapability<T>`/`TryGetCapability<T>`/`HasCapability<T>` can be constrained generically. Beyond the "is it available at all" check (`InvalidOperationException` from `GetCapability<T>`), capability access is also gated by `PluginPermission` — a `[Flags] enum` (file system, network, process/reflection/assembly-loading, and editor-specific bits like `MenuAccess`, `PanelAccess`, `InspectorAccess`, `ViewportAccess`, `ShortcutAccess`, `UndoAccess`, `SelectionAccess`, `AssetDatabaseAccess`) plus composites like `StandardEditor`, `EditorUI`, and `FullTrust`. Per its own remarks, `PermissionDeniedException` (carrying `PluginId`, `RequiredPermission`, and an optional `CapabilityType`) is thrown by `IEditorContext` implementations when a plugin attempts to use a capability it wasn't granted permission for.
+
+### Stateful plugins and hot reload
+
+Implement `IStatefulPlugin` (extends `IEditorPlugin`) to survive a hot reload: `object? SaveState()` is called before the plugin is unloaded, and `void RestoreState(object? state)` is called after the new instance's `Initialize` runs. The returned state object should avoid referencing types defined in the plugin's own assembly (dictionaries of primitives or host-defined record types are recommended) since that assembly is being unloaded and reloaded. See [Editor Plugin Hot Reload](editor-plugin-hot-reload.md) for the full reload sequence and constraints.
+
+### EditorExtensionAttribute
+
+`[EditorExtension(string propertyName)]`, applied to a class, tells the source generator to create a C# 13 extension member on `IEditorContext` that wraps `GetExtension<T>()`/`SetExtension<T>()` in a named property (`context.MyExtension` instead of `context.GetExtension<MyExtensionClass>()`). It has one constructor argument, `PropertyName`, and one settable property, `Nullable` (`bool`, default `false`) — when `true` the generated property returns `null` if the extension isn't registered instead of throwing.
+
+## Panels
+
+`IPanelCapability` registers and manages dockable panels:
+
+- `RegisterPanel<T>(PanelDescriptor descriptor)` where `T : IEditorPanel, new()`, or `RegisterPanel(PanelDescriptor descriptor, Func<IEditorPanel> factory)` when construction needs arguments.
+- `OpenPanel(string id)`, `ClosePanel(string id)`, `IsPanelOpen(string id)`, `FocusPanel(string id)`.
+- `GetPanelDescriptors()`, `GetOpenPanels()`, and the `PanelOpened` / `PanelClosed` events (`Action<string>?`).
+
+`PanelDescriptor` fields: `Id`, `Title`, `Icon` (nullable), `DefaultLocation` (`PanelDockLocation`: `Left`, `Right`, `Bottom`, `Top`, `Center`, `Floating`), `OpenByDefault`, `MinWidth`/`MinHeight`/`DefaultWidth`/`DefaultHeight`, `AllowMultiple`, `Category`, and `ToggleShortcut`.
+
+`IExtendedPanelCapability` extends `IPanelCapability` with `GetPanelState(string panelId)` / `SetPanelState(string panelId, ExtendedPanelState state)`, where `ExtendedPanelState` carries `X`, `Y`, `Width`, `Height`, and `DockLocation` — used to capture and restore panel layout across a hot reload.
+
+The extension point is `IEditorPanel`: `Initialize(PanelContext context)`, `Update(float deltaTime)` (called every frame), `Shutdown()`, and a `RootEntity` property (the UI entity the panel built). `PanelContext` supplies `EditorContext`, `EditorWorld`, the `Parent` entity to attach content under, the `Descriptor`, and a default `Font` (`FontHandle`).
+
+```csharp
+public sealed class MyPanel : IEditorPanel
+{
+    public Entity RootEntity { get; private set; }
+
+    public void Initialize(PanelContext context)
+    {
+        // Build UI entities under context.Parent using context.EditorWorld
+        RootEntity = context.Parent;
+    }
+
+    public void Update(float deltaTime) { }
+
+    public void Shutdown() { }
+}
+```
+
+## Inspector customization
+
+`IInspectorCapability` is how a plugin changes what the Inspector panel shows for a field or component type:
+
+- `RegisterPropertyDrawer(Type fieldType, PropertyDrawer drawer)` / `RegisterPropertyDrawer<T>(PropertyDrawer drawer)` — drawer for a field *type*.
+- `RegisterDrawerForAttribute<TAttribute>(PropertyDrawer drawer)` where `TAttribute : Attribute` — drawer for fields carrying a specific attribute, regardless of field type.
+- `RegisterComponentInspector<TComponent>(IComponentInspector inspector)` where `TComponent : struct, IComponent` — replaces the entire default per-field display for a component with custom UI.
+- `RegisterComponentActions<TComponent>(IComponentActionProvider provider)` — adds context-menu actions for a component.
+- `PropertyDrawers` — direct access to the underlying `IPropertyDrawerRegistry`.
+
+**Property drawers.** `PropertyDrawer` is an abstract class: `TargetType` (the type it handles), `GetHeight(FieldInfo field, object? value)` (defaults to `20f`), the abstract `CreateUI(PropertyDrawerContext context, FieldInfo field, object? value) : Entity`, and a virtual `UpdateUI(PropertyDrawerContext context, Entity uiEntity, object? value)` (no-op by default; override for reactive updates when the underlying value changes externally). `PropertyDrawerContext` supplies `EditorWorld`, `Parent`, `Font`, field `Metadata` (`FieldMetadata`), and an `OnValueChanged` callback to invoke when the user edits the value. `FieldMetadata` carries `DisplayName`, `Tooltip`, `Header`, `SpaceHeight`, a `Range` tuple (`Min`, `Max`) for numeric fields, `IsReadOnly`, `FoldoutGroup`, and a `TextArea` tuple (`MinLines`, `MaxLines`) for strings.
+
+`IPropertyDrawerRegistry` is the lookup table drawers are stored in: `Register<T>(PropertyDrawer)` / `Register(Type, PropertyDrawer)`, `GetDrawer(Type)` / `GetDrawer<T>()` (falls back to a default drawer if nothing is registered for the type), and `HasDrawer(Type)`.
+
+**Component inspectors.** `IComponentInspector` replaces the default field-by-field rendering for a component: `Entity CreateUI(ComponentInspectorContext context, object componentValue)` and `void UpdateUI(ComponentInspectorContext context, Entity rootEntity, object componentValue)`. `ComponentInspectorContext` supplies `EditorWorld`, `Parent`, the `InspectedEntity`, `ComponentType`, and `OnValueChanged`.
+
+**Component actions.** `IComponentActionProvider.GetActions(ComponentActionContext context)` returns `ComponentAction` entries (`Name`, `Execute`, `IsEnabled`, `Icon`) that appear as context-menu items next to a component in the Inspector.
+
+## Menus & toolbar
+
+`IMenuCapability` adds menu items, context-menu items, and toolbar buttons:
+
+- `AddMenuItem(MenuPath path, EditorCommand command)` — top-level menu bar item, e.g. `"File/Export/Scene"`.
+- `AddContextMenuItem<T>(MenuPath path, EditorCommand<T> command)` — item shown when right-clicking a `T`.
+- `AddToolbarButton(ToolbarSection section, EditorCommand command)` — `ToolbarSection` is `File`, `Edit`, `PlayMode`, `Tools`, `View`, or `Custom`.
+- `RemoveMenuItem(MenuPath path)`, `RemoveToolbarButton(string commandId)`, `GetMenuItems(MenuPath parentPath)`.
+
+`MenuPath` is a struct built from segments (`new MenuPath("File", "Export", "Scene")`) or parsed from a slash-delimited string via `MenuPath.Parse` — and strings convert to it implicitly, so `AddMenuItem("File/Export/Scene", command)` works directly.
+
+`EditorCommand` (used for menu items and toolbar buttons) has `Id`, `DisplayName`, `Execute` (`Action`), an optional `CanExecute` (`Func<bool>`), `Shortcut`, `Icon`, and `Tooltip`. `EditorCommand<T>` is the context-menu variant: same shape, but `Execute` is `Action<T>` and `CanExecute` is `Func<T, bool>`, so the command receives the right-clicked target.
+
+> `EditorCommand` (menu/toolbar action descriptor) is unrelated to `IEditorCommand` (the undo/redo primitive, covered under [Undo/redo commands](#undoredo-commands) below) — they share "command" in the name but serve different capabilities.
+
+## Shortcuts
+
+`IShortcutCapability` registers keyboard shortcuts with conflict detection and rebinding:
+
+- `RegisterShortcut(string actionId, string displayName, string category, string defaultShortcut, Action action)` and an overload taking an additional `Func<bool> canExecute` — both return a `ShortcutBinding`.
+- `UnregisterShortcut(string actionId)`, `GetShortcut(string actionId)`, `GetShortcutsInCategory(string category)`, `GetAllShortcuts()`, `GetCategories()`.
+- `RebindShortcut(string actionId, string newShortcut)`, `ResetShortcut(string actionId)`, `ResetAllShortcuts()`.
+- `FindConflict(string shortcut, string? excludeActionId = null)` — returns the conflicting `ShortcutBinding`, if any.
+- `ProcessKeyEvent(KeyEvent keyEvent)` — dispatches a key event to matching shortcuts, returning whether one fired.
+- Events: `ShortcutRegistered`, `ShortcutUnregistered`, `ShortcutRebound`.
+
+`ShortcutBinding` carries `ActionId`, `DisplayName`, `Category`, `DefaultShortcut`, a mutable `CurrentShortcut`, `Execute`, `CanExecute`, a derived `IsModified` (current vs. default), `IsEnabled`, and a parsed `ParsedShortcut` (`KeyCombination?`). Shortcut strings like `"Ctrl+Shift+S"` parse into a `KeyCombination` (`Key` + `KeyModifiers` flags: `Control`, `Alt`, `Shift`, `Meta`) via `KeyCombination.Parse`. `ShortcutCategories` supplies standard category name constants (`File`, `Edit`, `View`, `Selection`, `Transform`, `PlayMode`, `Navigation`, `Tools`, `Custom`).
+
+## Tools
+
+`IToolCapability` manages viewport interaction tools: `ActiveTool` / `ActiveToolId`, `RegisterTool(string id, IEditorTool tool)`, `UnregisterTool(string id)`, `ActivateTool(string id)`, `DeactivateTool()`, `GetTool(string id)`, `GetTools()`, `GetToolsInCategory(string category)`, and events `ActiveToolChanged` (`ToolChangedEventArgs`: `PreviousToolId`/`PreviousTool`/`NewToolId`/`NewTool`), `ToolRegistered`, `ToolUnregistered`.
+
+The extension point is `IEditorTool`: `DisplayName`, `Icon`, `Category`, `Tooltip`, `Shortcut`, `IsEnabled`, `OnActivate(ToolContext)` / `OnDeactivate(ToolContext)`, `Update(ToolContext, float deltaTime)`, `OnMouseDown`/`OnMouseUp(ToolContext, MouseButton, Vector2 position)` and `OnMouseMove(ToolContext, Vector2 position, Vector2 delta)` (each returns `bool` — whether the tool consumed the input), and `OnRender(GizmoRenderContext)` for drawing tool-specific overlays. `EditorToolBase` is an abstract class supplying default (mostly no-op / `false` / `"General"`) implementations of every member, so a concrete tool typically derives from it and overrides only what it needs. `ToolContext` supplies `EditorContext`, the nullable `SceneWorld`, `SelectedEntities`, `ViewportBounds`, `ViewMatrix`, `ProjectionMatrix`, `CameraPosition`, and `CameraForward`. `ToolCategories` supplies constants (`Selection`, `Transform`, `Creation`, `Terrain`, `Physics`, `Custom`); `MouseButton` is `Left`, `Right`, `Middle`, `Button4`, `Button5`.
+
+```csharp
+public sealed class MeasureTool : EditorToolBase
+{
+    public override string DisplayName => "Measure";
+    public override string Category => ToolCategories.Custom;
+
+    public override bool OnMouseDown(ToolContext context, MouseButton button, Vector2 position)
+    {
+        // Start a measurement at the clicked viewport position
+        return true;
+    }
+}
+```
+
+## Viewport & gizmos
+
+`IViewportCapability` customizes viewport rendering and picking:
+
+- `AddGizmoRenderer(IGizmoRenderer renderer)` / `RemoveGizmoRenderer` / `GetGizmoRenderers()`, plus `GizmoRendererAdded` / `GizmoRendererRemoved` events.
+- `AddOverlay(string id, IViewportOverlay overlay)` / `RemoveOverlay(string id)` / `SetOverlayVisible(string id, bool visible)` / `IsOverlayVisible(string id)` / `GetOverlayIds()`.
+- `AddPickHandler(IPickHandler handler)` / `RemovePickHandler` / `GetPickHandlers()`.
+
+`IGizmoRenderer` is what a plugin implements and registers: `Id`, `DisplayName`, a mutable `IsEnabled`, `Order` (render order — lower values render first, i.e. behind), `Render(GizmoRenderContext context)`, and `ShouldRender(Entity entity, IWorld sceneWorld)` (a filter deciding whether this renderer draws for a given entity). `GizmoRenderContext` gives the renderer `SceneWorld`, `SelectedEntities`, `ViewMatrix`, `ProjectionMatrix`, `CameraPosition`, `Bounds`, `DeltaTime`, and a `Drawer` (`IGizmoDrawer`) — plus `DrawTriangle`/`DrawLine`/`DrawPoint` convenience methods on the context itself that simply forward to `Drawer`. `IGizmoDrawer` is the actual primitive-drawing surface: `DrawTriangle`, `DrawLine` (with `width`), `DrawPoint` (with `size`), `DrawWireBox(min, max, color, lineWidth)`, `DrawWireSphere(center, radius, color, segments)`, and `DrawText(position, text, color)`.
+
+`IViewportOverlay` is for 2D content drawn on top of the viewport rather than 3D gizmos in scene space: `IsVisible`, `Order`, and `Render(OverlayRenderContext context)` (`EditorWorld`, nullable `SceneWorld`, `Bounds`, `DeltaTime`).
+
+`IPickHandler` intercepts entity picking: `Priority` (higher checked first) and `TryPick(PickContext context) : PickResult?`. `PickContext` supplies the normalized screen coordinates, ray origin/direction, view/projection matrices, and bounds; `PickResult` returns the picked `Entity`, `WorldPosition`, `Distance`, and optional `UserData`.
+
+## Assets
+
+`IAssetCapability` extends how the Project panel and asset pipeline handle files:
+
+- `RegisterImporter(string[] extensions, IAssetImporter importer)` / `UnregisterImporter(string importerId)` / `GetImporter(string extension)` / `GetImporters()`, with `ImporterRegistered` / `ImporterUnregistered` events. `IAssetImporter` exposes `Id`, `DisplayName`, `Priority`, `SupportedExtensions`, `CanImport(string filePath)`, `Task<AssetImportResult> ImportAsync(AssetImportContext context)`, and `GetSettingsUI() : IImportSettingsUI?`.
+- `RegisterThumbnailGenerator<TAsset>(IThumbnailGenerator generator)` / the `Type`-based overload / `GetThumbnailGenerator(Type)`. `IThumbnailGenerator` exposes `Id`, `Priority`, `CanGenerate(string assetPath)`, and `Task<ThumbnailResult> GenerateAsync(ThumbnailContext context)`.
+- `RegisterDragDropHandler<TAsset>(IAssetDragDropHandler handler)` / `Type` overload / `GetDragDropHandler(Type)`. `IAssetDragDropHandler` exposes `Id`, `Priority`, `CanDrag(AssetDragContext) : DragDropEffect`, `CanDrop(AssetDropContext) : DragDropEffect`, and `OnDrop(AssetDropContext) : bool`. `DragDropEffect` is `None`, `Copy`, `Move`, or `Link`.
+- `RegisterDoubleClickAction<TAsset>(Action<TAsset> action)` / `Type` overload / `GetDoubleClickAction(Type)`.
+- `RegisterContextMenuProvider<TAsset>(IAssetContextMenuProvider provider)` / `Type` overload / `GetContextMenuProviders(Type)`. `IAssetContextMenuProvider.GetMenuItems(AssetContextMenuContext)` returns `AssetMenuItem` entries (`Name`, `Execute`, `IsEnabled`, `Icon`, `Shortcut`, `SeparatorBefore`, nested `Children`).
+
+Assets themselves are represented as `AssetEntry` records (`RelativePath`, `FullPath`, `Name`, `Type`, `LastModified`) with `AssetType` values `Scene`, `Prefab`, `WorldConfig`, `Shader`, `Texture`, `Audio`, `Script`, `Data`, or `Unknown`.
+
+## Notifications
+
+`INotificationCapability` shows toast-style feedback: `Show(NotificationOptions options) : NotificationHandle`, plus shorthand `ShowSuccess`/`ShowError`/`ShowWarning`/`ShowInfo(string message, string? title = null)`. `Dismiss(NotificationHandle handle)` and `DismissAll()` remove notifications; `ActiveCount` reports how many are showing; `NotificationShown`/`NotificationDismissed` events fire on each transition.
+
+`NotificationOptions` (a record) has `Message`, `Title`, `Severity` (`NotificationSeverity`: `Info`, `Success`, `Warning`, `Error`), `Duration` (default 4 seconds; `TimeSpan.Zero` or negative means it stays until manually dismissed), `Icon`, `Dismissible`, an `OnClick` action, and optional `Actions` — a list of `NotificationAction` (`Label`, `Execute`, `DismissOnClick`).
+
+## Undo/redo commands
+
+Edits that should participate in undo/redo go through `IUndoRedoManager` (reached via `context.UndoRedo`, not a capability): `CanUndo`/`CanRedo`, `NextUndoDescription`/`NextRedoDescription`, `MaxHistorySize`, a `StateChanged` event, `Execute(IEditorCommand command)`, `Undo()`, `Redo()`, and batching via `BeginBatch(string description)` / `EndBatch()` / `CancelBatch()` (groups several commands into one undo step) plus `Clear()`.
+
+The extension point is `IEditorCommand`: `Description` (shown in undo/redo UI), `Execute()`, `Undo()`, and `TryMerge(IEditorCommand other)` — return `true` from `TryMerge` to coalesce a subsequent command into this one (e.g. successive drag-move commands collapsing into a single undo step) instead of pushing a separate history entry.
+
+## Next Steps
+
+- [Editor](editor.md) — launching the editor, default panels, and the plugin marketplace install flow
+- [Editor Plugin Dependencies](editor-plugin-dependencies.md) — version constraints and dependency resolution between plugins
+- [Editor Plugin Hot Reload](editor-plugin-hot-reload.md) — the reload sequence, `IStatefulPlugin` state preservation, and limitations
+- [SDK](sdk.md) — the MSBuild SDKs used to build plugin projects

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,86 @@
+# Editor
+
+The KeenEyes Editor (`KeenEyes.Editor`) is a desktop application for authoring KeenEyes games — a scene view, entity hierarchy, component inspector, console, and asset browser built on the same ECS, UI, graphics, and input libraries the runtime uses. It is itself extensible: editor features are delivered as plugins, and game-specific plugins are installed from NuGet via the [`keeneyes` CLI](cli.md).
+
+> The editor is distinct from the ECS plugin system in [Plugins](plugins.md). `IWorldPlugin` extends a `World`; `IEditorPlugin` (below) extends the *editor application*.
+
+## Launching
+
+```bash
+dotnet run --project editor/KeenEyes.Editor -c Release
+```
+
+On start the editor opens its window, initializes graphics/input/UI, and builds the default panel layout. It also starts a [TestBridge](testbridge.md) IPC server (`KeenEyes.Editor.TestBridge`) so external tools can inspect and drive the editor world.
+
+## Panels & tools
+
+The editor's default layout is composed of dockable panels:
+
+| Panel | Purpose |
+|-------|---------|
+| Viewport | Renders the scene; hosts transform gizmos and editor tools |
+| Hierarchy | The entity tree — select, rename, reparent, create, and delete entities |
+| Inspector | Edit the components of the selected entity via per-type property drawers |
+| Console | Editor and game log output (backed by the logging query layer) |
+| Project | Browse project assets through the `AssetDatabase` |
+| Frame Inspector | Step through recorded frames during replay playback |
+
+Editing actions run through an `UndoRedoManager` (every mutation is an `IEditorCommand`, e.g. create/delete/reparent/rename/set-component), a `SelectionManager` tracks the active entity, and an `EntityClipboard` supports copy/cut/paste. Layouts are saved and restored by the `LayoutManager`.
+
+## Play mode & hot reload
+
+- **Play mode** (`PlayModeManager`) runs the game world inside the editor and returns to the authoring state when stopped.
+- **Hot reload** (`HotReloadService`) rebuilds and swaps the game assembly while the editor stays open, so component and system changes take effect without a full restart. See the [Editor Plugin Hot Reload](editor-plugin-hot-reload.md) guide for details and constraints.
+
+## Extending the editor
+
+Editor plugins implement `IEditorPlugin` (or derive from `EditorPluginBase`, which supplies a default `Version` and `Description`). A plugin receives an `IEditorContext` on initialization and reaches editor functionality through **capabilities** requested from that context:
+
+```csharp
+using KeenEyes.Editor.Abstractions;
+
+public sealed class MyEditorPlugin : EditorPluginBase
+{
+    public override string Name => "My Editor Plugin";
+
+    public override void Initialize(IEditorContext context)
+    {
+        // Request the capabilities this plugin needs
+        var panels = context.GetCapability<IPanelCapability>();
+        var menus = context.GetCapability<IMenuCapability>();
+        // ...register panels, menu items, tools, inspectors, etc.
+    }
+
+    public override void Shutdown()
+    {
+        // Release anything registered in Initialize
+    }
+}
+```
+
+Available capabilities (from `KeenEyes.Editor.Abstractions`) include `IPanelCapability`, `IInspectorCapability`, `IMenuCapability`, `IShortcutCapability`, `IToolCapability`, `IViewportCapability`, `IAssetCapability`, and `INotificationCapability`. Common extension points:
+
+- **Panels** — implement `IEditorPanel` and register via `IPanelCapability`.
+- **Tools** — derive from `EditorToolBase` (viewport tools with activate/update hooks).
+- **Inspectors & property drawers** — implement `IComponentInspector` or a `PropertyDrawer` (registered through `IPropertyDrawerRegistry`) to customize how a component or field type is edited.
+- **Gizmos** — implement `IGizmoDrawer` to draw in the viewport.
+
+## Installing plugins (marketplace)
+
+Game and third-party editor plugins are distributed as NuGet packages and installed with the CLI, which shares its configuration with the editor:
+
+```bash
+keeneyes sources add studio-feed https://nuget.example.com/v3/index.json --default
+keeneyes plugin search inventory
+keeneyes plugin install Acme.KeenEyes.InventoryEditor
+```
+
+Plugin dependency resolution is described in [Editor Plugin Dependencies](editor-plugin-dependencies.md).
+
+## Next Steps
+
+- [Command-Line Interface](cli.md) - Manage editor plugins and package sources
+- [Editor Plugin Dependencies](editor-plugin-dependencies.md) - How plugin dependencies resolve
+- [Editor Plugin Hot Reload](editor-plugin-hot-reload.md) - Live assembly reload while editing
+- [TestBridge Architecture](testbridge.md) - Inspecting and driving the editor from external tools
+- [SDK](sdk.md) - Authoring plugins the editor can load

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -235,6 +235,57 @@ Custom node body content is drawn through `INodeTypeDefinition.RenderBody`, whic
 - `PortPositionCache` (a world extension registered by `GraphPlugin`) caches computed screen-space port positions so `GraphInputSystem` and `GraphRenderSystem` don't recompute node layout every frame for hit-testing.
 - Selection and drag state use tag components (`GraphNodeSelectedTag`, `GraphNodeDraggingTag`, etc.) so `world.Query<...>()` can filter selected/dragging nodes without scanning a boolean field on every `GraphNode`.
 
+## The Abstractions Layer (`KeenEyes.Graph.Abstractions`)
+
+Everything described above — `GraphContext`, `NodeTypeRegistry`, `PortRegistry`, and the six systems — lives in the `KeenEyes.Graph` package. A separate node-type library (a math-node pack, a KESL shader-node pack, etc.) doesn't need any of that: the components, the `INodeTypeDefinition`/`IGraphRenderer` contracts, and the shared enums it implements against all live in `KeenEyes.Graph.Abstractions`, which has no reference back to `KeenEyes.Graph`. Only the host application that installs `GraphPlugin` needs the concrete package.
+
+### INodeTypeDefinition
+
+`INodeTypeDefinition` (see [Defining a Custom Node Type](#defining-a-custom-node-type) above for a worked example) depends only on `Entity`, `IWorld`, and `KeenEyes.Graphics.Abstractions` (`I2DRenderer`, `Rectangle`) — nothing from `KeenEyes.Graph` itself. Its members:
+
+| Member | Type | Purpose |
+|--------|------|---------|
+| `TypeId` | `int` | Unique type ID. IDs 1–100 are reserved for built-ins; user-defined types start at 101 (`BuiltInNodeIds.UserDefinedStart`, defined in `KeenEyes.Graph`). |
+| `Name` | `string` | Display name shown in the header and node-creation menu. |
+| `Category` | `string` | Grouping used when the context menu organizes node types (e.g. `"Math"`, `"Logic"`, `"Flow"`, `"Utility"`). |
+| `InputPorts` / `OutputPorts` | `IReadOnlyList<PortDefinition>` | The type's fixed port layout. |
+| `IsCollapsible` | `bool` | Whether a collapse toggle appears in the node header. |
+| `Initialize(Entity node, IWorld world)` | `void` | Called after the node entity is created, to add type-specific components (e.g. `CommentNodeData`). |
+| `RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea)` | `float` | Draws custom body content below the header; returns the height actually consumed, or `0` for none. |
+
+A definition is passive — implementing the interface doesn't register anything by itself. Registration happens on the `KeenEyes.Graph` side, via `NodeTypeRegistry.Register<TDefinition>()` (or the instance overload `Register(INodeTypeDefinition)`), which stores the definition, mirrors its ports into the underlying `PortRegistry` for backward compatibility, and throws `ArgumentException` if `TypeId` is already registered. `NodeTypeRegistry.CreateNode` is what actually invokes `Initialize` on the matching definition after spawning the `GraphNode` entity.
+
+### PortDefinition and the port type system
+
+`PortDefinition` is the `readonly record struct` backing `InputPorts`/`OutputPorts`: `(string Name, PortDirection Direction, PortTypeId TypeId, Vector2 LocalOffset, bool AllowMultiple = false)`. `PortDirection` is a two-value enum (`Input`, `Output`). Build definitions with the `PortDefinition.Input(name, typeId, yOffset, allowMultiple)` / `PortDefinition.Output(name, typeId, yOffset, nodeWidth)` factories shown earlier rather than the constructor, since they compute `LocalOffset` for you.
+
+`PortTypeId` is the full set of port data types, with explicit numeric values grouped for future expansion room:
+
+| Value | Numeric ID | Notes |
+|-------|-----------|-------|
+| `Any` | 0 | Connects to/from anything. |
+| `Float`, `Float2`, `Float3`, `Float4` | 1–4 | Floating-point scalar/vectors. |
+| `Int`, `Int2`, `Int3`, `Int4` | 10–13 | Integer scalar/vectors. |
+| `Bool` | 20 | Boolean. |
+| `Entity` | 30 | Entity reference. |
+| `Flow` | 100 | Execution flow, for control-flow nodes. |
+
+`PortTypeCompatibility` (a static class) is the single source of truth for connection validity, and is what `GraphContext.Connect` calls before creating a `GraphConnection`:
+
+- `CanConnect(PortTypeId source, PortTypeId target)` — `true` for exact matches, anything into `Any`, and the implicit widening conversions already listed under [Ports and Type Compatibility](#ports-and-type-compatibility) above (`float`→`float2/3/4`, `float2`→`float3/4`, `float3`→`float4`, `int`→`float`, and the equivalent `int`→`int2/3/4` widenings). `Flow` connects only to `Flow`; anything else touching `Flow` is rejected before conversions are considered.
+- `RequiresConversion(PortTypeId source, PortTypeId target)` — `true` when `source != target`, `target` isn't `Any`, and `CanConnect` allows the pair; i.e. the connection is valid but not a same-type match. `GraphRenderSystem` uses this to flag connections that need an implicit conversion (via `IGraphRenderer.DrawConnection`'s `requiresConversion` parameter).
+
+### Core node, graph, and connection model types
+
+The `GraphCanvas`, `GraphNode`, and `GraphConnection` components documented under [Core Concepts](#core-concepts) above are all defined in `KeenEyes.Graph.Abstractions`, as are every state/tag component listed under [Node State and Interaction Components](#node-state-and-interaction-components) (`GraphNodeCollapsed`, `PendingConnection`, `HoveredPort`, `GraphContextMenu`, `GraphViewAnimation`, `WidgetFocus`, and the tag components). A custom node library can construct and query all of these without a dependency on `KeenEyes.Graph`.
+
+Two contracts round out the model:
+
+- **`IGraphRenderer`** — the rendering contract `GraphRenderSystem` implements: `DrawConnection(Vector2 start, Vector2 end, PortTypeId type, ConnectionStyle style, bool isSelected, bool requiresConversion)`, `DrawGrid(Rectangle visibleArea, float gridSize, float zoom)`, `DrawSelectionBox(Rectangle bounds)`, `DrawPortHighlight(Vector2 position, PortTypeId type, bool isValidTarget)`, and `DrawConnectionPreview(Vector2 start, Vector2 end, PortTypeId sourceType, PortTypeId? targetType, ConnectionStyle style)`. A custom renderer (e.g. for a headless test harness) implements this interface directly rather than subclassing `GraphRenderSystem`.
+- **`GraphInteractionMode`** — the enum stored on `GraphCanvas.Mode`: `None`, `Panning`, `Selecting`, `DraggingNode`, `ConnectingPort`, `ContextMenu`, `Duplicating`.
+
+Two smaller enums round out the widget/connection styling surface: `ConnectionStyle` (`Bezier`, `Straight`, `Stepped` — only `Bezier` is currently drawn by `GraphRenderSystem`) and `WidgetType` (`None`, `FloatField`, `IntField`, `ColorPicker`, `Dropdown`, `Slider`, `TextArea` — the set `NodeWidgets` and `WidgetFocus.Type` draw from).
+
 ## Next Steps
 
 - [Plugins Guide](plugins.md) - How plugins work

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,243 @@
+# Node Graph Editor
+
+The `KeenEyes.Graph` library (built on primitives from `KeenEyes.Graph.Abstractions`) provides a visual, pan/zoom node-graph editor for the ECS: canvases, nodes, ports, and connections, wired up as a plugin.
+
+## Overview
+
+Graphs use a **hybrid data model**:
+
+- **Nodes and connections are entities.** A node has a `GraphNode` component; a connection has a `GraphConnection` component. This gives them independent lifecycle, tagging (selection, dragging, etc.), and normal ECS queries.
+- **Ports are not entities.** Each node type declares a fixed set of `PortDefinition`s (name, direction, data type, layout offset). Port metadata lives in a registry and is looked up by index, keyed off the node's `NodeTypeId`.
+
+Custom node types (e.g. math operators, KESL shader nodes) are added by implementing `INodeTypeDefinition` and registering it with the `NodeTypeRegistry` extension.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Graph;
+
+using var world = new World();
+
+// Install the graph editor plugin
+world.InstallPlugin(new GraphPlugin());
+```
+
+`GraphPlugin` registers the graph components (`GraphCanvas`, `GraphNode`, `GraphConnection`, and related state/tag components) and the following systems:
+
+| Phase | Order | System | Responsibility |
+|-------|-------|--------|-----------------|
+| `EarlyUpdate` | -5 | `GraphWidgetSystem` | Process widget input (text editing, slider drag) |
+| `EarlyUpdate` | 0 | `GraphInputSystem` | Pan, zoom, select, drag nodes |
+| `EarlyUpdate` | 5 | `GraphContextMenuSystem` | Node-creation and context menus |
+| `Update` | 0 | `GraphViewAnimationSystem` | Animate pan/zoom transitions (`FrameSelection`) |
+| `LateUpdate` | -5 | `GraphLayoutSystem` | Calculate node bounds, port positions |
+| `Render` | 90 | `GraphRenderSystem` | Draw grid, nodes, connections |
+
+The plugin also exposes several world extensions, retrievable via `world.GetExtension<T>()`:
+
+- `GraphContext` — graph manipulation API (create/connect/delete/select).
+- `PortRegistry` — low-level port metadata storage.
+- `NodeTypeRegistry` — `INodeTypeDefinition` registry (wraps `PortRegistry`).
+- `PortPositionCache` — cached screen-space port positions used by input/render systems.
+
+It also registers three built-in node types: `CommentNode`, `RerouteNode`, and `GroupNode` (type IDs 1–3, see [Node Types](#node-types) below).
+
+### Your First Graph
+
+```csharp
+using KeenEyes.Graph;
+
+var graph = world.GetExtension<GraphContext>();
+var registry = world.GetExtension<NodeTypeRegistry>();
+
+// Register a custom node type before creating nodes of that type
+// (AddNode.TypeId is 102 - see the custom node type example below)
+registry.Register<AddNode>();
+
+// Create a canvas and two nodes
+var canvas = graph.CreateCanvas("MyGraph");
+var nodeA = graph.CreateNode(canvas, 102, new Vector2(0, 0));
+var nodeB = graph.CreateNode(canvas, 102, new Vector2(300, 0));
+
+// Connect output port 0 on nodeA to input port 0 on nodeB
+graph.Connect(nodeA, 0, nodeB, 0);
+```
+
+`GraphContext.CreateNode` validates the canvas and node type but does not call `INodeTypeDefinition.Initialize`; use `NodeTypeRegistry.CreateNode` (or the `*Undoable` methods below) when a node type needs to add its own components on creation, as `CommentNode` does for `CommentNodeData`.
+
+## Core Concepts
+
+### GraphCanvas
+
+`GraphCanvas` is the root component for a graph editor surface. It stores pan/zoom state, grid settings, and the current `GraphInteractionMode`. All nodes and connections are parented (via `world.SetParent`) to a canvas entity.
+
+```csharp
+public struct GraphCanvas : IComponent
+{
+    public Vector2 Pan;
+    public float Zoom;
+    public float MinZoom;
+    public float MaxZoom;
+    public float GridSize;
+    public bool SnapToGrid;
+    public GraphInteractionMode Mode;
+}
+```
+
+`GraphCanvas.Default` gives `Zoom = 1.0f`, `MinZoom = 0.25f`, `MaxZoom = 4.0f`, `GridSize = 20f`, `SnapToGrid = false`. `GraphContext.CreateCanvas` builds an entity with this default plus a `GraphCanvasTag`.
+
+### GraphNode and GraphConnection
+
+```csharp
+public struct GraphNode : IComponent
+{
+    public Vector2 Position;   // canvas coordinates, top-left
+    public float Width;
+    public float Height;       // calculated by GraphLayoutSystem
+    public int NodeTypeId;
+    public Entity Canvas;
+    public string? DisplayName;
+}
+
+public struct GraphConnection : IComponent
+{
+    public Entity SourceNode;
+    public int SourcePortIndex;
+    public Entity TargetNode;
+    public int TargetPortIndex;
+    public Entity Canvas;
+}
+```
+
+Connections reference ports by index into the source/target node type's `InputPorts`/`OutputPorts` arrays — ports themselves have no entity identity.
+
+### Ports and Type Compatibility
+
+A `PortDefinition` describes one input or output slot on a node type:
+
+```csharp
+public readonly record struct PortDefinition(
+    string Name,
+    PortDirection Direction,
+    PortTypeId TypeId,
+    Vector2 LocalOffset,
+    bool AllowMultiple = false);
+```
+
+Use the `PortDefinition.Input(...)` / `PortDefinition.Output(...)` factory methods rather than the constructor directly:
+
+```csharp
+PortDefinition.Input("A", PortTypeId.Float, yOffset: 60f);
+PortDefinition.Output("Result", PortTypeId.Float, yOffset: 75f);
+```
+
+`PortTypeId` covers `Any`, `Float`/`Float2`/`Float3`/`Float4`, `Int`/`Int2`/`Int3`/`Int4`, `Bool`, `Entity`, and `Flow` (execution flow for control-flow nodes). `PortTypeCompatibility.CanConnect(source, target)` allows exact matches, anything into `Any`, and implicit widening conversions (`float`→`float2/3/4`, `int`→`int2/3/4`, `int`→`float`); `Flow` only connects to `Flow`, and narrowing conversions are always rejected. `GraphContext.Connect` calls this before creating a `GraphConnection`.
+
+### Defining a Custom Node Type
+
+Implement `INodeTypeDefinition` and register it with `NodeTypeRegistry`. Type IDs 1–100 are reserved for built-ins (`BuiltInNodeIds`); user-defined types must use IDs starting at `BuiltInNodeIds.UserDefinedStart` (101):
+
+```csharp
+using KeenEyes.Graph.Abstractions;
+using KeenEyes.Graphics.Abstractions;
+
+public sealed class AddNode : INodeTypeDefinition
+{
+    public int TypeId => 102;
+    public string Name => "Add";
+    public string Category => "Math";
+
+    public IReadOnlyList<PortDefinition> InputPorts { get; } =
+    [
+        PortDefinition.Input("A", PortTypeId.Float, 60f),
+        PortDefinition.Input("B", PortTypeId.Float, 90f)
+    ];
+
+    public IReadOnlyList<PortDefinition> OutputPorts { get; } =
+    [
+        PortDefinition.Output("Result", PortTypeId.Float, 75f)
+    ];
+
+    public bool IsCollapsible => true;
+
+    public void Initialize(Entity node, IWorld world) { }
+
+    public float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea)
+        => 0f; // no custom body content, ports render by default
+}
+```
+
+Register it during setup, then create instances through the registry (which calls `Initialize` for you) or `GraphContext`:
+
+```csharp
+var registry = world.GetExtension<NodeTypeRegistry>();
+registry.Register<AddNode>();
+
+var node = registry.CreateNode(canvas, 102, new Vector2(100, 100), world);
+```
+
+This mirrors how the `KeenEyes.Sample.UI` sample registers its own math nodes (`samples/KeenEyes.Sample.UI/Nodes/MathNodes.cs`) after installing `GraphPlugin`:
+
+```csharp
+world.InstallPlugin(new GraphPlugin());
+// ...
+var nodeTypeRegistry = world.GetExtension<NodeTypeRegistry>();
+nodeTypeRegistry.Register<NumberNode>();
+nodeTypeRegistry.Register<AddNode>();
+nodeTypeRegistry.Register<MultiplyNode>();
+```
+
+### Node Types
+
+`GraphPlugin` registers three built-in node types (`BuiltInNodeIds.Comment` = 1, `.Reroute` = 2, `.Group` = 3):
+
+- **`CommentNode`** — no ports; adds a `CommentNodeData` component (`Text`, `FontScale`) for a free-form text annotation on the canvas.
+- **`RerouteNode`** — a single `Any`-typed input and output, used to visually bend connections without affecting data flow. Not collapsible, renders at a minimal 60-unit width.
+- **`GroupNode`** — a subgraph container; adds `GroupNodeData` (`InternalCanvas`, `InterfaceInputs`/`InterfaceOutputs` lists of `InterfacePort`, `IsEditing`) so an internal canvas of nodes can present a bridged set of ports to the outer graph.
+
+### Node State and Interaction Components
+
+Beyond `GraphNode`/`GraphConnection`, the plugin registers several supporting components:
+
+- `GraphNodeCollapsed` — added to a node to collapse it to just its header; stores `ExpandedHeight` so it can be restored.
+- `PendingConnection`, `HoveredPort` — added to the **canvas** entity while a connection drag or port hover is in progress; read by `GraphRenderSystem` to draw previews/highlights.
+- `GraphContextMenu` — canvas-entity state for the node-creation/context menu (`ScreenPosition`, `CanvasPosition`, `MenuType`, `TargetEntity`, `SearchFilter`, `SelectedIndex`).
+- `GraphViewAnimation` — canvas-entity state driving a pan/zoom transition; exposes `IsComplete`, `Progress` (eased), `CurrentPan`, and `CurrentZoom`. Added by `GraphContext.FrameSelection`.
+- `WidgetFocus` — canvas-entity state for whichever node body widget (from `NodeWidgets`, e.g. `FloatField`) currently has input focus.
+
+Selection and interaction state use tag components rather than fields on `GraphNode`: `GraphNodeSelectedTag`, `GraphConnectionSelectedTag`, `GraphNodeDraggingTag`, `GraphNodeGhostTag` (duplication preview), and `GraphCanvasTag`/`GraphSpacePanningTag`.
+
+### GraphContext API
+
+`GraphContext` (a `[PluginExtension("Graph")]`) is the main manipulation surface, retrieved with `world.GetExtension<GraphContext>()`. Key members observed on the type:
+
+- `Entity CreateCanvas(string? name = null)`
+- `Entity CreateNode(Entity canvas, int nodeTypeId, Vector2 position, string? displayName = null)`
+- `Entity Connect(Entity sourceNode, int sourcePortIndex, Entity targetNode, int targetPortIndex)` — returns `Entity.Null` if the entities, canvas, ports, or port types are invalid/incompatible.
+- `void DeleteNode(Entity node)` — also removes connections referencing the node.
+- `void DeleteConnection(Entity connection)`
+- `void SelectNode(Entity node, bool addToSelection = false)`, `void DeselectNode(Entity node)`, `void ClearSelection()`, `IEnumerable<Entity> GetSelectedNodes()`, `void SelectAll(Entity canvas)`
+- `Rectangle? GetSelectionBounds()`, `void FrameSelection(Entity canvas, float duration = 0.2f)` — animates pan/zoom to fit the current selection via `GraphViewAnimation`.
+- `Vector2 ScreenToCanvas(...)` / `Vector2 CanvasToScreen(...)` — coordinate conversion using the canvas's `Pan`/`Zoom`.
+- Undoable variants — `CreateNodeUndoable`, `DeleteNodesUndoable`, `MoveNodesUndoable`, `DuplicateSelectionUndoable`, `ConnectUndoable`, `DeleteConnectionUndoable` — route through `KeenEyes.Editor.Abstractions.IUndoRedoManager` when one has been registered as a world extension (`GraphPlugin.Install` wires it up automatically via `TryGetExtension<IUndoRedoManager>`), otherwise they execute immediately.
+
+### Rendering
+
+`GraphRenderSystem` implements `IGraphRenderer` and draws the canvas grid, node bodies/headers/ports, and connections each `Render` phase. Connections currently render as `ConnectionStyle.Bezier` curves (the enum also defines `Straight` and `Stepped` for future use); `IGraphRenderer` exposes `DrawConnection`, `DrawGrid`, `DrawSelectionBox`, `DrawPortHighlight`, and `DrawConnectionPreview` if you need to drive the same primitives from custom code.
+
+Custom node body content is drawn through `INodeTypeDefinition.RenderBody`, which can call into the static helpers on `NodeWidgets` (`FloatField`, and other widgets keyed by `WidgetType`) to render editable fields that participate in the same focus/input handling as built-in widgets.
+
+## Performance
+
+- Port lookups are index-based array access against the registry's `NodeTypeInfo`, not per-frame allocation.
+- `PortPositionCache` (a world extension registered by `GraphPlugin`) caches computed screen-space port positions so `GraphInputSystem` and `GraphRenderSystem` don't recompute node layout every frame for hit-testing.
+- Selection and drag state use tag components (`GraphNodeSelectedTag`, `GraphNodeDraggingTag`, etc.) so `world.Query<...>()` can filter selected/dragging nodes without scanning a boolean field on every `GraphNode`.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How plugins work
+- [Systems Guide](systems.md) - System design patterns
+- [UI System Guide](ui.md) - The retained-mode UI system graphs render alongside
+- [ADR-010: Graph Node Editor Architecture](adr/010-graph-node-editor.md) - Original design document (note: aspirational in places — e.g. it shows `GraphNode.IsSelected` as a bool field, but the shipped implementation uses `GraphNodeSelectedTag` instead)

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -429,6 +429,140 @@ world.AddSystem<RenderSystem>(SystemPhase.Render, order: 0);
 
 These systems are in `KeenEyes.Graphics` and work with any backend implementing `IGraphicsContext`.
 
+## Shadows
+
+The `KeenEyes.Graphics.Shadows` namespace provides shadow mapping for directional, point, and spot lights. Directional lights use Cascaded Shadow Maps (CSM, up to 4 cascades); point lights use cubemap shadow maps; spot lights use a single 2D shadow map.
+
+### Enabling Shadows
+
+Shadow casting is controlled per-light and per-renderable:
+
+```csharp
+// Light.Directional() and Light.Spot() enable CastShadows by default;
+// Light.Point() does not.
+world.Spawn()
+    .With(new Transform3D(Vector3.Zero,
+        Quaternion.CreateFromYawPitchRoll(0.5f, -0.8f, 0), Vector3.One))
+    .With(Light.Directional(new Vector3(1, 0.95f, 0.8f), 1.0f))  // CastShadows = true
+    .Build();
+
+// Renderable.CastShadows / ReceiveShadows default to true
+var graphics = world.GetExtension<IGraphicsContext>();
+var cube = graphics.CreateCube();
+world.Spawn()
+    .With(Transform3D.Identity)
+    .With(new Renderable(cube.Id, 0) { CastShadows = true, ReceiveShadows = true })
+    .With(new Material { ShaderId = graphics.LitShader.Id })
+    .Build();
+```
+
+### ShadowRenderingSystem
+
+`ShadowRenderingSystem` renders the depth-only shadow passes for every shadow-casting light before the main color pass. It owns a `ShadowMapManager`, which allocates and updates the render targets and light-space matrices for each shadow-casting light. To have the main render pass actually sample the resulting shadow maps, assign the `ShadowRenderingSystem` instance to `RenderSystem.ShadowSystem`:
+
+```csharp
+using KeenEyes.Graphics.Shadows;
+
+var shadowSystem = new ShadowRenderingSystem
+{
+    Settings = new ShadowSettings
+    {
+        Resolution = ShadowResolution.High,
+        FilterMode = ShadowFilterMode.Pcf3x3,
+        CascadeCount = 4,
+        CascadeSplitLambda = 0.75f,
+        MaxShadowDistance = 100f
+    }
+};
+var renderSystem = new RenderSystem { ShadowSystem = shadowSystem };
+
+// Shadow pass must run before the color pass that samples it
+world.AddSystem(shadowSystem, SystemPhase.Render, order: -1);
+world.AddSystem(renderSystem, SystemPhase.Render, order: 0);
+```
+
+`ShadowSettings` (in `KeenEyes.Graphics.Abstractions`) controls quality:
+
+| Property | Purpose |
+|----------|---------|
+| `Resolution` | `ShadowResolution.Low/Medium/High/VeryHigh` (512–4096px) |
+| `FilterMode` | `ShadowFilterMode.Hard/Pcf3x3/Pcf5x5/Pcf7x7` |
+| `CascadeCount` | Number of directional light cascades (clamped 1-4) |
+| `CascadeSplitLambda` | Blends uniform (0) vs. logarithmic (1) cascade splits |
+| `MaxShadowDistance` | Distance from the camera beyond which shadows aren't rendered |
+| `NormalBias` / `DepthBias` | Reduce shadow acne |
+
+The cascade math itself (split distances, frustum corners, light-space matrices, cubemap face matrices, and texel-snapping stabilization) lives in the static `CascadeUtils` class, which `ShadowMapManager` calls internally each frame.
+
+### Debug Visualization
+
+`ShadowMapVisualizationSystem` draws shadow maps as on-screen thumbnails for debugging. Point it at an existing `ShadowRenderingSystem` and add it after the render pass:
+
+```csharp
+var shadowViz = new ShadowMapVisualizationSystem
+{
+    ShadowSystem = shadowSystem,
+    Mode = ShadowVisualizationMode.Cascades,  // Cascades, SpotLights, PointLights, or All
+    ShowCascadeColors = true
+};
+world.AddSystem(shadowViz, SystemPhase.Render, order: 1);
+```
+
+Call `shadowViz.SetViewportSize(width, height)` from your `OnResize` callback so thumbnails stay correctly positioned.
+
+## Instanced Rendering
+
+`InstanceBatchingSystem` (in `KeenEyes.Graphics`) groups entities that share the same mesh, material, and a user-defined batch ID into a single GPU instanced draw call. This is intended for rendering many copies of the same object (trees, rocks, particles) with minimal CPU overhead.
+
+Mark entities with the `InstanceBatch` component alongside `Transform3D` and `Renderable`:
+
+```csharp
+using KeenEyes.Graphics.Abstractions;
+
+// 1000 trees rendered with a single draw call per material/mesh combination
+for (int i = 0; i < 1000; i++)
+{
+    world.Spawn()
+        .With(new Transform3D(positions[i], Quaternion.Identity, Vector3.One))
+        .With(new Renderable(treeMeshId, treeMaterialId))
+        .With(new InstanceBatch(batchId: 1))
+        .Build();
+}
+
+world.AddSystem(new InstanceBatchingSystem(), SystemPhase.Render, order: -1);
+world.AddSystem<RenderSystem>(SystemPhase.Render, order: 0);
+```
+
+`InstanceBatch.ColorTint` (a `Vector4`) is multiplied with the material's base color, giving per-instance color variation without separate materials. `RenderSystem` automatically skips any entity that has an `InstanceBatch` component — those entities are drawn by `InstanceBatchingSystem` itself, which issues the instanced draw calls directly during its `Update`.
+
+## Level of Detail (LOD)
+
+`LodSystem` (in `KeenEyes.Graphics`) automatically swaps an entity's mesh based on distance from the camera or projected screen coverage, reducing triangle counts for distant objects. It should run before `RenderSystem` so the mesh swap happens before the object is drawn.
+
+Attach a `LodGroup` component (in `KeenEyes.Graphics.Abstractions`) alongside `Transform3D` and `Renderable`:
+
+```csharp
+using KeenEyes.Graphics.Abstractions;
+
+var highDetail = graphics.CreateMesh(highVertices, highIndices);
+var mediumDetail = graphics.CreateMesh(mediumVertices, mediumIndices);
+var lowDetail = graphics.CreateMesh(lowVertices, lowIndices);
+
+world.Spawn()
+    .With(Transform3D.Identity)
+    .With(new Renderable(highDetail.Id, materialId))
+    .With(LodGroup.Create(
+        new LodLevel(highDetail.Id, 0f),      // Level 0: used up to 20 units
+        new LodLevel(mediumDetail.Id, 20f),   // Level 1: used 20-50 units
+        new LodLevel(lowDetail.Id, 50f)))     // Level 2: used beyond 50 units
+    .Build();
+
+world.AddSystem(new LodSystem { HysteresisFactor = 0.1f });
+world.AddSystem<RenderSystem>(SystemPhase.Render);
+```
+
+`LodGroup.Create(...)` overloads support 1-4 levels; each `LodLevel(MeshId, Threshold)` pairs a mesh handle with a distance (or screen-coverage) threshold. `LodGroup.SelectionMode` chooses between `LodSelectionMode.Distance` (threshold is world-space distance) and `LodSelectionMode.ScreenSize` (threshold is projected screen coverage, 0-1); `LodGroup.Bias` offsets the calculation per-entity. `LodSystem.HysteresisFactor` (default 0.05) widens the switch threshold in the direction the entity is currently trending, to prevent flickering when an entity sits near a boundary; `LodSystem.GlobalBias` applies the same kind of offset to every entity.
+
 ## 2D Rendering Patterns
 
 While KeenEyes graphics primarily targets 3D, 2D games can use orthographic cameras and specialized patterns.

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,18 +190,28 @@ using var world = new WorldBuilder()
 ## Libraries
 
 - [Abstractions](abstractions.md) - Lightweight interfaces for plugin development
+- [Animation](animation.md) - Skeletal playback, animator state machines, sprite animation, and tweening
+- [Asset Management](assets.md) - Loading, caching, reference counting, and hot reload for game assets
+- [Audio](audio.md) - ECS-driven sound playback, 3D spatial audio, and mixer channels (OpenAL)
 - [Common](common.md) - Shared utilities (float extensions, velocity components)
-- [Spatial](spatial.md) - 3D transform components with System.Numerics
-  - [Getting Started with Spatial Partitioning](spatial-partitioning/getting-started.md)
-  - [Strategy Selection Guide](spatial-partitioning/strategy-selection.md)
-  - [Performance Tuning](spatial-partitioning/performance-tuning.md)
 - [Graphics](graphics.md) - OpenGL/Vulkan rendering with Silk.NET
 - [Input](input.md) - Keyboard, mouse, and gamepad input handling
+- [Localization](localization.md) - Multi-language text and locale-aware assets/fonts
+- [Navigation & Pathfinding](navigation.md) - Path following with pluggable Grid (A*) and DotRecast (navmesh) providers
 - [Networking](networking.md) - Server-authoritative multiplayer with prediction
   - `KeenEyes.Network` - Core networking plugins and LocalTransport
   - `KeenEyes.Network.Transport.Tcp` - TCP transport (reliable ordered)
   - `KeenEyes.Network.Transport.Udp` - UDP transport (configurable reliability)
+- [Node Graph Editor](graph.md) - Visual pan/zoom node-graph editor (canvases, nodes, ports, connections)
+- [Particles](particles.md) - High-performance pooled particle effects
+- [Replay Recording & Playback](replay.md) - Frame-by-frame recording for crash repro, killcams, demos, and ghosts
+- [Shaders & KESL](shaders.md) - The KESL shader language, its compiler pipeline, and GPU compute abstractions
+- [Spatial](spatial.md) - 3D transform components with System.Numerics
+  - [Getting Started with Spatial Partitioning](spatial-partitioning/getting-started.md)
+  - [Strategy Selection Guide](spatial-partitioning/strategy-selection.md)
+  - [Performance Tuning](spatial-partitioning/performance-tuning.md)
 - [UI](ui.md) - ECS-based retained-mode UI system
+- [UI Theming](themes.md) - OS-aware light/dark theming and automatic UIStyle application
 
 ## Architecture Decisions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,8 @@ using var world = new WorldBuilder()
 - [Testing Guide](testing.md) - Unit testing with mocks
 - [TestBridge Architecture](testbridge.md) - External tool integration, IPC protocol, command reference
 - [MCP Server](mcp-server.md) - AI tool integration via Model Context Protocol
+- [Editor](editor.md) - The visual editor: panels, play mode, hot reload, and the plugin model
+- [CLI (`keeneyes`)](cli.md) - Manage editor plugins, package sources, and save-file migrations
 
 ### UI Features
 - [UI System](ui.md) - Retained-mode UI with ECS entities

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,6 +181,7 @@ using var world = new WorldBuilder()
 - [TestBridge Architecture](testbridge.md) - External tool integration, IPC protocol, command reference
 - [MCP Server](mcp-server.md) - AI tool integration via Model Context Protocol
 - [Editor](editor.md) - The visual editor: panels, play mode, hot reload, and the plugin model
+- [Editor Plugin Development](editor-plugin-development.md) - Reference for authoring editor plugins (lifecycle, capabilities, extension points)
 - [CLI (`keeneyes`)](cli.md) - Manage editor plugins, package sources, and save-file migrations
 
 ### UI Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,6 +194,7 @@ using var world = new WorldBuilder()
 - [Asset Management](assets.md) - Loading, caching, reference counting, and hot reload for game assets
 - [Audio](audio.md) - ECS-driven sound playback, 3D spatial audio, and mixer channels (OpenAL)
 - [Common](common.md) - Shared utilities (float extensions, velocity components)
+- [Debugging & Profiling](debugging.md) - Profilers, memory/GC tracking, entity inspection, and timeline recording
 - [Graphics](graphics.md) - OpenGL/Vulkan rendering with Silk.NET
 - [Input](input.md) - Keyboard, mouse, and gamepad input handling
 - [Localization](localization.md) - Multi-language text and locale-aware assets/fonts
@@ -204,6 +205,8 @@ using var world = new WorldBuilder()
   - `KeenEyes.Network.Transport.Udp` - UDP transport (configurable reliability)
 - [Node Graph Editor](graph.md) - Visual pan/zoom node-graph editor (canvases, nodes, ports, connections)
 - [Particles](particles.md) - High-performance pooled particle effects
+- [Persistence & Encryption](persistence.md) - Save slots with optional AES-256 encryption over the snapshot system
+- [Physics](physics.md) - BepuPhysics v2 integration (rigid bodies, colliders, collision events)
 - [Replay Recording & Playback](replay.md) - Frame-by-frame recording for crash repro, killcams, demos, and ghosts
 - [Shaders & KESL](shaders.md) - The KESL shader language, its compiler pipeline, and GPU compute abstractions
 - [Spatial](spatial.md) - 3D transform components with System.Numerics

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,255 @@
+# Localization
+
+The `KeenEyes.Localization` library adds multi-language text and locale-aware asset support to a `World`. It manages locale switching and fallback, loads translations from JSON/CSV/in-memory sources, keeps UI text and localized assets in sync automatically, and resolves per-locale fonts.
+
+## Overview
+
+`KeenEyes.Localization` provides:
+
+- **Locale management** - switch the active `Locale` at runtime with automatic fallback (custom overrides → language-only → default locale)
+- **String sources** - load translations from JSON files (`JsonStringSource`), spreadsheet-friendly CSV files (`CsvStringSource`), or in-memory dictionaries (`DictionaryStringSource`)
+- **Automatic UI updates** - entities with `LocalizedText` and a UI text component are updated whenever the locale changes, no manual wiring required
+- **Localized assets** - entities with `LocalizedAsset` get their resolved path recomputed automatically, following an exact-locale → language-only → default fallback chain
+- **Formatting** - simple `{0}`/`{name}` substitution via `Format`, or full ICU MessageFormat (pluralization, gender, select) via `FormatIcu`
+- **Locale-specific fonts** - configure primary/fallback fonts and size/line-height multipliers per locale
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Localization;
+
+using var world = new World();
+
+world.InstallPlugin(new LocalizationPlugin(new LocalizationConfig
+{
+    DefaultLocale = Locale.EnglishUS,
+    MissingKeyBehavior = MissingKeyBehavior.ReturnPlaceholder,
+    AssetRootPath = "Assets",
+}));
+```
+
+`LocalizationPlugin.Install` registers:
+
+- Components: `LocalizedText`, `LocalizedTextTag`, `LocalizedAsset`
+- Extensions: `world.Localization` (an `ILocalization` backed by `LocalizationManager`) and an `ILocalizedAssetResolver`
+- Systems: `LocalizedAssetSystem` (`SystemPhase.EarlyUpdate`, order `-50`) and `LocalizedTextSystem` (`SystemPhase.Update`, order `100`)
+
+`LocalizationManager` is annotated with `[PluginExtension("Localization")]`, which is what generates the `world.Localization` accessor property.
+
+### Loading Translations
+
+```csharp
+var source = JsonStringSource.FromFile("locales/en-US.json", Locale.EnglishUS);
+world.Localization.AddSource(source);
+
+string title = world.Localization.Get("game.title");
+```
+
+A matching JSON file is a flat or nested key-value document; nested objects are flattened with dot notation:
+
+```json
+{
+    "menu.start": "Start Game",
+    "dialog": {
+        "greeting": "Hello, {0}!"
+    }
+}
+```
+
+### Localized UI Text
+
+```csharp
+var startButton = world.Spawn()
+    .With(UIElement.Default)
+    .With(UIText.Create(""))
+    .With(LocalizedText.Create("menu.start"))
+    .Build();
+
+// LocalizedTextSystem fills in UIText.Content automatically, both on
+// creation and whenever the locale changes.
+world.Localization.SetLocale(Locale.JapaneseJP);
+```
+
+## Core Concepts
+
+### Locale
+
+`Locale` is a `readonly record struct` wrapping an IETF BCP 47 language tag (e.g. `"en-US"`, `"ja-JP"`):
+
+```csharp
+var locale = new Locale("en-US");
+locale.Language;      // "en"
+locale.Region;         // "US"
+locale.HasRegion;      // true
+locale.LanguageOnly;   // Locale("en")
+locale.IsRightToLeft;  // false
+locale.TextDirection;  // TextDirection.LeftToRight
+```
+
+Predefined statics cover common locales, including several right-to-left languages: `Locale.EnglishUS`, `Locale.EnglishGB`, `Locale.JapaneseJP`, `Locale.ChineseSimplified`, `Locale.ChineseTraditional`, `Locale.KoreanKR`, `Locale.GermanDE`, `Locale.FrenchFR`, `Locale.SpanishES`, `Locale.PortugueseBR`, `Locale.ItalianIT`, `Locale.RussianRU`, `Locale.Arabic`, `Locale.ArabicSA`, `Locale.ArabicEG`, `Locale.HebrewIL`, `Locale.PersianIR`, `Locale.UrduPK`, `Locale.ThaiTH`, and `Locale.HindiIN`. A `Locale` also converts implicitly from `string`.
+
+### LocalizationConfig
+
+```csharp
+var config = new LocalizationConfig
+{
+    DefaultLocale = Locale.EnglishUS,
+    MissingKeyBehavior = MissingKeyBehavior.ReturnPlaceholder,
+    EnableFallback = true,
+    AssetRootPath = "Assets",
+    FallbackOverrides =
+    {
+        [new Locale("en-GB")] = new Locale("en-US"),
+        [new Locale("pt-PT")] = new Locale("pt-BR"),
+    },
+    FontConfigs =
+    {
+        [Locale.EnglishUS] = new LocalizedFontConfig { PrimaryFont = "fonts/Roboto.ttf" },
+        [Locale.JapaneseJP] = new LocalizedFontConfig
+        {
+            PrimaryFont = "fonts/NotoSansJP.ttf",
+            FallbackFonts = ["fonts/Roboto.ttf"],
+        },
+    },
+};
+```
+
+`LocalizationPlugin`'s constructor calls `config.Validate()` and throws `ArgumentException` if `DefaultLocale.Code` is null/whitespace. `LocalizationConfig.Default` returns a config with sensible development defaults (`MissingKeyBehavior.ReturnKey`, fallback enabled).
+
+### String Sources
+
+All sources implement `IStringSource` (`SupportedLocales`, `TryGetString`, `GetKeys`, `HasLocale`). `world.Localization.AddSource(source)` registers one; later-added sources take priority over earlier ones for the same key.
+
+```csharp
+// In-memory, useful for tests and small string sets
+var dict = new DictionaryStringSource(Locale.EnglishUS, new Dictionary<string, string>
+{
+    ["menu.start"] = "Start Game",
+    ["menu.quit"] = "Quit",
+});
+
+// JSON file (flat or nested keys)
+var json = JsonStringSource.FromFile("locales/ja-JP.json", Locale.JapaneseJP);
+
+// CSV file with one "key" column and one column per locale
+var csv = CsvStringSource.FromFile("translations.csv");
+
+world.Localization.AddSource(dict);
+world.Localization.AddSource(json);
+world.Localization.AddSource(csv);
+```
+
+`JsonStringSource` and `CsvStringSource` both offer `FromFile`, `FromFileAsync`, `FromString`, and `FromStream`/`FromStreamAsync` factories. `CsvStringSource` additionally exposes `ToCsv`/`Export`/`ExportAsync` for round-tripping translations through spreadsheet tools, and `MergeFromString` on both types to merge in additional translations.
+
+### Retrieving and Formatting Strings
+
+`world.Localization` implements `ILocalization`:
+
+```csharp
+string title = world.Localization.Get("game.title");
+
+// .NET-style positional/composite formatting
+string greeting = world.Localization.Format("greeting", player.Name);
+// "greeting" = "Hello, {0}!" -> "Hello, Alex!"
+
+// ICU MessageFormat for pluralization/gender/select
+string count = world.Localization.FormatIcu("items.count", new { count = 5 });
+// "items.count" = "{count, plural, =0 {No items} =1 {One item} other {# items}}" -> "5 items"
+
+bool exists = world.Localization.HasKey("menu.start");
+bool found = world.Localization.TryGet("menu.start", out var value);
+```
+
+`Get` and `Format` fall back through `LocalizationConfig.FallbackOverrides`, then the language-only locale, then `DefaultLocale`, before invoking `MissingKeyBehavior` (`ReturnKey`, `ReturnEmpty`, `ReturnPlaceholder`, or `ThrowException`). `TryGet` does not apply fallback or missing-key handling.
+
+`FormatIcu` is powered by `IMessageFormatter` — `SimpleFormatter` (positional `{0}` and named `{name}` placeholders) or `IcuFormatter` (full ICU MessageFormat via the `MessageFormat` NuGet package), which `LocalizationManager` uses by default. Both formatters are marked `[RequiresUnreferencedCode]` when passed an anonymous object, because reading its properties uses reflection; pass a `Dictionary<string, object?>` instead for full AOT compatibility.
+
+### Locale Changes
+
+```csharp
+world.Localization.SetLocale(Locale.JapaneseJP);
+```
+
+`SetLocale` is a no-op if the locale is unchanged; otherwise it publishes a `LocaleChangedEvent(PreviousLocale, NewLocale)` via `world.Send`:
+
+```csharp
+world.Subscribe<LocaleChangedEvent>(e =>
+{
+    Console.WriteLine($"Locale changed from {e.PreviousLocale} to {e.NewLocale}");
+});
+```
+
+`ILocalization.CurrentTextDirection` and `ILocalization.IsRightToLeft` are convenience accessors over `CurrentLocale`, useful for deciding whether to mirror UI layouts.
+
+### Localized Text Components
+
+`LocalizedText` marks an entity's text as translatable:
+
+```csharp
+[Component]
+public partial struct LocalizedText : IComponent
+{
+    public string Key;
+    public object?[]? FormatArgs;
+}
+```
+
+`LocalizedText.Create(key)` and `LocalizedText.Create(key, args)` build the component. `LocalizedTextSystem` adds/removes the `LocalizedTextTag` tag component alongside it, subscribes to `LocaleChangedEvent`, and on the next `Update` writes the resolved string into any entity's `UIText.Content` — using `Format` when `FormatArgs` is non-empty, otherwise `Get`. Call `LocalizedTextSystem.RefreshAllText()` to force a refresh without changing the locale (e.g. after mutating `FormatArgs` in place).
+
+### Localized Asset Components
+
+`LocalizedAsset` marks an entity's asset reference as locale-dependent:
+
+```csharp
+[Component]
+public partial struct LocalizedAsset : IComponent
+{
+    public string AssetKey;
+    public string? ResolvedPath;
+    public readonly bool IsResolved => !string.IsNullOrEmpty(ResolvedPath);
+}
+```
+
+```csharp
+var logo = world.Spawn()
+    .With(new LocalizedAsset { AssetKey = "textures/logo" })
+    .Build();
+```
+
+`LocalizedAssetSystem` subscribes to `LocaleChangedEvent` and calls `ILocalizedAssetResolver.Resolve(AssetKey, locale)` to fill in `ResolvedPath`, trying (in order) the exact locale (`textures/logo.en-US.png`), the language only (`textures/logo.en.png`), then the unlocalized default (`textures/logo.png`). The default resolver, `LocalizedAssetResolver`, checks the file system under `LocalizationConfig.AssetRootPath` for these variants. Call `asset.Invalidate()` to clear `ResolvedPath` and force re-resolution, or `LocalizedAssetSystem.RefreshAllAssets()` to re-resolve every entity.
+
+### Fonts and Preloading
+
+```csharp
+LocalizedFontConfig? fontConfig = world.Localization.GetCurrentFontConfig();
+```
+
+`LocalizedFontConfig` holds `PrimaryFont`, `FallbackFonts`, `SizeMultiplier`, and `LineHeightMultiplier` for a locale, and exposes `GetAllFontPaths()` for preloading. `ILocalization.GetFontConfig(locale)` falls back from the exact locale to its language-only form to the default locale's configuration.
+
+Before switching locales, preload all of the target locale's assets (and fonts) to avoid stutter:
+
+```csharp
+await world.Localization.PreloadLocaleAssetsAsync(
+    Locale.JapaneseJP,
+    ["textures/logo", "textures/menu_background", "audio/intro_voice"]);
+
+world.Localization.SetLocale(Locale.JapaneseJP);
+```
+
+`PreloadLocaleAssetsAsync` requires the `KeenEyes.Assets` plugin to be installed; it resolves each key/font via the asset resolver and loads them as `RawAsset` with `LoadPriority.Low`, silently skipping assets that fail to preload.
+
+## Performance
+
+- String lookups walk registered sources in reverse-registration order and stop at the first hit — keep the number of sources reasonable, or consolidate frequently-queried locales into a single source.
+- `LocalizedTextSystem` only re-evaluates entities when a `LocaleChangedEvent` fires (or on its first `Update`) and is otherwise idle. `LocalizedAssetSystem` does the same full sweep on locale change, but every other frame it still iterates entities with `LocalizedAsset` to resolve any that are newly added and not yet `IsResolved`.
+- `LocalizedAssetResolver.Resolve` performs file-system existence checks per fallback step; call `PreloadLocaleAssetsAsync` ahead of a locale switch to move that I/O off the critical path.
+- `FormatIcu`/`IcuFormatter` cache compiled `MessageFormatter` instances (`useCache: true`) but still use reflection for anonymous-object arguments — prefer `Dictionary<string, object?>` args in hot paths and for AOT builds.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How plugins work
+- [Systems Guide](systems.md) - System design patterns
+- [UI System](ui.md) - `UIText` and other UI components updated by `LocalizedTextSystem`
+- [Localization Plugin Design](research/localization-plugin.md) - Original design document

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -168,6 +168,73 @@ A no-op provider useful for testing or disabling logging:
 logManager.AddProvider(new NullLogProvider());
 ```
 
+### RingBufferLogProvider
+
+Stores entries in a bounded, thread-safe in-memory buffer that supports querying. This is the provider to reach for when a tool (an editor console, an MCP server, a debug session capture) needs to browse log history rather than just watch a stream:
+
+```csharp
+using KeenEyes.Logging.Providers;
+
+var ringBuffer = new RingBufferLogProvider(capacity: 5000); // default is RingBufferLogProvider.DefaultCapacity (10,000)
+logManager.AddProvider(ringBuffer);
+```
+
+When the buffer fills up, the oldest entries are evicted to make room for new ones. See [Querying Log History](#querying-log-history) below for how to read entries back out.
+
+## Querying Log History
+
+Providers that store entries in memory can implement `ILogQueryable` to expose retrieval and filtering. `RingBufferLogProvider` implements both `ILogProvider` and `ILogQueryable`, so it can be added to a `LogManager` for live logging and queried independently for history:
+
+```csharp
+var ringBuffer = new RingBufferLogProvider();
+logManager.AddProvider(ringBuffer);
+
+// ... application runs and logs ...
+
+// Get everything currently stored
+IReadOnlyList<LogEntry> all = ringBuffer.GetEntries();
+
+// Filter with a LogQuery
+var errors = ringBuffer.Query(new LogQuery
+{
+    MinLevel = LogLevel.Error,
+    CategoryPattern = "ECS.*",
+    MessageContains = "failed",
+    After = DateTime.Now.AddMinutes(-10),
+    MaxResults = 50,
+    NewestFirst = true
+});
+```
+
+`LogQuery` properties are all optional filters — leaving one unset means "no filter" for that dimension:
+
+| Property | Description |
+|----------|--------------|
+| `MinLevel` / `MaxLevel` | Inclusive level range |
+| `CategoryPattern` | Wildcard pattern (`*` and `?`) matched against `LogEntry.Category` |
+| `MessageContains` | Case-insensitive substring match against `LogEntry.Message` |
+| `After` / `Before` | Inclusive timestamp range |
+| `MaxResults` | Maximum entries returned (default 1000) |
+| `Skip` | Entries to skip, for pagination with `MaxResults` |
+| `NewestFirst` | Reverse-chronological order when true (default); chronological when false |
+
+Each result is a `LogEntry` record (`Timestamp`, `Level`, `Category`, `Message`, `Properties`).
+
+Call `GetStats()` for a summary without pulling every entry:
+
+```csharp
+LogStats stats = ringBuffer.GetStats();
+
+Console.WriteLine($"{stats.TotalCount} entries ({stats.ErrorCount} errors, {stats.FatalCount} fatal)");
+Console.WriteLine($"Buffer capacity: {stats.Capacity}");
+Console.WriteLine($"Oldest: {stats.OldestTimestamp}, Newest: {stats.NewestTimestamp}");
+
+// Per-level counts by LogLevel value
+int warnings = stats.GetCountForLevel(LogLevel.Warning);
+```
+
+`ILogQueryable` also exposes `EntryCount`, `Clear()`, and the `LogAdded` / `LogsCleared` events, so a console UI or MCP resource can subscribe for live updates instead of polling.
+
 ## Creating Custom Providers
 
 Implement `ILogProvider` to create custom log destinations:
@@ -286,6 +353,69 @@ logManager.Dispose();
 - `LogManager` is thread-safe
 - All built-in providers are thread-safe
 - Scopes use `AsyncLocal` for proper async context flow
+
+## ECS-Specific Logging
+
+`LogManager` and its providers are ECS-agnostic — they know nothing about worlds, entities, or systems. `EcsLoggingPlugin` bridges the gap: it's a `IWorldPlugin` that hooks into world events and turns them into structured log messages via an internal `EcsLogger`.
+
+### Installing the Plugin
+
+```csharp
+using KeenEyes.Logging;
+
+var logManager = new LogManager();
+logManager.AddProvider(new ConsoleLogProvider());
+
+var world = new World();
+world.InstallPlugin(new EcsLoggingPlugin(logManager));
+```
+
+Once installed, the plugin automatically logs:
+- **System execution** — start/complete timing (via the system hook capability, when available) and enable/disable changes
+- **Entity lifecycle** — creation and destruction
+
+Messages are written under the `ECS.System`, `ECS.Entity`, `ECS.Component`, and `ECS.Query` categories.
+
+### Per-Category Verbosity
+
+Each category in `EcsLogCategory` (`System`, `Entity`, `Component`, `Query`) can have its own minimum level, independent of `LogManager.MinimumLevel`. Access the logger through the plugin's `Logger` property:
+
+```csharp
+var plugin = new EcsLoggingPlugin(logManager);
+
+plugin.Logger.SetCategoryLevel(EcsLogCategory.System, LogLevel.Debug);
+plugin.Logger.SetCategoryLevel(EcsLogCategory.Component, LogLevel.Warning); // quiet down noisy component churn
+plugin.Logger.IsEnabled = true; // master on/off switch for all ECS logging
+
+world.InstallPlugin(plugin);
+```
+
+`EcsLogger.IsLevelEnabled(category, level)` combines the master switch, the per-category level, and the underlying `LogManager`'s level check, so callers can guard expensive work the same way they would with `LogManager.IsLevelEnabled`.
+
+### Component Logging
+
+Component add/remove/change logging is opt-in per type, since subscribing requires compile-time type information and unconditionally logging every component would be expensive in busy scenes:
+
+```csharp
+// After the plugin is installed:
+plugin.EnableComponentLogging<Position>();
+plugin.EnableComponentLogging<Velocity>();
+```
+
+This subscribes to `IWorld.OnComponentAdded<T>`, `OnComponentRemoved<T>`, and `OnComponentChanged<T>` for the given component type and logs each event under `ECS.Component` at `LogLevel.Trace`. Calling `EnableComponentLogging<T>()` before the plugin is installed throws `InvalidOperationException`.
+
+### Query Cache Statistics
+
+`EcsLoggingPlugin.LogQueryStats(cachedQueries, cacheHits, cacheMisses, hitRate)` logs a summary line under `ECS.Query` at `LogLevel.Info`. It doesn't hook into the query system automatically — call it yourself (e.g., from your own system or a periodic diagnostic) with numbers from wherever your query cache tracks them.
+
+### Accessing the Logger via Extension
+
+`EcsLoggingPlugin` registers the `EcsLogger` as a world extension on install, so other plugins or systems can retrieve it without holding a reference to the plugin itself:
+
+```csharp
+var ecsLogger = world.GetExtension<EcsLogger>();
+ecsLogger.LogEntityParentChanged(childId: 5, parentId: 2);
+```
 
 ## Integration Example
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,262 @@
+# Navigation & Pathfinding
+
+The `KeenEyes.Navigation` library provides pathfinding, path following, and dynamic obstacle handling for the ECS world. It defines a pluggable `INavigationProvider` abstraction, with concrete implementations shipped in `KeenEyes.Navigation.Grid` (2D A* pathfinding) and `KeenEyes.Navigation.DotRecast` (3D navigation mesh pathfinding via DotRecast).
+
+## Overview
+
+Navigation is split across four packages:
+
+| Package | Purpose |
+|---------|---------|
+| `KeenEyes.Navigation.Abstractions` | Core interfaces and types: `INavigationProvider`, `IPathRequest`, `NavPath`, `NavPoint`, `AgentSettings`, `NavAreaMask`, and the `NavMeshAgent`/`NavMeshObstacle`/`NavMeshSurface`/`NavMeshModifier` components |
+| `KeenEyes.Navigation` | `NavigationPlugin` - the orchestration layer that runs pathfinding requests and moves agents each frame |
+| `KeenEyes.Navigation.Grid` | `GridNavigationPlugin` - a grid-based `INavigationProvider` implementation using A* |
+| `KeenEyes.Navigation.DotRecast` | `DotRecastNavigationPlugin` - a navmesh-based `INavigationProvider` implementation using DotRecast (a C# port of Recast/Detour) |
+
+`NavigationPlugin` itself does not compute paths. It delegates to whichever `INavigationProvider` is registered in the world, so you must install a provider plugin (`GridNavigationPlugin` or `DotRecastNavigationPlugin`) before or alongside `NavigationPlugin`, or supply a custom provider via `NavigationConfig.CustomProvider`.
+
+## Quick Start
+
+### Installation
+
+Install a navigation provider plugin, then `NavigationPlugin` on top of it:
+
+```csharp
+using KeenEyes.Navigation;
+using KeenEyes.Navigation.Grid;
+
+using var world = new World();
+
+// Install a provider first - grid-based A* for this example
+world.InstallPlugin(new GridNavigationPlugin(new GridConfig
+{
+    Width = 100,
+    Height = 100,
+    CellSize = 1f,
+    AllowDiagonal = true
+}));
+
+// Install the navigation orchestration plugin
+world.InstallPlugin(new NavigationPlugin());
+```
+
+`NavigationPlugin.Install` registers the `NavMeshAgent` and `NavMeshObstacle` components and adds these systems:
+
+- `PathRequestSystem` - `SystemPhase.Update`, order `-100`. Drives `INavigationProvider.Update` and resolves completed path requests.
+- `NavMeshAgentSystem` - `SystemPhase.Update`, order `0`. Moves agents along their computed paths. Only registered when `NavigationConfig.AgentSteeringEnabled` is `true` (the default).
+- `ObstacleUpdateSystem` - `SystemPhase.LateUpdate`, order `0`. Tracks `NavMeshObstacle` movement and marks navigation data dirty for carving updates. Only registered when `NavigationConfig.DynamicObstaclesEnabled` is `true` (the default).
+
+The plugin also exposes a `NavigationContext` extension (annotated `[PluginExtension("Navigation")]`), reachable as `world.GetExtension<NavigationContext>()` or the generated `world.Navigation` property.
+
+### Your First Navigating Agent
+
+```csharp
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions.Components;
+
+// Spawn an entity with a Transform3D and a NavMeshAgent
+var agent = world.Spawn()
+    .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+    .With(NavMeshAgent.Create())
+    .Build();
+
+// Request a path to a destination
+var nav = world.Navigation;
+nav.SetDestination(agent, new Vector3(10, 0, 10));
+```
+
+Each frame, `world.Update(deltaTime)` drives `PathRequestSystem` (which resolves the pending path request) and `NavMeshAgentSystem` (which steers the agent's `Transform3D` toward the destination). Progress can be inspected on the `NavMeshAgent` component itself: `HasPath`, `PathPending`, `RemainingDistance`, `IsStopped`.
+
+## Core Concepts
+
+### NavMeshAgent
+
+`NavMeshAgent` is the component that opts an entity into navigation. It carries both movement configuration (`Speed`, `Acceleration`, `AngularSpeed`, `StoppingDistance`, `AutoBraking`) and live navigation state (`Destination`, `SteeringTarget`, `DesiredVelocity`, `RemainingDistance`, `HasPath`, `PathPending`, `IsOnNavMesh`, `IsStopped`):
+
+```csharp
+// Default settings suitable for a humanoid character
+var defaultAgent = NavMeshAgent.Create();
+
+// Custom AgentSettings and speed
+var fastAgent = NavMeshAgent.Create(AgentSettings.Large, speed: 6f);
+```
+
+Agents also carry an `AreaMask` (a `NavAreaMask`) that restricts which `NavAreaType` regions the agent is allowed to traverse.
+
+### NavigationContext
+
+`NavigationContext` (accessible via `world.GetExtension<NavigationContext>()` / `world.Navigation`) is the primary API surface for driving navigation:
+
+```csharp
+var nav = world.Navigation;
+
+// Start navigating toward a destination
+nav.SetDestination(agent, new Vector3(10, 0, 10));
+
+// Pause and resume without losing the current path
+nav.Stop(agent);
+nav.Resume(agent);
+
+// Teleport an agent onto the navmesh without pathfinding
+bool onMesh = nav.Warp(agent, new Vector3(3, 0, 3));
+
+// Query pathfinding directly, independent of any agent entity
+NavPath path = nav.FindPath(Vector3.Zero, new Vector3(20, 0, 20), AgentSettings.Default);
+if (path.IsValid)
+{
+    foreach (NavPoint waypoint in path)
+    {
+        // waypoint.Position, waypoint.AreaType
+    }
+}
+
+// Other query helpers
+NavPoint? nearest = nav.FindNearestPoint(new Vector3(5, 0, 5));
+bool navigable = nav.IsNavigable(new Vector3(5, 0, 5), AgentSettings.Default);
+bool blocked = nav.Raycast(Vector3.Zero, new Vector3(10, 0, 0), out var hitPosition);
+```
+
+`NavigationContext` also exposes `IsReady`, `Strategy`, `ActiveAgentCount`, and `PendingRequestCount` for diagnostics, plus `Config` for read access to the active `NavigationConfig`.
+
+### NavigationConfig
+
+`NavigationConfig` controls the plugin's behavior:
+
+```csharp
+var config = new NavigationConfig
+{
+    Strategy = NavigationStrategy.Grid,
+    MaxPathRequestsPerFrame = 10,
+    MaxPendingRequests = 100,
+    AgentSteeringEnabled = true,
+    WaypointReachDistance = 0.5f,
+    DynamicObstaclesEnabled = true,
+    ObstacleUpdateInterval = 0.1f,
+    AutoProjectToNavMesh = true,
+    MaxProjectionDistance = 5f
+};
+
+world.InstallPlugin(new NavigationPlugin(config));
+```
+
+`NavigationConfig.Validate()` runs automatically when the plugin is constructed and throws `ArgumentException` if any value is out of range (for example, a non-positive `MaxPathRequestsPerFrame`).
+
+### Dynamic Obstacles
+
+Entities that should block or influence navigation carry a `NavMeshObstacle` component:
+
+```csharp
+using KeenEyes.Navigation.Abstractions.Components;
+
+// A carving box obstacle - actually removes the area from the navmesh
+var crate = world.Spawn()
+    .With(new Transform3D(new Vector3(5, 0, 5), Quaternion.Identity, Vector3.One))
+    .With(NavMeshObstacle.Box(new Vector3(1, 1, 1)))
+    .Build();
+
+// A non-carving cylindrical obstacle - used only for local avoidance
+var pillar = world.Spawn()
+    .With(new Transform3D(new Vector3(8, 0, 2), Quaternion.Identity, Vector3.One))
+    .With(NavMeshObstacle.Cylinder(radius: 0.5f, height: 2f, carving: false))
+    .Build();
+```
+
+`ObstacleUpdateSystem` tracks obstacle positions frame to frame and flags navigation data as dirty when a carving obstacle moves past `CarvingMoveThreshold`, subject to the `NavigationConfig.ObstacleUpdateInterval` throttle.
+
+### Navmesh Surface Authoring
+
+`NavMeshSurface` and `NavMeshModifier` mark geometry for inclusion in navmesh baking (used by navmesh-based providers such as `KeenEyes.Navigation.DotRecast`):
+
+```csharp
+// Mark a floor entity as walkable
+world.Spawn("Ground")
+    .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+    .With(NavMeshSurface.Create(NavAreaType.Walkable))
+    .Build();
+
+// Exclude a decoration from the navmesh entirely
+world.Spawn("Decoration")
+    .With(new Transform3D(new Vector3(5, 0, 5), Quaternion.Identity, Vector3.One))
+    .With(NavMeshModifier.CreateExclude())
+    .Build();
+```
+
+## Choosing a Provider
+
+### Grid Navigation (`KeenEyes.Navigation.Grid`)
+
+`GridNavigationPlugin` provides A* pathfinding over a `NavigationGrid` of `GridCell` entries. It is well suited to 2D games or tile-based movement:
+
+```csharp
+using KeenEyes.Navigation.Grid;
+
+world.InstallPlugin(new GridNavigationPlugin(new GridConfig
+{
+    Width = 100,
+    Height = 100,
+    CellSize = 1f,
+    AllowDiagonal = true,
+    Heuristic = GridHeuristic.Octile
+}));
+
+var provider = world.GetExtension<GridNavigationProvider>();
+
+// Block a cell directly
+provider.Grid[10, 10] = GridCell.Blocked;
+
+var path = provider.FindPath(Vector3.Zero, new Vector3(50, 0, 50), AgentSettings.Default);
+```
+
+`GridNavigationPlugin` registers `GridNavigationProvider` under both its concrete type and `INavigationProvider`, so `NavigationPlugin` can pick it up automatically as long as it's installed first.
+
+### Navmesh Navigation (`KeenEyes.Navigation.DotRecast`)
+
+`DotRecastNavigationPlugin` provides navmesh-based pathfinding via `DotRecastProvider`, suited to complex 3D environments:
+
+```csharp
+using KeenEyes.Navigation.DotRecast;
+
+var meshConfig = new NavMeshConfig
+{
+    CellSize = 0.3f,
+    AgentRadius = 0.5f,
+    AgentHeight = 2.0f
+};
+
+// Build a navmesh from level geometry
+var builder = new DotRecastMeshBuilder(meshConfig);
+var navMeshData = builder.Build(vertices, indices);
+
+world.InstallPlugin(new DotRecastNavigationPlugin(navMeshData));
+```
+
+Alternatively, construct `DotRecastNavigationPlugin()` with just a `NavMeshConfig` and call `DotRecastProvider.SetNavMesh` once a mesh is available.
+
+### Custom Providers
+
+Any type implementing `INavigationProvider` can be supplied directly, bypassing the built-in plugins:
+
+```csharp
+var config = new NavigationConfig
+{
+    Strategy = NavigationStrategy.Custom,
+    CustomProvider = myCustomProvider
+};
+
+world.InstallPlugin(new NavigationPlugin(config));
+```
+
+## Performance
+
+- `PathRequestSystem` runs first in `SystemPhase.Update` (order `-100`) so completed path results are applied to `NavMeshAgent` before `NavMeshAgentSystem` moves entities in the same frame.
+- `NavigationConfig.MaxPathRequestsPerFrame` and provider-specific settings such as `GridConfig.RequestsPerUpdate` bound how many path computations happen per frame, trading path latency for frame-time stability.
+- `ObstacleUpdateSystem` throttles navmesh-carving recalculation via `NavigationConfig.ObstacleUpdateInterval`, avoiding a full update every time a moving obstacle shifts slightly.
+- `GridNavigationProvider.FindPath(GridCoordinate, GridCoordinate, Span<GridCoordinate>)` offers a zero-allocation path query for hot paths that can supply their own result buffer.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How `IWorldPlugin` installation, extensions, and lifecycle work
+- [Systems Guide](systems.md) - System phases and ordering used by `PathRequestSystem`, `NavMeshAgentSystem`, and `ObstacleUpdateSystem`
+- [AI System Guide](ai.md) - Pairing navigation with behavior trees or utility AI for NPC movement decisions
+- [Pathfinding & Navigation Design](research/pathfinding-navigation.md) - Original design document

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -1,0 +1,161 @@
+# Particles
+
+The `KeenEyes.Particles` library provides a high-performance particle system for visual effects such as fire, smoke, explosions, and magic effects, installed into a `World` via `ParticlesPlugin`.
+
+## Overview
+
+Particles are **not** individual ECS entities. An emitter is an entity carrying a `ParticleEmitter` component (and, optionally, a `ParticleEmitterModifiers` component), while the actual particles it spawns are pooled data managed internally by `ParticleManager`. This keeps thousands of particles cheap to spawn and update, since they never go through archetype storage or component lookups - they live in a `ParticlePool` using a Structure-of-Arrays (SOA) layout indexed by a free list.
+
+An emitter's world position is read from the entity's `Transform2D` component (or `Transform3D`, which is projected to 2D) each frame.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Particles;
+
+using var world = new World();
+
+// Install with default configuration
+world.InstallPlugin(new ParticlesPlugin());
+
+// Or with custom configuration
+world.InstallPlugin(new ParticlesPlugin(new ParticlesConfig
+{
+    MaxParticlesPerEmitter = 5000,
+    MaxEmitters = 50
+}));
+```
+
+`ParticlesPlugin` registers two components (`ParticleEmitter`, `ParticleEmitterModifiers`) and three systems:
+
+| System | Phase | Order | Responsibility |
+|--------|-------|-------|-----------------|
+| `ParticleSpawnSystem` | `SystemPhase.Update` | 100 | Spawns new particles from continuous emission and bursts |
+| `ParticleUpdateSystem` | `SystemPhase.Update` | 101 | Ages particles, applies modifiers, integrates position/rotation, releases dead particles |
+| `ParticleRenderSystem` | `SystemPhase.Render` | 100 | Batches active particles by `BlendMode` and draws them via `I2DRenderer` |
+
+It also exposes a `ParticleManager` as a world extension, retrievable with `world.GetExtension<ParticleManager>()`.
+
+### Creating an Emitter
+
+```csharp
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Particles.Components;
+using KeenEyes.Particles.Data;
+
+var fire = world.Spawn()
+    .With(new Transform2D(new Vector2(400, 300), 0, Vector2.One))
+    .With(ParticleEmitter.Default with
+    {
+        EmissionRate = 100,
+        StartColor = new Vector4(1, 0.5f, 0, 1),
+        BlendMode = BlendMode.Additive
+    })
+    .With(ParticleEmitterModifiers.WithFadeOut(new Vector4(1, 0.3f, 0, 1)))
+    .Build();
+```
+
+Adding a `ParticleEmitter` component fires `World.OnComponentAdded<ParticleEmitter>`, which `ParticlesPlugin` uses to register the entity with `ParticleManager` and allocate its `ParticlePool`. Removing the component, or destroying the entity, unregisters it and disposes the pool.
+
+## Core Concepts
+
+### `ParticleEmitter`
+
+`ParticleEmitter` is a `[Component]` struct describing how an emitter spawns particles:
+
+- **Continuous emission** - `EmissionRate` (particles per second); set to `0` to disable.
+- **Burst emission** - `BurstCount` particles every `BurstInterval` seconds; `BurstInterval = 0` fires a single one-shot burst instead of repeating.
+- **Spawn ranges** - `LifetimeMin`/`LifetimeMax`, `StartSizeMin`/`StartSizeMax`, `StartSpeedMin`/`StartSpeedMax`, `StartRotationMin`/`StartRotationMax` are all sampled uniformly at random per particle.
+- **Shape** - `Shape` (an `EmissionShape`) controls where particles spawn and their initial direction.
+- **Visuals** - `Texture` (a `TextureHandle`; particles render as filled circles when it's not valid), `StartColor`, and `BlendMode`.
+- **Playback** - `IsPlaying` toggles emission on and off without removing the component.
+
+`ParticleEmitter.Default` provides sensible starting values, and `ParticleEmitter.Burst(count, lifetime)` / `ParticleEmitter.Continuous(rate, lifetime)` are convenience factories for the two emission modes.
+
+`EmissionShape` supports four shapes via static factories: `EmissionShape.Point`, `EmissionShape.Sphere(radius)`, `EmissionShape.Cone(radius, angle)` / `EmissionShape.Cone(radius, angle, direction)`, and `EmissionShape.Box(width, height)`.
+
+### `ParticleEmitterModifiers`
+
+`ParticleEmitterModifiers` is an optional `[Component]` struct that changes particle properties over their lifetime. Each group of fields is gated by a `bool` flag so it only runs when explicitly enabled. During `ParticleUpdateSystem.Update`, modifiers are applied in this order: gravity → velocity over lifetime → size over lifetime → color over lifetime → rotation over lifetime.
+
+```csharp
+var modifiers = new ParticleEmitterModifiers
+{
+    HasGravity = true,
+    GravityX = 0f,
+    GravityY = 98f, // Downward gravity
+    Drag = 0.3f,
+    HasColorOverLifetime = true,
+    ColorGradient = ParticleGradient.FadeOut(new Vector4(1, 0.5f, 0, 1))
+};
+```
+
+`ParticleEmitterModifiers.None` is an all-disabled baseline, and `WithGravity(gravityY, drag)` / `WithFadeOut(startColor)` build on top of it for common cases.
+
+Curves and gradients (`VelocityCurve`, `SizeCurve`, `RotationCurve`, `ColorGradient`) are evaluated with a normalized age in `[0, 1]`:
+
+- `ParticleCurve` - a 64-sample lookup table with factories `Constant(value)`, `LinearFadeIn()`, `LinearFadeOut()`, `EaseIn()`, `EaseOut()`, and `FromPoints(points)` for arbitrary control points.
+- `ParticleGradient` - the same idea for `Vector4` colors, with `Constant(color)`, `FadeIn(color)`, `FadeOut(color)`, `TwoColor(start, end)`, and `FromPoints(points)`.
+
+Both are pre-sampled into fixed-size arrays at construction time so `Evaluate(t)` is a cheap linear interpolation - no allocations or reflection on the hot path.
+
+### `ParticleEffects`
+
+`ParticleEffects` is a static factory class with ready-made emitter/modifier pairs for common effects: `Fire()`/`FireModifiers()`, `Smoke()`/`SmokeModifiers()`, `Explosion()`/`ExplosionModifiers()`, `MagicSparkles()`/`MagicSparklesModifiers()`, `BloodSplatter()`/`BloodSplatterModifiers()`, and `Rain()`/`RainModifiers()`, `Snow()`/`SnowModifiers()`. Use these as starting points and customize with `with` expressions:
+
+```csharp
+using KeenEyes.Particles;
+
+var entity = world.Spawn()
+    .With(new Transform2D(position, 0, Vector2.One))
+    .With(ParticleEffects.Fire())
+    .With(ParticleEffects.FireModifiers())
+    .Build();
+```
+
+### `ParticleManager`
+
+`ParticleManager` is the world extension that owns every emitter's `ParticlePool`:
+
+- `EmitterCount` - number of currently registered emitters.
+- `TotalActiveParticles` - sum of `ActiveCount` across all pools.
+- `GetPool(entity)` - returns the `ParticlePool?` for an emitter entity, or `null` if it isn't registered.
+- `HasPool(entity)` - checks registration without allocating.
+- `GetAllPools()` - enumerates `(Entity, ParticlePool)` pairs for every active emitter.
+- `ClearAll()` - clears every pool's particles without removing the emitters themselves.
+- `Config` - the `ParticlesConfig` the manager was created with.
+
+```csharp
+var particles = world.GetExtension<ParticleManager>();
+int totalActive = particles.TotalActiveParticles;
+```
+
+### `ParticlesConfig`
+
+`ParticlesConfig` caps resource usage across the whole world:
+
+| Property | Default | Effect |
+|----------|---------|--------|
+| `MaxParticlesPerEmitter` | 1000 | Once a pool hits this size, new particles aren't spawned until existing ones expire |
+| `MaxEmitters` | 100 | Additional emitters beyond this limit are silently ignored |
+| `InitialPoolCapacity` | 256 | Starting array size per pool; grows dynamically (doubling, via `ParticlePool.Grow`) up to `MaxParticlesPerEmitter` |
+
+`ParticlesConfig.Default`, `ParticlesConfig.HighPerformance` (5000/50/1024), and `ParticlesConfig.LowMemory` (200/20/64) cover common presets. `Validate()` returns a descriptive error string (or `null`) and is called automatically by the `ParticlesPlugin(ParticlesConfig)` constructor, which throws `ArgumentException` for an invalid configuration.
+
+## Performance
+
+- Particles live in `ParticlePool`'s parallel arrays (`PositionsX`/`PositionsY`, `VelocitiesX`/`VelocitiesY`, `ColorsR/G/B/A`, `Sizes`, `Rotations`, `Ages`, `Lifetimes`, etc.), not as ECS entities, so spawning and updating thousands of particles avoids archetype moves and per-particle component lookups entirely.
+- Allocation and release use an O(1) free list (`ParticlePool.Allocate`/`Release`); pools grow by doubling capacity on demand rather than reallocating per particle.
+- `ParticleRenderSystem` groups active emitters by `BlendMode` before rendering, issuing one `I2DRenderer.Begin()`/`End()` batch per blend mode (rendered in multiply → transparent → premultiplied → additive order) instead of one draw call per particle.
+- `ParticleCurve` and `ParticleGradient` pre-sample 64 points at construction, so evaluating them during `ParticleUpdateSystem` is a constant-time lookup and lerp with no per-frame allocation.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How `IWorldPlugin` and `IPluginContext` work in general
+- [Systems Guide](systems.md) - System phases, ordering, and execution
+- [Components Guide](components.md) - The `[Component]` attribute and generated builder methods
+- [Graphics Guide](graphics.md) - `I2DRenderer`, `TextureHandle`, and rendering primitives used by `ParticleRenderSystem`
+- [Particle System Design](research/particle-system.md) - Original design document (note: some sections describe an aspirational GPU-instanced/module-based design that differs from the current CPU-pooled implementation described above)

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,148 @@
+# Persistence & Encryption
+
+The `KeenEyes.Persistence` library adds password-based AES-256 encryption on top of the World's built-in save-slot system, so save files on disk cannot be read or tampered with without the correct password.
+
+## Overview
+
+`World` already exposes save-slot functionality directly (`world.SaveToSlot`, `world.LoadFromSlot`, `world.SaveDirectory`) built on the snapshot and serialization mechanism described in [Serialization and Snapshots](serialization.md). `KeenEyes.Persistence` does not replace that mechanism — it wraps it with an encryption step:
+
+1. A `WorldSnapshot` is created and serialized (binary or JSON), exactly as it would be for an unencrypted save.
+2. The serialized bytes are passed through an `IEncryptionProvider` before being written to the `.ksave` container.
+3. On load, the container is read, the payload is decrypted, and the result is handed back to the same snapshot deserialization path.
+
+Because the encryption step sits *around* the existing snapshot pipeline, everything documented in [Serialization and Snapshots](serialization.md) about what gets captured, entity ID mapping, and AOT-compatible serializers still applies unchanged.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.Persistence;
+
+using var world = new World();
+
+// Install with no encryption (pass-through)
+world.InstallPlugin(new PersistencePlugin());
+```
+
+Installing `PersistencePlugin` registers an `EncryptedPersistenceApi` extension on the world. Retrieve it with `world.GetExtension<EncryptedPersistenceApi>()`.
+
+### Enabling Encryption
+
+Use `PersistenceConfig.WithEncryption` to configure AES-256 encryption with a password:
+
+```csharp
+using KeenEyes.Persistence;
+
+var config = PersistenceConfig.WithEncryption("myPassword");
+world.InstallPlugin(new PersistencePlugin(config));
+
+var persistence = world.GetExtension<EncryptedPersistenceApi>();
+
+// Save (creates a snapshot, serializes it, then encrypts it before writing)
+var serializer = new ComponentSerializer(); // generated serializer
+var slotInfo = persistence.SaveToSlot("slot1", serializer);
+
+// Load (reads the file, decrypts it, then restores the snapshot into the world)
+var (info, entityMap) = persistence.LoadFromSlot("slot1", serializer);
+```
+
+`PersistenceConfig` is a record, so the same result can be built explicitly:
+
+```csharp
+using KeenEyes.Persistence;
+using KeenEyes.Persistence.Encryption;
+
+var config = new PersistenceConfig
+{
+    EncryptionProvider = new AesEncryptionProvider("myPassword"),
+    SaveDirectory = "encrypted_saves"
+};
+world.InstallPlugin(new PersistencePlugin(config));
+```
+
+**Note:** When using a custom `IWorld` implementation (not the standard `World` class), `PersistenceConfig.SaveDirectory` must be set explicitly. `EncryptedPersistenceApi` falls back to `World.SaveDirectory` only when the world is a concrete `World` instance; otherwise it throws an `ArgumentException` during construction.
+
+## Core Concepts
+
+### PersistencePlugin
+
+`PersistencePlugin` is an `IWorldPlugin`. On `Install`, it:
+
+- Applies `PersistenceConfig.SaveDirectory` to the world via the `IPersistenceCapability` capability, if one is available and a directory was configured.
+- Constructs an `EncryptedPersistenceApi` for the world and registers it with `context.SetExtension(api)`.
+
+On `Uninstall`, it removes the extension with `context.RemoveExtension<EncryptedPersistenceApi>()`.
+
+```csharp
+public sealed class PersistencePlugin(PersistenceConfig? config = null) : IWorldPlugin
+{
+    public string Name => "Persistence";
+    // Install / Uninstall as described above
+}
+```
+
+### PersistenceConfig
+
+`PersistenceConfig` is an immutable record with two settings:
+
+| Property | Description |
+|----------|--------------|
+| `EncryptionProvider` | An `IEncryptionProvider`. Defaults to `NoEncryptionProvider.Instance` (no encryption). |
+| `SaveDirectory` | Optional override for where `.ksave` files are stored. Falls back to `World.SaveDirectory` when null (concrete `World` only). |
+
+`PersistenceConfig.Default` returns the no-encryption configuration. `PersistenceConfig.WithEncryption(password, saveDirectory?)` is a convenience factory that sets `EncryptionProvider` to a new `AesEncryptionProvider(password)`.
+
+### EncryptedPersistenceApi
+
+`EncryptedPersistenceApi` is the world extension installed by `PersistencePlugin`. It mirrors the shape of `World`'s own save-slot methods, but routes the serialized snapshot bytes through the configured `IEncryptionProvider` before writing, and through decryption before restoring:
+
+| Member | Description |
+|--------|-------------|
+| `IsEncryptionEnabled` | `true` when the configured provider actually encrypts (`IEncryptionProvider.IsEncrypted`). |
+| `EncryptionProviderName` | The provider's `Name` (`"AES-256"` or `"None"`). |
+| `SaveDirectory` | The resolved save directory for this API instance. |
+| `SaveToSlot<TSerializer>(slotName, serializer, options?)` | Creates a snapshot, serializes it, encrypts it, and writes it to a `.ksave` file. Returns a `SaveSlotInfo`. |
+| `LoadFromSlot<TSerializer>(slotName, serializer, validateChecksum = true)` | Reads a `.ksave` file, decrypts it, deserializes the snapshot, and restores it into the world. Returns the `SaveSlotInfo` and the old-ID-to-new-`Entity` map. |
+| `SaveToSlotAsync` / `LoadFromSlotAsync` | Async equivalents that use the provider's `EncryptAsync`/`DecryptAsync`. |
+| `GetSlotInfo(slotName)` | Reads only the `SaveSlotInfo` metadata, without decrypting the payload. |
+| `ListSlots()` | Enumerates `SaveSlotInfo` for every `.ksave` file in the save directory. |
+| `SlotExists(slotName)` / `DeleteSlot(slotName)` | Slot existence check and deletion. |
+| `GetSlotFilePath(slotName)` | Resolves the full path for a slot name, validated by `SlotNameValidator`. |
+
+`TSerializer` must implement both `IComponentSerializer` and `IBinaryComponentSerializer` — the same constraint used by `World.SaveToSlot`/`World.LoadFromSlot` and by `SnapshotManager.ToBinary`/`FromBinary`.
+
+The returned `SaveSlotInfo` (and the `SaveSlotOptions` accepted by `SaveToSlot`) are the same types used by the World's unencrypted save API — see [Serialization and Snapshots](serialization.md) for the full snapshot lifecycle they describe. `GetSlotInfo` and `ListSlots` can still enumerate and inspect encrypted saves without a password, because the encryption only covers the snapshot payload, not the `SaveSlotInfo` metadata stored alongside it in the `.ksave` container.
+
+### Encryption Providers
+
+`IEncryptionProvider` is the extension point for encryption. It exposes `Name`, `IsEncrypted`, and sync/async `Encrypt`/`Decrypt` pairs operating on `byte[]`.
+
+Two implementations ship with the library:
+
+- **`NoEncryptionProvider`** — a pass-through singleton (`NoEncryptionProvider.Instance`) with `IsEncrypted => false`. This is `PersistenceConfig.Default`'s provider.
+- **`AesEncryptionProvider`** — AES-256 in CBC mode with PKCS7 padding. The key is derived from the supplied password with PBKDF2 (SHA-256, 100,000 iterations) and a random 16-byte salt generated per encrypt call. A random 16-byte IV is also generated per call. The output layout is `[Salt (16 bytes)][IV (16 bytes)][Ciphertext]`, so each encrypted payload is fully self-describing and needs only the password to decrypt.
+
+```csharp
+using KeenEyes.Persistence.Encryption;
+
+var provider = new AesEncryptionProvider("MySecretPassword");
+byte[] encrypted = provider.Encrypt(plaintextBytes);
+byte[] decrypted = provider.Decrypt(encrypted);
+```
+
+Because the salt and IV are regenerated on every `Encrypt` call, encrypting the same snapshot twice produces different ciphertext — this is expected and does not affect round-tripping through `Decrypt`.
+
+A custom `IEncryptionProvider` can be supplied instead of `AesEncryptionProvider` (for example, to integrate with a platform key vault) by setting `PersistenceConfig.EncryptionProvider` directly.
+
+## Performance Considerations
+
+- `SaveToSlot` encrypts the serialized snapshot bytes *before* handing them to `SaveFileFormat.Write`, which performs the actual GZip/Brotli compression configured via `SaveSlotOptions.Compression`. Because encrypted data is high-entropy, it compresses far less effectively than the original plaintext snapshot — expect encrypted `.ksave` files to be noticeably larger than unencrypted ones using the same `SaveSlotOptions`.
+- `AesEncryptionProvider` derives its key with 100,000 PBKDF2 iterations on every `Encrypt`/`Decrypt` call. This is deliberate (it makes brute-forcing the password expensive) but means each save/load pays a fixed key-derivation cost in addition to serialization and compression time.
+- Use `SaveToSlotAsync`/`LoadFromSlotAsync` to keep encryption and file I/O off the main thread; `AesEncryptionProvider`'s async methods currently wrap the synchronous implementation in `Task.FromResult`, so the CPU-bound work still runs on the calling thread unless the caller offloads it (e.g. with `Task.Run`).
+
+## Next Steps
+
+- [Serialization and Snapshots](serialization.md) — the snapshot creation, binary/JSON serialization, and restore mechanism that `EncryptedPersistenceApi` builds on.
+- [Plugins](plugins.md) — how `IWorldPlugin`, `IPluginContext`, extensions, and capabilities work in general.
+- [Change Tracking](change-tracking.md) — for scenarios that need incremental save data rather than full snapshots.

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -1,0 +1,235 @@
+# Physics
+
+The `KeenEyes.Physics` library integrates [BepuPhysics v2](https://github.com/bepu/bepuphysics2) into the ECS, giving entities rigid-body dynamics, collision detection, and constraint solving. It is installed as a plugin so a `World` only pays for physics when it opts in.
+
+## Overview
+
+`KeenEyes.Physics` adds:
+
+- **Rigid bodies** — `RigidBody` marks an entity as dynamic, kinematic, or static.
+- **Collision shapes** — `PhysicsShape` describes spheres, boxes, capsules, and cylinders.
+- **Materials and filtering** — `PhysicsMaterial` (friction/restitution/damping) and `CollisionFilter` (layer/mask + trigger support).
+- **A stepped simulation** — `PhysicsStepSystem` advances BepuPhysics on a fixed timestep and publishes collision events; `PhysicsSyncSystem` optionally interpolates transforms for smooth rendering.
+- **A query/control API** — the `PhysicsWorld` extension exposes raycasts, overlap queries, forces/impulses, and velocity control.
+
+Bodies read and write the same `Transform3D`, `Velocity3D`, and `AngularVelocity3D` components used elsewhere in the engine (from `KeenEyes.Common`), so physics composes naturally with rendering, animation, and gameplay systems that already consume those components.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes;
+using KeenEyes.Physics;
+
+using var world = new World();
+
+// Install with default configuration (60 Hz, Earth gravity)
+world.InstallPlugin(new PhysicsPlugin());
+```
+
+Installing `PhysicsPlugin` registers the `RigidBody`, `PhysicsShape`, `PhysicsMaterial`, and `CollisionFilter` components, creates a `PhysicsWorld` extension, and adds:
+
+- `PhysicsStepSystem` in `SystemPhase.FixedUpdate` — advances the simulation.
+- `PhysicsSyncSystem` in `SystemPhase.LateUpdate` — only added when `PhysicsConfig.EnableInterpolation` is true.
+
+To customize the simulation, pass a `PhysicsConfig`:
+
+```csharp
+using System.Numerics;
+using KeenEyes.Physics.Core;
+
+world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig
+{
+    FixedTimestep = 1f / 60f,
+    Gravity = new Vector3(0, -9.81f, 0),
+    VelocityIterations = 10,
+    SubstepCount = 2,
+}));
+```
+
+`PhysicsPlugin`'s constructor validates the supplied `PhysicsConfig` via `PhysicsConfig.Validate()` and throws `ArgumentException` if, for example, `FixedTimestep` is non-positive or exceeds 0.1 seconds.
+
+### Your First Rigid Body
+
+```csharp
+using KeenEyes.Common;
+using KeenEyes.Physics.Components;
+
+// A static ground plane - never moves
+var ground = world.Spawn()
+    .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+    .With(RigidBody.Static())
+    .With(PhysicsShape.Box(100, 1, 100))
+    .Build();
+
+// A dynamic ball that falls and bounces
+var ball = world.Spawn()
+    .With(new Transform3D(new Vector3(0, 10, 0), Quaternion.Identity, Vector3.One))
+    .With(new Velocity3D(0, 0, 0))
+    .With(RigidBody.Dynamic(mass: 1.0f))
+    .With(PhysicsShape.Sphere(radius: 0.5f))
+    .With(PhysicsMaterial.Rubber)
+    .Build();
+```
+
+`PhysicsPlugin` listens for `RigidBody` being added to an entity and creates the corresponding BepuPhysics body as soon as the entity also has `Transform3D` and `PhysicsShape`. Removing the `RigidBody` component, or destroying the entity, removes the body from the simulation.
+
+### Stepping the Simulation
+
+Physics runs in `SystemPhase.FixedUpdate`. Advance it by calling `World.FixedUpdate` on a fixed-timestep loop, or `World.Update` to run every phase (including `FixedUpdate`) for the frame:
+
+```csharp
+float dt = 1f / 60f;
+float accumulator = 0f;
+
+// Inside your game loop:
+accumulator += frameTime;
+while (accumulator >= dt)
+{
+    world.FixedUpdate(dt);
+    accumulator -= dt;
+}
+```
+
+`PhysicsStepSystem.Update` delegates to `PhysicsWorld.Step`, which itself accumulates elapsed time and runs as many fixed-size BepuPhysics timesteps as needed (bounded by `PhysicsConfig.MaxStepsPerFrame`) to catch up.
+
+## Core Concepts
+
+### RigidBody
+
+`RigidBody` is the component that opts an entity into simulation. It carries a `BodyType` (`RigidBodyType.Dynamic`, `Kinematic`, or `Static`), a `Mass` (used only for dynamic bodies), and an `Activity` description that controls sleeping:
+
+```csharp
+public struct RigidBody : IComponent
+{
+    public float Mass;
+    public RigidBodyType BodyType;
+    public ActivityDescription Activity;
+
+    public static RigidBody Dynamic(float mass) => /* ... */;
+    public static RigidBody Kinematic() => /* ... */;
+    public static RigidBody Static() => /* ... */;
+}
+```
+
+- **Dynamic** bodies respond to gravity, forces, and collisions.
+- **Kinematic** bodies are moved directly (via `Transform3D`/`Velocity3D`) and can push dynamic bodies but are never pushed themselves.
+- **Static** bodies never move and are the cheapest to simulate — use them for level geometry.
+
+`ActivityDescription` controls when a dynamic body is allowed to sleep: `SleepThreshold` is the velocity magnitude below which a body becomes a sleep candidate, and `MinimumTimestepsBeforeSleep` is how many consecutive sub-threshold steps are required before it actually sleeps. Use `ActivityDescription.NeverSleep` for bodies that must always stay simulated.
+
+### PhysicsShape
+
+`PhysicsShape` describes the collision geometry. Factory methods keep the underlying `Size` encoding (which varies per shape type) out of user code:
+
+```csharp
+var sphere = PhysicsShape.Sphere(radius: 0.5f);
+var box = PhysicsShape.Box(width: 2, height: 2, depth: 2);
+var capsule = PhysicsShape.Capsule(radius: 0.5f, length: 2f);
+var cylinder = PhysicsShape.Cylinder(radius: 0.5f, length: 2f);
+```
+
+### PhysicsMaterial
+
+`PhysicsMaterial` is an optional component describing collision response — `Friction`, `Restitution` (bounciness), `LinearDamping`, and `AngularDamping`. When two colliding bodies both have a material, friction is averaged and the higher restitution wins. If a body has no `PhysicsMaterial`, `PhysicsMaterial.Default` is used. Presets are provided for common cases: `PhysicsMaterial.Rubber`, `.Ice`, `.Metal`, and `.Wood`.
+
+### CollisionFilter
+
+`CollisionFilter` controls *which* bodies can collide, using a layer/mask bitmask, and whether a body is a trigger:
+
+```csharp
+const uint PlayerLayer = 1 << 0;
+const uint EnemyLayer = 1 << 1;
+
+var player = world.Spawn()
+    .With(new CollisionFilter { Layer = PlayerLayer, Mask = EnemyLayer })
+    // ... rigid body / shape / transform
+    .Build();
+```
+
+Two bodies collide only if each one's `Layer` appears in the other's `Mask` — `CollisionFilter.CanCollideWith` implements this bidirectional check. Setting `IsTrigger` to `true` (or using `CollisionFilter.Trigger(...)`) makes a body detect overlaps and still raise collision events without generating a physical response — useful for pickups, damage zones, and checkpoints. Entities without a `CollisionFilter` behave as `CollisionFilter.Default` (layer 1, collides with everything).
+
+### PhysicsConfig
+
+`PhysicsConfig` is passed to `PhysicsPlugin`'s constructor and controls the simulation as a whole:
+
+| Property | Purpose |
+|----------|---------|
+| `FixedTimestep` | Physics tick rate in seconds (default `1/60`). |
+| `MaxStepsPerFrame` | Caps how many fixed steps can run in one frame call (default 3), to avoid a spiral of death. |
+| `Gravity` | Gravity vector applied to dynamic bodies (default `(0, -9.81, 0)`). |
+| `VelocityIterations` | Constraint solver velocity iterations (default 8). |
+| `SubstepCount` | Position-correction substeps (default 1). |
+| `EnableInterpolation` | Whether `PhysicsSyncSystem` is registered to interpolate rendering transforms (default `true`). |
+| `InitialBodyCapacity`, `InitialStaticCapacity`, `InitialConstraintCapacity` | Pre-sizing hints to avoid reallocations. |
+
+### The PhysicsWorld Extension
+
+Physics operations that don't fit a component/system model — raycasts, overlap queries, and applying forces — live on the `PhysicsWorld` extension, retrieved with `World.GetExtension<PhysicsWorld>()`:
+
+```csharp
+var physics = world.GetExtension<PhysicsWorld>();
+
+// Raycast
+if (physics.Raycast(origin, direction, maxDistance: 50f, out var hit))
+{
+    // hit.Entity, hit.Position, hit.Normal, hit.Distance
+}
+
+// Overlap queries
+foreach (var entity in physics.OverlapSphere(center, radius: 5f))
+{
+    // ...
+}
+
+// Forces and impulses
+physics.ApplyForce(ball, new Vector3(0, 100, 0));
+physics.ApplyImpulse(ball, new Vector3(5, 0, 0));
+physics.SetVelocity(ball, Vector3.Zero);
+```
+
+`PhysicsWorld` also exposes `Gravity`, `BodyCount`/`StaticCount`, `WakeUp`/`IsAwake`, `SetGravity`, and `SetSolverIterations` for runtime tuning.
+
+### Collision Events
+
+Collisions are published through the ECS messaging system rather than callbacks, so any system can subscribe:
+
+```csharp
+using KeenEyes.Physics.Events;
+
+var subscription = world.Subscribe<CollisionStartedEvent>(collision =>
+{
+    // collision.EntityA, collision.EntityB, collision.ContactNormal,
+    // collision.ContactPoint, collision.PenetrationDepth, collision.IsTrigger
+});
+
+world.Subscribe<CollisionEvent>(collision => { /* fires every step while touching */ });
+world.Subscribe<CollisionEndedEvent>(collision => { /* fires once separation occurs */ });
+```
+
+- `CollisionStartedEvent` fires once when two bodies first make contact.
+- `CollisionEvent` fires every physics step for each active collision pair (including the first).
+- `CollisionEndedEvent` fires once when a previously-colliding pair separates.
+
+Events are published at the end of each fixed step, after `PhysicsStepSystem` has run the BepuPhysics timestep and synced results back to `Transform3D`/`Velocity3D`.
+
+### Interpolation for Rendering
+
+When `PhysicsConfig.EnableInterpolation` is `true` (the default), `PhysicsSyncSystem` runs in `SystemPhase.LateUpdate` and blends each dynamic body's `Transform3D` between its previous and current physics state using `PhysicsWorld.InterpolationAlpha`. This smooths visuals when the render rate differs from the fixed physics rate, without affecting the physics state itself (gameplay code reading `Transform3D` during `FixedUpdate` still sees exact simulation results).
+
+## Performance Considerations
+
+- **Prefer static bodies for non-moving geometry.** Static bodies skip integration and are cheaper to store and query than sleeping dynamic bodies.
+- **Tune `VelocityIterations`/`SubstepCount` deliberately.** Higher values improve stacking stability and penetration recovery at a direct CPU cost; the sample project raises both for stable box-stacking scenes.
+- **Size capacities up front.** `InitialBodyCapacity`, `InitialStaticCapacity`, and `InitialConstraintCapacity` avoid reallocation churn when you know roughly how many bodies a world will hold.
+- **Let bodies sleep.** The default `ActivityDescription` allows dynamic bodies to sleep once their velocity drops below `SleepThreshold` for `MinimumTimestepsBeforeSleep` steps; only override this with `ActivityDescription.NeverSleep` for bodies that truly need to stay active (e.g., player-controlled bodies awaiting input).
+- **Cap runaway catch-up.** `MaxStepsPerFrame` bounds how many fixed steps `PhysicsWorld.Step` will run in a single call, trading simulation accuracy for frame stability if the game falls behind.
+
+## Next Steps
+
+- [Physics Integration Cookbook](cookbook/physics-integration.md) - Worked integration patterns
+- [Common Components](common.md) - `Transform3D`, `Velocity3D`, and other shared components physics reads/writes
+- [Systems Guide](systems.md) - How `SystemPhase.FixedUpdate` and `SystemPhase.LateUpdate` fit into the frame
+- [Messaging](messaging.md) - Subscribing to `CollisionEvent` and other world messages
+- [Plugins Guide](plugins.md) - How `IWorldPlugin` installation and extensions work

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -1,0 +1,265 @@
+# Replay Recording & Playback
+
+The `KeenEyes.Replay` library records gameplay sessions frame-by-frame and plays them back later, enabling crash reproduction, killcams, demo/attract modes, and racing-style ghosts.
+
+## Overview
+
+Replay recording and playback are split across two plugins:
+
+- **`ReplayPlugin`** installs a `ReplayRecorder` that captures frame boundaries, system execution, entity lifecycle events, and periodic world snapshots while the world runs.
+- **`ReplayPlaybackPlugin`** installs a `ReplayPlayer` that loads previously recorded data and drives play/pause/stop/step/seek controls.
+
+A single `World` can have one or the other installed, but not both — `ReplayPlaybackPlugin.Install` throws `InvalidOperationException` if a `ReplayRecorder` extension is already present, since "a world can either record or play back replays, but not both simultaneously."
+
+Recorded sessions are serialized to the `.kreplay` binary container format via `ReplayFileFormat`, which supports GZip/Brotli compression and an optional CRC32 checksum. A lightweight companion feature, **Ghost replays** (`KeenEyes.Replay.Ghost`), extracts just the transform data for one entity out of a full replay for cheap racing-ghost style playback.
+
+A runnable walkthrough of most of the features below lives in `samples/KeenEyes.Sample.Replay`.
+
+## Quick Start
+
+### Installation — Recording
+
+```csharp
+using KeenEyes;
+using KeenEyes.Generated;
+using KeenEyes.Replay;
+
+using var world = new World();
+
+// ReplayPlugin needs a component serializer to build world snapshots.
+// The source generator produces a `ComponentSerializer` with a singleton `Instance`.
+var replayOptions = new ReplayOptions
+{
+    SnapshotInterval = TimeSpan.FromSeconds(0.5),
+    RecordSystemEvents = true,
+    RecordEntityEvents = true,
+    RecordComponentEvents = true
+};
+
+world.InstallPlugin(new ReplayPlugin(ComponentSerializer.Instance, replayOptions));
+
+// Get the recorder through the world's extension API
+var recorder = world.GetExtension<ReplayRecorder>();
+
+recorder.StartRecording("Tutorial Playthrough");
+
+for (int frame = 0; frame < 60; frame++)
+{
+    world.Update(1f / 60f); // frame boundaries are detected automatically
+}
+
+var replayData = recorder.StopRecording();
+Console.WriteLine($"Recorded {replayData!.FrameCount} frames over {replayData.Duration.TotalSeconds:F2}s");
+```
+
+`ReplayPlugin` requires a concrete `World` (not a mock `IWorld`) and an `ISystemHookCapability` on the plugin context, both of which are present on a normal `World`. On install it registers an internal `ReplayFrameEndSystem` at `SystemPhase.Update` with order `int.MaxValue`, so it always runs after your own systems and can reliably close out the frame.
+
+### Installation — Playback
+
+```csharp
+using KeenEyes.Replay;
+
+using var world = new World();
+world.InstallPlugin(new ReplayPlaybackPlugin());
+
+var player = world.GetExtension<ReplayPlayer>();
+player.LoadReplay("recording.kreplay");
+player.Play();
+
+while (player.State == PlaybackState.Playing)
+{
+    player.Update(deltaTime);
+
+    var frame = player.GetCurrentFrame();
+    // ... inspect frame.Events / frame.InputEvents ...
+}
+```
+
+`ReplayPlayer` can also be constructed and used standalone (without any plugin or `World`) — it is a pure playback engine with no ECS dependency of its own.
+
+## Core Concepts
+
+### ReplayOptions
+
+`ReplayOptions` is an immutable record passed to `ReplayPlugin` that controls what gets recorded:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `SnapshotInterval` | 1 second | How often a full `WorldSnapshot` is captured for fast seeking. `TimeSpan.Zero` disables automatic snapshots. |
+| `RecordSystemEvents` | `true` | Records `SystemStart`/`SystemEnd` events for each system execution. |
+| `RecordEntityEvents` | `true` | Records `EntityCreated`/`EntityDestroyed` events. |
+| `RecordComponentEvents` | `true` | Records `ComponentAdded`/`ComponentRemoved`/`ComponentChanged` events. |
+| `SystemEventPhase` | `null` | Optional `SystemPhase` filter — when set, only that phase's systems are recorded. |
+| `MaxFrames` / `MaxDuration` | `null` | Automatic recording limits. |
+| `UseRingBuffer` | `false` | When combined with `MaxFrames`, overwrites the oldest frame instead of stopping — ideal for "last N seconds before a crash" buffers. |
+| `DefaultRecordingName` | `null` | Fallback name used when `StartRecording` is called without one. |
+| `RecordChecksums` | `false` | Calculates a `WorldChecksum` per frame/snapshot for desync detection (~1ms/frame cost). |
+
+```csharp
+var crashOptions = new ReplayOptions
+{
+    SnapshotInterval = TimeSpan.FromSeconds(1),
+    MaxFrames = 30,
+    UseRingBuffer = true,
+    RecordSystemEvents = false
+};
+
+var crashPlugin = new ReplayPlugin(ComponentSerializer.Instance, crashOptions);
+crashWorld.InstallPlugin(crashPlugin);
+```
+
+### ReplayRecorder
+
+`ReplayRecorder` is the extension installed by `ReplayPlugin`. Beyond `StartRecording`/`StopRecording`/`CancelRecording`, it exposes:
+
+- `RecordEvent(ReplayEvent)` and `RecordCustomEvent(string customType, IReadOnlyDictionary<string, object>? data = null)` for application-defined events.
+- `CaptureSnapshot()` to force an out-of-band snapshot (e.g. on a significant game event) in addition to the automatic interval.
+- `IsRecording`, `CurrentFrameNumber`, `ElapsedTime`, `RecordedFrameCount`, `SnapshotCount` for status reporting.
+- The `IInputRecorder` interface (`RecordKeyDown`, `RecordMouseMove`, `RecordGamepadAxis`, `RecordCustomInput<T>`, etc.) for capturing per-frame input alongside world events.
+
+```csharp
+recorder.RecordCustomEvent("PlayerShot", new Dictionary<string, object>
+{
+    ["projectileId"] = projectile.Id,
+    ["fromX"] = playerPos.X,
+    ["fromY"] = playerPos.Y
+});
+
+recorder.RecordKeyDown("Space");
+```
+
+### ReplayData, ReplayFrame, and ReplayEvent
+
+`StopRecording()` returns a `ReplayData` record — the root container for a recording:
+
+- `Frames`: an `IReadOnlyList<ReplayFrame>`, each with `FrameNumber`, `DeltaTime`, `ElapsedTime`, `Events`, `InputEvents`, an optional `PrecedingSnapshotIndex`, and an optional `Checksum`.
+- `Snapshots`: an `IReadOnlyList<SnapshotMarker>`, each pairing a `FrameNumber`/`ElapsedTime` with a full `WorldSnapshot` (and optional `Checksum`) for restoration.
+- `Name`, `RecordingStarted`, `RecordingEnded`, `Duration`, `FrameCount`, `Metadata`, and the computed `AverageFrameRate`.
+
+Each `ReplayEvent` has a `Type` (`ReplayEventType`: `Custom`, `FrameStart`, `FrameEnd`, `SystemStart`, `SystemEnd`, `EntityCreated`, `EntityDestroyed`, `ComponentAdded`, `ComponentRemoved`, `ComponentChanged`, `Snapshot`), a `Timestamp` relative to the frame start, and optional `EntityId`/`SystemTypeName`/`ComponentTypeName`/`CustomType`/`Data` depending on the type.
+
+```csharp
+var eventCounts = new Dictionary<ReplayEventType, int>();
+foreach (var frame in replayData.Frames)
+{
+    foreach (var evt in frame.Events)
+    {
+        eventCounts.TryGetValue(evt.Type, out var count);
+        eventCounts[evt.Type] = count + 1;
+    }
+}
+```
+
+### Saving and loading — ReplayFileFormat
+
+`ReplayFileFormat` reads and writes the `.kreplay` container: a header (magic bytes `"KRPL"`, version, flags), JSON-encoded `ReplayFileInfo` metadata, compressed `ReplayData`, and an optional CRC32 checksum.
+
+```csharp
+using KeenEyes.Replay;
+
+// Save
+ReplayFileFormat.WriteToFile("replay_demo.kreplay", replayData);
+
+// Compare compression modes
+var noCompression = ReplayFileFormat.Write(replayData, new ReplayFileOptions { Compression = CompressionMode.None });
+var gzip = ReplayFileFormat.Write(replayData, new ReplayFileOptions { Compression = CompressionMode.GZip });
+var brotli = ReplayFileFormat.Write(replayData, new ReplayFileOptions { Compression = CompressionMode.Brotli });
+
+// Read just the metadata (fast — doesn't decompress/deserialize frame data)
+var info = ReplayFileFormat.ReadMetadataFromFile("replay_demo.kreplay");
+Console.WriteLine($"{info.Name}: {info.FrameCount} frames, {info.CompressionRatio:P1} of original size");
+
+// Read the full replay
+var (fileInfo, loadedData) = ReplayFileFormat.ReadFromFile("replay_demo.kreplay");
+```
+
+`ReplayFileOptions` controls `Compression` (`CompressionMode.None`/`GZip`/`Brotli`, default `GZip`), `CompressionLevel`, and `IncludeChecksum` (default `true`).
+
+### ReplayPlayer
+
+`ReplayPlayer` (installed as an extension by `ReplayPlaybackPlugin`, or constructed directly) loads a replay via `LoadReplay(string path, bool validateChecksum = true)`, `LoadReplay(Stream, bool)`, `LoadReplay(byte[], bool)`, or `LoadReplay(ReplayData)`, then exposes:
+
+- Transport controls: `Play()`, `Pause()`, `Stop()`, `Step(int frames = 1)`.
+- Timeline navigation: `SeekToFrame(int)`, `SeekToTime(TimeSpan)`, `GetNearestSnapshot(int targetFrame)` (binary search for the nearest preceding `SnapshotMarker`).
+- Status: `State` (`PlaybackState.Stopped`/`Playing`/`Paused`), `CurrentFrame`, `TotalFrames`, `CurrentTime`, `TotalDuration`, `IsLoaded`, `LoadedReplay`, `FileInfo`.
+- `PlaybackSpeed` — a `float` clamped to `PlaybackSpeeds.MinSpeed`..`PlaybackSpeeds.MaxSpeed` (0.25x–4x); `PlaybackSpeeds` also defines `QuarterSpeed`, `HalfSpeed`, `NormalSpeed`, `DoubleSpeed`, `QuadrupleSpeed` constants.
+- Events: `PlaybackStarted`, `PlaybackPaused`, `PlaybackStopped`, `PlaybackEnded`, `FrameChanged`, `DesyncDetected`.
+
+`Update(float deltaTime)` accumulates time scaled by `PlaybackSpeed` and advances `CurrentFrame` accordingly, firing `FrameChanged` for each frame that advances and `PlaybackEnded` (transitioning to `PlaybackState.Stopped`) when the replay completes.
+
+```csharp
+var player = new ReplayPlayer();
+player.LoadReplay("recording.kreplay");
+player.PlaybackSpeed = PlaybackSpeeds.HalfSpeed;
+
+player.FrameChanged += frame => Console.WriteLine($"Now at frame {frame}");
+player.PlaybackEnded += () => Console.WriteLine("Replay finished");
+
+player.Play();
+```
+
+### Replaying input
+
+Register handlers with `RegisterInputHandler(InputEventType, Action<InputEvent>)` for built-in input types, or `RegisterInputHandler<T>(string customType, Action<T> handler)` for `InputEventType.Custom` events, then call `ApplyInputFrame()` after each `Update` that advances a frame:
+
+```csharp
+player.RegisterInputHandler(InputEventType.KeyDown, input =>
+    inputSystem.SimulateKeyDown(input.Key));
+
+player.Play();
+
+while (player.State == PlaybackState.Playing)
+{
+    if (player.Update(deltaTime))
+    {
+        player.ApplyInputFrame();
+    }
+}
+```
+
+### Desync detection
+
+When `ReplayOptions.RecordChecksums` was enabled during recording, `WorldChecksum.Calculate(World, IComponentSerializer)` (an FNV-1a hash over entity IDs/versions, component data, and singletons in deterministic order) is stored per frame and snapshot. During playback, call `player.SetValidationContext(world, serializer)` and either poll `player.ValidateCurrentFrame()` or set `player.AutoValidate = true` to have `Update` validate automatically. A mismatch raises `DesyncDetected` with a `ReplayDesyncException` carrying `Frame`, `ExpectedChecksum`, and `ActualChecksum`.
+
+```csharp
+player.SetValidationContext(world, ComponentSerializer.Instance);
+player.AutoValidate = true;
+player.DesyncDetected += ex =>
+    Console.WriteLine($"Desync at frame {ex.Frame}: expected 0x{ex.ExpectedChecksum:X8}, got 0x{ex.ActualChecksum:X8}");
+```
+
+## Ghost Replays
+
+`KeenEyes.Replay.Ghost` extracts a lightweight `GhostData` (just position/rotation/scale per frame, orders of magnitude smaller than a full `ReplayData`) from an existing recording using `GhostExtractor.ExtractGhost(ReplayData replay, string entityName)`. Ghosts are saved/loaded with `GhostFileFormat` (`.keghost` files) and played back independently with `GhostPlayer`, which supports four `GhostSyncMode` values (`TimeSynced`, `FrameSynced`, `DistanceSynced`, `Independent`) for racing-ghost style comparisons against live gameplay. `GhostManager` coordinates several simultaneous ghosts (e.g. "Personal Best" and "World Record") for rendering.
+
+```csharp
+using KeenEyes.Replay.Ghost;
+
+var extractor = new GhostExtractor();
+var ghostData = extractor.ExtractGhost(replayData, "Player");
+
+if (ghostData is not null)
+{
+    GhostFileFormat.WriteToFile("personal_best.keghost", ghostData);
+}
+
+using var ghostPlayer = new GhostPlayer();
+ghostPlayer.Load(ghostData!);
+ghostPlayer.SyncMode = GhostSyncMode.TimeSynced;
+ghostPlayer.Play();
+```
+
+## Performance
+
+- Recording has effectively zero overhead when `IsRecording` is `false` — the plugin's system hooks and event subscriptions short-circuit immediately.
+- `WorldChecksum.Calculate` targets sub-millisecond performance for typical world sizes; enabling `RecordChecksums` (recording) or `AutoValidate` (playback) adds roughly 1ms per frame, so enable it for determinism testing rather than always-on production recording.
+- `ReplayOptions.SnapshotInterval` trades file size against seek speed: more frequent snapshots make `SeekToFrame`/`SeekToTime` cheaper (less forward replay needed after restoring the nearest snapshot) at the cost of a larger `.kreplay` file.
+- `ReplayFileOptions.Compression` (`GZip` vs `Brotli`) trades save/load speed against file size; `CompressionMode.None` is useful for debugging the raw JSON payload.
+
+## Next Steps
+
+- [Plugins Guide](plugins.md) - How `IWorldPlugin`, `IPluginContext`, and the world extension API used by `ReplayPlugin`/`ReplayPlaybackPlugin` work
+- [Systems Guide](systems.md) - System phases and ordering, relevant to the internal `ReplayFrameEndSystem` and `SystemEventPhase` filtering
+- [Serialization Guide](serialization.md) - `IComponentSerializer`, `WorldSnapshot`, and `SnapshotManager`, which underpin replay snapshots
+- `samples/KeenEyes.Sample.Replay` - Runnable sample covering recording, custom events, ring-buffer crash replay, file save/load, and snapshot-based seeking
+- [ADR-014: Replay Playback Runtime and Editor Integration](adr/014-replay-playback-runtime-editor-integration.md) - Original design document (note: proposed/aspirational; some API shapes in the ADR differ from the shipped implementation described above)

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -1,0 +1,231 @@
+# Shaders & KESL
+
+The `KeenEyes.Shaders` library provides the GPU abstractions (devices, buffers, command buffers, compiled shaders) used by GPU compute and rendering code. Alongside it, `KeenEyes.Shaders.Compiler` implements **KESL** (KeenEyes Shader Language) — a small, ECS-aware shader language that transpiles to GLSL/HLSL and generates matching C# bindings — and `KeenEyes.Shaders.Generator` is a Roslyn incremental source generator that runs the compiler automatically over `.kesl` files at build time.
+
+## Overview
+
+KESL lets you describe a compute, vertex, fragment, or geometry shader once and get three outputs for free:
+
+1. **Shader source** for one or more `ShaderBackend`s (GLSL and HLSL are implemented today; `ShaderBackend` also defines `MSL` and `SPIRV` values for future backends).
+2. **C# bindings** — a generated partial class that describes the shader's inputs, outputs, and uniforms.
+3. **Diagnostics** with source spans and "did you mean?" suggestions when a `.kesl` file fails to compile.
+
+Unlike most KeenEyes subsystems, there is no `IWorldPlugin` for shaders — `KeenEyes.Shaders` is a standalone abstraction library. You supply an `IGpuDevice` implementation from your graphics backend and use it directly, or implement `IGpuComputeSystem`/`IWorldGpuComputeSystem` yourself (by hand or via KESL) to run compute work against a world's entities.
+
+The three pieces:
+
+| Project | Role |
+|---------|------|
+| `KeenEyes.Shaders` | Runtime abstractions: `IGpuDevice`, `GpuBuffer<T>`, `GpuCommandBuffer`, `CompiledShader`, `IGpuComputeSystem`, `IGpuVertexShader`, `IGpuFragmentShader`, descriptor types, and shader hot-reload support. |
+| `KeenEyes.Shaders.Compiler` | The KESL compiler: lexer, parser, AST, GLSL/HLSL/C# code generators, and diagnostics. Exposed through `KeslCompiler`. |
+| `KeenEyes.Shaders.Generator` | An `IIncrementalGenerator` (`KeslSourceGenerator`) that compiles `.kesl` files marked as `AdditionalFiles` and emits the generated C# directly into your build. |
+
+## Quick Start
+
+### Writing a KESL compute shader
+
+A `.kesl` compute shader declares which components it needs via a `query` block, any scalar parameters via `params`, and its per-entity logic via `execute()`:
+
+```
+// physics.kesl
+
+compute UpdatePhysics {
+    query {
+        write Position
+        read Velocity
+        without Frozen
+    }
+
+    params {
+        deltaTime: float
+    }
+
+    execute() {
+        Position.x += Velocity.x * deltaTime;
+        Position.y += Velocity.y * deltaTime;
+        Position.z += Velocity.z * deltaTime;
+    }
+}
+```
+
+`write`, `read`, and `optional` map to the `ComponentAccess` values on a `QueryDescriptor`'s `ComponentBinding`s — `write` components are uploaded and downloaded, `read` components are uploaded only, and `optional` components are included when present. `without` is tracked separately as an exclusion filter (`QueryDescriptor.WithoutComponents`) and excludes entities that have the named component.
+
+### Enabling shader compilation
+
+If your project uses `KeenEyes.Sdk`, `.kesl` files are picked up automatically: the SDK adds a reference to `KeenEyes.Shaders.Generator` as an analyzer and includes `**/*.kesl` as `AdditionalFiles` whenever the `IncludeKeenEyesShaders` MSBuild property is `true` (the default). No extra project configuration is needed — just add the `.kesl` file to your project.
+
+Outside the SDK, wire it up manually:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="KeenEyes.Shaders.Generator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <AdditionalFiles Include="**/*.kesl" />
+</ItemGroup>
+```
+
+### Compiling KESL directly
+
+You can also drive the compiler yourself with `KeslCompiler`, which is useful for tooling, tests, or a custom build step:
+
+```csharp
+using KeenEyes.Shaders.Compiler;
+
+var compiler = new KeslCompiler { Namespace = "MyGame.Shaders" };
+var output = compiler.CompileAndGenerate(source, "physics.kesl");
+
+if (output.HasErrors)
+{
+    foreach (var diagnostic in output.Diagnostics)
+    {
+        Console.WriteLine(diagnostic.ToMsBuildFormat());
+    }
+}
+else
+{
+    foreach (var shader in output.Shaders)
+    {
+        // shader.GlslCode, shader.HlslCode, and shader.CSharpCode
+        // are the generated outputs for shader.ShaderName
+    }
+}
+```
+
+`CompileAndGenerate` handles `compute`, `vertex`, `fragment`, `geometry`, and `pipeline` declarations in a single source file and returns a `CompilationOutput` containing one `ShaderOutput` per declared shader. Lower-level entry points (`KeslCompiler.Compile`, `KeslCompiler.GenerateGlsl`, `GenerateHlsl`, `GenerateShader`) are available if you already have a parsed AST and only need one output.
+
+## Core Concepts
+
+### GPU device and buffers
+
+`IGpuDevice` is the main runtime entry point: it compiles shader source, allocates typed `GpuBuffer<T>` instances, and creates `GpuCommandBuffer`s for recording GPU work.
+
+```csharp
+using KeenEyes.Shaders;
+
+// device is an IGpuDevice implementation supplied by your graphics backend.
+IGpuDevice device = ...;
+
+var positions = device.CreateBuffer<float>(entityCount, BufferUsage.ShaderReadWrite);
+var shader = device.CompileComputeShader(glslSource, ShaderBackend.GLSL, "UpdatePhysics");
+
+using var cmd = device.CreateCommandBuffer();
+cmd.Begin();
+cmd.BindComputeShader(shader);
+cmd.BindBuffer(0, positions);
+cmd.SetUniform("deltaTime", 0.016f);
+cmd.DispatchAuto(shader, entityCount);
+cmd.End();
+
+device.Submit(cmd);
+device.WaitIdle();
+```
+
+`GpuBuffer<T>.Upload`/`Download` move data between CPU and GPU; `DownloadAll()` is a convenience that allocates and returns a fresh array. `CompiledShader.CalculateDispatchX(itemCount)` (used internally by `GpuCommandBuffer.DispatchAuto`) and `CalculateDispatch2D(width, height)` compute the workgroup counts needed to cover a given item count from the shader's `LocalSizeX`/`LocalSizeY`/`LocalSizeZ`.
+
+### Query descriptors
+
+`QueryDescriptor` describes which components a compute shader reads, writes, treats as optional, or excludes — the runtime representation of a KESL `query` block. Build one with `QueryDescriptorBuilder`:
+
+```csharp
+using KeenEyes.Shaders;
+
+var query = QueryDescriptor.Builder("UpdatePhysics")
+    .Write("Position")
+    .Read("Velocity")
+    .Without("Frozen")
+    .Build();
+
+var binding = query.GetBinding("Position"); // ComponentBinding? with a GPU binding index
+bool required = query.IsRequired("Velocity");
+```
+
+Bindings are assigned GPU binding indices in the order they're added (`Read`, then `Write`, then `Optional`), and `QueryDescriptor.AllBindings` exposes them sorted by binding index for buffer setup.
+
+### Compute systems
+
+`IGpuComputeSystem` is the interface each generated (or hand-written) compute shader class implements. It exposes the shader's `Query`, target `Backend`, and lifecycle (`Initialize(IGpuDevice)`, `GetShaderSource()`, `IsInitialized`/`IsDisposed`).
+
+`IWorldGpuComputeSystem` extends this with world-aware execution — `Execute(IGpuDevice, IWorld, float deltaTime)` and an async `ExecuteAsync` overload. The `IWorld` referenced here is a minimal, `KeenEyes.Shaders`-local interface exposing only `EntityCount`, defined to avoid a compile-time dependency from `KeenEyes.Shaders` on `KeenEyes.Core`.
+
+### Vertex and fragment shaders
+
+Compiled vertex and fragment shaders implement `IGpuVertexShader` and `IGpuFragmentShader` respectively. Each exposes its name, an `InputLayoutDescriptor`/`IReadOnlyList<InputAttribute>` describing its I/O, its `IReadOnlyList<UniformDescriptor>`, and `GetShaderSource(ShaderBackend)`:
+
+```csharp
+public sealed partial class TransformVertexShader : IGpuVertexShader
+{
+    public string Name => "TransformVertex";
+
+    public InputLayoutDescriptor InputLayout { get; } = new([
+        new InputAttribute("position", AttributeType.Float3, 0),
+        new InputAttribute("normal", AttributeType.Float3, 1),
+        new InputAttribute("texCoord", AttributeType.Float2, 2)
+    ]);
+
+    public IReadOnlyList<UniformDescriptor> Uniforms { get; } = [
+        new UniformDescriptor("model", UniformType.Matrix4),
+        new UniformDescriptor("view", UniformType.Matrix4),
+        new UniformDescriptor("projection", UniformType.Matrix4)
+    ];
+
+    public IReadOnlyList<InputAttribute> Outputs { get; } = [];
+
+    public string GetShaderSource(ShaderBackend backend) => backend switch
+    {
+        ShaderBackend.GLSL => GlslSource,
+        ShaderBackend.HLSL => HlslSource,
+        _ => throw new NotSupportedException($"Backend {backend} not supported")
+    };
+}
+```
+
+`InputLayoutDescriptor` computes a vertex `Stride` from its attributes and can look attributes up `GetAttribute(int location)` / `GetAttribute(string name)` / `GetOffset(int location)`. `UniformDescriptor` similarly reports `ElementSizeInBytes`, `TotalSizeInBytes` (accounting for `ArraySize`), and whether it `IsSampler`.
+
+### Diagnostics
+
+Compiler errors carry a `DiagnosticSeverity`, a `KESLxxx` error code, and a `SourceSpan`. `DiagnosticFormatter` renders them with the offending source line underlined and an optional hint and "did you mean?" suggestion:
+
+```
+error[KESL202] at input:1:8:
+  Expected 'component' or 'compute' declaration
+
+  invalid_keyword MyShader {
+         ^
+
+  Hint: Valid declarations are 'component' or 'compute'.
+```
+
+`DiagnosticFormatter.FormatCompact(Diagnostic)` (equivalently `diagnostic.ToMsBuildFormat()`) produces a single-line `file(line,column): severity code: message` form suitable for build output.
+
+### Hot reload
+
+`KeenEyes.Shaders.HotReload` provides a small runtime registry for reloading shaders during development. Implement `IHotReloadable` (`Name`, `SourcePath`, `Reload(newSource, backend)`) on your shader classes, register them, and point a `KeslFileWatcher` at your shader directory:
+
+```csharp
+using KeenEyes.Shaders.HotReload;
+
+var registry = new ShaderRegistry();
+registry.Register(myShader); // myShader : IHotReloadable
+registry.OnShaderUpdated += (name, shader) => Console.WriteLine($"{name} reloaded");
+
+using var watcher = new KeslFileWatcher(registry, ShaderBackend.GLSL);
+watcher.OnShaderRecompiled += (path, result) => Console.WriteLine($"Recompiled {path}");
+watcher.OnCompilationError += (path, errors) => Console.WriteLine($"{path}: {string.Join(", ", errors)}");
+watcher.Watch("Assets/Shaders");
+```
+
+`KeslFileWatcher` watches `*.kesl` files under the given directory (recursively by default) and calls `ShaderRegistry.Update` on successful recompilation, which in turn invokes `IHotReloadable.Reload` on the matching registered shader.
+
+## Performance
+
+- Prefer batch uploads/downloads over frequent small transfers when working with `GpuBuffer<T>`; use `BufferUsage.DynamicUpload` for buffers that change every frame and `BufferUsage.Static` for buffers that rarely change.
+- `IGpuDevice.WaitIdle()` is a hard synchronization point that blocks until all submitted GPU work completes — use it sparingly, and prefer `IGpuFence` for finer-grained synchronization when you only need to know that specific work has finished.
+- `GpuCommandBuffer.DispatchAuto` and `CompiledShader.CalculateDispatchX`/`CalculateDispatch2D` compute workgroup counts from the shader's declared local size, so dispatch sizing stays correct if a shader's `numthreads`/`local_size` changes.
+
+## Next Steps
+
+- [ADR-009: KESL Shader Language](adr/009-kesl-shader-language.md) - Original design document
+- [Shader Language Design](research/shader-language.md) - Research document on the KESL language
+- [Shader Management Design](research/shader-management.md) - Research document on shader lifecycle and hot-reload
+- [Plugins Guide](plugins.md) - How `IWorldPlugin` subsystems are installed, for contrast with this standalone library
+- [Graphics Guide](graphics.md) - The graphics abstractions that shaders render into
+- [SDK Documentation](sdk.md) - How `KeenEyes.Sdk` wires up `.kesl` files automatically

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -221,6 +221,40 @@ watcher.Watch("Assets/Shaders");
 - `IGpuDevice.WaitIdle()` is a hard synchronization point that blocks until all submitted GPU work completes — use it sparingly, and prefer `IGpuFence` for finer-grained synchronization when you only need to know that specific work has finished.
 - `GpuCommandBuffer.DispatchAuto` and `CompiledShader.CalculateDispatchX`/`CalculateDispatch2D` compute workgroup counts from the shader's declared local size, so dispatch sizing stays correct if a shader's `numthreads`/`local_size` changes.
 
+## Compiler internals
+
+This section is for contributors working on `KeenEyes.Shaders.Compiler` itself. If you're only consuming KESL from a game or plugin project, the sections above are all you need.
+
+`KeslCompiler` orchestrates a straightforward, linear pipeline: **lexer → parser → AST → generators**. Each stage is a separate, independently testable class with no shared mutable state between compilations — a new `Lexer`/`Parser` pair is created per call, so nothing carries over between files.
+
+### Lexing
+
+`Lexer` (`Lexing/Lexer.cs`) turns raw KESL source text into a flat `List<Token>`. `Tokenize()` repeatedly calls `NextToken()` until it produces a `TokenKind.EndOfFile` token. Each `Token` carries its `TokenKind`, raw text, and a `SourceLocation` (file, line, column) used later for diagnostics.
+
+The lexer recognizes KESL's keywords (`component`, `compute`, `vertex`, `fragment`, `geometry`, `pipeline`, the query modifiers `read`/`write`/`optional`/`without`, primitive types like `float3` and `mat4`, and so on) via a static `Dictionary<string, TokenKind>` lookup applied to scanned identifiers — anything not in that table becomes a plain `TokenKind.Identifier`. It also handles `//` line comments and `/* */` block comments, integer and float literals (including exponents and an `f`/`F` suffix), and multi-character operators such as `==`, `!=`, `&&`, and `+=`. Any character the lexer doesn't recognize produces a `TokenKind.Error` token rather than throwing; `KeslCompiler.Compile` scans the token list for `TokenKind.Error` up front and turns each into a `Diagnostic` with the `KeslErrorCodes.UnexpectedCharacter` code before parsing ever starts.
+
+### Parsing
+
+`Parser` (`Parsing/Parser.cs`) is a hand-written recursive-descent parser over the token list produced by the lexer. `Parse()` loops over top-level declarations, dispatching on the current token's `TokenKind` to one of `ParseComponentDeclaration`, `ParseComputeDeclaration`, `ParseVertexDeclaration`, `ParseFragmentDeclaration`, `ParseGeometryDeclaration`, or `ParsePipelineDeclaration`. Each of those methods recursively parses the nested blocks specific to that declaration kind — `query`/`params`/`execute` for compute shaders, `input`/`output`/`textures`/`samplers`/`layout` for vertex, fragment, and geometry shaders.
+
+Parse errors are represented by an internal `ParseException`. When a parse method can't consume the token it expects, it records a `Diagnostic` (via the parser's `Error`/`Consume` helpers) and throws `ParseException` to unwind out of the current declaration. `Parse()` catches this at the top level and calls `Synchronize()` to skip forward to a likely declaration boundary, so a single malformed declaration doesn't abort the entire file — the parser keeps collecting diagnostics for the rest of the source. Several error paths (`ErrorExpectedDeclaration`, `ErrorExpectedBindingMode`, `ErrorExpectedTypeName`, `ErrorExpectedInputTopology`, and similar) also call `SuggestionEngine.GetSuggestions` against a fixed candidate list (declaration keywords, binding modes, type names, topology names) to populate the "did you mean?" suggestions rendered by `DiagnosticFormatter`.
+
+### AST
+
+The parser's output is a `SourceFile`, a `Declaration` list of `ComponentDeclaration`, `ComputeDeclaration`, `VertexDeclaration`, `FragmentDeclaration`, `GeometryDeclaration`, and `PipelineDeclaration` nodes (`Parsing/Ast/AstNode.cs`). Every AST node is an immutable `record` deriving from the abstract `AstNode(SourceLocation Location)`, so nodes are cheap to construct and safe to share across the code generators that read them. Nested blocks are their own records too — `QueryBlock`/`QueryBinding`, `ParamsBlock`/`ParamDeclaration`, `InputBlock`/`OutputBlock`/`AttributeDeclaration`, `TexturesBlock`/`SamplersBlock`, `GeometryLayoutBlock`, and `ExecuteBlock`, whose `Body` is a list of `Statement` nodes (assignments, `if`/`for`, etc. — defined in `Parsing/Ast/Statements.cs` and `Expressions.cs`). This AST is the sole hand-off point between parsing and code generation; none of the generators re-consult tokens or source text.
+
+### Code generators
+
+`GlslGenerator` and `HlslGenerator` both implement `IShaderGenerator`, which defines one `Generate` overload per declaration type (`ComputeDeclaration`, `VertexDeclaration`, `FragmentDeclaration`, `GeometryDeclaration`) plus a `Backend` and `FileExtension`. Both walk the same AST shape but emit different textual conventions for the same concepts — for example, a `write` query binding becomes an `std430` GLSL buffer under `GlslGenerator` but a `RWStructuredBuffer`/`register(u#)` declaration under `HlslGenerator`, and `mat4` becomes GLSL's `mat4` versus HLSL's `float4x4`. Each generator builds its output into an internal `StringBuilder`, tracking its own indentation and buffer/resource binding-index counters (`_bindingIndex` in `GlslGenerator`; separate `srvIndex`/`uavIndex` counters for read-only vs. read-write resources in `HlslGenerator`) as it walks the query bindings and execute-block statements.
+
+`CSharpBindingGenerator` is a third generator with the same per-declaration-type `Generate` overloads (plus one for `PipelineDeclaration`, which the shader-language generators don't handle) but no `IShaderGenerator` conformance, since it emits C# rather than shader source. It produces the partial binding classes described in the SDK integration above — one per shader — using its own `Namespace` property to control the generated namespace.
+
+### How `KeslCompiler` ties it together
+
+`KeslCompiler.Compile` runs the lexer, checks for `TokenKind.Error` tokens, then runs the parser and merges its diagnostics, returning a `CompilationResult` (a parsed `SourceFile?` plus the accumulated `Diagnostics`). The static `GenerateGlsl`/`GenerateHlsl`/`GenerateShader` methods and the instance `GenerateCSharp` methods are thin overload sets that construct the matching generator and call `Generate` on a single AST node — `GenerateShader(declaration, backend)` is the one that switches on `ShaderBackend` to pick `GlslGenerator` or `HlslGenerator` at runtime.
+
+`CompileAndGenerate` is the all-in-one entry point: it calls `Compile`, and if there are no errors, iterates every top-level `Declaration` in the `SourceFile`, running the appropriate GLSL, HLSL, and C# generators for each and collecting the results into a `ShaderOutput` (name plus each generated file's name and contents) per shader. `PipelineDeclaration`s are handled specially — a pipeline itself only produces a C# binding (no shader source), but `GenerateInlineShaderOutputs` recurses into any `PipelineStage.InlineShader` (an inline `vertex`/`geometry`/`fragment` block defined directly inside the `pipeline` rather than referenced by name) to emit outputs for those stages too. The final `CompilationOutput` is what `KeslSourceGenerator` (in `KeenEyes.Shaders.Generator`) writes into the build as generated files, and what `KeslCompiler.CompileAndGenerate`'s direct callers inspect via `HasErrors`/`Diagnostics` when driving the compiler by hand.
+
 ## Next Steps
 
 - [ADR-009: KESL Shader Language](adr/009-kesl-shader-language.md) - Original design document

--- a/docs/testbridge.md
+++ b/docs/testbridge.md
@@ -80,6 +80,7 @@ The TestBridge architecture consists of multiple layers, each with a specific re
 | `KeenEyes.TestBridge.Abstractions` | Interfaces and data types | Reference for custom implementations |
 | `KeenEyes.TestBridge` | Core implementation | In-process testing, game integration |
 | `KeenEyes.TestBridge.Ipc` | IPC layer | External tool connections |
+| `KeenEyes.TestBridge.Client` | `TestBridgeClient` for external .NET processes | Connecting to a running game from a separate test process |
 | `KeenEyes.Mcp.TestBridge` | MCP server | AI tool integration |
 
 ## Integration Guide
@@ -1320,6 +1321,62 @@ Pre-built prompts for common workflows:
 1. Requires graphics context (not headless)
 2. Must be called from render thread
 3. Check for OpenGL/Vulkan context errors
+
+## Connecting from an External .NET Process
+
+The layers above cover in-process usage (`TestBridgePlugin` + `ITestBridge`) and the raw
+IPC/MCP protocol. For a .NET test process or tool that wants to talk to a running game
+without hand-rolling the IPC protocol, add the `KeenEyes.TestBridge.Client` package and use
+`TestBridgeClient`.
+
+`TestBridgeClient` implements `ITestBridge` over the same named-pipe/TCP transport used by
+the MCP server, so the exact same calling code (`client.Input`, `client.State`, etc.) works
+whether you're in-process or out-of-process.
+
+```csharp
+using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.Client;
+
+// Connect to a running game's TestBridge pipe
+await using var client = new TestBridgeClient(new IpcOptions
+{
+    PipeName = "MyGame.TestBridge",
+    TransportMode = IpcTransportMode.NamedPipe
+});
+
+await client.ConnectAsync();
+
+// Same controller-based API as the in-process bridge
+var entity = await client.State.GetEntityByNameAsync("Player");
+var stats = await client.State.GetWorldStatsAsync();
+
+await client.Input.KeyPressAsync(Key.Space);
+
+await client.DisconnectAsync();
+```
+
+### `TestBridgeClient` Members
+
+| Member | Description |
+|--------|-------------|
+| `TestBridgeClient(IpcOptions? options = null)` | Constructs a client for the given transport (`IpcTransportMode.NamedPipe` or `IpcTransportMode.Tcp`); defaults to named pipes on `KeenEyes.TestBridge` if `options` is omitted. |
+| `ConnectAsync(CancellationToken cancellationToken = default)` | Opens the transport connection to the server. |
+| `DisconnectAsync()` | Closes the transport connection. |
+| `IsConnected` | Whether the transport is currently connected. |
+| `Input`, `State`, `Capture`, `Logs`, `Window`, `Time`, `Systems`, `Mutation`, `Profile`, `Snapshot`, `AI`, `Replay` | The same controller interfaces (`IInputController`, `IStateController`, etc.) exposed by the in-process bridge, backed by remote IPC calls. |
+| `ExecuteAsync(ITestCommand command, CancellationToken cancellationToken = default)` | Executes a raw `ITestCommand` and returns a `CommandResult`. |
+| `WaitForAsync(...)` | Polls a condition against `State` until it's true or the timeout elapses (overloads for sync and async predicates). |
+| `ConnectionChanged` | Event raised when the connection state changes. |
+
+Two members intentionally throw `NotSupportedException` over IPC, since they require direct
+in-process access to the game:
+
+- `Process` - process management is only available via the in-process bridge.
+- `InputContext` - use the `Input` controller to inject events instead of touching the
+  input context directly.
+
+`TestBridgeClient` implements `IAsyncDisposable` (and `IDisposable`); disposing cancels any
+pending requests and closes the transport.
 
 ## Related Documentation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,7 +24,6 @@ With `KeenEyes.Testing`, you can test in isolation:
 
 ```csharp
 // With KeenEyes.Testing - focused, fast tests
-var mockWorld = new MockWorld();
 var mockContext = new MockPluginContext("Test");
 
 var plugin = new MyPlugin();
@@ -275,23 +274,24 @@ public void MovementSystem_UpdatesPositions()
 }
 ```
 
-### Unit Test with MockWorld
+### Unit Test with TestWorld
+
+Build an isolated world with `TestWorldBuilder`, opting into only the mocks the test needs. `TestWorld.Step()` advances the manual clock and runs one update; the mock renderer records every draw call it received:
 
 ```csharp
 [Fact]
-public void RenderSystem_SkipsInvisibleEntities()
+public void RenderSystem_RecordsDrawCommands()
 {
-    var mockWorld = new MockWorld();
-    var renderer = new MockRenderer();
+    using var test = new TestWorldBuilder()
+        .WithManualTime()
+        .WithMock2DRenderer()
+        .Build();
 
-    // Set up test entity as invisible
-    mockWorld.SetupEntity(entity, visible: false);
+    // Arrange entities in test.World and register your render system here...
 
-    var system = new RenderSystem(renderer);
-    system.Initialize(mockWorld);
-    system.Update(0.016f);
+    test.Step(); // advance one frame at the manual clock's fps
 
-    Assert.Empty(renderer.RenderedEntities);
+    Assert.NotEmpty(test.Mock2DRenderer!.Commands);
 }
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -351,6 +351,218 @@ public void RegisterPrefab_WithDuplicateName_ThrowsArgumentException() { }
 public void Update_WhenDisabled_SkipsExecution() { }
 ```
 
+## Assertion Helpers
+
+`KeenEyes.Testing` provides FluentAssertions-style extension methods that throw `AssertionException` with a descriptive message on failure. They live in the `KeenEyes.Testing` namespace and work against `Entity`, `World`/`IWorld`, `TestWorld`, and component values directly - no assertion library dependency required.
+
+### Entity Assertions
+
+`EntityAssertions` checks alive/dead state, component presence, tags, and predicate matches:
+
+```csharp
+var entity = world.Spawn().With(new Position { X = 10 }).Build();
+
+entity.ShouldBeAlive(world);
+entity.ShouldHaveComponent<Position>(world);
+entity.ShouldNotHaveComponent<Velocity>(world);
+entity.ShouldHaveTag<EnemyTag>(world);
+entity.ShouldHaveComponentMatching<Position>(world, p => p.X > 0);
+```
+
+Overloads accepting a `TestWorld` instead of `World`/`IWorld` are also available, so assertions can chain directly off `TestWorldBuilder.Build()` results.
+
+### Component Assertions
+
+`ComponentAssertions` operates on component struct values directly - useful after pulling a component out with `world.Get<T>()`:
+
+```csharp
+var position = world.Get<Position>(entity);
+
+position.ShouldEqual(new Position { X = 10, Y = 20 });
+position.ShouldMatch(p => p.X >= 0 && p.Y >= 0, "position should be in positive quadrant");
+position.ShouldHaveField(p => p.X, 10);
+position.ShouldHaveFieldInRange(p => p.X, 0f, 100f);
+position.ShouldBeDefault();
+```
+
+`ShouldHaveField` and `ShouldHaveFieldMatching` take an `Expression<Func<T, TField>>` field selector and are reflection-free (AOT-compatible) - the expression tree is compiled once and the field name is only used for the failure message.
+
+### World Assertions
+
+`WorldAssertions` checks entity counts, installed plugins, and query results:
+
+```csharp
+world.ShouldHaveEntityCount(2);
+world.ShouldNotBeEmpty();
+world.ShouldHavePlugin<PhysicsPlugin>();
+world.ShouldNotHavePlugin<RenderingPlugin>();
+world.ShouldContainEntitiesWith<Position, Velocity>();
+world.ShouldContainExactlyWith<EnemyTag>(5);
+```
+
+Every assertion accepts an optional `because` string that is appended to the failure message.
+
+## Snapshot Testing
+
+`KeenEyes.Testing.Snapshots` captures the full state of a world (or a subset of entities) as plain data, then diffs two captures to verify that an operation produced exactly the changes you expect - or none at all.
+
+### Capturing Snapshots
+
+`WorldSnapshot.Create(world)` walks every live entity and records an `EntitySnapshot` per entity (ID, version, name, and a `Dictionary<string, Dictionary<string, object?>>` of component field values, keyed by component type name):
+
+```csharp
+using KeenEyes.Testing.Snapshots;
+
+var before = WorldSnapshot.Create(world);
+world.Update(1.0f);
+var after = WorldSnapshot.Create(world);
+```
+
+An overload, `WorldSnapshot.Create(world, entities)`, captures only the specified entities. `WorldSnapshot` exposes `EntityCount`, `EntityIds`, `GetEntity(id)`, `EntitiesWithComponent<T>()`, and `AllComponentTypes` for inspecting a capture directly.
+
+### Comparing Snapshots
+
+`SnapshotComparer.Compare(expected, actual)` returns a `SnapshotComparison` describing every difference - added/removed entities, version or name changes, added/removed components, and per-field value changes - each as a `SnapshotDifference` with a `DifferenceType` (`EntityAdded`, `ComponentRemoved`, `FieldChanged`, etc.):
+
+```csharp
+var comparison = SnapshotComparer.Compare(before, after);
+
+if (!comparison.AreEqual)
+{
+    Console.WriteLine(comparison.GetReport());
+}
+```
+
+`SnapshotComparer.CompareEntities(expected, actual)` compares two `EntitySnapshot` instances directly when you only care about one entity.
+
+### Snapshot Assertions
+
+`SnapshotAssertions` wraps the comparer in fluent, `AssertionException`-throwing checks:
+
+```csharp
+after.ShouldEqual(before);
+after.ShouldHaveEntityCount(before.EntityCount);
+after.ShouldContainEntity(entity.Id);
+after.ShouldHaveEntitiesWithComponent<Health>();
+
+comparison.ShouldBeEqual();
+comparison.ShouldHaveDifferenceCount(1);
+```
+
+`EntitySnapshot` has its own `ShouldHaveComponent<T>()`, `ShouldNotHaveComponent<T>()`, and `ShouldEqual()` for entity-level checks.
+
+## Recording and Playback
+
+Two recorders capture activity during a test run for later inspection or replay.
+
+### InputRecorder / InputPlayer
+
+`KeenEyes.Testing.Input.InputRecorder` subscribes to an `IInputContext` (keyboard, mouse, gamepad events) and records each event as a timestamped `RecordedInputEvent` (e.g. `RecordedKeyDownEvent`, `RecordedMouseMoveEvent`, `RecordedGamepadAxisEvent`). Pairing it with a `TestClock` synchronizes timestamps to simulation time:
+
+```csharp
+using KeenEyes.Testing.Input;
+
+using var testWorld = new TestWorldBuilder()
+    .WithManualTime()
+    .WithMockInput()
+    .Build();
+
+var recorder = new InputRecorder(testWorld.MockInput!, testWorld.Clock);
+
+recorder.StartRecording(name: "jump-sequence");
+testWorld.MockInput!.SimulateKeyDown(Key.Space);
+testWorld.Step();
+testWorld.MockInput.SimulateKeyUp(Key.Space);
+
+var recording = recorder.StopRecording();
+var json = recording.ToJson(); // or recording.ToBinary()
+```
+
+`InputRecording` can round-trip through `ToJson()`/`FromJson()` or `ToBinary()`/`FromBinary()`, making recorded sequences reusable as fixtures across test runs.
+
+`InputPlayer` plays a loaded `InputRecording` back through a `MockInputContext`, firing each event once the `TestClock` reaches its timestamp:
+
+```csharp
+var player = new InputPlayer(testWorld.MockInput!, testWorld.Clock!);
+
+player.LoadRecording(InputRecording.FromJson(json));
+player.Play();
+
+while (player.IsPlaying)
+{
+    player.Update();
+    testWorld.Step();
+}
+```
+
+`InputPlayer` also supports `Pause()`, `Stop()`, `Seek(positionMs)`, and an `OnPlaybackComplete` event.
+
+### SystemRecorder
+
+`KeenEyes.Testing.Systems.SystemRecorder` attaches to a world's system hooks (`AttachTo(world, phase)`) and records every system execution as a `SystemCall` (system type, name, delta time, and UTC timestamp). `TestWorldBuilder.WithSystemRecording()` wires one up automatically and exposes it via `TestWorld.SystemRecorder`:
+
+```csharp
+using var testWorld = new TestWorldBuilder()
+    .WithSystemRecording()
+    .WithSystem<MovementSystem>()
+    .WithManualTime()
+    .Build();
+
+testWorld.Step();
+
+var recorder = testWorld.SystemRecorder!;
+recorder
+    .ShouldHaveCalledSystem<MovementSystem>()
+    .ShouldHaveCalledSystemTimes<MovementSystem>(1);
+
+Assert.Equal(1, recorder.GetCallCount<MovementSystem>());
+```
+
+`SystemRecorderAssertions` adds `ShouldHaveCalledSystemAtLeast<T>()`, `ShouldNotHaveCalledSystem<T>()`, `ShouldHaveTotalCallCount()`, `ShouldHaveNoCalls()`, and `ShouldHaveAccumulatedDeltaTime<T>()`. `SystemRecorder` itself also exposes `GetCalls<T>()`, `GetLastCall<T>()`, `GetTotalDeltaTime<T>()`, and `Clear()` for direct inspection.
+
+## Test Fixtures
+
+`KeenEyes.Testing.Fixtures` provides ready-made components and entity builders so tests don't need to declare throwaway component types.
+
+### CommonComponents
+
+A set of `[Component]`-generated structs prefixed `Test` (`TestPosition`, `TestPosition3D`, `TestVelocity`, `TestHealth`, `TestDamage`, `TestSpeed`, `TestRotation`, `TestScale`, `TestLifetime`, `TestTeam`, `TestCounter`) plus `[TagComponent]` tags (`PlayerTag`, `EnemyTag`, `ProjectileTag`, `PickupTag`, `DeadTag`, `ActiveTag`, `DisabledTag`, `InvulnerableTag`). Each component has a `Create(...)` factory and most have convenience properties like `TestHealth.Full(max)`, `TestPosition.Zero`, or `TestHealth.Percentage`:
+
+```csharp
+using KeenEyes.Testing.Fixtures;
+
+var entity = world.Spawn()
+    .With(TestPosition.Create(0, 0))
+    .With(TestHealth.Full(100))
+    .WithTag<EnemyTag>()
+    .Build();
+```
+
+### EntityPresets / EntityPresetBuilder
+
+`EntityPresets` provides factory methods - `Player(world)`, `Enemy(world)`, `Projectile(world)`, `Pickup(world)`, `MovingEntity(world)` - that return a fluent `EntityPresetBuilder` pre-populated with sensible defaults built from the `CommonComponents` above:
+
+```csharp
+using var world = new World();
+
+var player = EntityPresets.Player(world)
+    .WithName("Player1")
+    .AtPosition(100, 50)
+    .WithHealth(100)
+    .Build();
+```
+
+`EntityPresetBuilder` supports `WithName`, `AtPosition`, `WithVelocity`, `WithHealth` (single value or current/max pair), `WithDamage`, `WithSpeed`, `WithLifetime`, `OnTeam`, and `WithTag<T>()`, finished with `Build()`.
+
+For batches, `EntityPresets.CreatePlayers(world, count)`, `CreateEnemies(world, count)`, and `CreateProjectiles(world, count)` return a `BatchEntityBuilder` that applies the same modifiers - `WithHealth`, `WithDamage`, `WithSpeed`, `InGrid(columns, spacing)`, `InLine(spacing, horizontal)`, `WithSequentialTeams()`, `WithAlternatingTeams(teamA, teamB)`, or a custom `WithModifier((builder, index) => ...)` - to every entity before calling `Build()`, which returns an `Entity[]`:
+
+```csharp
+var enemies = EntityPresets.CreateEnemies(world, count: 5)
+    .WithHealth(50)
+    .InGrid(columns: 5, spacing: 32f)
+    .Build();
+```
+
 ## Next Steps
 
 - [TestBridge Architecture Guide](testbridge.md) - TestBridge for external tool integration and automated testing

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,144 @@
+# UI Theming
+
+The `KeenEyes.UI.Themes` library adds OS-aware theme detection and automatic style application to the `KeenEyes.UI` system, using contracts defined in `KeenEyes.UI.Themes.Abstractions`.
+
+## Overview
+
+A theme (`ITheme`) bundles a semantic `ColorPalette` with a set of methods that produce a `UIStyle` for each kind of widget (buttons, panels, inputs, menus, modals, scrollbars, tooltips). The `ThemePlugin` registers two built-in themes, "Light" and "Dark", detects the operating system's color scheme on Windows, macOS, and Linux, and can automatically switch between them when the OS preference changes. Individual UI entities opt in to automatic styling by attaching a `UIThemed` component; a system then keeps their `UIStyle` in sync with the active theme.
+
+## Quick Start
+
+### Installation
+
+```csharp
+using KeenEyes.UI;
+using KeenEyes.UI.Themes;
+using KeenEyes.UI.Themes.Abstractions;
+
+using var world = new World();
+
+// UI before Themes: the theme applicator styles UIStyle components
+// created by the UI system's widgets.
+world.InstallPlugin(new UIPlugin());
+world.InstallPlugin(new ThemePlugin());
+
+// Access the theme context extension
+var theme = world.GetExtension<IThemeContext>();
+```
+
+Installing `ThemePlugin` does the following:
+
+- Detects a platform-appropriate `ISystemThemeProvider` (Windows, macOS, or Linux; a no-op fallback otherwise) and uses it to pick the initial "Light" or "Dark" theme.
+- Registers the built-in `LightTheme` and `DarkTheme` under the names `"Light"` and `"Dark"`.
+- Exposes a `ThemeContext` as the `IThemeContext` world extension.
+- Registers the `UIThemed` component.
+- Adds `ThemeApplicatorSystem` to the `SystemPhase.LateUpdate` phase at `order: -20`, so it runs before layout/render systems in that phase.
+
+## Core Concepts
+
+### IThemeContext
+
+`IThemeContext` (implemented by `ThemeContext`) is the entry point for working with themes at runtime. Retrieve it with `world.GetExtension<IThemeContext>()`.
+
+```csharp
+var theme = world.GetExtension<IThemeContext>();
+
+// Inspect the active theme
+var isDark = theme.CurrentTheme.BaseTheme == SystemTheme.Dark;
+
+// Follow the OS preference automatically
+theme.FollowSystemTheme = true;
+
+// Or switch manually by name (also sets FollowSystemTheme to false)
+theme.SetTheme("Dark");
+
+// Register a custom theme (can reuse "Light"/"Dark" to override the built-ins)
+theme.RegisterTheme("HighContrast", new MyHighContrastTheme());
+
+// React to changes
+world.Subscribe<ThemeChangedEvent>(e =>
+    Console.WriteLine($"Theme changed to {e.NewTheme.Name}"));
+```
+
+Key members:
+
+| Member | Description |
+|--------|-------------|
+| `CurrentTheme` | The active `ITheme`. |
+| `SystemTheme` | The OS's current preference (`SystemTheme.Unknown`/`Light`/`Dark`/`HighContrast`). |
+| `FollowSystemTheme` | When `true`, theme switches automatically follow OS changes. Setting a theme manually via `SetTheme` sets this back to `false`. |
+| `SetTheme(ITheme)` / `SetTheme(string)` | Activates a theme directly, or by registered name (returns `false` if the name is unknown). |
+| `RegisterTheme(string, ITheme)` | Registers a theme under a name; built-in `"Light"`/`"Dark"` names can be overridden. |
+| `GetTheme(string)` | Looks up a registered theme, or `null`. |
+| `RegisteredThemes` | All registered theme names. |
+| `OnThemeChanged` | `Action<ThemeChangedEvent>` raised on theme changes (also broadcast on the world via `world.Send`). |
+
+### ITheme and ColorPalette
+
+`ITheme` exposes a `Name`, a `BaseTheme` (`SystemTheme.Light` or `SystemTheme.Dark`, used to pick correct contrast), a `Colors` palette, and one style-producing method per `UIComponentType`: `GetButtonStyle`, `GetPanelStyle`, `GetInputStyle`, `GetMenuStyle`, `GetMenuItemStyle`, `GetModalStyle`, `GetScrollbarTrackStyle`, `GetScrollbarThumbStyle`, and `GetTooltipStyle`. The interactive variants (button, input, menu item, scrollbar thumb) accept a `UIInteractionState` so the returned `UIStyle` can react to hover/press/focus.
+
+`ColorPalette` is a set of semantic `Vector4` (RGBA, 0-1) colors rather than raw hex values, so themes stay legible regardless of light/dark base: `Background`, `Surface`, `SurfaceElevated`, `Primary`, `PrimaryVariant`, `Secondary`, `Accent`, `TextPrimary`, `TextSecondary`, `TextDisabled`, `TextOnPrimary`, `Success`, `Warning`, `Error`, `Info`, `Border`, `BorderFocused`, `Divider`, `HoverOverlay`, `PressedOverlay`, and `DisabledOverlay`.
+
+The built-in `LightTheme` and `DarkTheme` (in `KeenEyes.UI.Themes.Themes`) show the expected pattern for a custom theme - a `ColorPalette` plus per-component style logic:
+
+```csharp
+public UIStyle GetButtonStyle(UIInteractionState state)
+{
+    var baseColor = Colors.Primary;
+
+    if (state.HasFlag(UIInteractionState.Pressed))
+    {
+        baseColor = Colors.PrimaryVariant;
+    }
+    else if (state.HasFlag(UIInteractionState.Hovered))
+    {
+        baseColor = BlendColor(Colors.Primary, Colors.HoverOverlay);
+    }
+
+    return new UIStyle
+    {
+        BackgroundColor = baseColor,
+        BorderColor = Vector4.Zero,
+        BorderWidth = 0,
+        CornerRadius = 4,
+        Padding = new UIEdges(12, 8, 12, 8)
+    };
+}
+```
+
+To ship a custom theme, implement `ITheme` and register it with `theme.RegisterTheme("MyTheme", new MyTheme())`.
+
+### UIThemed and ThemeApplicatorSystem
+
+`UIThemed` is the marker component that opts a UI entity into automatic styling. It carries a `UIComponentType` that tells `ThemeApplicatorSystem` which `ITheme` method to call. Use the static factories (`UIThemed.Button`, `UIThemed.Panel`, `UIThemed.Input`, `UIThemed.Menu`, `UIThemed.MenuItem`, `UIThemed.Modal`, or `UIThemed.For(UIComponentType)` for the remaining types) when building an entity:
+
+```csharp
+using System.Numerics;
+using KeenEyes.UI.Abstractions;
+using KeenEyes.UI.Themes;
+
+var button = world.Spawn()
+    .With(new UIElement { Visible = true, RaycastTarget = true })
+    .With(UIRect.Fixed(x: 0, y: 0, width: 120, height: 32))
+    .With(theme.CurrentTheme.GetButtonStyle(UIInteractionState.None))
+    .With(new UIInteractable { CanClick = true, CanFocus = true })
+    .With(UIThemed.Button)
+    .Build();
+```
+
+Every frame, `ThemeApplicatorSystem` queries entities with both `UIStyle` and `UIThemed`, reads the entity's `UIInteractionState` from its `UIInteractable` component (if present), and overwrites `UIStyle` with the result of the matching `ITheme` method. Entities with a `UIDisabledTag` are skipped so their current style is preserved. Because the system runs in `SystemPhase.LateUpdate` at `order: -20`, styles are refreshed before later layout/render systems read them, and every entity picks up a theme switch on the very next frame without any manual re-styling.
+
+### System Theme Detection
+
+`ISystemThemeProvider` abstracts OS-level theme queries: `IsAvailable`, `SupportsRuntimeNotification`, `GetCurrentTheme()`, and an `OnThemeChanged` event for platforms that support live notifications. `ThemePlugin` selects a concrete provider (`WindowsThemeProvider`, `MacOSThemeProvider`, `LinuxThemeProvider`, or `FallbackThemeProvider` when the platform isn't recognized) and forwards its `SystemThemeChangedEvent` onto the world's messaging system whenever `IThemeContext.FollowSystemTheme` is enabled.
+
+## Performance
+
+`ThemeApplicatorSystem` only visits entities that have both `UIStyle` and `UIThemed`; UI elements that don't opt in to theming are never touched. Style updates just replace the `UIStyle` struct - since `UIStyle` is a plain-data component, this is a cheap per-entity write, not a re-layout, and only occurs while the theme is actively changing (the query still runs every `LateUpdate`, so keep the themed-entity count proportional to what's on screen).
+
+## Next Steps
+
+- [UI Guide](ui.md) - the retained-mode UI system, widgets, and `WidgetFactory`
+- [Plugins Guide](plugins.md) - how `IWorldPlugin` installation, extensions, and system registration work
+- [Systems Guide](systems.md) - system phases and ordering
+- [9-Slice Theming Design](research/9slice-theming.md) - original exploratory design document (note: the shipped `ThemePlugin`/`ITheme` API described above supersedes the theme-system sketch in that document)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -152,6 +152,10 @@
   href: sdk.md
 - name: Editor Integration
   items:
+    - name: Editor
+      href: editor.md
+    - name: CLI (keeneyes)
+      href: cli.md
     - name: Plugin Dependencies
       href: editor-plugin-dependencies.md
     - name: Plugin Hot Reload

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -103,8 +103,30 @@
   items:
     - name: Abstractions
       href: abstractions.md
+    - name: Animation
+      href: animation.md
+    - name: Asset Management
+      href: assets.md
+    - name: Audio
+      href: audio.md
     - name: Common
       href: common.md
+    - name: Graphics
+      href: graphics.md
+    - name: Input
+      href: input.md
+    - name: Localization
+      href: localization.md
+    - name: Navigation & Pathfinding
+      href: navigation.md
+    - name: Node Graph Editor
+      href: graph.md
+    - name: Particles
+      href: particles.md
+    - name: Replay Recording & Playback
+      href: replay.md
+    - name: Shaders & KESL
+      href: shaders.md
     - name: Spatial
       href: spatial.md
       items:
@@ -114,12 +136,10 @@
           href: spatial-partitioning/strategy-selection.md
         - name: Performance Tuning
           href: spatial-partitioning/performance-tuning.md
-    - name: Graphics
-      href: graphics.md
-    - name: Input
-      href: input.md
     - name: UI
       href: ui.md
+    - name: UI Theming
+      href: themes.md
     - name: Runtime
       href: runtime.md
 - name: SDK

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -111,6 +111,8 @@
       href: audio.md
     - name: Common
       href: common.md
+    - name: Debugging & Profiling
+      href: debugging.md
     - name: Graphics
       href: graphics.md
     - name: Input
@@ -123,6 +125,10 @@
       href: graph.md
     - name: Particles
       href: particles.md
+    - name: Persistence & Encryption
+      href: persistence.md
+    - name: Physics
+      href: physics.md
     - name: Replay Recording & Playback
       href: replay.md
     - name: Shaders & KESL

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -156,6 +156,8 @@
       href: editor.md
     - name: CLI (keeneyes)
       href: cli.md
+    - name: Plugin Development
+      href: editor-plugin-development.md
     - name: Plugin Dependencies
       href: editor-plugin-dependencies.md
     - name: Plugin Hot Reload

--- a/src/KeenEyes.Animation/Components/BoneReference.cs
+++ b/src/KeenEyes.Animation/Components/BoneReference.cs
@@ -18,12 +18,12 @@ namespace KeenEyes.Animation.Components;
 /// // Create a skeleton hierarchy
 /// var hip = world.Spawn()
 ///     .With(Transform3D.Identity)
-///     .With(new BoneReference { BoneName = "Hip", SkeletonRoot = characterEntity })
+///     .With(new BoneReference { BoneName = "Hip", SkeletonRootId = characterEntity.Id })
 ///     .Build();
 ///
 /// var spine = world.Spawn()
 ///     .With(Transform3D.Identity)
-///     .With(new BoneReference { BoneName = "Spine", SkeletonRoot = characterEntity })
+///     .With(new BoneReference { BoneName = "Spine", SkeletonRootId = characterEntity.Id })
 ///     .Build();
 ///
 /// world.SetParent(spine, hip);


### PR DESCRIPTION
## Summary
Author user-facing guides for subsystems that previously had **no** `docs/` page (only research/design docs), refresh stale ones, and add editor/CLI references — 18 pages total, each grounded in and grep-verified against real source (no fabricated APIs).
- **New subsystem guides**: Animation, Asset Management, Audio, Localization, Navigation, Particles, Replay, Shaders & KESL, UI Theming, Node Graph Editor, Debugging & Profiling, Physics, Persistence.
- **Refreshed**: `graphics.md` (Shadows/InstanceBatching/LOD), `logging.md` (EcsLogger + query layer), `testbridge.md` (TestBridge.Client), `testing.md` (assertions/snapshots/recorders/fixtures + `MockWorld`→`TestWorld`).
- **Editor/tooling references**: `editor.md`, `cli.md`, `editor-plugin-development.md`; plus `graph.md` abstractions and `shaders.md` compiler-internals sections.
- Wired everything into `docs/toc.yml` + `docs/index.md` (all links resolve); fixed the `BoneReference` doc example (`SkeletonRoot`→`SkeletonRootId`).

## Test plan
- [x] Markdown + one comment fix; all `docs/toc.yml` hrefs resolve
- [x] Plugin types / key APIs spot-verified against source
- [ ] CI green

Note: `docs/testing.md`'s `MockWorld`→`TestWorld` fix is duplicated here and in the policy PR (identical), so the two merge cleanly in any order.