### PR TITLE
feat(animation): Add IK joint constraints (Hinge, BallSocket, Euler)

### DIFF
--- a/src/KeenEyes.Animation/IK/Solvers/FABRIKSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/FABRIKSolver.cs
@@ -26,6 +26,15 @@ namespace KeenEyes.Animation.IK.Solvers;
 /// solver composes world positions by walking the entity hierarchy and writes results back
 /// as local rotations (see <see cref="IKSolverMath"/> for the space determination).
 /// </para>
+/// <para>
+/// Bones carrying an <see cref="Components.IKConstraint"/> component are constrained by
+/// re-projection after every iteration: the pass results are written back as clamped local
+/// rotations and the resulting world positions are re-read before the next iteration.
+/// Constraining in rotation space (rather than nudging joint positions) preserves bone
+/// lengths exactly and keeps each iteration starting from a constraint-satisfying pose,
+/// which avoids oscillation between the forward and backward passes. Chains without any
+/// constrained bone follow the original position-only iteration path unchanged.
+/// </para>
 /// </remarks>
 [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase",
     Justification = "FABRIK is an established algorithm acronym, consistent with IKSolverType.FABRIK.")]
@@ -65,6 +74,7 @@ public sealed class FABRIKSolver : IIKSolver
             return IKSolverResult.Partial(0, Vector3.Distance(positions[^1], target));
         }
 
+        var constraints = IKConstraintSolver.GetChainConstraints(world, bones);
         var rootPos = positions[0];
         var tolerance = MathF.Max(context.Chain.Tolerance, 0f);
         var rootToTarget = target - rootPos;
@@ -78,7 +88,15 @@ public sealed class FABRIKSolver : IIKSolver
                 positions[i + 1] = positions[i] + (direction * lengths[i]);
             }
 
-            IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null);
+            IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null, constraints);
+
+            if (constraints is not null)
+            {
+                // Clamping may have bent the chain away from the straight stretch;
+                // measure the error from the actual tip position.
+                IKSolverMath.GetWorldPositions(world, bones, positions);
+            }
+
             return IKSolverResult.Partial(0, Vector3.Distance(positions[^1], target));
         }
 
@@ -106,10 +124,22 @@ public sealed class FABRIKSolver : IIKSolver
                 positions[i + 1] = positions[i] + (direction * lengths[i]);
             }
 
+            if (constraints is not null)
+            {
+                // Constraint re-projection: write the pass results back as clamped local
+                // rotations, then re-read the constrained world positions so the next
+                // iteration (and the error check) starts from a valid pose.
+                IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null, constraints);
+                IKSolverMath.GetWorldPositions(world, bones, positions);
+            }
+
             error = Vector3.Distance(positions[^1], target);
         }
 
-        IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null);
+        if (constraints is null)
+        {
+            IKSolverMath.ApplyWorldPositions(world, bones, positions, tipWorldRotation: null);
+        }
 
         return error <= tolerance
             ? IKSolverResult.Success(iterations, error)

