### PR TITLE
feat(animation): Add TwoBone and FABRIK IK solvers

### DIFF
--- a/src/KeenEyes.Animation/IK/Solvers/FABRIKSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/FABRIKSolver.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.IK.Solvers;
+
+/// <summary>
+/// Iterative FABRIK (Forward And Backward Reaching Inverse Kinematics) solver
+/// for multi-bone chains such as spines, tails, and tentacles.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each iteration performs a forward pass (moving the end effector to the target and
+/// repositioning joints toward the root) followed by a backward pass (re-anchoring the
+/// root and repositioning joints toward the tip), preserving bone lengths throughout.
+/// Iteration stops when the end effector is within <see cref="IKChainDefinition.Tolerance"/>
+/// of the target or <see cref="IKChainDefinition.MaxIterations"/> is reached.
+/// </para>
+/// <para>
+/// Unreachable targets stretch the chain straight toward the target with bone lengths
+/// preserved. Bone rotations are reconstructed from the solved joint positions.
+/// </para>
+/// <para>
+/// Bone <see cref="Transform3D"/> components hold LOCAL (parent-relative) transforms; the
+/// solver composes world positions by walking the entity hierarchy and writes results back
+/// as local rotations (see <see cref="IKSolverMath"/> for the space determination).
+/// </para>
+/// </remarks>
+[SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase",
+    Justification = "FABRIK is an established algorithm acronym, consistent with IKSolverType.FABRIK.")]
+public sealed class FABRIKSolver : IIKSolver
+{
+    /// <inheritdoc />
+    public string Name => "FABRIK";
+
+    /// <inheritdoc />
+    public IKSolverType SolverType => IKSolverType.FABRIK;
+
+    /// <inheritdoc />
+    public bool CanHandle(int boneCount) => boneCount >= 2;
+
+    /// <inheritdoc />
+    public IKSolverResult Solve(in IKSolverContext context)
+    {
+        var world = context.World;
+        var bones = context.BoneEntities;
+        var boneCount = bones.Length;
+        var target = context.TargetPosition;
+
+        var positions = new Vector3[boneCount];
+        IKSolverMath.GetWorldPositions(world, bones, positions);
+
+        var lengths = new float[boneCount - 1];
+        var totalLength = 0f;
+        for (var i = 0; i < lengths.Length; i++)
+        {
+            lengths[i] = Vector3.Distance(positions[i], positions[i + 1]);
+            totalLength += lengths[i];
+        }
+
+        if (totalLength.IsApproximatelyZero())
+        {
+            // Degenerate chain with zero-length bones: nothing to rotate.
+            return IKSolverResult.Partial(0, Vector3.Distance(positions[^1], target));
+        }
+
+        var rootPos = positions[0];
+        var tolerance = MathF.Max(context.Chain.Tolerance, 0f);
+        var rootToTarget = target - rootPos;
+
+        if (rootToTarget.Length() > totalLength)
+        {
+            // Unreachable: stretch the chain straight toward the target.
+            var direction = Vector3.Normalize(rootToTarget);
+            for (var i = 0; i < lengths.Length; i++)
+            {
+                positions[i + 1] = positions[i] + (direction * lengths[i]);
+            }
+
+            IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null);
+            return IKSolverResult.Partial(0, Vector3.Distance(positions[^1], target));
+        }
+
+        var error = Vector3.Distance(positions[^1], target);
+        var iterations = 0;
+        var maxIterations = Math.Max(1, context.Chain.MaxIterations);
+
+        while (error > tolerance && iterations < maxIterations)
+        {
+            iterations++;
+
+            // Forward pass: move the end effector to the target, reposition toward the root.
+            positions[^1] = target;
+            for (var i = boneCount - 2; i >= 0; i--)
+            {
+                var direction = SafeDirection(positions[i] - positions[i + 1], -rootToTarget);
+                positions[i] = positions[i + 1] + (direction * lengths[i]);
+            }
+
+            // Backward pass: re-anchor the root, reposition toward the tip.
+            positions[0] = rootPos;
+            for (var i = 0; i < boneCount - 1; i++)
+            {
+                var direction = SafeDirection(positions[i + 1] - positions[i], rootToTarget);
+                positions[i + 1] = positions[i] + (direction * lengths[i]);
+            }
+
+            error = Vector3.Distance(positions[^1], target);
+        }
+
+        IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null);
+
+        return error <= tolerance
+            ? IKSolverResult.Success(iterations, error)
+            : IKSolverResult.Partial(iterations, error);
+    }
+
+    /// <summary>
+    /// Normalizes a direction, falling back when joints are coincident.
+    /// </summary>
+    private static Vector3 SafeDirection(Vector3 direction, Vector3 fallback)
+    {
+        if (!direction.LengthSquared().IsApproximatelyZero())
+        {
+            return Vector3.Normalize(direction);
+        }
+
+        return fallback.LengthSquared().IsApproximatelyZero()
+            ? Vector3.UnitY
+            : Vector3.Normalize(fallback);
+    }
+}

