### PR TITLE
feat(network): Add owner-authoritative sync strategy

### DIFF
--- a/editor/KeenEyes.Generators/ReplicatedGenerator.cs
+++ b/editor/KeenEyes.Generators/ReplicatedGenerator.cs
@@ -647,8 +647,9 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
             var strategy = comp.Strategy switch
             {
                 0 => "SyncStrategy.Authoritative",
-                1 => "SyncStrategy.OwnerPredicted",
-                2 => "SyncStrategy.InterpolatedOnly",
+                1 => "SyncStrategy.Interpolated",
+                2 => "SyncStrategy.Predicted",
+                3 => "SyncStrategy.OwnerAuthoritative",
                 _ => "SyncStrategy.Authoritative"
             };
             sb.AppendLine($"        new NetworkComponentInfo");

--- a/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
+++ b/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
@@ -152,6 +152,42 @@ public record class ServerNetworkConfig : NetworkPluginConfig
     /// Gets or sets the maximum number of clients.
     /// </summary>
     public int MaxClients { get; set; } = 16;
+
+    /// <summary>
+    /// Gets or sets the validation hook for owner-authoritative state updates.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Invoked once per component in an
+    /// <c>OwnerStateUpdate</c> message after the server
+    /// has confirmed the sending client owns the entity and the component uses
+    /// <see cref="SyncStrategy.OwnerAuthoritative"/>. Return <see langword="true"/>
+    /// to accept the update or <see langword="false"/> to reject it (leaving server
+    /// state unchanged).
+    /// </para>
+    /// <para>
+    /// When <see langword="null"/> (the default), all owner-authoritative updates
+    /// that pass the ownership and strategy checks are accepted.
+    /// </para>
+    /// </remarks>
+    public Func<OwnerStateValidationContext, bool>? OwnerStateValidator { get; set; }
+
+    /// <summary>
+    /// Gets or sets the policy hook for client ownership requests.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Invoked when a client sends an
+    /// <c>OwnershipRequest</c>. Return
+    /// <see langword="true"/> to grant ownership (the server transfers ownership and
+    /// broadcasts an <c>OwnershipTransfer</c>) or
+    /// <see langword="false"/> to deny it.
+    /// </para>
+    /// <para>
+    /// When <see langword="null"/> (the default), all ownership requests are denied.
+    /// </para>
+    /// </remarks>
+    public Func<OwnershipRequestContext, bool>? OwnershipRequestPolicy { get; set; }
 }
 
 /// <summary>

--- a/src/KeenEyes.Network.Abstractions/OwnerAuthoritativeHooks.cs
+++ b/src/KeenEyes.Network.Abstractions/OwnerAuthoritativeHooks.cs
@@ -1,0 +1,66 @@
+namespace KeenEyes.Network;
+
+/// <summary>
+/// Context passed to the server's owner-authoritative state validation hook.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server invokes the validator once per component contained in an
+/// <c>OwnerStateUpdate</c> message, after it has
+/// confirmed that the sending client owns the target entity and that the
+/// component uses <see cref="SyncStrategy.OwnerAuthoritative"/>.
+/// </para>
+/// <para>
+/// Returning <see langword="false"/> rejects the update for that component,
+/// leaving the server's authoritative state unchanged.
+/// </para>
+/// </remarks>
+public readonly struct OwnerStateValidationContext
+{
+    /// <summary>
+    /// Gets the client ID that sent the state update.
+    /// </summary>
+    public required int ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the server-side entity the update targets.
+    /// </summary>
+    public required Entity Entity { get; init; }
+
+    /// <summary>
+    /// Gets the component type being updated.
+    /// </summary>
+    public required Type ComponentType { get; init; }
+
+    /// <summary>
+    /// Gets the proposed component value (boxed) sent by the client.
+    /// </summary>
+    public required object Value { get; init; }
+}
+
+/// <summary>
+/// Context passed to the server's ownership request policy hook.
+/// </summary>
+/// <remarks>
+/// The server invokes the policy when a client sends an
+/// <c>OwnershipRequest</c>. Returning
+/// <see langword="true"/> grants ownership; returning <see langword="false"/>
+/// denies it. When no policy is configured, requests are denied by default.
+/// </remarks>
+public readonly struct OwnershipRequestContext
+{
+    /// <summary>
+    /// Gets the client ID requesting ownership.
+    /// </summary>
+    public required int ClientId { get; init; }
+
+    /// <summary>
+    /// Gets the server-side entity ownership is being requested for.
+    /// </summary>
+    public required Entity Entity { get; init; }
+
+    /// <summary>
+    /// Gets the network ID of the entity ownership is being requested for.
+    /// </summary>
+    public required uint NetworkId { get; init; }
+}

--- a/src/KeenEyes.Network/NetworkClientPlugin.cs
+++ b/src/KeenEyes.Network/NetworkClientPlugin.cs
@@ -43,6 +43,9 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
     private readonly Dictionary<Entity, SnapshotBuffer> snapshotBuffers = [];
     private readonly Dictionary<Entity, object> inputBuffers = []; // Stores InputBuffer<T> instances
 
+    private OwnerAuthoritativeComponentSet? ownerAuthTypes;
+    private INetworkSerializer? ownerAuthTypesSource;
+
     private IPluginContext? context;
     private ClientPredictionSystem? predictionSystem;
     private uint currentTick;
@@ -596,6 +599,15 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
             return;
         }
 