--- a/src/KeenEyes.Animation/IK/Solvers/IKConstraintSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/IKConstraintSolver.cs
@@ -1,0 +1,200 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.IK.Solvers;
+
+/// <summary>
+/// Clamps bone rotations to <see cref="IKConstraint"/> joint limits during IK solving.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constraints operate on LOCAL (parent-relative) bone rotations, the same space
+/// <see cref="IKSolverMath.ApplyWorldPositions"/> writes solved poses into. All angle
+/// limits are expressed in degrees, matching the <see cref="IKConstraint"/> field
+/// conventions.
+/// </para>
+/// <para>
+/// Hinge constraints keep only the rotation component about <see cref="IKConstraint.Axis"/>
+/// (any swing off the hinge axis is removed) and clamp the signed angle to
+/// <c>[MinAngles.X, MaxAngles.X]</c>. Ball-socket constraints use swing-twist decomposition
+/// about <see cref="IKConstraint.Axis"/>: the swing angle is clamped to
+/// <see cref="IKConstraint.ConeAngle"/> and the twist angle to
+/// ±<see cref="IKConstraint.TwistLimit"/>. Euler constraints clamp the pitch/yaw/roll
+/// angles (rotations about X/Y/Z respectively) independently against
+/// <see cref="IKConstraint.MinAngles"/> and <see cref="IKConstraint.MaxAngles"/>.
+/// </para>
+/// </remarks>
+internal static class IKConstraintSolver
+{
+    private const float DegToRad = MathF.PI / 180f;
+    private const float RadToDeg = 180f / MathF.PI;
+
+    /// <summary>
+    /// Clamps a bone's parent-relative rotation to the limits of its constraint.
+    /// </summary>
+    /// <param name="localRotation">The bone's local (parent-relative) rotation.</param>
+    /// <param name="constraint">The joint constraint to enforce.</param>
+    /// <returns>The rotation clamped to the constraint limits.</returns>
+    internal static Quaternion Apply(Quaternion localRotation, in IKConstraint constraint)
+        => constraint.ConstraintType switch
+        {
+            IKConstraintType.Hinge => ApplyHinge(localRotation, constraint),
+            IKConstraintType.BallSocket => ApplyBallSocket(localRotation, constraint),
+            IKConstraintType.Euler => ApplyEuler(localRotation, constraint),
+            _ => localRotation,
+        };
+
+    /// <summary>
+    /// Collects the per-bone constraints for a chain, indexed to match <paramref name="bones"/>.
+    /// </summary>
+    /// <param name="world">The world containing the bones.</param>
+    /// <param name="bones">Bone entities ordered root to tip.</param>
+    /// <returns>
+    /// An array with one entry per bone (unconstrained bones hold
+    /// <see cref="IKConstraintType.None"/>), or <see langword="null"/> when no bone in the
+    /// chain carries an active constraint so solvers can skip constraint handling entirely.
+    /// </returns>
+    internal static IKConstraint[]? GetChainConstraints(IWorld world, Entity[] bones)
+    {
+        IKConstraint[]? constraints = null;
+
+        for (var i = 0; i < bones.Length; i++)
+        {
+            if (!world.Has<IKConstraint>(bones[i]))
+            {
+                continue;
+            }
+
+            ref readonly var constraint = ref world.Get<IKConstraint>(bones[i]);
+            if (constraint.ConstraintType == IKConstraintType.None)
+            {
+                continue;
+            }
+
+            constraints ??= new IKConstraint[bones.Length];
+            constraints[i] = constraint;
+        }
+
+        return constraints;
+    }
+
+    /// <summary>
+    /// Clamps a hinge joint: only rotation about the hinge axis is kept, with the signed
+    /// angle limited to <c>[MinAngles.X, MaxAngles.X]</c> degrees.
+    /// </summary>
+    private static Quaternion ApplyHinge(Quaternion rotation, in IKConstraint constraint)
+    {
+        if (constraint.Axis.LengthSquared().IsApproximatelyZero())
+        {
+            return rotation;
+        }
+
+        var axis = Vector3.Normalize(constraint.Axis);
+        DecomposeSwingTwist(Canonicalize(rotation), axis, out _, out var twist);
+
+        var angle = SignedTwistAngle(twist, axis) * RadToDeg;
+        var clamped = Math.Clamp(angle, constraint.MinAngles.X, constraint.MaxAngles.X);
+
+        return Quaternion.CreateFromAxisAngle(axis, clamped * DegToRad);
+    }
+
+    /// <summary>
+    /// Clamps a ball-socket joint: the swing away from the socket axis is limited to the
+    /// cone angle and the twist about the axis to ±<see cref="IKConstraint.TwistLimit"/>.
+    /// </summary>
+    private static Quaternion ApplyBallSocket(Quaternion rotation, in IKConstraint constraint)
+    {
+        if (constraint.Axis.LengthSquared().IsApproximatelyZero())
+        {
+            return rotation;
+        }
+
+        var axis = Vector3.Normalize(constraint.Axis);
+        DecomposeSwingTwist(Canonicalize(rotation), axis, out var swing, out var twist);
+
+        swing = Canonicalize(swing);
+        var swingAngle = 2f * MathF.Acos(Math.Clamp(swing.W, -1f, 1f));
+        var coneAngle = constraint.ConeAngle * DegToRad;
+
+        if (swingAngle > coneAngle)
+        {
+            var swingAxis = new Vector3(swing.X, swing.Y, swing.Z);
+            if (!swingAxis.LengthSquared().IsApproximatelyZero())
+            {
+                swing = Quaternion.CreateFromAxisAngle(Vector3.Normalize(swingAxis), coneAngle);
+            }
+        }
+
+        var twistAngle = SignedTwistAngle(twist, axis) * RadToDeg;
+        var clampedTwist = Math.Clamp(twistAngle, -constraint.TwistLimit, constraint.TwistLimit);
+        var twistRotation = Quaternion.CreateFromAxisAngle(axis, clampedTwist * DegToRad);
+
+        return Quaternion.Normalize(swing * twistRotation);
+    }
+
+    /// <summary>
+    /// Clamps an Euler joint: pitch (X), yaw (Y), and roll (Z) angles are extracted in the
+    /// <see cref="Quaternion.CreateFromYawPitchRoll"/> convention and clamped independently.
+    /// </summary>
+    private static Quaternion ApplyEuler(Quaternion rotation, in IKConstraint constraint)
+    {
+        var q = Canonicalize(rotation);
+
+        var pitch = MathF.Asin(Math.Clamp(2f * ((q.W * q.X) - (q.Y * q.Z)), -1f, 1f));
+        var yaw = MathF.Atan2(
+            2f * ((q.X * q.Z) + (q.W * q.Y)),
+            1f - (2f * ((q.X * q.X) + (q.Y * q.Y))));
+        var roll = MathF.Atan2(
+            2f * ((q.X * q.Y) + (q.W * q.Z)),
+            1f - (2f * ((q.X * q.X) + (q.Z * q.Z))));
+
+        var clampedPitch = Math.Clamp(pitch * RadToDeg, constraint.MinAngles.X, constraint.MaxAngles.X);
+        var clampedYaw = Math.Clamp(yaw * RadToDeg, constraint.MinAngles.Y, constraint.MaxAngles.Y);
+        var clampedRoll = Math.Clamp(roll * RadToDeg, constraint.MinAngles.Z, constraint.MaxAngles.Z);
+
+        return Quaternion.CreateFromYawPitchRoll(
+            clampedYaw * DegToRad, clampedPitch * DegToRad, clampedRoll * DegToRad);
+    }
+
+    /// <summary>
+    /// Decomposes a rotation into swing (perpendicular to the axis) and twist (about the
+    /// axis) components such that <c>rotation = swing * twist</c>.
+    /// </summary>
+    private static void DecomposeSwingTwist(
+        Quaternion rotation, Vector3 axis, out Quaternion swing, out Quaternion twist)
+    {
+        var projection = Vector3.Dot(new Vector3(rotation.X, rotation.Y, rotation.Z), axis);
+        var candidate = new Quaternion(axis * projection, rotation.W);
+
+        if (candidate.LengthSquared().IsApproximatelyZero())
+        {
+            // 180-degree rotation about an axis perpendicular to the twist axis: pure swing.
+            twist = Quaternion.Identity;
+        }
+        else
+        {
+            twist = Quaternion.Normalize(candidate);
+        }
+
+        swing = Quaternion.Normalize(rotation * Quaternion.Inverse(twist));
+    }
+
+    /// <summary>
+    /// Returns the signed rotation angle (radians) of a twist quaternion about the axis.
+    /// </summary>
+    private static float SignedTwistAngle(Quaternion twist, Vector3 axis)
+    {
+        var canonical = Canonicalize(twist);
+        var projection = Vector3.Dot(new Vector3(canonical.X, canonical.Y, canonical.Z), axis);
+        return 2f * MathF.Atan2(projection, canonical.W);
+    }
+
+    /// <summary>
+    /// Negates a quaternion when its scalar part is negative so angle extraction stays in
+    /// the shortest-arc range.
+    /// </summary>
+    private static Quaternion Canonicalize(Quaternion rotation)
+        => rotation.W < 0f ? Quaternion.Negate(rotation) : rotation;
+}