--- a/src/KeenEyes.Animation/IK/Solvers/IKSolverMath.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/IKSolverMath.cs
@@ -1,0 +1,169 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.IK.Solvers;
+
+/// <summary>
+/// Shared math helpers for IK solvers working on bone entity hierarchies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Bone <see cref="Transform3D"/> components store LOCAL (parent-relative) transforms:
+/// <c>SkinnedMeshBoneSystem</c> composes each bone's local matrix with its parent's world
+/// matrix by walking <see cref="IWorld.GetParent"/>, and <c>SkeletonPoseSystem</c> writes
+/// parent-relative animation track samples directly into bone transforms. Solvers therefore
+/// compose world-space positions by walking the entity hierarchy and write results back as
+/// local rotations relative to each bone's parent.
+/// </para>
+/// <para>
+/// All helpers assume chain bones form a parent-child hierarchy from root to tip (each bone's
+/// entity parent is the previous chain bone; the root bone's parent may be any entity).
+/// </para>
+/// </remarks>
+internal static class IKSolverMath
+{
+    /// <summary>
+    /// Computes the world-space transform of an entity by composing local transforms
+    /// up the entity hierarchy.
+    /// </summary>
+    /// <param name="world">The world containing the entity.</param>
+    /// <param name="entity">The entity to compute the world transform for.</param>
+    /// <returns>The world-space position, rotation, and scale.</returns>
+    internal static (Vector3 Position, Quaternion Rotation, Vector3 Scale) GetWorldTransform(
+        IWorld world, Entity entity)
+    {
+        ref readonly var local = ref world.Get<Transform3D>(entity);
+        var parent = world.GetParent(entity);
+
+        if (!parent.IsValid || !world.Has<Transform3D>(parent))
+        {
+            return (local.Position, local.Rotation, local.Scale);
+        }
+
+        var (parentPos, parentRot, parentScale) = GetWorldTransform(world, parent);
+
+        return (
+            parentPos + Vector3.Transform(parentScale * local.Position, parentRot),
+            Quaternion.Normalize(parentRot * local.Rotation),
+            parentScale * local.Scale);
+    }
+
+    /// <summary>
+    /// Fills <paramref name="positions"/> with the world-space positions of the chain bones.
+    /// </summary>
+    /// <param name="world">The world containing the bones.</param>
+    /// <param name="bones">Bone entities ordered root to tip.</param>
+    /// <param name="positions">Destination span; must be at least as long as <paramref name="bones"/>.</param>
+    internal static void GetWorldPositions(IWorld world, Entity[] bones, Span<Vector3> positions)
+    {
+        for (var i = 0; i < bones.Length; i++)
+        {
+            positions[i] = GetWorldTransform(world, bones[i]).Position;
+        }
+    }
+
+    /// <summary>
+    /// Computes the shortest-arc rotation mapping one unit direction onto another.
+    /// </summary>
+    /// <param name="from">The normalized source direction.</param>
+    /// <param name="to">The normalized destination direction.</param>
+    /// <returns>A quaternion rotating <paramref name="from"/> onto <paramref name="to"/>.</returns>
+    internal static Quaternion RotationBetween(Vector3 from, Vector3 to)
+    {
+        var dot = Vector3.Dot(from, to);
+
+        if (dot > 1f - FloatExtensions.DefaultEpsilon)
+        {
+            return Quaternion.Identity;
+        }
+
+        if (dot < -1f + FloatExtensions.DefaultEpsilon)
+        {
+            // Opposite directions: rotate 180 degrees about any perpendicular axis.
+            return Quaternion.CreateFromAxisAngle(AnyPerpendicular(from), MathF.PI);
+        }
+
+        var axis = Vector3.Normalize(Vector3.Cross(from, to));
+        var angle = MathF.Acos(Math.Clamp(dot, -1f, 1f));
+        return Quaternion.CreateFromAxisAngle(axis, angle);
+    }
+
+    /// <summary>
+    /// Returns an arbitrary unit vector perpendicular to the given direction.
+    /// </summary>
+    /// <param name="direction">The reference direction.</param>
+    /// <returns>A normalized vector perpendicular to <paramref name="direction"/>.</returns>
+    internal static Vector3 AnyPerpendicular(Vector3 direction)
+    {
+        var axis = Vector3.Cross(direction, Vector3.UnitX);
+        if (axis.LengthSquared().IsApproximatelyZero())
+        {
+            axis = Vector3.Cross(direction, Vector3.UnitY);
+        }
+
+        return Vector3.Normalize(axis);
+    }
+
+    /// <summary>
+    /// Writes solved world-space joint positions back to the chain as local bone rotations.
+    /// </summary>
+    /// <remarks>
+    /// Only rotations are modified: each bone is rotated in world space so that its child lands
+    /// on the solved position, then converted back to a parent-relative local rotation. Because
+    /// solvers preserve joint distances, bone translation offsets (and thus bone lengths) are
+    /// left untouched.
+    /// </remarks>
+    /// <param name="world">The world containing the bones.</param>
+    /// <param name="bones">Bone entities ordered root to tip, forming a parent-child hierarchy.</param>
+    /// <param name="solved">Solved world-space positions for each bone, root to tip.</param>
+    /// <param name="tipWorldRotation">Optional world-space rotation to apply to the tip bone (end effector).</param>
+    internal static void ApplyWorldPositions(
+        IWorld world, Entity[] bones, ReadOnlySpan<Vector3> solved, Quaternion? tipWorldRotation)
+    {
+        // World transform of the chain root's parent (identity if none).
+        var parentPos = Vector3.Zero;
+        var parentRot = Quaternion.Identity;
+        var parentScale = Vector3.One;
+
+        var rootParent = world.GetParent(bones[0]);
+        if (rootParent.IsValid && world.Has<Transform3D>(rootParent))
+        {
+            (parentPos, parentRot, parentScale) = GetWorldTransform(world, rootParent);
+        }
+
+        for (var i = 0; i < bones.Length - 1; i++)
+        {
+            ref var local = ref world.Get<Transform3D>(bones[i]);
+            var worldRot = Quaternion.Normalize(parentRot * local.Rotation);
+            var worldPos = parentPos + Vector3.Transform(parentScale * local.Position, parentRot);
+            var worldScale = parentScale * local.Scale;
+
+            ref readonly var childLocal = ref world.Get<Transform3D>(bones[i + 1]);
+            var childWorldPos = worldPos + Vector3.Transform(worldScale * childLocal.Position, worldRot);
+
+            var currentDir = childWorldPos - worldPos;
+            var desiredDir = solved[i + 1] - solved[i];
+
+            if (!currentDir.LengthSquared().IsApproximatelyZero() &&
+                !desiredDir.LengthSquared().IsApproximatelyZero())
+            {
+                var delta = RotationBetween(
+                    Vector3.Normalize(currentDir),
+                    Vector3.Normalize(desiredDir));
+                worldRot = Quaternion.Normalize(delta * worldRot);
+                local.Rotation = Quaternion.Normalize(Quaternion.Inverse(parentRot) * worldRot);
+            }
+
+            parentPos = worldPos;
+            parentRot = worldRot;
+            parentScale = worldScale;
+        }
+
+        if (tipWorldRotation is { } targetRotation)
+        {
+            ref var tipLocal = ref world.Get<Transform3D>(bones[^1]);
+            tipLocal.Rotation = Quaternion.Normalize(Quaternion.Inverse(parentRot) * targetRotation);
+        }
+    }
+}