+        // Owner-authoritative components on locally owned entities: the local client
+        // is authoritative, so its own state wins. Ignore incoming server state for
+        // these components (the server suppresses echoing them in steady state, but
+        // full snapshots and spawns still carry an initial value).
+        if (context.World.Has<LocallyOwned>(entity) && IsOwnerAuthoritative(componentType))
+        {
+            return;
+        }
+
         // If interpolation is enabled for this entity and component,
         // push to snapshot buffer instead of applying directly
         if (snapshotBuffer is not null &&
@@ -760,6 +772,51 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
 
         // Notify listeners
         OwnershipChanged?.Invoke(entity, oldOwnerId, newOwnerId);
+    }
+
+    /// <summary>
+    /// Requests ownership of a networked entity from the server.
+    /// </summary>
+    /// <param name="networkId">The network ID of the entity to request ownership of.</param>
+    /// <remarks>
+    /// <para>
+    /// The server evaluates the request against its ownership request policy and,
+    /// if granted, transfers ownership and broadcasts an ownership transfer that
+    /// this client processes to update local ownership tags.
+    /// </para>
+    /// <para>
+    /// Does nothing when the client is not connected.
+    /// </para>
+    /// </remarks>
+    public void RequestOwnership(uint networkId)
+    {
+        if (!isConnected)
+        {
+            return;
+        }
+
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.OwnershipRequest, currentTick);
+        writer.WriteNetworkId(networkId);
+        transport.Send(0, writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+    }
+
+    private bool IsOwnerAuthoritative(Type componentType)
+    {
+        var serializer = config.Serializer;
+        if (serializer is null)
+        {
+            return false;
+        }
+
+        if (ownerAuthTypes is null || !ReferenceEquals(ownerAuthTypesSource, serializer))
+        {
+            ownerAuthTypes = new OwnerAuthoritativeComponentSet(serializer);
+            ownerAuthTypesSource = serializer;
+        }
+
+        return ownerAuthTypes.Contains(componentType);
     }
 
     private void HandleHierarchyChange(ref NetworkMessageReader reader)

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -2,6 +2,7 @@ using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Protocol;
 using KeenEyes.Network.Replication;
+using KeenEyes.Network.Serialization;
 using KeenEyes.Network.Systems;
 using KeenEyes.Network.Transport;
 
@@ -36,6 +37,8 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     private readonly Dictionary<int, ClientState> clients = [];
 
     private IPluginContext? context;
+    private OwnerAuthoritativeComponentSet? ownerAuthTypes;
+    private INetworkSerializer? ownerAuthTypesSource;
     private uint currentTick;
     private float tickAccumulator;
     private EventSubscription? entityCreatedSubscription;
@@ -415,6 +418,14 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
                 ClientInputReceived?.Invoke(clientId, tick, inputPayload);
                 break;
 
+            case MessageType.OwnerStateUpdate:
+                HandleOwnerStateUpdate(clientId, ref reader);
+                break;
+
+            case MessageType.OwnershipRequest:
+                HandleOwnershipRequest(clientId, ref reader);
+                break;
+
             case MessageType.Ping:
                 // Respond with pong
                 Span<byte> pongBuffer = stackalloc byte[8];
@@ -423,6 +434,139 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
                 transport.Send(clientId, pongWriter.GetWrittenSpan(), DeliveryMode.Unreliable);
                 break;
         }
+    }
+
+    private void HandleOwnerStateUpdate(int clientId, ref NetworkMessageReader reader)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        var serializer = config.Serializer;
+        if (serializer is null)
+        {
+            return;
+        }
+
+        var networkId = reader.ReadNetworkId();
+
+        // Resolve the target entity and confirm the sending client owns it.
+        var ownsEntity =
+            networkIdManager.TryGetLocalEntity(networkId, out var entity)
+            && context.World.IsAlive(entity)
+            && context.World.Has<NetworkOwner>(entity)
+            && context.World.Get<NetworkOwner>(entity).ClientId == clientId;
+
+        // Collect the component types the entity currently has so unknown or
+        // absent components can be rejected without adding new component types.
+        var existingTypes = ownsEntity ? CollectComponentTypes(entity) : null;
+
+        var ownerAuth = GetOwnerAuthTypes(serializer);
+        var validator = config.OwnerStateValidator;
+
+        var componentCount = reader.ReadComponentCount();
+        for (int i = 0; i < componentCount; i++)
+        {
+            // Always read the component so the reader advances even when rejected.
+            var component = reader.ReadComponent(serializer, out var componentType);
+            if (component is null || componentType is null)
+            {
+                continue;
+            }
+
+            // Reject silently: wrong owner, non-owner-authoritative component, or a
+            // component the server entity does not already have.
+            if (!ownsEntity
+                || !ownerAuth.Contains(componentType)
+                || existingTypes is null
+                || !existingTypes.Contains(componentType))
+            {
+                continue;
+            }
+
+            // Run the configurable validation hook (default accept).
+            if (validator is not null && !validator(new OwnerStateValidationContext
+            {
+                ClientId = clientId,
+                Entity = entity,
+                ComponentType = componentType,
+                Value = component,
+            }))
+            {
+                continue;
+            }
+
+            // Apply to the authoritative server world. NetworkServerSendSystem detects
+            // the change and relays it to other clients; echoes back to the owner are
+            // suppressed there.
+            context.World.SetComponent(entity, componentType, component);
+        }
+    }
+
+    private void HandleOwnershipRequest(int clientId, ref NetworkMessageReader reader)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        var networkId = reader.ReadNetworkId();
+
+        if (!networkIdManager.TryGetLocalEntity(networkId, out var entity)
+            || !context.World.IsAlive(entity))
+        {
+            return;
+        }
+
+        var policy = config.OwnershipRequestPolicy;
+        var granted = policy is not null && policy(new OwnershipRequestContext
+        {
+            ClientId = clientId,
+            Entity = entity,
+            NetworkId = networkId,
+        });
+
+        if (!granted)
+        {
+            // Deny silently (default deny when no policy is configured).
+            return;
+        }
+
+        // Grant ownership on the server and broadcast the transfer to all clients.
+        context.World.Set(entity, new NetworkOwner { ClientId = clientId });
+
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.OwnershipTransfer, currentTick);
+        writer.WriteNetworkId(networkId);
+        writer.WriteSignedBits(clientId, 16);
+        transport.SendToAll(writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+    }
+
+    private HashSet<Type> CollectComponentTypes(Entity entity)
+    {
+        var types = new HashSet<Type>();
+        if (context?.World is ISnapshotCapability snapshot)
+        {
+            foreach (var (type, _) in snapshot.GetComponents(entity))
+            {
+                types.Add(type);
+            }
+        }
+
+        return types;
+    }
+
+    private OwnerAuthoritativeComponentSet GetOwnerAuthTypes(INetworkSerializer serializer)
+    {
+        if (ownerAuthTypes is null || !ReferenceEquals(ownerAuthTypesSource, serializer))
+        {
+            ownerAuthTypes = new OwnerAuthoritativeComponentSet(serializer);
+            ownerAuthTypesSource = serializer;
+        }
+
+        return ownerAuthTypes;
     }
 
     private void OnEntityCreated(Entity entity, string? name)