--- a/src/KeenEyes.Animation/IK/Solvers/IKSolverMath.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/IKSolverMath.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 
+using KeenEyes.Animation.Components;
 using KeenEyes.Common;
 
 namespace KeenEyes.Animation.IK.Solvers;
@@ -109,17 +110,31 @@ internal static class IKSolverMath
     /// Writes solved world-space joint positions back to the chain as local bone rotations.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Only rotations are modified: each bone is rotated in world space so that its child lands
     /// on the solved position, then converted back to a parent-relative local rotation. Because
     /// solvers preserve joint distances, bone translation offsets (and thus bone lengths) are
     /// left untouched.
+    /// </para>
+    /// <para>
+    /// When <paramref name="constraints"/> is provided, each bone's local rotation is clamped
+    /// to its joint limits via <see cref="IKConstraintSolver.Apply"/> immediately after being
+    /// computed, and the constrained world rotation propagates to all descendant bones. The
+    /// resulting pose therefore always satisfies the constraints, at the cost of possibly
+    /// deviating from the requested <paramref name="solved"/> positions.
+    /// </para>
     /// </remarks>
     /// <param name="world">The world containing the bones.</param>
     /// <param name="bones">Bone entities ordered root to tip, forming a parent-child hierarchy.</param>
     /// <param name="solved">Solved world-space positions for each bone, root to tip.</param>
     /// <param name="tipWorldRotation">Optional world-space rotation to apply to the tip bone (end effector).</param>