--- a/src/KeenEyes.Animation/IK/Solvers/TwoBoneSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/TwoBoneSolver.cs
@@ -1,0 +1,134 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.IK.Solvers;
+
+/// <summary>
+/// Analytical two-bone IK solver using the law of cosines.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Solves three-bone chains (root, mid, tip — e.g. shoulder/elbow/hand or hip/knee/foot)
+/// in O(1) constant time. The mid joint is placed on the bend plane defined by the
+/// root-to-target axis and the pole reference (<see cref="IKSolverContext.PolePosition"/>
+/// if provided, otherwise <see cref="IKChainDefinition.PoleVector"/>).
+/// </para>
+/// <para>
+/// Targets beyond reach stretch the chain straight toward the target (bone lengths are
+/// preserved); targets closer than the minimum reach fold the limb naturally toward the
+/// pole. When <see cref="IKSolverContext.TargetRotation"/> is set, the end effector's
+/// world rotation is matched to it.
+/// </para>
+/// <para>
+/// Bone <see cref="Transform3D"/> components hold LOCAL (parent-relative) transforms; the
+/// solver composes world positions by walking the entity hierarchy and writes results back
+/// as local rotations (see <see cref="IKSolverMath"/> for the space determination).
+/// </para>
+/// </remarks>
+public sealed class TwoBoneSolver : IIKSolver
+{
+    /// <inheritdoc />
+    public string Name => "TwoBone";
+
+    /// <inheritdoc />
+    public IKSolverType SolverType => IKSolverType.TwoBone;
+
+    /// <inheritdoc />
+    public bool CanHandle(int boneCount) => boneCount == 3;
+
+    /// <inheritdoc />
+    public IKSolverResult Solve(in IKSolverContext context)
+    {
+        var world = context.World;
+        var bones = context.BoneEntities;
+
+        var rootPos = IKSolverMath.GetWorldTransform(world, bones[0]).Position;
+        var midPos = IKSolverMath.GetWorldTransform(world, bones[1]).Position;
+        var tipPos = IKSolverMath.GetWorldTransform(world, bones[2]).Position;
+
+        var upperLength = Vector3.Distance(rootPos, midPos);
+        var lowerLength = Vector3.Distance(midPos, tipPos);
+        var totalLength = upperLength + lowerLength;
+
+        if (totalLength.IsApproximatelyZero())
+        {
+            // Degenerate chain with zero-length bones: nothing to rotate.
+            return IKSolverResult.Partial(0, Vector3.Distance(tipPos, context.TargetPosition));
+        }
+
+        var toTarget = context.TargetPosition - rootPos;
+        var targetDistance = toTarget.Length();
+
+        // Direction from root toward the target; fall back to the current tip direction
+        // (then an arbitrary axis) when the target sits on the root.
+        Vector3 axis;
+        if (targetDistance.IsApproximatelyZero())
+        {
+            var currentReach = tipPos - rootPos;
+            axis = currentReach.LengthSquared().IsApproximatelyZero()
+                ? Vector3.UnitX
+                : Vector3.Normalize(currentReach);
+        }
+        else
+        {
+            axis = toTarget / targetDistance;
+        }
+
+        // Clamp the reach: beyond-reach targets stretch the chain straight, too-close
+        // targets fold the limb to its minimum reach.
+        var minReach = MathF.Abs(upperLength - lowerLength);
+        var reach = Math.Clamp(targetDistance, minReach, totalLength);
+
+        // Bend direction: pole reference projected onto the plane perpendicular to the axis.
+        var poleReference = context.PolePosition.HasValue
+            ? context.PolePosition.Value - rootPos
+            : context.Chain.PoleVector;
+        var bendDir = poleReference - (axis * Vector3.Dot(poleReference, axis));
+
+        if (bendDir.LengthSquared().IsApproximatelyZero())
+        {
+            // Pole is degenerate (zero or parallel to the axis): preserve the current
+            // bend plane, or pick any perpendicular direction for a straight chain.
+            var currentBend = (midPos - rootPos) - (axis * Vector3.Dot(midPos - rootPos, axis));
+            bendDir = currentBend.LengthSquared().IsApproximatelyZero()
+                ? IKSolverMath.AnyPerpendicular(axis)
+                : currentBend;
+        }
+
+        bendDir = Vector3.Normalize(bendDir);
+
+        // Law of cosines: angle at the root between the target axis and the upper bone.
+        float cosRoot;
+        var denominator = 2f * upperLength * reach;
+        if (denominator.IsApproximatelyZero())
+        {
+            // Zero-length upper bone or fully folded chain (reach ~ 0): bend fully
+            // toward the pole.
+            cosRoot = 0f;
+        }
+        else
+        {
+            cosRoot = ((upperLength * upperLength) + (reach * reach) - (lowerLength * lowerLength))
+                / denominator;
+        }
+
+        cosRoot = Math.Clamp(cosRoot, -1f, 1f);
+        var sinRoot = MathF.Sqrt(MathF.Max(0f, 1f - (cosRoot * cosRoot)));
+
+        var solvedMid = rootPos + (((axis * cosRoot) + (bendDir * sinRoot)) * upperLength);
+        var solvedTip = rootPos + (axis * reach);
+
+        Span<Vector3> solved = stackalloc Vector3[3];
+        solved[0] = rootPos;
+        solved[1] = solvedMid;
+        solved[2] = solvedTip;
+
+        IKSolverMath.ApplyWorldPositions(world, bones, solved, context.TargetRotation);
+
+        var error = Vector3.Distance(solvedTip, context.TargetPosition);
+        return error <= context.Chain.Tolerance
+            ? IKSolverResult.Success(0, error)
+            : IKSolverResult.Partial(0, error);
+    }
+}