--- a/src/KeenEyes.Network/Protocol/MessageType.cs
+++ b/src/KeenEyes.Network/Protocol/MessageType.cs
@@ -101,6 +101,16 @@ public enum MessageType : byte
     /// </summary>
     ClientAck = 0x21,
 
+    /// <summary>
+    /// Client sends owner-authoritative component state for an entity it owns.
+    /// </summary>
+    /// <remarks>
+    /// Only valid for entities the sending client owns whose replicated components
+    /// use <see cref="SyncStrategy.OwnerAuthoritative"/>. The server validates
+    /// ownership and strategy before applying and relaying the state.
+    /// </remarks>
+    OwnerStateUpdate = 0x22,
+
     // Ownership (0x30-0x3F)
 
     /// <summary>

--- a/src/KeenEyes.Network/Replication/OwnerAuthoritativeComponentSet.cs
+++ b/src/KeenEyes.Network/Replication/OwnerAuthoritativeComponentSet.cs
@@ -1,0 +1,42 @@
+using KeenEyes.Network.Serialization;
+
+namespace KeenEyes.Network.Replication;
+
+/// <summary>
+/// Resolves which replicated component types use the
+/// <see cref="SyncStrategy.OwnerAuthoritative"/> synchronization strategy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The set is built once from the strategy metadata exposed by
+/// <see cref="INetworkSerializer.GetRegisteredComponentInfo"/>, which the network
+/// source generator emits per replicated component. This keeps runtime strategy
+/// dispatch reflection-free and AOT-compatible.
+/// </para>
+/// </remarks>
+internal sealed class OwnerAuthoritativeComponentSet
+{
+    private readonly HashSet<Type> types = [];
+
+    /// <summary>
+    /// Initializes the set from a network serializer's component metadata.
+    /// </summary>
+    /// <param name="serializer">The serializer providing component strategy metadata.</param>
+    public OwnerAuthoritativeComponentSet(INetworkSerializer serializer)
+    {
+        foreach (var info in serializer.GetRegisteredComponentInfo())
+        {
+            if (info.Strategy == SyncStrategy.OwnerAuthoritative)
+            {
+                types.Add(info.Type);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the specified component type is owner-authoritative.
+    /// </summary>
+    /// <param name="type">The component type to check.</param>
+    /// <returns><see langword="true"/> if the type uses the owner-authoritative strategy.</returns>
+    public bool Contains(Type type) => types.Contains(type);
+}

--- a/src/KeenEyes.Network/Systems/NetworkClientSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkClientSendSystem.cs
@@ -1,6 +1,9 @@
+using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Prediction;
 using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Replication;
+using KeenEyes.Network.Serialization;
 using KeenEyes.Network.Transport;
 
 namespace KeenEyes.Network.Systems;
@@ -17,6 +20,14 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
     private float pingTimer;
     private const float PingInterval = 1.0f; // Send ping every second
     private uint lastSentInputTick;
+
+    // Owner-authoritative state tracking.
+    private float ownerStateAccumulator;
+    private OwnerAuthoritativeComponentSet? ownerAuthTypes;
+    private INetworkSerializer? ownerAuthTypesSource;
+
+    // Track last sent owner-authoritative component values per entity for dirty detection.
+    private readonly Dictionary<Entity, Dictionary<Type, object>> lastSentOwnerState = [];
 
     /// <inheritdoc/>
     public override void Update(float deltaTime)
@@ -39,6 +50,9 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
         {
             SendInput();
         }
+
+        // Send owner-authoritative component state at the network tick cadence.
+        SendOwnerState(deltaTime);
 
         // Pump the transport to flush outgoing data
         plugin.Transport.Update();
@@ -86,5 +100,122 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
 
             lastSentInputTick = inputBuffer.NewestTick;
         }
+    }
+
+    private void SendOwnerState(float deltaTime)
+    {
+        var serializer = plugin.Config.Serializer;
+        if (serializer is null)
+        {
+            return;
+        }
+
+        // Gate sends to the configured network tick cadence.
+        var tickInterval = 1f / plugin.Config.TickRate;
+        ownerStateAccumulator += deltaTime;
+        if (ownerStateAccumulator < tickInterval)
+        {
+            return;
+        }
+
+        ownerStateAccumulator -= tickInterval;
+
+        var ownerAuth = GetOwnerAuthTypes(serializer);
+        if (World is not ISnapshotCapability snapshot)
+        {
+            return;
+        }
+
+        // Send owner-authoritative state for entities this client owns.
+        foreach (var entity in World.Query<LocallyOwned, NetworkId>())
+        {
+            ref readonly var networkId = ref World.Get<NetworkId>(entity);
+            SendEntityOwnerState(entity, networkId, snapshot, serializer, ownerAuth);
+        }
+    }
+
+    private void SendEntityOwnerState(
+        Entity entity,
+        NetworkId networkId,
+        ISnapshotCapability snapshot,
+        INetworkSerializer serializer,
+        OwnerAuthoritativeComponentSet ownerAuth)
+    {
+        // Collect owner-authoritative components whose value changed since the last send.
+        lastSentOwnerState.TryGetValue(entity, out var entityLastState);
+
+        var toSend = new List<(Type type, object value)>();
+        foreach (var (type, value) in snapshot.GetComponents(entity))
+        {
+            if (!ownerAuth.Contains(type) || !serializer.IsNetworkSerializable(type))
+            {
+                continue;
+            }
+
+            if (!HasChanged(serializer, type, value, entityLastState))
+            {
+                continue;
+            }
+
+            toSend.Add((type, value));
+        }
+
+        if (toSend.Count == 0)
+        {
+            return;
+        }
+
+        var writer = new NetworkMessageWriter(sendBuffer);
+        writer.WriteHeader(MessageType.OwnerStateUpdate, plugin.CurrentTick);
+        writer.WriteNetworkId(networkId.Value);
+        writer.WriteComponentCount((byte)toSend.Count);
+        foreach (var (type, value) in toSend)
+        {
+            writer.WriteComponent(serializer, type, value);
+        }
+
+        plugin.SendToServer(writer.GetWrittenSpan(), DeliveryMode.UnreliableSequenced);
+
+        // Record the sent state so unchanged components are not re-sent next tick.
+        if (entityLastState is null)
+        {
+            entityLastState = [];
+            lastSentOwnerState[entity] = entityLastState;
+        }
+
+        foreach (var (type, value) in toSend)
+        {
+            entityLastState[type] = value;
+        }
+    }
+
+    private static bool HasChanged(
+        INetworkSerializer serializer,
+        Type type,
+        object value,
+        Dictionary<Type, object>? entityLastState)
+    {
+        if (entityLastState is null || !entityLastState.TryGetValue(type, out var lastValue))
+        {
+            return true;
+        }
+
+        if (serializer.SupportsDelta(type))
+        {
+            return serializer.GetDirtyMask(type, value, lastValue) != 0;
+        }
+
+        return !Equals(lastValue, value);
+    }
+
+    private OwnerAuthoritativeComponentSet GetOwnerAuthTypes(INetworkSerializer serializer)
+    {
+        if (ownerAuthTypes is null || !ReferenceEquals(ownerAuthTypesSource, serializer))
+        {
+            ownerAuthTypes = new OwnerAuthoritativeComponentSet(serializer);
+            ownerAuthTypesSource = serializer;
+        }
+
+        return ownerAuthTypes;
     }
 }