+    /// <param name="constraints">
+    /// Optional per-bone joint constraints indexed to match <paramref name="bones"/>; pass
+    /// <see langword="null"/> when the chain is unconstrained.
+    /// </param>
     internal static void ApplyWorldPositions(
-        IWorld world, Entity[] bones, ReadOnlySpan<Vector3> solved, Quaternion? tipWorldRotation)
+        IWorld world, Entity[] bones, ReadOnlySpan<Vector3> solved, Quaternion? tipWorldRotation,
+        IKConstraint[]? constraints = null)
     {
         // World transform of the chain root's parent (identity if none).
         var parentPos = Vector3.Zero;
@@ -155,6 +170,12 @@ internal static class IKSolverMath
                 local.Rotation = Quaternion.Normalize(Quaternion.Inverse(parentRot) * worldRot);
             }
 
+            if (constraints is not null && constraints[i].ConstraintType != IKConstraintType.None)
+            {
+                local.Rotation = IKConstraintSolver.Apply(local.Rotation, in constraints[i]);
+                worldRot = Quaternion.Normalize(parentRot * local.Rotation);
+            }
+
             parentPos = worldPos;
             parentRot = worldRot;
             parentScale = worldScale;
@@ -164,6 +185,11 @@ internal static class IKSolverMath
         {
             ref var tipLocal = ref world.Get<Transform3D>(bones[^1]);
             tipLocal.Rotation = Quaternion.Normalize(Quaternion.Inverse(parentRot) * targetRotation);
+
+            if (constraints is not null && constraints[^1].ConstraintType != IKConstraintType.None)
+            {
+                tipLocal.Rotation = IKConstraintSolver.Apply(tipLocal.Rotation, in constraints[^1]);
+            }
         }
     }
 }

--- a/src/KeenEyes.Animation/IK/Solvers/TwoBoneSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/TwoBoneSolver.cs
@@ -25,6 +25,13 @@ namespace KeenEyes.Animation.IK.Solvers;
 /// solver composes world positions by walking the entity hierarchy and writes results back
 /// as local rotations (see <see cref="IKSolverMath"/> for the space determination).
 /// </para>