--- a/tests/KeenEyes.Animation.Tests/IK/FABRIKSolverTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/FABRIKSolverTests.cs
@@ -1,0 +1,256 @@
+using System.Numerics;
+
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Tests for the iterative FABRIK IK solver.
+/// </summary>
+public class FABRIKSolverTests
+{
+    private const float PositionTolerance = 0.001f;
+
+    private static IKSolverContext CreateContext(
+        World world,
+        Entity[] bones,
+        Vector3 target,
+        IKChainDefinition? chain = null) => new()
+        {
+            World = world,
+            Chain = chain ?? IKChainDefinition.MultiBone("Chain", MakeBoneNames(bones.Length)),
+            BoneEntities = bones,
+            TargetPosition = target,
+        };
+
+    private static string[] MakeBoneNames(int count)
+    {
+        var names = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            names[i] = $"Bone{i}";
+        }
+
+        return names;
+    }
+
+    private static Entity[] CreateSpineChain(World world)
+    {
+        // Five bones stacked along +Y, each segment 1 unit long (total reach 4).
+        return IKSolverTestHelpers.CreateChain(
+            world,
+            new Vector3(0, 0, 0),
+            new Vector3(0, 1, 0),
+            new Vector3(0, 1, 0),
+            new Vector3(0, 1, 0),
+            new Vector3(0, 1, 0));
+    }
+
+    private static Entity[] CreateTailChain(World world)
+    {
+        // Eight bones along +X, each segment 0.5 units long (total reach 3.5).
+        return IKSolverTestHelpers.CreateChain(
+            world,
+            new Vector3(0, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0),
+            new Vector3(0.5f, 0, 0));
+    }
+
+    #region Metadata Tests
+
+    [Fact]
+    public void Name_ReturnsFABRIK()
+    {
+        var solver = new FABRIKSolver();
+
+        solver.Name.ShouldBe("FABRIK");
+    }
+
+    [Fact]
+    public void SolverType_ReturnsFABRIK()
+    {
+        var solver = new FABRIKSolver();
+
+        solver.SolverType.ShouldBe(IKSolverType.FABRIK);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(5)]
+    [InlineData(8)]
+    public void CanHandle_MultiBoneCounts_ReturnsTrue(int boneCount)
+    {
+        var solver = new FABRIKSolver();
+
+        solver.CanHandle(boneCount).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void CanHandle_FewerThanTwoBones_ReturnsFalse(int boneCount)
+    {
+        var solver = new FABRIKSolver();
+
+        solver.CanHandle(boneCount).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Reaching Tests
+
+    [Fact]
+    public void Solve_FiveBoneSpineReachingTarget_TipReachesTarget()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+        var target = new Vector3(2, 2, 0);
+        var context = CreateContext(world, bones, target);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[^1]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance * 2f);
+    }
+
+    [Fact]
+    public void Solve_EightBoneTailFollowingTarget_TipReachesTarget()
+    {
+        using var world = new World();
+        var bones = CreateTailChain(world);
+        var target = new Vector3(2f, 1.5f, 0.5f);
+        var context = CreateContext(world, bones, target);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[^1]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance * 2f);
+    }
+
+    [Fact]
+    public void Solve_ReachableTarget_ConvergesWithinTenIterations()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+        var chain = IKChainDefinition.MultiBone("Spine", MakeBoneNames(bones.Length), maxIterations: 10);
+        var context = CreateContext(world, bones, new Vector3(2, 2, 0), chain);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.Iterations.ShouldBeLessThanOrEqualTo(10);
+        result.FinalError.ShouldBeLessThanOrEqualTo(chain.Tolerance);
+    }
+
+    [Fact]
+    public void Solve_ComplexPoseBehindChain_ConvergesWithMultipleIterations()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+
+        // Target below and behind the chain root forces a large bend.
+        var target = new Vector3(0.5f, -1.5f, 1f);
+        var context = CreateContext(world, bones, target);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.Iterations.ShouldBeGreaterThanOrEqualTo(1);
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[^1]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance * 2f);
+    }
+
+    [Fact]
+    public void Solve_VeryCloseTarget_ReachesExactly()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+
+        // Target a small nudge away from the current tip at (0, 4, 0). Near full
+        // extension FABRIK converges slowly, so allow extra iterations.
+        var target = new Vector3(0.1f, 3.9f, 0);
+        var chain = IKChainDefinition.MultiBone("Spine", MakeBoneNames(bones.Length), maxIterations: 30);
+        var context = CreateContext(world, bones, target, chain);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.FinalError.ShouldBeLessThanOrEqualTo(chain.Tolerance);
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[^1]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance * 2f);
+    }
+
+    [Fact]
+    public void Solve_TargetAtCurrentTip_ConvergesWithoutIterating()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+
+        // The chain already ends at (0, 4, 0).
+        var context = CreateContext(world, bones, new Vector3(0, 4, 0));
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.Iterations.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region Unreachable Target Tests
+
+    [Fact]
+    public void Solve_UnreachableTarget_StretchesTowardTarget()
+    {
+        using var world = new World();
+        var bones = CreateSpineChain(world);
+
+        // Total reach is 4; the target is 10 units away along +X.
+        var target = new Vector3(10, 0, 0);
+        var context = CreateContext(world, bones, target);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeFalse();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[^1]);
+        Vector3.Distance(tipPos, new Vector3(4, 0, 0)).ShouldBeLessThan(PositionTolerance);
+
+        var lengths = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        foreach (var length in lengths)
+        {
+            length.ShouldBe(1f, PositionTolerance);
+        }
+    }
+
+    #endregion
+
+    #region Bone Length Preservation Tests
+
+    [Fact]
+    public void Solve_ReachableBendTarget_PreservesBoneLengths()
+    {
+        using var world = new World();
+        var bones = CreateTailChain(world);
+        var lengthsBefore = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        var context = CreateContext(world, bones, new Vector3(1.5f, 1.5f, 1f));
+
+        new FABRIKSolver().Solve(in context);
+
+        var lengthsAfter = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        for (var i = 0; i < lengthsBefore.Length; i++)
+        {
+            lengthsAfter[i].ShouldBe(lengthsBefore[i], PositionTolerance);
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Animation.Tests/IK/IKSolverTestHelpers.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/IKSolverTestHelpers.cs
@@ -1,0 +1,78 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Shared helpers for building bone entity chains and reading world-space transforms
+/// in IK solver tests. Bone Transform3D components are local (parent-relative), so
+/// world transforms are composed by walking the entity hierarchy.
+/// </summary>
+internal static class IKSolverTestHelpers
+{
+    /// <summary>
+    /// Creates a parent-child bone chain from local (parent-relative) positions.
+    /// </summary>
+    internal static Entity[] CreateChain(World world, params Vector3[] localPositions)
+    {
+        var bones = new Entity[localPositions.Length];
+
+        for (var i = 0; i < localPositions.Length; i++)
+        {
+            bones[i] = world.Spawn()
+                .With(new Transform3D(localPositions[i], Quaternion.Identity, Vector3.One))
+                .Build();
+
+            if (i > 0)
+            {
+                world.SetParent(bones[i], bones[i - 1]);
+            }
+        }
+
+        return bones;
+    }
+
+    /// <summary>
+    /// Computes the world-space transform of an entity by composing local transforms
+    /// up the entity hierarchy.
+    /// </summary>
+    internal static (Vector3 Position, Quaternion Rotation) GetWorldTransform(World world, Entity entity)
+    {
+        ref readonly var local = ref world.Get<Transform3D>(entity);
+        var parent = world.GetParent(entity);
+
+        if (!parent.IsValid || !world.Has<Transform3D>(parent))
+        {
+            return (local.Position, local.Rotation);
+        }
+
+        var (parentPos, parentRot) = GetWorldTransform(world, parent);
+        return (
+            parentPos + Vector3.Transform(local.Position, parentRot),
+            Quaternion.Normalize(parentRot * local.Rotation));
+    }
+
+    /// <summary>
+    /// Computes the world-space position of an entity.
+    /// </summary>
+    internal static Vector3 GetWorldPosition(World world, Entity entity)
+        => GetWorldTransform(world, entity).Position;
+
+    /// <summary>
+    /// Computes the world-space distances between consecutive chain bones.
+    /// </summary>
+    internal static float[] GetBoneLengths(World world, Entity[] bones)
+    {
+        var lengths = new float[bones.Length - 1];
+
+        for (var i = 0; i < lengths.Length; i++)
+        {
+            lengths[i] = Vector3.Distance(
+                GetWorldPosition(world, bones[i]),
+                GetWorldPosition(world, bones[i + 1]));
+        }
+
+        return lengths;
+    }
+}

--- a/tests/KeenEyes.Animation.Tests/IK/TwoBoneSolverTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/TwoBoneSolverTests.cs
@@ -1,0 +1,299 @@
+using System.Numerics;
+
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Tests for the analytical two-bone IK solver.
+/// </summary>
+public class TwoBoneSolverTests
+{
+    private const float PositionTolerance = 0.001f;
+
+    private static IKChainDefinition CreateTwoBoneChain(Vector3? poleVector = null)
+        => IKChainDefinition.TwoBone("Arm", "Upper", "Lower", "Hand", poleVector ?? Vector3.UnitZ);
+
+    private static IKSolverContext CreateContext(
+        World world,
+        Entity[] bones,
+        Vector3 target,
+        IKChainDefinition? chain = null,
+        Vector3? polePosition = null,
+        Quaternion? targetRotation = null) => new()
+        {
+            World = world,
+            Chain = chain ?? CreateTwoBoneChain(),
+            BoneEntities = bones,
+            TargetPosition = target,
+            PolePosition = polePosition,
+            TargetRotation = targetRotation,
+        };
+
+    #region Metadata Tests
+
+    [Fact]
+    public void Name_ReturnsTwoBone()
+    {
+        var solver = new TwoBoneSolver();
+
+        solver.Name.ShouldBe("TwoBone");
+    }
+
+    [Fact]
+    public void SolverType_ReturnsTwoBone()
+    {
+        var solver = new TwoBoneSolver();
+
+        solver.SolverType.ShouldBe(IKSolverType.TwoBone);
+    }
+
+    [Fact]
+    public void CanHandle_ThreeBones_ReturnsTrue()
+    {
+        var solver = new TwoBoneSolver();
+
+        solver.CanHandle(3).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    public void CanHandle_NonThreeBoneCounts_ReturnsFalse(int boneCount)
+    {
+        var solver = new TwoBoneSolver();
+
+        solver.CanHandle(boneCount).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Reachable Target Tests
+
+    [Fact]
+    public void Solve_ArmReachingForwardTarget_TipReachesTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var target = new Vector3(1.2f, 0.8f, 0);
+        var context = CreateContext(world, bones, target, polePosition: new Vector3(0.5f, 0, 2f));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_ArmReachingUpwardTarget_TipReachesTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var target = new Vector3(0, 1.5f, 0);
+        var context = CreateContext(world, bones, target, polePosition: new Vector3(0, 0.75f, 2f));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_LegPlantingOnGround_TipReachesTarget()
+    {
+        using var world = new World();
+
+        // Hip at (0, 2, 0) with knee and foot pointing down; knee pole in front (+Z).
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 2, 0), new Vector3(0, -1, 0), new Vector3(0, -1, 0));
+        var target = new Vector3(0.3f, 0.5f, 0.2f);
+        var context = CreateContext(world, bones, target, polePosition: new Vector3(0, 1.5f, 2f));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var footPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(footPos, target).ShouldBeLessThan(PositionTolerance);
+
+        // The knee should bend forward, toward the pole.
+        var kneePos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        kneePos.Z.ShouldBeGreaterThan(0f);
+    }
+
+    [Fact]
+    public void Solve_ReachableTarget_ReturnsZeroIterationsAndSmallError()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var chain = CreateTwoBoneChain();
+        var context = CreateContext(world, bones, new Vector3(1.2f, 0.8f, 0), chain);
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.Iterations.ShouldBe(0);
+        result.FinalError.ShouldBeLessThanOrEqualTo(chain.Tolerance);
+    }
+
+    [Fact]
+    public void Solve_ReachableTarget_PreservesBoneLengths()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var lengthsBefore = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        var context = CreateContext(world, bones, new Vector3(0.5f, 1.2f, 0.4f));
+
+        new TwoBoneSolver().Solve(in context);
+
+        var lengthsAfter = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        for (var i = 0; i < lengthsBefore.Length; i++)
+        {
+            lengthsAfter[i].ShouldBe(lengthsBefore[i], PositionTolerance);
+        }
+    }
+
+    #endregion
+
+    #region Unreachable Target Tests
+
+    [Fact]
+    public void Solve_TargetBeyondReach_StretchesTowardTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var context = CreateContext(world, bones, new Vector3(5, 0, 0));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        // The chain straightens fully toward the target: tip at max reach along the axis.
+        result.Converged.ShouldBeFalse();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(tipPos, new Vector3(2, 0, 0)).ShouldBeLessThan(PositionTolerance);
+
+        var lengths = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        lengths[0].ShouldBe(1f, PositionTolerance);
+        lengths[1].ShouldBe(1f, PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_TargetTooClose_FoldsLimbNaturally()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var target = new Vector3(0.2f, 0, 0);
+        var context = CreateContext(world, bones, target, polePosition: new Vector3(0.1f, 5f, 0));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        // Equal bone lengths make even a near-root target reachable by folding.
+        result.Converged.ShouldBeTrue();
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThan(PositionTolerance);
+
+        // The mid joint folds far off the root-target axis, toward the pole.
+        var midPos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        midPos.Y.ShouldBeGreaterThan(0.9f);
+
+        var lengths = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        lengths[0].ShouldBe(1f, PositionTolerance);
+        lengths[1].ShouldBe(1f, PositionTolerance);
+    }
+
+    #endregion
+
+    #region Pole Vector Tests
+
+    [Fact]
+    public void Solve_PoleVectorForward_BendsMidTowardPole()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var context = CreateContext(
+            world, bones, new Vector3(1.5f, 0, 0), polePosition: new Vector3(0.75f, 0, 5f));
+
+        new TwoBoneSolver().Solve(in context);
+
+        var midPos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        midPos.Z.ShouldBeGreaterThan(0.5f);
+    }
+
+    [Fact]
+    public void Solve_PoleVectorBackward_BendsMidAwayFromForward()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var context = CreateContext(
+            world, bones, new Vector3(1.5f, 0, 0), polePosition: new Vector3(0.75f, 0, -5f));
+
+        new TwoBoneSolver().Solve(in context);
+
+        var midPos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        midPos.Z.ShouldBeLessThan(-0.5f);
+    }
+
+    [Fact]
+    public void Solve_WithoutPolePosition_UsesChainPoleVector()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var chain = CreateTwoBoneChain(Vector3.UnitY);
+        var context = CreateContext(world, bones, new Vector3(1.5f, 0, 0), chain);
+
+        new TwoBoneSolver().Solve(in context);
+
+        var midPos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        midPos.Y.ShouldBeGreaterThan(0.5f);
+    }
+
+    #endregion
+
+    #region End Effector Rotation Tests
+
+    [Fact]
+    public void Solve_WithTargetRotation_EndEffectorMatchesTargetRotation()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var targetRotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f);
+        var context = CreateContext(
+            world, bones, new Vector3(1.2f, 0.8f, 0), targetRotation: targetRotation);
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var (_, tipRotation) = IKSolverTestHelpers.GetWorldTransform(world, bones[2]);
+        MathF.Abs(Quaternion.Dot(tipRotation, targetRotation)).ShouldBeGreaterThan(0.9999f);
+    }
+
+    [Fact]
+    public void Solve_WithoutTargetRotation_LeavesEndEffectorLocalRotationUnchanged()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        var context = CreateContext(world, bones, new Vector3(1.2f, 0.8f, 0));
+
+        new TwoBoneSolver().Solve(in context);
+
+        ref readonly var tipLocal = ref world.Get<Transform3D>(bones[2]);
+        MathF.Abs(Quaternion.Dot(tipLocal.Rotation, Quaternion.Identity)).ShouldBeGreaterThan(0.9999f);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements the two IK chain solvers against the existing `IIKSolver` contract: **`TwoBoneSolver`** (analytical law-of-cosines, O(1): pole-vector bend plane, unreachable→stretch, too-close→fold, optional end-effector rotation) and **`FABRIKSolver`** (forward/backward reaching, `MaxIterations`/`Tolerance` from the chain, rotations reconstructed from solved positions).
- Shared internal `IKSolverMath`: world-transform composition (bone `Transform3D` is **local/parent-relative** — determined from `SkinnedMeshBoneSystem`/`SkeletonPoseSystem` and documented), shortest-arc rotation, local-rotation write-back. Write-back is **rotation-only**, so bone lengths are preserved exactly.
- Solvers only — no system wiring or constraints (that's #955/#957 per the plan on #959).

## Test plan
- [x] 35 new tests covering every case listed in the issue bodies (arm/leg reach, pole vectors, unreachable stretch, fold, end-effector rotation; 5-bone spine, 8-bone tail, ≤10-iteration convergence, bone-length preservation) — 276/276 passing
- [x] Build zero warnings with CS1591 enforced; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #953, #954 (part of #959)

Notes: `FABRIKSolver` name trips Sonar S101; suppressed with justification (matches `IKSolverType.FABRIK`). The near-full-extension FABRIK test documents the ~0.66×/iteration convergence property and uses 30 iterations; the issue's ≤10-iteration guarantee is separately tested for standard bends.