--- a/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
@@ -1,6 +1,7 @@
 using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Replication;
 using KeenEyes.Network.Serialization;
 using KeenEyes.Network.Transport;
 
@@ -21,6 +22,10 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
 
     // Track bytes sent this tick for bandwidth limiting
     private int bytesSentThisTick;
+
+    // Cached owner-authoritative strategy lookup (rebuilt if the serializer changes).
+    private OwnerAuthoritativeComponentSet? ownerAuthTypes;
+    private INetworkSerializer? ownerAuthTypesSource;
 
     // Pre-allocated list to avoid per-tick allocations
     private readonly List<(Entity entity, float priority, bool needsFullSync)> entitiesToUpdate = [];
@@ -165,12 +170,15 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
 
     private void SendEntityUpdate(Entity entity, NetworkId networkId, ref NetworkState state)
     {
-        var writer = new NetworkMessageWriter(sendBuffer);
         var serializer = plugin.Config.Serializer;
 
         if (state.NeedsFullSync)
         {
-            // Send full entity state
+            // Send full entity state. The full snapshot is always broadcast to every
+            // client (including a client owner) because it carries the entity's initial
+            // component values; the owner immediately overrides its owner-authoritative
+            // components with its own upstream state.
+            var writer = new NetworkMessageWriter(sendBuffer);
             writer.WriteHeader(MessageType.EntitySpawn, plugin.CurrentTick);
 
             var owner = World.Has<NetworkOwner>(entity)
@@ -183,23 +191,93 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             WriteReplicatedComponentsFull(entity, ref writer, serializer);
 
             state.NeedsFullSync = false;
+
+            var span = writer.GetWrittenSpan();
+            bytesSentThisTick += span.Length;
+            plugin.SendToAll(span, DeliveryMode.UnreliableSequenced);
         }
         else
         {
-            // Send delta update (only changed fields within components)
-            writer.WriteHeader(MessageType.ComponentDelta, plugin.CurrentTick);
-            writer.WriteUInt32(networkId.Value);
-
-            // Write components with delta encoding
-            WriteReplicatedComponentsDelta(entity, ref writer, serializer);
+            SendDeltaUpdate(entity, networkId, serializer);
         }
+
+        // Update last sent state for delta tracking
+        SaveSentState(entity, serializer);
+    }
+
+    private void SendDeltaUpdate(Entity entity, NetworkId networkId, INetworkSerializer? serializer)
+    {
+        var owner = World.Has<NetworkOwner>(entity)
+            ? World.Get<NetworkOwner>(entity)
+            : NetworkOwner.Server;
+
+        // Echo suppression: for a client-owned entity, owner-authoritative components
+        // must not be sent back to the owner (its own state is authoritative). Other
+        // components (server-authoritative, predicted, interpolated) still reach the
+        // owner so reconciliation and server updates work. Server-owned entities have
+        // no client owner to echo to and use the standard single broadcast.
+        if (serializer is not null && owner.ClientId != NetworkOwner.ServerClientId)
+        {
+            SendClientOwnedDelta(entity, networkId, owner.ClientId, serializer);
+            return;
+        }
+
+        var writer = new NetworkMessageWriter(sendBuffer);
+        writer.WriteHeader(MessageType.ComponentDelta, plugin.CurrentTick);
+        writer.WriteUInt32(networkId.Value);
+        WriteReplicatedComponentsDelta(entity, ref writer, serializer);
 
         var span = writer.GetWrittenSpan();
         bytesSentThisTick += span.Length;
         plugin.SendToAll(span, DeliveryMode.UnreliableSequenced);
+    }
 