+/// <para>
+/// Bones carrying an <see cref="Components.IKConstraint"/> component have their computed
+/// local rotations clamped to the joint limits when the analytic pose is written back
+/// (root and mid rotations, plus the end effector when a target rotation is requested).
+/// Constrained chains may not reach the target; the reported error always measures the
+/// actual end effector position. Bones without a constraint are unaffected.
+/// </para>
 /// </remarks>
 public sealed class TwoBoneSolver : IIKSolver
 {
@@ -124,9 +131,17 @@ public sealed class TwoBoneSolver : IIKSolver
         solved[1] = solvedMid;
         solved[2] = solvedTip;
 
-        IKSolverMath.ApplyWorldPositions(world, bones, solved, context.TargetRotation);
+        var constraints = IKConstraintSolver.GetChainConstraints(world, bones);
+        IKSolverMath.ApplyWorldPositions(world, bones, solved, context.TargetRotation, constraints);
 
-        var error = Vector3.Distance(solvedTip, context.TargetPosition);
+        // Constraint clamping can pull the end effector off the analytic solution, so
+        // measure the error from the actual tip position when constraints are active.
+        var error = constraints is null
+            ? Vector3.Distance(solvedTip, context.TargetPosition)
+            : Vector3.Distance(
+                IKSolverMath.GetWorldTransform(world, bones[2]).Position,
+                context.TargetPosition);
+
         return error <= context.Chain.Tolerance
             ? IKSolverResult.Success(0, error)
             : IKSolverResult.Partial(0, error);

--- a/tests/KeenEyes.Animation.Tests/IK/IKConstraintTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/IKConstraintTests.cs
@@ -1,0 +1,418 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Tests for joint angle constraints: the <see cref="IKConstraintSolver"/> clamping math
+/// and constraint enforcement inside the TwoBone and FABRIK solvers.
+/// </summary>
+public class IKConstraintTests
+{
+    private const float PositionTolerance = 0.001f;
+    private const float QuaternionDotTolerance = 0.9999f;
+    private const float DegToRad = MathF.PI / 180f;
+
+    private static void AssertRotationsEqual(Quaternion actual, Quaternion expected)
+        => MathF.Abs(Quaternion.Dot(actual, expected)).ShouldBeGreaterThan(QuaternionDotTolerance);
+
+    private static IKSolverContext CreateContext(
+        World world,
+        Entity[] bones,
+        Vector3 target,
+        IKChainDefinition chain,
+        Vector3? polePosition = null) => new()
+        {
+            World = world,
+            Chain = chain,
+            BoneEntities = bones,
+            TargetPosition = target,
+            PolePosition = polePosition,
+        };
+
+    private static IKChainDefinition CreateLegChain()
+        => IKChainDefinition.TwoBone("Leg", "Hip", "Knee", "Foot", Vector3.UnitZ);
+
+    #region Hinge Clamping Tests
+
+    [Fact]
+    public void Apply_NoneConstraint_ReturnsRotationUnchanged()
+    {
+        var rotation = Quaternion.CreateFromYawPitchRoll(0.5f, 0.3f, -0.2f);
+
+        var result = IKConstraintSolver.Apply(rotation, IKConstraint.Default);
+
+        AssertRotationsEqual(result, rotation);
+    }
+
+    [Fact]
+    public void Apply_HingeWithinLimits_ReturnsRotationUnchanged()
+    {
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 45f * DegToRad);
+        var constraint = IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, rotation);
+    }
+
+    [Fact]
+    public void Apply_HingeAboveMax_ClampsToMaxAngle()
+    {
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 170f * DegToRad);
+        var constraint = IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 160f * DegToRad));
+    }
+
+    [Fact]
+    public void Apply_HingeBelowMin_ClampsToMinAngle()
+    {
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, -30f * DegToRad);
+        var constraint = IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.Identity);
+    }
+
+    [Fact]
+    public void Apply_HingeOffAxisRotation_RemovesSwingComponent()
+    {
+        // A rotation purely about Y has no twist about the Z hinge axis, so the
+        // hinge reduces it to its clamped (zero) hinge angle.
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitY, 40f * DegToRad);
+        var constraint = IKConstraint.Hinge(Vector3.UnitZ, -160f, 160f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.Identity);
+    }
+
+    #endregion
+
+    #region Ball-Socket Clamping Tests
+
+    [Fact]
+    public void Apply_BallSocketWithinCone_ReturnsRotationUnchanged()
+    {
+        // Rotation about Y swings the default X socket axis by 30 degrees.
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitY, 30f * DegToRad);
+        var constraint = IKConstraint.BallSocket(45f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, rotation);
+    }
+
+    [Fact]
+    public void Apply_BallSocketBeyondCone_ClampsSwingToConeAngle()
+    {
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 90f * DegToRad);
+        var constraint = IKConstraint.BallSocket(45f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 45f * DegToRad));
+    }
+
+    [Fact]
+    public void Apply_BallSocketTwistBeyondLimit_ClampsTwist()
+    {
+        // Rotation about the default X socket axis is pure twist.
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitX, 90f * DegToRad);
+        var constraint = IKConstraint.BallSocket(90f, twistLimit: 30f);
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.CreateFromAxisAngle(Vector3.UnitX, 30f * DegToRad));
+    }
+
+    [Fact]
+    public void Apply_BallSocketSwingAndTwist_ClampsBothIndependently()
+    {
+        var swing = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 60f * DegToRad);
+        var twist = Quaternion.CreateFromAxisAngle(Vector3.UnitX, 50f * DegToRad);
+        var constraint = IKConstraint.BallSocket(45f, twistLimit: 20f);
+
+        var result = IKConstraintSolver.Apply(swing * twist, constraint);
+
+        var expected = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, 45f * DegToRad)
+            * Quaternion.CreateFromAxisAngle(Vector3.UnitX, 20f * DegToRad);
+        AssertRotationsEqual(result, expected);
+    }
+
+    #endregion
+
+    #region Euler Clamping Tests
+
+    [Fact]
+    public void Apply_EulerWithinLimits_ReturnsRotationUnchanged()
+    {
+        var rotation = Quaternion.CreateFromYawPitchRoll(
+            20f * DegToRad, 10f * DegToRad, -5f * DegToRad);
+        var constraint = IKConstraint.Euler(
+            new Vector3(-30f, -45f, -20f), new Vector3(30f, 45f, 20f));
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, rotation);
+    }
+
+    [Fact]
+    public void Apply_EulerBeyondLimits_ClampsEachAxisIndependently()
+    {
+        // Yaw 50 / pitch 40 / roll -35 degrees against limits of X (pitch) +/-30,
+        // Y (yaw) +/-45, Z (roll) +/-20.
+        var rotation = Quaternion.CreateFromYawPitchRoll(
+            50f * DegToRad, 40f * DegToRad, -35f * DegToRad);
+        var constraint = IKConstraint.Euler(
+            new Vector3(-30f, -45f, -20f), new Vector3(30f, 45f, 20f));
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        var expected = Quaternion.CreateFromYawPitchRoll(
+            45f * DegToRad, 30f * DegToRad, -20f * DegToRad);
+        AssertRotationsEqual(result, expected);
+    }
+
+    [Fact]
+    public void Apply_EulerSingleAxisBeyondLimit_ClampsOnlyThatAxis()
+    {
+        var rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitX, 60f * DegToRad);
+        var constraint = IKConstraint.Euler(
+            new Vector3(-45f, -90f, -90f), new Vector3(45f, 90f, 90f));
+
+        var result = IKConstraintSolver.Apply(rotation, constraint);
+
+        AssertRotationsEqual(result, Quaternion.CreateFromAxisAngle(Vector3.UnitX, 45f * DegToRad));
+    }
+
+    #endregion
+
+    #region TwoBone Solver Constraint Tests
+
+    [Fact]
+    public void Solve_KneeHingeAgainstBendDirection_PreventsHyperextension()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        // Knee may only bend with a positive hinge angle; the pole asks for the
+        // opposite (negative) bend, so the knee must clamp at 0 and stay straight.
+        world.Add(bones[1], IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f));
+        var target = new Vector3(1.2f, 0.8f, 0);
+        var context = CreateContext(
+            world, bones, target, CreateLegChain(), polePosition: new Vector3(0.6f, 2f, 0));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeFalse();
+
+        // A blocked knee keeps the leg straight: root-to-foot distance stays at
+        // full reach instead of folding to the 1.44 target distance.
+        var rootPos = IKSolverTestHelpers.GetWorldPosition(world, bones[0]);
+        var footPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(rootPos, footPos).ShouldBeGreaterThan(1.9f);
+        Vector3.Distance(footPos, target).ShouldBeGreaterThan(PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_KneeHingeBendWithinLimits_ReachesTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        // Bending toward the negative-Y pole produces a positive hinge angle,
+        // which the limits allow.
+        world.Add(bones[1], IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f));
+        var target = new Vector3(1.2f, -0.8f, 0);
+        var context = CreateContext(
+            world, bones, target, CreateLegChain(), polePosition: new Vector3(0.6f, -2f, 0));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        var footPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(footPos, target).ShouldBeLessThan(PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_ShoulderBallSocket_RespectsConeReachingExtremeTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        // Shoulder swing limited to 45 degrees around the +X rest direction.
+        world.Add(bones[0], IKConstraint.BallSocket(45f));
+        var target = new Vector3(0, 1.5f, 0);
+        var context = CreateContext(world, bones, target, CreateLegChain());
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        // The target straight above needs ~90 degrees of shoulder swing; the cone
+        // clamps the upper bone to exactly its 45-degree boundary.
+        var rootPos = IKSolverTestHelpers.GetWorldPosition(world, bones[0]);
+        var midPos = IKSolverTestHelpers.GetWorldPosition(world, bones[1]);
+        var upperDirection = Vector3.Normalize(midPos - rootPos);
+        Vector3.Dot(upperDirection, Vector3.UnitX).ShouldBe(MathF.Cos(45f * DegToRad), 0.01f);
+
+        result.Converged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Solve_ConstrainedTwoBone_FinalErrorMatchesActualTipDistance()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        world.Add(bones[1], IKConstraint.Hinge(Vector3.UnitZ, 0f, 160f));
+        var target = new Vector3(1.2f, 0.8f, 0);
+        var context = CreateContext(
+            world, bones, target, CreateLegChain(), polePosition: new Vector3(0.6f, 2f, 0));
+
+        var result = new TwoBoneSolver().Solve(in context);
+
+        var footPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        result.FinalError.ShouldBe(Vector3.Distance(footPos, target), PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_TwoBoneWithNoneConstraintComponents_MatchesUnconstrainedSolve()
+    {
+        using var unconstrained = new World();
+        var plainBones = IKSolverTestHelpers.CreateChain(
+            unconstrained, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        using var constrained = new World();
+        var taggedBones = IKSolverTestHelpers.CreateChain(
+            constrained, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        foreach (var bone in taggedBones)
+        {
+            constrained.Add(bone, IKConstraint.Default);
+        }
+
+        var target = new Vector3(1.2f, 0.8f, 0);
+        var pole = new Vector3(0.6f, 0, 2f);
+        var plainContext = CreateContext(
+            unconstrained, plainBones, target, CreateLegChain(), polePosition: pole);
+        var taggedContext = CreateContext(
+            constrained, taggedBones, target, CreateLegChain(), polePosition: pole);
+
+        var plainResult = new TwoBoneSolver().Solve(in plainContext);
+        var taggedResult = new TwoBoneSolver().Solve(in taggedContext);
+
+        taggedResult.Converged.ShouldBe(plainResult.Converged);
+        for (var i = 0; i < plainBones.Length; i++)
+        {
+            var plainPos = IKSolverTestHelpers.GetWorldPosition(unconstrained, plainBones[i]);
+            var taggedPos = IKSolverTestHelpers.GetWorldPosition(constrained, taggedBones[i]);
+            Vector3.Distance(plainPos, taggedPos).ShouldBeLessThan(1e-5f);
+        }
+    }
+
+    #endregion
+
+    #region FABRIK Solver Constraint Tests
+
+    [Fact]
+    public void Solve_FABRIKWithTightHinges_RespectsLimitsAndPreservesBoneLengths()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world,
+            new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        var hinge = IKConstraint.Hinge(Vector3.UnitZ, -15f, 15f);
+        world.Add(bones[1], hinge);
+        world.Add(bones[2], hinge);
+
+        // Target closer than the chain's minimum constrained reach: the nearly
+        // rigid chain cannot curl enough, so the solve stays partial.
+        var chain = IKChainDefinition.MultiBone("Tail", ["A", "B", "C", "D"], maxIterations: 20);
+        var context = CreateContext(world, bones, new Vector3(0, 2.5f, 0), chain);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeFalse();
+
+        var lengths = IKSolverTestHelpers.GetBoneLengths(world, bones);
+        foreach (var length in lengths)
+        {
+            length.ShouldBe(1f, PositionTolerance);
+        }
+
+        // The written pose must satisfy the hinge limits: clamping again is a no-op.
+        for (var i = 1; i <= 2; i++)
+        {
+            ref readonly var local = ref world.Get<Transform3D>(bones[i]);
+            var reclamped = IKConstraintSolver.Apply(local.Rotation, hinge);
+            MathF.Abs(Quaternion.Dot(reclamped, local.Rotation))
+                .ShouldBeGreaterThan(QuaternionDotTolerance);
+        }
+    }
+
+    [Fact]
+    public void Solve_FABRIKWithLooseHinge_ConvergesToReachableTarget()
+    {
+        using var world = new World();
+        var bones = IKSolverTestHelpers.CreateChain(
+            world, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        world.Add(bones[1], IKConstraint.Hinge(Vector3.UnitZ, -170f, 170f));
+
+        var chain = IKChainDefinition.MultiBone("Arm", ["A", "B", "C"], maxIterations: 30);
+        var target = new Vector3(1f, 1f, 0);
+        var context = CreateContext(world, bones, target, chain);
+
+        var result = new FABRIKSolver().Solve(in context);
+
+        result.Converged.ShouldBeTrue();
+        result.Iterations.ShouldBeLessThanOrEqualTo(chain.MaxIterations);
+        var tipPos = IKSolverTestHelpers.GetWorldPosition(world, bones[2]);
+        Vector3.Distance(tipPos, target).ShouldBeLessThanOrEqualTo(chain.Tolerance + PositionTolerance);
+    }
+
+    [Fact]
+    public void Solve_FABRIKWithNoneConstraintComponents_MatchesUnconstrainedSolve()
+    {
+        using var unconstrained = new World();
+        var plainBones = IKSolverTestHelpers.CreateChain(
+            unconstrained, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+
+        using var constrained = new World();
+        var taggedBones = IKSolverTestHelpers.CreateChain(
+            constrained, new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 0, 0));
+        foreach (var bone in taggedBones)
+        {
+            constrained.Add(bone, IKConstraint.Default);
+        }
+
+        var chain = IKChainDefinition.MultiBone("Arm", ["A", "B", "C"]);
+        var target = new Vector3(1f, 1f, 0);
+        var plainContext = CreateContext(unconstrained, plainBones, target, chain);
+        var taggedContext = CreateContext(constrained, taggedBones, target, chain);
+
+        var plainResult = new FABRIKSolver().Solve(in plainContext);
+        var taggedResult = new FABRIKSolver().Solve(in taggedContext);
+
+        taggedResult.Converged.ShouldBe(plainResult.Converged);
+        taggedResult.Iterations.ShouldBe(plainResult.Iterations);
+        for (var i = 0; i < plainBones.Length; i++)
+        {
+            var plainPos = IKSolverTestHelpers.GetWorldPosition(unconstrained, plainBones[i]);
+            var taggedPos = IKSolverTestHelpers.GetWorldPosition(constrained, taggedBones[i]);
+            Vector3.Distance(plainPos, taggedPos).ShouldBeLessThan(1e-5f);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- `IKConstraintSolver` (internal): clamps a bone's parent-relative rotation against its `IKConstraint` — **Hinge** (swing-twist about the hinge axis, swing discarded, signed twist clamped), **BallSocket** (swing clamped to cone, twist to ±limit), **Euler** (per-axis clamp). Angles in **degrees**, matching the pre-existing component docs; the existing `Hinge`/`BallSocket`/`Euler` factories are used as-is.
- Integrated into both solvers from #1007: `TwoBoneSolver` clamps during write-back and re-measures `FinalError` from the actual tip; `FABRIKSolver` re-projects per iteration (positions → clamped local rotations → re-read), preserving bone lengths exactly (rationale in XML remarks).
- Unconstrained chains take a guaranteed zero-behavior-change fast path — all 35 solver tests pass unmodified; None-constraint passthrough asserted bit-identical.

## Test plan
- [x] 15 new tests (hinge/cone/twist/Euler clamp math; knee hyperextension blocked; in-limit bend reaches; shoulder clamped to exact cone boundary; bone-length preservation + idempotent re-clamp) — 296/296 passing, re-verified after rebase onto main
- [x] Build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green (needs #1009 for repo-wide NU1901)

## Related Issues
Refs #957 (part of #959). Rebased onto main after #1007 merged.