### PR TITLE
feat(animation): Wire IKSolverSystem into the animation pipeline

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -29,6 +29,8 @@ world.InstallPlugin(new AnimationPlugin());
 
 - `AnimationPlayer`, `Animator`, `SpriteAnimator`, `BoneReference`
 - `TweenFloat`, `TweenVector2`, `TweenVector3`, `TweenVector4`
+- With `AnimationConfig.EnableIK`: `IKRig`, `IKChainReference`, `IKTarget`, `IKConstraint`
+- With `AnimationConfig.EnableGpuSkinning`: `SkinnedMesh`
 
 and the following systems, all in `SystemPhase.Update` (order matters, since later systems depend on earlier ones having run):
 
@@ -39,11 +41,13 @@ and the following systems, all in `SystemPhase.Update` (order matters, since lat
 | 52 | `SpriteAnimationSystem` | Advances `SpriteAnimator` time and resolves the current frame |
 | 53 | `AnimationEventSystem` | Detects and publishes clip events crossed this frame |
 | 55 | `SkeletonPoseSystem` | Samples clips and writes pose data to bone `Transform3D`s |
+| 57 | `IKSolverSystem` | Solves IK chains on top of the FK pose (only with `EnableIK`) |
 | 60 | `TweenSystem` | Advances all tween components and computes `CurrentValue` |
+| 80 | `SkinnedMeshBoneSystem` | Computes GPU bone matrices from final transforms (only with `EnableGpuSkinning`) |
 
-It also creates an `AnimationManager` and exposes it as a world extension via `context.SetExtension`.
+It also creates an `AnimationManager` and exposes it as a world extension via `context.SetExtension`. With `EnableIK` it additionally exposes an `IKManager` extension preloaded with the `TwoBone` and `FABRIK` solvers.
 
-> `SkinnedMeshBoneSystem` (GPU bone matrix computation for `SkinnedMesh` entities) exists in `KeenEyes.Animation.Systems` but is **not** registered by `AnimationPlugin`; add it explicitly with `world.AddSystem<SkinnedMeshBoneSystem>(...)` if you render skinned meshes. Similarly, the IK components (`IKRig`, `IKChainReference`, `IKConstraint`, `IKTarget`) and `LookAtTarget` are not registered by the plugin and have no bundled solver systems yet — see [IK Rigs](#ik-rigs-unwired) below.
+> Both `EnableIK` and `EnableGpuSkinning` default to **false**: worlds only pay for the IK and skinning systems when they opt in. `LookAtTarget` is still not registered by the plugin and has no bundled system yet. See [Inverse Kinematics](#inverse-kinematics) below for IK usage.
 
 ### Registering Assets
 
@@ -148,7 +152,7 @@ An `AnimationClip` holds one `BoneTrack` per animated bone (added with `AddBoneT
 
 ### Skinned Mesh Rendering
 
-`SkinnedMesh` marks a mesh entity for GPU skinning: it carries `MeshAssetId`, `BoneEntityIds` (in skeleton order), `InverseBindMatrices`, and a `Generation` counter. `SkinnedMeshBoneSystem` (not auto-registered — see above) walks each bone entity's world transform, multiplies by its inverse bind matrix, and stores the result in a `BoneMatrixBuffer`, which tracks per-bone generations so only changed matrices need re-uploading to the GPU.
+`SkinnedMesh` marks a mesh entity for GPU skinning: it carries `MeshAssetId`, `BoneEntityIds` (in skeleton order), `InverseBindMatrices`, and a `Generation` counter. `SkinnedMeshBoneSystem` (registered at order 80 when `AnimationConfig.EnableGpuSkinning` is set — see above) walks each bone entity's world transform, multiplies by its inverse bind matrix, and stores the result in a `BoneMatrixBuffer`, which tracks per-bone generations so only changed matrices need re-uploading to the GPU.
 
 ```csharp
 var character = world.Spawn()
@@ -210,11 +214,38 @@ var alpha = tween.CurrentValue;
 
 `TweenSystem` advances all four tween component types every frame and evaluates the easing curve via `Easing.Evaluate(EaseType, t)`. `EaseType` covers linear plus in/out/in-out variants of quadratic, cubic, quartic, quintic, sine, exponential, circular, elastic, back, and bounce curves. `AnimationConfig.MaxTweensPerEntity` documents an intended per-entity cap (default 16) but is not currently enforced by `TweenSystem`.
 
-### IK Rigs (unwired)
+### Inverse Kinematics
 
-`KeenEyes.Animation.IK` and the `IKManager` class provide the data model for inverse-kinematics rigs: `IKRigDefinition` (a named collection of `IKChainDefinition`s, built with `AddTwoBoneChain`/`AddFABRIKChain`), `IKChainDefinition` (bone names root-to-tip, `IKSolverType` — `TwoBone`, `FABRIK`, `CCD`, or `LookAt` — iteration/tolerance settings), and the `IKRig`, `IKChainReference`, `IKConstraint`, and `IKTarget` components that would attach a rig to a skeleton entity. `IKManager` registers rigs/chains and looks up solver instances by `IKSolverType` via `RegisterSolver`/`GetSolver`/`GetSolverForType`.
+`KeenEyes.Animation.IK` and the `IKManager` class provide the data model for inverse-kinematics rigs: `IKRigDefinition` (a named collection of `IKChainDefinition`s, built with `AddTwoBoneChain`/`AddFABRIKChain`), `IKChainDefinition` (bone names root-to-tip, `IKSolverType` — `TwoBone`, `FABRIK`, `CCD`, or `LookAt` — iteration/tolerance settings), and the `IKRig`, `IKChainReference`, `IKConstraint`, and `IKTarget` components that attach a rig to a skeleton. `IKManager` registers rigs/chains and looks up solver instances by `IKSolverType` via `RegisterSolver`/`GetSolver`/`GetSolverForType`.
 
-As of this writing, **`AnimationPlugin` does not register the IK components, does not create/expose an `IKManager` extension, and ships no `IIKSolver` implementations or IK system** — the types exist as a foundation for a future feature. If you want to use them today, construct your own `IKManager`, register solver implementations of `IIKSolver`, register the IK components with `world.Components.Register<T>()`, and drive solving from a custom system.
+IK is opt-in: install the plugin with `AnimationConfig.EnableIK = true` and the plugin registers the four IK components, exposes an `IKManager` world extension with the two bundled `IIKSolver` implementations (`TwoBoneSolver` for three-bone limbs, `FABRIKSolver` for chains of two or more bones), and adds `IKSolverSystem` at order 57 — after `SkeletonPoseSystem` (order 55) writes the FK pose, so IK layers on top of the sampled animation.
+
+```csharp
+world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableIK = true }));
+
+// 1. Register the chain (bone names root-to-tip must match the BoneReference names)
+var ik = world.GetExtension<IKManager>();
+var chainId = ik.RegisterChain(
+    IKChainDefinition.TwoBone("LeftArm", "UpperArm.L", "Forearm.L", "Hand.L", Vector3.UnitZ));
+
+// 2. Spawn a target entity holding the world-space goal
+var target = world.Spawn()
+    .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+    .Build();
+
+// 3. Attach the chain reference to the end-effector bone (the tip, e.g. the hand)
+world.Add(handBone, IKChainReference.ForChain(chainId, target.Id));
+
+world.Update(deltaTime);  // FK pose at order 55, IK solve at order 57
+```
+
+Each frame, `IKSolverSystem` queries entities with `IKChainReference` + `BoneReference` + `Transform3D`, resolves the chain definition from `IKManager`, and collects the chain's bones by walking the entity hierarchy up from the end effector, validating each bone's `BoneReference.BoneName` against the definition's `BoneNames`. The solver is chosen by the chain's `IKSolverType`, falling back to FABRIK when the configured solver is unavailable or cannot handle the chain's bone count (e.g. a `TwoBone` chain that is not exactly three bones); chains with no usable solver are skipped. If the target's `PoleTargetEntityId` refers to a live entity with a `Transform3D`, its world position is passed to the solver as the pole; otherwise the chain's `PoleVector` applies. Bones carrying an `IKConstraint` component have their joint limits applied by the solvers automatically.
+
+**FK/IK blending:** the effective weight is `IKRig.GlobalWeight × IKChainReference.Weight × IKTarget.Weight`, clamped to [0, 1]. The `IKRig` component is looked up on the end effector's `SkeletonRootId` entity and is optional (its absence means global weight 1). Weight 0 skips the chain entirely, leaving the FK pose untouched; weight 1 applies the full IK result; anything in between slerps each bone's local rotation from the FK pose toward the IK pose.
+
+**Graceful degradation:** disabled rigs/chains (`IKRig.Enabled`, `IKChainReference.Enabled`), missing or despawned target entities, unregistered chain IDs, and incomplete or misnamed bone hierarchies are all skipped without throwing — the FK pose is never corrupted by a misconfigured chain.
+
+Note that the `CCD` and `LookAt` solver types have no bundled implementations yet; chains configured with them fall back to FABRIK (register your own `IIKSolver` with `IKManager.RegisterSolver` to override). `LookAtTarget` is likewise not yet driven by any bundled system.
 
 ## Performance
 

--- a/src/KeenEyes.Animation/AnimationConfig.cs
+++ b/src/KeenEyes.Animation/AnimationConfig.cs
@@ -28,6 +28,40 @@ public sealed class AnimationConfig
     public int MaxTweensPerEntity { get; set; } = 16;
 
     /// <summary>
+    /// Gets or sets whether inverse kinematics support is enabled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the plugin registers the IK components (<see cref="Components.IKRig"/>,
+    /// <see cref="Components.IKChainReference"/>, <see cref="Components.IKTarget"/>,
+    /// <see cref="Components.IKConstraint"/>), exposes an <see cref="IKManager"/> world
+    /// extension preloaded with the TwoBone and FABRIK solvers, and adds
+    /// <see cref="Systems.IKSolverSystem"/> at order 57 so IK chains are solved after
+    /// <see cref="Systems.SkeletonPoseSystem"/> writes the FK pose.
+    /// </para>
+    /// <para>
+    /// Disabled by default: worlds that do not use IK pay no per-frame cost.
+    /// </para>
+    /// </remarks>
+    public bool EnableIK { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether GPU skinning support is enabled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the plugin registers the <see cref="Components.SkinnedMesh"/> component
+    /// and adds <see cref="Systems.SkinnedMeshBoneSystem"/> at order 80, which computes final
+    /// bone matrices (world transform × inverse bind matrix) after animation and IK have
+    /// produced the frame's final bone transforms.
+    /// </para>
+    /// <para>
+    /// Disabled by default: only worlds that render skinned meshes need it.
+    /// </para>
+    /// </remarks>
+    public bool EnableGpuSkinning { get; set; }
+
+    /// <summary>
     /// Validates the configuration.
     /// </summary>
     /// <returns>An error message if invalid, or null if valid.</returns>

--- a/src/KeenEyes.Animation/AnimationPlugin.cs
+++ b/src/KeenEyes.Animation/AnimationPlugin.cs
@@ -1,5 +1,6 @@
 using KeenEyes.Animation.Components;
 using KeenEyes.Animation.Events;
+using KeenEyes.Animation.IK.Solvers;
 using KeenEyes.Animation.Systems;
 
 namespace KeenEyes.Animation;
@@ -58,6 +59,7 @@ namespace KeenEyes.Animation;
 public sealed class AnimationPlugin : IWorldPlugin
 {
     private AnimationManager? animationManager;
+    private IKManager? ikManager;
 
     /// <summary>
     /// Creates a new animation plugin with default configuration.
@@ -132,10 +134,39 @@ public sealed class AnimationPlugin : IWorldPlugin
             SystemPhase.Update,
             order: 55);
 
+        if (Config.EnableIK)
+        {
+            context.RegisterComponent<IKRig>();
+            context.RegisterComponent<IKChainReference>();
+            context.RegisterComponent<IKTarget>();
+            context.RegisterComponent<IKConstraint>();
+
+            // Expose the IK manager with the bundled solvers pre-registered.
+            ikManager = new IKManager();
+            ikManager.RegisterSolver(new TwoBoneSolver());
+            ikManager.RegisterSolver(new FABRIKSolver());
+            context.SetExtension(ikManager);
+
+            // IK solving runs after the FK pose has been written (order 55)
+            context.AddSystem<IKSolverSystem>(
+                SystemPhase.Update,
+                order: 57);
+        }
+
         // Tweens update after animation state
         context.AddSystem<TweenSystem>(
             SystemPhase.Update,
             order: 60);
+
+        if (Config.EnableGpuSkinning)
+        {
+            context.RegisterComponent<SkinnedMesh>();
+
+            // Bone matrices are computed last, from the frame's final bone transforms
+            context.AddSystem<SkinnedMeshBoneSystem>(
+                SystemPhase.Update,
+                order: 80);
+        }
     }
 
     /// <inheritdoc/>
@@ -147,6 +178,14 @@ public sealed class AnimationPlugin : IWorldPlugin
         // Dispose the animation manager
         animationManager?.Dispose();
         animationManager = null;
+
+        // Remove and dispose the IK manager if IK was enabled
+        if (ikManager != null)
+        {
+            context.RemoveExtension<IKManager>();
+            ikManager.Dispose();
+            ikManager = null;
+        }
 
         // Systems are automatically cleaned up by PluginManager
     }

--- a/src/KeenEyes.Animation/Systems/IKSolverSystem.cs
+++ b/src/KeenEyes.Animation/Systems/IKSolverSystem.cs
@@ -1,0 +1,281 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.IK.Solvers;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Systems;
+
+/// <summary>
+/// System that solves IK chains after FK animation has been applied.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs after <see cref="SkeletonPoseSystem"/> (order 55) at order 57 so that
+/// IK adjustments are layered on top of the sampled FK pose. For each entity carrying an
+/// <see cref="IKChainReference"/>, the system resolves the chain definition from the
+/// <see cref="IKManager"/> world extension, collects the chain's bone entities by walking
+/// the entity hierarchy up from the end effector, resolves the target from the referenced
+/// <see cref="IKTarget"/> entity, and solves the chain with the solver registered for the
+/// chain's <see cref="IKChainDefinition.SolverType"/> (falling back to FABRIK when that
+/// solver cannot handle the chain's bone count).
+/// </para>
+/// <para>
+/// The solved pose is blended against the FK pose using the effective weight
+/// <c>IKRig.GlobalWeight × IKChainReference.Weight × IKTarget.Weight</c> (clamped to [0, 1]).
+/// A weight of zero skips solving entirely, leaving the FK pose untouched; a weight of one
+/// applies the full IK result; intermediate weights spherically interpolate each bone's
+/// local rotation between the FK and IK poses.
+/// </para>
+/// <para>
+/// Invalid configurations degrade gracefully: chains with missing or dead target entities,
+/// unregistered chain IDs, incomplete bone hierarchies, or unavailable solvers are skipped
+/// without modifying the FK pose.
+/// </para>
+/// </remarks>
+public sealed class IKSolverSystem : SystemBase
+{
+    private IKManager? manager;
+
+    // Per-frame caches keyed by entity ID (component IDs reference entities by ID).
+    private readonly Dictionary<int, IKTarget> targetCache = [];
+    private readonly Dictionary<int, IKRig> rigCache = [];
+    private readonly Dictionary<int, Entity> poleEntityCache = [];
+    private readonly HashSet<int> requiredPoleIds = [];
+
+    // Reusable scratch buffers keyed by chain length to avoid per-frame allocation.
+    private readonly Dictionary<int, Entity[]> boneBuffers = [];
+    private readonly Dictionary<int, Quaternion[]> rotationBuffers = [];
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        World.TryGetExtension(out manager);
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        manager ??= World.TryGetExtension<IKManager>(out var m) ? m : null;
+        if (manager == null)
+        {
+            return;
+        }
+
+        BuildFrameCaches();
+
+        foreach (var entity in World.Query<IKChainReference, BoneReference, Transform3D>())
+        {
+            SolveChain(entity, deltaTime);
+        }
+    }
+
+    private void BuildFrameCaches()
+    {
+        targetCache.Clear();
+        rigCache.Clear();
+        poleEntityCache.Clear();
+        requiredPoleIds.Clear();
+
+        foreach (var entity in World.Query<IKTarget>())
+        {
+            ref readonly var target = ref World.Get<IKTarget>(entity);
+            targetCache[entity.Id] = target;
+
+            if (target.PoleTargetEntityId >= 0)
+            {
+                requiredPoleIds.Add(target.PoleTargetEntityId);
+            }
+        }
+
+        foreach (var entity in World.Query<IKRig>())
+        {
+            rigCache[entity.Id] = World.Get<IKRig>(entity);
+        }
+
+        // Pole targets are referenced by entity ID; resolve the referenced entity
+        // handles in a single pass only when at least one target uses a pole.
+        if (requiredPoleIds.Count > 0)
+        {
+            foreach (var entity in World.Query<Transform3D>())
+            {
+                if (requiredPoleIds.Contains(entity.Id))
+                {
+                    poleEntityCache[entity.Id] = entity;
+                }
+            }
+        }
+    }
+
+    private void SolveChain(Entity endEffector, float deltaTime)
+    {
+        ref readonly var chainRef = ref World.Get<IKChainReference>(endEffector);
+        if (!chainRef.Enabled || chainRef.ChainId < 0)
+        {
+            return;
+        }
+
+        if (!manager!.TryGetChain(chainRef.ChainId, out var chain) || chain is null)
+        {
+            return;
+        }
+
+        // The rig (if any) lives on the skeleton root referenced by the end effector's bone.
+        ref readonly var boneRef = ref World.Get<BoneReference>(endEffector);
+        var globalWeight = 1f;
+        if (rigCache.TryGetValue(boneRef.SkeletonRootId, out var rig))
+        {
+            if (!rig.Enabled)
+            {
+                return;
+            }
+
+            globalWeight = rig.GlobalWeight;
+        }
+
+        if (chainRef.TargetEntityId < 0 ||
+            !targetCache.TryGetValue(chainRef.TargetEntityId, out var target))
+        {
+            return;
+        }
+
+        var weight = Math.Clamp(globalWeight * chainRef.Weight * target.Weight, 0f, 1f);
+        if (weight.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        if (!TryCollectBones(endEffector, chain, out var bones))
+        {
+            return;
+        }
+
+        var solver = ResolveSolver(chain.SolverType, bones.Length);
+        if (solver is null)
+        {
+            return;
+        }
+
+        Vector3? polePosition = null;
+        if (target.PoleTargetEntityId >= 0 &&
+            poleEntityCache.TryGetValue(target.PoleTargetEntityId, out var poleEntity))
+        {
+            polePosition = IKSolverMath.GetWorldTransform(World, poleEntity).Position;
+        }
+
+        // Snapshot the FK rotations so the solved pose can be blended back toward them.
+        // Solvers only modify local rotations, so rotations are all that need saving.
+        var fkRotations = GetRotationBuffer(bones.Length);
+        for (var i = 0; i < bones.Length; i++)
+        {
+            fkRotations[i] = World.Get<Transform3D>(bones[i]).Rotation;
+        }
+
+        var context = new IKSolverContext
+        {
+            World = World,
+            Chain = chain,
+            BoneEntities = bones,
+            TargetPosition = target.Position,
+            TargetRotation = target.UseRotation ? target.Rotation : null,
+            PolePosition = polePosition,
+            DeltaTime = deltaTime,
+        };
+
+        solver.Solve(in context);
+
+        if (weight < 1f && !weight.ApproximatelyEquals(1f))
+        {
+            for (var i = 0; i < bones.Length; i++)
+            {
+                ref var transform = ref World.Get<Transform3D>(bones[i]);
+                transform.Rotation = Quaternion.Slerp(fkRotations[i], transform.Rotation, weight);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects the chain's bone entities by walking the hierarchy up from the end
+    /// effector, validating each bone against the chain definition's bone names.
+    /// </summary>
+    private bool TryCollectBones(Entity endEffector, IKChainDefinition chain, out Entity[] bones)
+    {
+        if (chain.BoneCount < 2)
+        {
+            bones = [];
+            return false;
+        }
+
+        bones = GetBoneBuffer(chain.BoneCount);
+
+        var current = endEffector;
+        for (var i = chain.BoneCount - 1; i >= 0; i--)
+        {
+            if (!current.IsValid ||
+                !World.IsAlive(current) ||
+                !World.Has<Transform3D>(current) ||
+                !World.Has<BoneReference>(current))
+            {
+                return false;
+            }
+
+            ref readonly var boneRef = ref World.Get<BoneReference>(current);
+            if (!string.Equals(boneRef.BoneName, chain.BoneNames[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            bones[i] = current;
+            current = World.GetParent(current);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the solver for a chain, falling back to FABRIK when the configured
+    /// solver is unavailable or cannot handle the chain's bone count.
+    /// </summary>
+    private IIKSolver? ResolveSolver(IKSolverType solverType, int boneCount)
+    {
+        if (manager!.TryGetSolver(solverType, out var solver) &&
+            solver is not null &&
+            solver.CanHandle(boneCount))
+        {
+            return solver;
+        }
+
+        if (solverType != IKSolverType.FABRIK &&
+            manager.TryGetSolver(IKSolverType.FABRIK, out var fallback) &&
+            fallback is not null &&
+            fallback.CanHandle(boneCount))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+
+    private Entity[] GetBoneBuffer(int length)
+    {
+        if (!boneBuffers.TryGetValue(length, out var buffer))
+        {
+            buffer = new Entity[length];
+            boneBuffers[length] = buffer;
+        }
+
+        return buffer;
+    }
+
+    private Quaternion[] GetRotationBuffer(int length)
+    {
+        if (!rotationBuffers.TryGetValue(length, out var buffer))
+        {
+            buffer = new Quaternion[length];
+            rotationBuffers[length] = buffer;
+        }
+
+        return buffer;
+    }
+}

--- a/tests/KeenEyes.Animation.Tests/IK/IKSolverSystemTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/IKSolverSystemTests.cs
@@ -1,0 +1,489 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.Data;
+using KeenEyes.Animation.IK;
+using KeenEyes.Animation.Systems;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Full-pipeline integration tests for <see cref="IKSolverSystem"/> running inside
+/// a world with <see cref="AnimationPlugin"/> installed with IK enabled.
+/// </summary>
+public class IKSolverSystemTests
+{
+    private const float DeltaTime = 1f / 60f;
+    private const float ReachTolerance = 0.01f;
+
+    private static AnimationConfig IKEnabledConfig => new() { EnableIK = true };
+
+    /// <summary>
+    /// Creates a three-bone arm skeleton (Upper at origin, Lower at +1X, Hand at +2X world)
+    /// parented under a skeleton root that carries an <see cref="IKRig"/>.
+    /// </summary>
+    private static (Entity Root, Entity Upper, Entity Lower, Entity Hand) CreateArmSkeleton(World world)
+    {
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(IKRig.Default)
+            .Build();
+
+        var upper = CreateBone(world, "Upper", root, Vector3.Zero, root.Id);
+        var lower = CreateBone(world, "Lower", upper, Vector3.UnitX, root.Id);
+        var hand = CreateBone(world, "Hand", lower, Vector3.UnitX, root.Id);
+
+        return (root, upper, lower, hand);
+    }
+
+    private static Entity CreateBone(World world, string name, Entity parent, Vector3 localPosition, int skeletonRootId)
+    {
+        var bone = world.Spawn()
+            .With(new Transform3D(localPosition, Quaternion.Identity, Vector3.One))
+            .With(BoneReference.Create(name, skeletonRootId))
+            .Build();
+
+        world.SetParent(bone, parent);
+        return bone;
+    }
+
+    private static int RegisterArmChain(World world)
+    {
+        var ikManager = world.GetExtension<IKManager>();
+        return ikManager.RegisterChain(
+            IKChainDefinition.TwoBone("Arm", "Upper", "Lower", "Hand", Vector3.UnitZ));
+    }
+
+    private static Transform3D[] SnapshotLocalTransforms(World world, params Entity[] entities)
+    {
+        var snapshot = new Transform3D[entities.Length];
+        for (var i = 0; i < entities.Length; i++)
+        {
+            snapshot[i] = world.Get<Transform3D>(entities[i]);
+        }
+
+        return snapshot;
+    }
+
+    private static void AssertLocalTransformsUnchanged(World world, Transform3D[] snapshot, params Entity[] entities)
+    {
+        for (var i = 0; i < entities.Length; i++)
+        {
+            ref readonly var current = ref world.Get<Transform3D>(entities[i]);
+
+            Vector3.Distance(current.Position, snapshot[i].Position).ShouldBeLessThan(1e-6f);
+            Vector3.Distance(current.Scale, snapshot[i].Scale).ShouldBeLessThan(1e-6f);
+            MathF.Abs(Quaternion.Dot(current.Rotation, snapshot[i].Rotation)).ShouldBeGreaterThan(1f - 1e-6f);
+        }
+    }
+
+    #region Plugin Wiring Tests
+
+    [Fact]
+    public void Install_WithDefaultConfig_DoesNotRegisterIKSolverSystem()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        world.GetSystem<IKSolverSystem>().ShouldBeNull();
+        world.HasExtension<IKManager>().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Install_WithEnableIK_RegistersIKSolverSystemAndManager()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        world.GetSystem<IKSolverSystem>().ShouldNotBeNull();
+        world.HasExtension<IKManager>().ShouldBeTrue();
+
+        var ikManager = world.GetExtension<IKManager>();
+        ikManager.HasSolver(IKSolverType.TwoBone).ShouldBeTrue();
+        ikManager.HasSolver(IKSolverType.FABRIK).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Install_WithDefaultConfig_DoesNotRegisterSkinnedMeshBoneSystem()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        world.GetSystem<SkinnedMeshBoneSystem>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Install_WithEnableGpuSkinning_RegistersSkinnedMeshBoneSystem()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableGpuSkinning = true }));
+
+        world.GetSystem<SkinnedMeshBoneSystem>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Uninstall_WithEnableIK_RemovesIKManagerExtension()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        world.UninstallPlugin<AnimationPlugin>().ShouldBeTrue();
+
+        world.HasExtension<IKManager>().ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Solving Tests
+
+    [Fact]
+    public void Update_WithFullWeight_ChainTipReachesTarget()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, _, _, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+        var targetPosition = new Vector3(1f, 1f, 0f);
+
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(targetPosition))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        world.Update(DeltaTime);
+
+        var tip = IKSolverTestHelpers.GetWorldPosition(world, hand);
+        Vector3.Distance(tip, targetPosition).ShouldBeLessThan(ReachTolerance);
+    }
+
+    [Fact]
+    public void Update_WithFabrikChain_ChainTipReachesTarget()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(IKRig.Default)
+            .Build();
+
+        var boneA = CreateBone(world, "A", root, Vector3.Zero, root.Id);
+        var boneB = CreateBone(world, "B", boneA, Vector3.UnitX, root.Id);
+        var boneC = CreateBone(world, "C", boneB, Vector3.UnitX, root.Id);
+        var boneD = CreateBone(world, "D", boneC, Vector3.UnitX, root.Id);
+
+        var ikManager = world.GetExtension<IKManager>();
+        var chainId = ikManager.RegisterChain(
+            IKChainDefinition.MultiBone("Tail", ["A", "B", "C", "D"]));
+
+        var targetPosition = new Vector3(1.5f, 1.5f, 0f);
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(targetPosition))
+            .Build();
+        world.Add(boneD, IKChainReference.ForChain(chainId, target.Id));
+
+        world.Update(DeltaTime);
+
+        var tip = IKSolverTestHelpers.GetWorldPosition(world, boneD);
+        Vector3.Distance(tip, targetPosition).ShouldBeLessThan(0.02f);
+    }
+
+    [Fact]
+    public void Update_WithPoleTargetEntity_BendsMidJointTowardPole()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, _, lower, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+
+        // Pole entity placed on the -Z side; the default chain pole vector is +Z.
+        var pole = world.Spawn()
+            .With(new Transform3D(new Vector3(0.5f, 0f, -5f), Quaternion.Identity, Vector3.One))
+            .Build();
+
+        var target = world.Spawn()
+            .With(IKTarget.WithPole(new Vector3(1f, 1f, 0f), pole.Id))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        world.Update(DeltaTime);
+
+        var midJoint = IKSolverTestHelpers.GetWorldPosition(world, lower);
+        midJoint.Z.ShouldBeLessThan(0f);
+    }
+
+    #endregion
+
+    #region Blending Tests
+
+    [Fact]
+    public void Update_WithZeroGlobalWeight_LeavesFkPoseUntouched()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (root, upper, lower, hand) = CreateArmSkeleton(world);
+        world.Get<IKRig>(root).GlobalWeight = 0f;
+
+        var chainId = RegisterArmChain(world);
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithZeroTargetWeight_LeavesFkPoseUntouched()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)) with { Weight = 0f })
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithHalfWeight_BlendsBetweenFkAndIkPoses()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (root, _, _, hand) = CreateArmSkeleton(world);
+        world.Get<IKRig>(root).GlobalWeight = 0.5f;
+
+        var chainId = RegisterArmChain(world);
+        var targetPosition = new Vector3(1f, 1f, 0f);
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(targetPosition))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        var fkTip = IKSolverTestHelpers.GetWorldPosition(world, hand);
+
+        world.Update(DeltaTime);
+
+        var blendedTip = IKSolverTestHelpers.GetWorldPosition(world, hand);
+
+        // The blended pose must have moved away from FK but not fully reached the target.
+        Vector3.Distance(blendedTip, fkTip).ShouldBeGreaterThan(0.05f);
+        Vector3.Distance(blendedTip, targetPosition).ShouldBeGreaterThan(ReachTolerance);
+        Vector3.Distance(blendedTip, targetPosition).ShouldBeLessThan(Vector3.Distance(fkTip, targetPosition));
+    }
+
+    #endregion
+
+    #region Graceful Degradation Tests
+
+    [Fact]
+    public void Update_WithMissingTargetEntity_PreservesFkPoseWithoutThrowing()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+
+        // Reference an entity ID that does not exist.
+        world.Add(hand, IKChainReference.ForChain(chainId, 99999));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithDespawnedTargetEntity_PreservesFkPoseWithoutThrowing()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+        world.Despawn(target);
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithUnregisteredChainId_PreservesFkPose()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(9999, target.Id));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithDisabledRig_PreservesFkPose()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (root, upper, lower, hand) = CreateArmSkeleton(world);
+        world.Get<IKRig>(root).Enabled = false;
+
+        var chainId = RegisterArmChain(world);
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithDisabledChainReference_PreservesFkPose()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+        var chainId = RegisterArmChain(world);
+
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id) with { Enabled = false });
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    [Fact]
+    public void Update_WithEnableIKFalse_LeavesPoseUntouched()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+
+        // Without EnableIK there is no IKManager to register chains with; the IK
+        // components can still be attached but must have no effect.
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(new Vector3(1f, 1f, 0f)))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(1, target.Id));
+
+        var snapshot = SnapshotLocalTransforms(world, upper, lower, hand);
+
+        world.Update(DeltaTime);
+
+        world.GetSystem<IKSolverSystem>().ShouldBeNull();
+        AssertLocalTransformsUnchanged(world, snapshot, upper, lower, hand);
+    }
+
+    #endregion
+
+    #region Pipeline Integration Tests
+
+    [Fact]
+    public void Update_WithFkAnimationPlaying_AppliesIkAfterFkPose()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (root, _, _, hand) = CreateArmSkeleton(world);
+
+        // FK clip rotates the Upper bone 90 degrees about Z, which alone would
+        // swing the arm so the hand ends up at (0, 2, 0).
+        var rotationCurve = new QuaternionCurve();
+        rotationCurve.AddKeyframe(0f, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f));
+
+        var clip = new AnimationClip { Name = "Raise", Duration = 1f, WrapMode = WrapMode.Loop };
+        clip.AddBoneTrack(new BoneTrack { BoneName = "Upper", RotationCurve = rotationCurve });
+
+        var animations = world.GetExtension<AnimationManager>();
+        var clipId = animations.RegisterClip(clip);
+        world.Add(root, AnimationPlayer.ForClip(clipId));
+
+        var chainId = RegisterArmChain(world);
+        var targetPosition = new Vector3(1f, 1f, 0f);
+        var target = world.Spawn()
+            .With(IKTarget.AtPosition(targetPosition))
+            .Build();
+        world.Add(hand, IKChainReference.ForChain(chainId, target.Id));
+
+        world.Update(DeltaTime);
+
+        // If IK ran before (or instead of) the FK pose, the hand would sit at the
+        // FK result (0, 2, 0); reaching the target proves IK solved after FK.
+        var tip = IKSolverTestHelpers.GetWorldPosition(world, hand);
+        Vector3.Distance(tip, targetPosition).ShouldBeLessThan(ReachTolerance);
+    }
+
+    [Fact]
+    public void Update_WithFkAnimationAndNoChain_AppliesFkPoseOnly()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (root, _, _, hand) = CreateArmSkeleton(world);
+
+        var rotationCurve = new QuaternionCurve();
+        rotationCurve.AddKeyframe(0f, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f));
+
+        var clip = new AnimationClip { Name = "Raise", Duration = 1f, WrapMode = WrapMode.Loop };
+        clip.AddBoneTrack(new BoneTrack { BoneName = "Upper", RotationCurve = rotationCurve });
+
+        var animations = world.GetExtension<AnimationManager>();
+        var clipId = animations.RegisterClip(clip);
+        world.Add(root, AnimationPlayer.ForClip(clipId));
+
+        world.Update(DeltaTime);
+
+        // FK alone swings the whole arm up: hand lands at (0, 2, 0).
+        var tip = IKSolverTestHelpers.GetWorldPosition(world, hand);
+        Vector3.Distance(tip, new Vector3(0f, 2f, 0f)).ShouldBeLessThan(ReachTolerance);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`IKSolverSystem`** (order 57, between FK pose at 55 and tweens at 60): resolves chains from `IKManager`, collects bones by hierarchy walk validated against the chain's `BoneNames`, solves via TwoBone/FABRIK (fallback to FABRIK when the configured solver can't handle the chain), and **blends FK↔IK** per bone with `Quaternion.Slerp` at effective weight `IKRig.GlobalWeight × IKChainReference.Weight × IKTarget.Weight`. Zero per-frame allocation (chain-length-keyed scratch buffers, solvers instantiated once). Missing/dead targets, unregistered chains, and bad bone paths all degrade gracefully — FK pose untouched.
- **Two new opt-in `AnimationConfig` flags** (both default false, per explicit-over-implicit): `EnableIK` (registers IK components, IKManager extension preloaded with both solvers, system at 57; cleaned up in `Uninstall`) and `EnableGpuSkinning` — which **fixes the pre-existing gap** where `SkinnedMeshBoneSystem` was defined but never registered (now order 80).
- Pole-target entity resolution wired (`IKTarget.PoleTargetEntityId` → `IKSolverContext.PolePosition`) — the field existed but was dead.
- `docs/animation.md` updated: system table now 55→57→60→80 with flag annotations; the "IK Rigs (unwired)" section rewritten as a verified usage walkthrough.

## Test plan
- [x] 19 new integration tests (tip reaches target at weight 1; FK untouched at weight 0; intermediate blend; missing/despawned/unregistered targets; both flags' wiring + uninstall cleanup; FK+IK ordering) — 315/315 passing
- [x] Build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #955 (part of #959). LookAtSystem (order 58) deliberately excluded — that's #956.