-        // Update last sent state for delta tracking
-        SaveSentState(entity, serializer);
+    private void SendClientOwnedDelta(Entity entity, NetworkId networkId, int ownerId, INetworkSerializer serializer)
+    {
+        var ownerAuth = GetOwnerAuthTypes(serializer);
+        var changed = CollectChangedComponents(entity, serializer);
+
+        var toOwnerAndOthers = new List<(Type type, object current, object? baseline)>();
+        var toOthersOnly = new List<(Type type, object current, object? baseline)>();
+        foreach (var component in changed)
+        {
+            if (ownerAuth.Contains(component.type))
+            {
+                toOthersOnly.Add(component);
+            }
+            else
+            {
+                toOwnerAndOthers.Add(component);
+            }
+        }
+
+        // Owner-authoritative components: relay to every client except the owner.
+        if (toOthersOnly.Count > 0)
+        {
+            var span = WriteDeltaMessage(networkId, toOthersOnly, serializer);
+            bytesSentThisTick += span.Length;
+            plugin.SendToAllExcept(ownerId, span, DeliveryMode.UnreliableSequenced);
+        }
+
+        // Remaining components: broadcast to all clients including the owner.
+        if (toOwnerAndOthers.Count > 0)
+        {
+            var span = WriteDeltaMessage(networkId, toOwnerAndOthers, serializer);
+            bytesSentThisTick += span.Length;
+            plugin.SendToAll(span, DeliveryMode.UnreliableSequenced);
+        }
+    }
+
+    private ReadOnlySpan<byte> WriteDeltaMessage(
+        NetworkId networkId,
+        List<(Type type, object current, object? baseline)> components,
+        INetworkSerializer serializer)
+    {
+        var writer = new NetworkMessageWriter(sendBuffer);
+        writer.WriteHeader(MessageType.ComponentDelta, plugin.CurrentTick);
+        writer.WriteUInt32(networkId.Value);
+        WriteDeltaComponents(ref writer, components, serializer);
+        return writer.GetWrittenSpan();
     }
 
     private void WriteReplicatedComponentsFull(Entity entity, ref NetworkMessageWriter writer, INetworkSerializer? serializer)
@@ -238,6 +316,12 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             return;
         }
 
+        var toSend = CollectChangedComponents(entity, serializer);
+        WriteDeltaComponents(ref writer, toSend, serializer);
+    }
+
+    private List<(Type type, object current, object? baseline)> CollectChangedComponents(Entity entity, INetworkSerializer serializer)
+    {
         // Get last sent state for delta comparison
         lastSentState.TryGetValue(entity, out var entityLastState);
 
@@ -280,10 +364,18 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             }
         }
 
-        writer.WriteComponentCount((byte)toSend.Count);
+        return toSend;
+    }
+
+    private static void WriteDeltaComponents(
+        ref NetworkMessageWriter writer,
+        List<(Type type, object current, object? baseline)> components,
+        INetworkSerializer serializer)
+    {
+        writer.WriteComponentCount((byte)components.Count);
 
         // Write each component with delta encoding where supported
-        foreach (var (type, current, baseline) in toSend)
+        foreach (var (type, current, baseline) in components)
         {
             // Use delta serialization if we have a baseline and the type supports it
             if (baseline is not null && serializer.SupportsDelta(type))
@@ -296,6 +388,17 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
                 writer.WriteComponent(serializer, type, current);
             }
         }
+    }
+
+    private OwnerAuthoritativeComponentSet GetOwnerAuthTypes(INetworkSerializer serializer)
+    {
+        if (ownerAuthTypes is null || !ReferenceEquals(ownerAuthTypesSource, serializer))
+        {
+            ownerAuthTypes = new OwnerAuthoritativeComponentSet(serializer);
+            ownerAuthTypesSource = serializer;
+        }
+
+        return ownerAuthTypes;
     }
 
     private void SaveSentState(Entity entity, INetworkSerializer? serializer)

--- a/tests/KeenEyes.Generators.Tests/ReplicatedGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/ReplicatedGeneratorTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Tests for the network replication source generator, focused on the
+/// per-component <c>SyncStrategy</c> metadata it emits into the generated
+/// <c>NetworkSerializer</c>.
+/// </summary>
+public class ReplicatedGeneratorTests
+{
+    [Theory]
+    [InlineData("Authoritative", "SyncStrategy.Authoritative")]
+    [InlineData("Interpolated", "SyncStrategy.Interpolated")]
+    [InlineData("Predicted", "SyncStrategy.Predicted")]
+    [InlineData("OwnerAuthoritative", "SyncStrategy.OwnerAuthoritative")]
+    public void ReplicatedGenerator_EmitsCorrectStrategyMetadata(string strategy, string expectedEmit)
+    {
+        var source = $$"""
+            namespace KeenEyes.Network
+            {
+                public enum SyncStrategy
+                {
+                    Authoritative = 0,
+                    Interpolated = 1,
+                    Predicted = 2,
+                    OwnerAuthoritative = 3,
+                }
+
+                [System.AttributeUsage(System.AttributeTargets.Struct)]
+                public sealed class ReplicatedAttribute : System.Attribute
+                {
+                    public SyncStrategy Strategy { get; set; }
+                }
+            }
+
+            namespace TestApp
+            {
+                using KeenEyes.Network;
+
+                [Replicated(Strategy = SyncStrategy.{{strategy}})]
+                public partial struct Position
+                {
+                    public float X;
+                    public float Y;
+                }
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(generatedTrees, t => t.Contains($"Strategy = {expectedEmit},"));
+    }
+
+    [Fact]
+    public void ReplicatedGenerator_DoesNotEmitInvalidStrategyNames()
+    {
+        // Regression guard: the generator previously emitted the non-existent
+        // "OwnerPredicted" and "InterpolatedOnly" enum members.
+        var source = """
+            namespace KeenEyes.Network
+            {
+                public enum SyncStrategy
+                {
+                    Authoritative = 0,
+                    Interpolated = 1,
+                    Predicted = 2,
+                    OwnerAuthoritative = 3,
+                }
+
+                [System.AttributeUsage(System.AttributeTargets.Struct)]
+                public sealed class ReplicatedAttribute : System.Attribute
+                {
+                    public SyncStrategy Strategy { get; set; }
+                }
+            }
+
+            namespace TestApp
+            {
+                using KeenEyes.Network;
+
+                [Replicated(Strategy = SyncStrategy.OwnerAuthoritative)]
+                public partial struct Position
+                {
+                    public float X;
+                }
+            }
+            """;
+
+        var (_, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("SyncStrategy.OwnerPredicted"));
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("SyncStrategy.InterpolatedOnly"));
+    }
+
+    private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+        };
+
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new ReplicatedGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out var diagnostics);
+
+        var runResult = driver.GetRunResult();
+        var generatedSources = runResult.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToList();
+
+        return (diagnostics, generatedSources);
+    }
+}

--- a/tests/KeenEyes.Network.Tests/OwnerAuthoritativeTests.cs
+++ b/tests/KeenEyes.Network.Tests/OwnerAuthoritativeTests.cs
@@ -1,0 +1,622 @@
+using KeenEyes.Network.Components;
+using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Transport;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+// LocalTransport completes synchronously, so Wait() is safe
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// Owner-authoritative test component: the owning client is authoritative for its value.
+/// </summary>
+public struct OwnerState : IComponent
+{
+    /// <summary>The owner-controlled value.</summary>
+    public float Value;
+}
+
+/// <summary>
+/// Server-authoritative test component used to verify per-component echo behavior.
+/// </summary>
+public struct ServerHealth : IComponent
+{
+    /// <summary>The server-controlled value.</summary>
+    public float Value;
+}
+
+/// <summary>
+/// Tests for the owner-authoritative synchronization strategy (issue #587):
+/// upstream owner state, server-side ownership and validation, echo suppression,
+/// runtime strategy metadata, and ownership requests.
+/// </summary>
+public sealed class OwnerAuthoritativeTests
+{
+    private const int TickRate = 60;
+
+    private static MockNetworkSerializer CreateSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+
+        serializer.RegisterComponent<OwnerState>(
+            serialize: (ref BitWriter w, OwnerState c) => w.WriteFloat(c.Value),
+            deserialize: (ref BitReader r) => new OwnerState { Value = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(OwnerState),
+                NetworkTypeId = 1,
+                Strategy = SyncStrategy.OwnerAuthoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+
+        serializer.RegisterComponent<ServerHealth>(
+            serialize: (ref BitWriter w, ServerHealth c) => w.WriteFloat(c.Value),
+            deserialize: (ref BitReader r) => new ServerHealth { Value = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(ServerHealth),
+                NetworkTypeId = 2,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+
+        return serializer;
+    }
+
+    /// <summary>
+    /// Performs the connection handshake and returns the assigned client ID.
+    /// </summary>
+    private static int Handshake(LocalTransport server, LocalTransport client, NetworkClientPlugin clientPlugin)
+    {
+        server.ListenAsync(7777).Wait();
+        clientPlugin.ConnectAsync().Wait();
+        server.Update();
+        client.Update();
+        return clientPlugin.LocalClientId;
+    }
+
+    #region Upstream owner state
+
+    [Fact]
+    public async Task SendOwnerState_LocallyOwnedEntity_ReachesServerWorld()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await server.ListenAsync(7777);
+        await clientPlugin.ConnectAsync();
+        server.Update();
+        client.Update();
+        var clientId = clientPlugin.LocalClientId;
+
+        // Server owns an entity on behalf of the client.
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 0f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        // Client has the same entity locally, owns it, and sets its authoritative value.
+        var clientEntity = clientPlugin.SpawnNetworkedEntity(netId.Value, clientId);
+        clientWorld.Add(clientEntity, new OwnerState { Value = 42f });
+        Assert.True(clientWorld.Has<LocallyOwned>(clientEntity));
+
+        // One client frame sends the owner-authoritative state upstream.
+        clientWorld.Update(0.1f);
+        server.Update();
+
+        Assert.Equal(42f, serverWorld.Get<OwnerState>(serverEntity).Value, 0.001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void SendOwnerState_UnchangedValue_NotResent()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        var clientId = Handshake(server, client, clientPlugin);
+
+        var ownerStateUpdates = 0;
+        server.DataReceived += (_, data) =>
+        {
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var type, out uint _);
+            if (type == MessageType.OwnerStateUpdate)
+            {
+                ownerStateUpdates++;
+            }
+        };
+
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 0f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        var clientEntity = clientPlugin.SpawnNetworkedEntity(netId.Value, clientId);
+        clientWorld.Add(clientEntity, new OwnerState { Value = 7f });
+
+        // First frame: value changed, one update sent.
+        clientWorld.Update(0.1f);
+        server.Update();
+        Assert.Equal(1, ownerStateUpdates);
+
+        // Second frame: value unchanged, no additional update (dirty-checked).
+        clientWorld.Update(0.1f);
+        server.Update();
+        Assert.Equal(1, ownerStateUpdates);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region Server receive + validation
+
+    [Fact]
+    public void HandleOwnerStateUpdate_NonOwnerClient_ServerStateUnchanged()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+
+        // Entity is owned by client 2, but the connected/sending client is client 1.
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 5f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, ownerId: 2);
+
+        SendOwnerStateMessage(client, netId.Value, new OwnerState { Value = 99f });
+        server.Update();
+
+        // Spoofed update rejected: server state unchanged.
+        Assert.Equal(5f, serverWorld.Get<OwnerState>(serverEntity).Value, 0.001f);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void HandleOwnerStateUpdate_ValidationHookRejects_ServerStateUnchanged()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+            OwnerStateValidator = _ => false, // Reject everything.
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 5f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        SendOwnerStateMessage(client, netId.Value, new OwnerState { Value = 99f });
+        server.Update();
+
+        // Rejected by the validation hook: server state unchanged.
+        Assert.Equal(5f, serverWorld.Get<OwnerState>(serverEntity).Value, 0.001f);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void HandleOwnerStateUpdate_ValidationHookAccepts_ServerStateApplied()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var validated = new List<int>();
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+            OwnerStateValidator = ctx =>
+            {
+                validated.Add(ctx.ClientId);
+                return true;
+            },
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 5f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        SendOwnerStateMessage(client, netId.Value, new OwnerState { Value = 99f });
+        server.Update();
+
+        Assert.Equal(99f, serverWorld.Get<OwnerState>(serverEntity).Value, 0.001f);
+        Assert.Contains(clientId, validated);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void HandleOwnerStateUpdate_ServerAuthoritativeComponent_Rejected()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+
+        // Entity owned by the sender, but the component is server-authoritative.
+        var serverEntity = serverWorld.Spawn().With(new ServerHealth { Value = 100f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        var serializer = CreateSerializer();
+        Span<byte> buffer = stackalloc byte[64];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.OwnerStateUpdate, 1);
+        writer.WriteNetworkId(netId.Value);
+        writer.WriteComponentCount(1);
+        writer.WriteComponent(serializer, typeof(ServerHealth), new ServerHealth { Value = 1f });
+        client.Send(0, writer.GetWrittenSpan(), DeliveryMode.UnreliableSequenced);
+        server.Update();
+
+        // Non-owner-authoritative component ignored: server state unchanged.
+        Assert.Equal(100f, serverWorld.Get<ServerHealth>(serverEntity).Value, 0.001f);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region Echo suppression
+
+    [Fact]
+    public void ServerSend_OwnerAuthoritativeComponent_NotEchoedToOwner()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+
+        var componentDeltas = 0;
+        client.DataReceived += (_, data) =>
+        {
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var type, out uint _);
+            if (type == MessageType.ComponentDelta)
+            {
+                componentDeltas++;
+            }
+        };
+
+        // Entity owned by the client with only an owner-authoritative component.
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 1f }).Build();
+        serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        // First tick: full sync (EntitySpawn), not a delta.
+        serverWorld.Update(0.02f);
+        client.Update();
+
+        // Server changes the owner-authoritative value and ticks again.
+        serverWorld.Set(serverEntity, new OwnerState { Value = 2f });
+        serverWorld.Update(0.02f);
+        client.Update();
+
+        // The owner never receives its own owner-authoritative state back.
+        Assert.Equal(0, componentDeltas);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void ServerSend_ServerAuthoritativeComponentOnClientOwnedEntity_ReachesOwner()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        server.ListenAsync(7777).Wait();
+        client.ConnectAsync("localhost", 7777).Wait();
+        server.Update();
+        client.Update();
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+
+        var componentDeltas = 0;
+        client.DataReceived += (_, data) =>
+        {
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var type, out uint _);
+            if (type == MessageType.ComponentDelta)
+            {
+                componentDeltas++;
+            }
+        };
+
+        // Entity owned by the client but carrying a server-authoritative component.
+        var serverEntity = serverWorld.Spawn().With(new ServerHealth { Value = 100f }).Build();
+        serverPlugin.RegisterNetworkedEntity(serverEntity, clientId);
+
+        serverWorld.Update(0.02f); // full sync
+        client.Update();
+
+        serverWorld.Set(serverEntity, new ServerHealth { Value = 50f });
+        serverWorld.Update(0.02f); // delta
+        client.Update();
+
+        // Server-authoritative components still reach the owner (per-component split).
+        Assert.True(componentDeltas >= 1);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void ClientReceive_OwnerAuthoritativeComponentOnLocallyOwnedEntity_Ignored()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        var clientId = Handshake(server, client, clientPlugin);
+
+        // Locally owned entity with the client's authoritative value.
+        var clientEntity = clientPlugin.SpawnNetworkedEntity(1u, clientId);
+        clientWorld.Add(clientEntity, new OwnerState { Value = 42f });
+
+        // Server sends a component update for that entity (as would arrive in a snapshot).
+        var serializer = CreateSerializer();
+        Span<byte> buffer = stackalloc byte[64];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.ComponentUpdate, 1);
+        writer.WriteNetworkId(1u);
+        writer.WriteComponentCount(1);
+        writer.WriteComponent(serializer, typeof(OwnerState), new OwnerState { Value = 999f });
+        server.SendToAll(writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+        client.Update();
+
+        // The client's own state wins; the incoming server value is ignored.
+        Assert.Equal(42f, clientWorld.Get<OwnerState>(clientEntity).Value, 0.001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region Strategy metadata
+
+    [Fact]
+    public void GetRegisteredComponentInfo_IdentifiesOwnerAuthoritativeVsAuthoritative()
+    {
+        var serializer = CreateSerializer();
+
+        var infos = serializer.GetRegisteredComponentInfo().ToList();
+
+        var ownerInfo = infos.Single(i => i.Type == typeof(OwnerState));
+        var authInfo = infos.Single(i => i.Type == typeof(ServerHealth));
+
+        Assert.Equal(SyncStrategy.OwnerAuthoritative, ownerInfo.Strategy);
+        Assert.Equal(SyncStrategy.Authoritative, authInfo.Strategy);
+    }
+
+    #endregion
+
+    #region Ownership requests
+
+    [Fact]
+    public void RequestOwnership_PolicyGrants_TransfersOwnership()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+            OwnershipRequestPolicy = _ => true,
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        var clientId = Handshake(server, client, clientPlugin);
+
+        // Server-owned entity; client has a remote copy.
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 0f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, NetworkOwner.ServerClientId);
+        var clientEntity = clientPlugin.SpawnNetworkedEntity(netId.Value, NetworkOwner.ServerClientId);
+        Assert.True(clientWorld.Has<RemotelyOwned>(clientEntity));
+
+        clientPlugin.RequestOwnership(netId.Value);
+        server.Update(); // server grants + broadcasts transfer
+        client.Update(); // client applies transfer
+
+        Assert.Equal(clientId, serverWorld.Get<NetworkOwner>(serverEntity).ClientId);
+        Assert.True(clientWorld.Has<LocallyOwned>(clientEntity));
+        Assert.False(clientWorld.Has<RemotelyOwned>(clientEntity));
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void RequestOwnership_PolicyDeniesByDefault_OwnershipUnchanged()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+            // No OwnershipRequestPolicy -> default deny.
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        Handshake(server, client, clientPlugin);
+
+        var serverEntity = serverWorld.Spawn().With(new OwnerState { Value = 0f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity, NetworkOwner.ServerClientId);
+        var clientEntity = clientPlugin.SpawnNetworkedEntity(netId.Value, NetworkOwner.ServerClientId);
+
+        clientPlugin.RequestOwnership(netId.Value);
+        server.Update();
+        client.Update();
+
+        // Denied: ownership stays with the server on both sides.
+        Assert.Equal(NetworkOwner.ServerClientId, serverWorld.Get<NetworkOwner>(serverEntity).ClientId);
+        Assert.True(clientWorld.Has<RemotelyOwned>(clientEntity));
+        Assert.False(clientWorld.Has<LocallyOwned>(clientEntity));
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    private static void SendOwnerStateMessage(LocalTransport client, uint networkId, OwnerState state)
+    {
+        var serializer = CreateSerializer();
+        Span<byte> buffer = stackalloc byte[64];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.OwnerStateUpdate, 1);
+        writer.WriteNetworkId(networkId);
+        writer.WriteComponentCount(1);
+        writer.WriteComponent(serializer, typeof(OwnerState), state);
+        client.Send(0, writer.GetWrittenSpan(), DeliveryMode.UnreliableSequenced);
+    }
+}


### PR DESCRIPTION
## Summary
- **Upstream state path (new):** `MessageType.OwnerStateUpdate` — `NetworkClientSendSystem` sends owner-authoritative components for `LocallyOwned` entities at tick cadence, dirty-checked (no unchanged-state spam). Until now only inputs flowed client→server.
- **Server validation + apply:** sender must actually own the entity (`NetworkOwner.ClientId` match) and the component must be owner-authoritative and already present — otherwise silently rejected. A `ServerNetworkConfig.OwnerStateValidator` hook (default accept) gates application; accepted state applies via `SetComponent` and relays through the normal delta replication (no bespoke relay path).
- **Per-component echo suppression:** for client-owned entities the server splits deltas — owner-authoritative components go `SendToAllExcept(owner)`, everything else broadcasts, so `Predicted` components still reach the owner for reconciliation. Client side: owners ignore incoming state for components they own authoritatively.
- **`OwnershipRequest` implemented:** client `RequestOwnership(networkId)`; server policy hook (default **deny**) grants via the existing `OwnershipTransfer` flow.
- **Runtime strategy dispatch via generator metadata** (AOT-safe, no reflection, no new registration surface): uses the generated `GetRegisteredComponentInfo()`. **This surfaced a real pre-existing generator bug** — `ReplicatedGenerator`'s strategy switch mapped to nonexistent enum members and never emitted `OwnerAuthoritative`; fixed with a regression test.

## Test plan
- [x] 12 new network tests (owner state reaches server world; non-owner spoof rejected; validator rejection leaves state unchanged; owner not echoed its own owner-auth state while still receiving server-auth deltas — proving the per-component split; ownership request grant + default-deny) — 255 passed / 2 pre-existing skips
- [x] 5 new generator regression tests (strategy enum mapping incl. OwnerAuthoritative) — 466 passed / 5 pre-existing skips
- [x] Builds zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #587 (Phase 1 of the plan on #353)

Note: `LocalTransport` is strictly 1:1, so two-client relay is proven via server-state application + the echo-split assertions rather than a literal second client (documented in the test file).