### PR TITLE
feat(network): Add server-side tick-indexed state history

### DIFF
--- a/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
+++ b/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
@@ -188,6 +188,24 @@ public record class ServerNetworkConfig : NetworkPluginConfig
     /// </para>
     /// </remarks>
     public Func<OwnershipRequestContext, bool>? OwnershipRequestPolicy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of network ticks of authoritative entity state to retain
+    /// per entity for lag compensation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default of <c>0</c> disables the history entirely: the server allocates nothing
+    /// and captures nothing, so there is zero cost when the feature is off.
+    /// </para>
+    /// <para>
+    /// One entry is recorded per entity per network tick, so roughly <see cref="NetworkPluginConfig.TickRate"/>
+    /// ticks is approximately one second of history. Larger values allow compensating for
+    /// higher latency at the cost of memory (one boxed component snapshot per retained tick
+    /// per entity).
+    /// </para>
+    /// </remarks>
+    public int StateHistoryTicks { get; set; }
 }
 
 /// <summary>

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -35,6 +35,8 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     private readonly ServerNetworkConfig config = config ?? new ServerNetworkConfig();
     private readonly NetworkIdManager networkIdManager = new(isServer: true);
     private readonly Dictionary<int, ClientState> clients = [];
+    private readonly ServerStateHistory? stateHistory =
+        config is { StateHistoryTicks: > 0 } cfg ? new ServerStateHistory(cfg.StateHistoryTicks) : null;
 
     private IPluginContext? context;
     private OwnerAuthoritativeComponentSet? ownerAuthTypes;
@@ -76,6 +78,17 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     /// Gets the server configuration.
     /// </summary>
     public ServerNetworkConfig Config => config;
+
+    /// <summary>
+    /// Gets the tick-indexed history of authoritative entity states used for lag
+    /// compensation, or <see langword="null"/> when history is disabled.
+    /// </summary>
+    /// <remarks>
+    /// History is enabled by setting <see cref="ServerNetworkConfig.StateHistoryTicks"/>
+    /// to a positive value. When disabled this is <see langword="null"/> and no state is
+    /// captured. States are recorded once per network tick by the server send system.
+    /// </remarks>
+    public ServerStateHistory? StateHistory => stateHistory;
 
     /// <summary>
     /// Raised when a client input is received.
@@ -580,6 +593,9 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
 
     private void OnEntityDestroyed(Entity entity)
     {
+        // Drop any recorded state history for the despawned entity.
+        stateHistory?.Remove(entity);
+
         // Remove from network tracking
         if (networkIdManager.TryGetNetworkId(entity, out var networkId))
         {

--- a/src/KeenEyes.Network/Replication/ServerStateHistory.cs
+++ b/src/KeenEyes.Network/Replication/ServerStateHistory.cs
@@ -1,0 +1,240 @@
+using KeenEyes.Capabilities;
+using KeenEyes.Network.Serialization;
+
+namespace KeenEyes.Network.Replication;
+
+/// <summary>
+/// Server-side, per-entity ring of tick-indexed authoritative component states.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server records each networked entity's authoritative state once per network
+/// tick. This history is the enabler for lag compensation: a later system can rewind
+/// the world to the tick a client acted on and resolve interactions against the state
+/// the client actually saw.
+/// </para>
+/// <para>
+/// Each entity keeps a fixed-capacity ring keyed by tick. Storing a new tick reuses the
+/// dictionary that held <c>tick - capacity</c>, so steady-state capture allocates only
+/// the boxed component values and never grows the ring. Ticks older than the ring window
+/// are evicted implicitly as the ring advances; despawned entities are dropped via
+/// <see cref="Remove(Entity)"/>.
+/// </para>
+/// <para>
+/// The dictionaries returned from the query methods are the live storage and remain valid
+/// only until the corresponding tick is evicted from the ring; callers must not retain
+/// them across network ticks.
+/// </para>
+/// </remarks>
+public sealed class ServerStateHistory
+{
+    private readonly int capacity;
+    private readonly Dictionary<Entity, EntityRing> histories = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerStateHistory"/> class.
+    /// </summary>
+    /// <param name="capacity">
+    /// The number of ticks to retain per entity. Roughly one tick per network tick,
+    /// so <c>TickRate</c> ticks is approximately one second of history.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="capacity"/> is not positive.
+    /// </exception>
+    public ServerStateHistory(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+        this.capacity = capacity;
+    }
+
+    /// <summary>
+    /// Gets the per-entity ring capacity in ticks.
+    /// </summary>
+    public int Capacity => capacity;
+
+    /// <summary>
+    /// Records the authoritative network-serializable state of an entity for a tick.
+    /// </summary>
+    /// <param name="entity">The networked entity to capture.</param>
+    /// <param name="tick">The network tick the state belongs to.</param>
+    /// <param name="snapshot">The world snapshot capability used to read components.</param>
+    /// <param name="serializer">The serializer used to filter replicated component types.</param>
+    /// <remarks>
+    /// Only components that are network-serializable are recorded, matching the state the
+    /// server replicates. Component values are boxed structs, so a stored value is an
+    /// independent copy that is unaffected by later mutations of the live component.
+    /// </remarks>
+    public void Capture(Entity entity, uint tick, ISnapshotCapability snapshot, INetworkSerializer serializer)
+    {
+        if (!histories.TryGetValue(entity, out var ring))
+        {
+            ring = new EntityRing(capacity);
+            histories[entity] = ring;
+        }
+
+        var slot = ring.BeginWrite(tick);
+        foreach (var (type, value) in snapshot.GetComponents(entity))
+        {
+            if (serializer.IsNetworkSerializable(type))
+            {
+                slot[type] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the recorded state of an entity at an exact tick.
+    /// </summary>
+    /// <param name="entity">The entity to query.</param>
+    /// <param name="tick">The exact tick to look up.</param>
+    /// <param name="state">
+    /// When this method returns <see langword="true"/>, the recorded component states
+    /// keyed by component type; otherwise an empty dictionary.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if a state was recorded for the entity at the tick and has
+    /// not been evicted; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool TryGetState(Entity entity, uint tick, out IReadOnlyDictionary<Type, object> state)
+    {
+        if (histories.TryGetValue(entity, out var ring) && ring.TryGet(tick, out var slot))
+        {
+            state = slot;
+            return true;
+        }
+
+        state = EmptyState.Instance;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the recorded state of an entity at the latest tick at or before the given tick.
+    /// </summary>
+    /// <param name="entity">The entity to query.</param>
+    /// <param name="tick">The upper bound tick (inclusive).</param>
+    /// <param name="matchedTick">
+    /// When this method returns <see langword="true"/>, the actual tick whose state was
+    /// returned; otherwise zero.
+    /// </param>
+    /// <param name="state">
+    /// When this method returns <see langword="true"/>, the recorded component states for
+    /// <paramref name="matchedTick"/>; otherwise an empty dictionary.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if any retained state at or before <paramref name="tick"/>
+    /// exists for the entity; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// Lag compensation uses this to locate the pair of ticks surrounding a client's
+    /// action time; interpolation between ticks is a later concern and is not performed here.
+    /// </remarks>
+    public bool TryGetStateAtOrBefore(Entity entity, uint tick, out uint matchedTick, out IReadOnlyDictionary<Type, object> state)
+    {
+        if (histories.TryGetValue(entity, out var ring) && ring.TryGetAtOrBefore(tick, out matchedTick, out var slot))
+        {
+            state = slot;
+            return true;
+        }
+
+        matchedTick = 0;
+        state = EmptyState.Instance;
+        return false;
+    }
+
+    /// <summary>
+    /// Drops all recorded history for an entity. Call when the entity despawns.
+    /// </summary>
+    /// <param name="entity">The entity whose history should be dropped.</param>
+    /// <returns><see langword="true"/> if history existed and was removed; otherwise <see langword="false"/>.</returns>
+    public bool Remove(Entity entity) => histories.Remove(entity);
+
+    /// <summary>
+    /// Clears all recorded history for all entities.
+    /// </summary>
+    public void Clear() => histories.Clear();
+
+    /// <summary>
+    /// A fixed-capacity ring of tick-indexed component snapshots for a single entity.
+    /// </summary>
+    private sealed class EntityRing(int capacity)
+    {
+        private readonly uint[] ticks = new uint[capacity];
+        private readonly bool[] occupied = new bool[capacity];
+        private readonly Dictionary<Type, object>[] slots = new Dictionary<Type, object>[capacity];
+        private bool hasAny;
+        private uint newestTick;
+
+        public Dictionary<Type, object> BeginWrite(uint tick)
+        {
+            var index = (int)(tick % (uint)capacity);
+            var slot = slots[index];
+            if (slot is null)
+            {
+                slot = [];
+                slots[index] = slot;
+            }
+            else
+            {
+                slot.Clear();
+            }
+
+            ticks[index] = tick;
+            occupied[index] = true;
+
+            if (!hasAny || tick > newestTick)
+            {
+                newestTick = tick;
+            }
+
+            hasAny = true;
+            return slot;
+        }
+
+        public bool TryGet(uint tick, out Dictionary<Type, object> slot)
+        {
+            var index = (int)(tick % (uint)capacity);
+            if (occupied[index] && ticks[index] == tick)
+            {
+                slot = slots[index];
+                return true;
+            }
+
+            slot = null!;
+            return false;
+        }
+
+        public bool TryGetAtOrBefore(uint tick, out uint matchedTick, out Dictionary<Type, object> slot)
+        {
+            if (hasAny)
+            {
+                // Never look past the newest recorded tick; that also bounds the search
+                // to within the ring window so eviction can't produce a false match.
+                var start = tick < newestTick ? tick : newestTick;
+                for (uint offset = 0; offset < (uint)capacity && offset <= start; offset++)
+                {
+                    var candidate = start - offset;
+                    var index = (int)(candidate % (uint)capacity);
+                    if (occupied[index] && ticks[index] == candidate)
+                    {
+                        matchedTick = candidate;
+                        slot = slots[index];
+                        return true;
+                    }
+                }
+            }
+
+            matchedTick = 0;
+            slot = null!;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Shared empty state returned when no history is found, avoiding per-miss allocation.
+    /// </summary>
+    private static class EmptyState
+    {
+        public static readonly IReadOnlyDictionary<Type, object> Instance =
+            new Dictionary<Type, object>();
+    }
+}

--- a/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
@@ -61,12 +61,23 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
         // Collect entities that need updates and sort by priority
         entitiesToUpdate.Clear();
 
+        // Capture authoritative state for lag compensation once per network tick.
+        // This reuses the same iteration over networked entities and records every
+        // entity (not just those sent this tick), so history stays complete even for
+        // entities that did not change or were dropped by the bandwidth budget.
+        var history = plugin.StateHistory;
+
         foreach (var entity in World.Query<NetworkId, NetworkState>())
         {
             ref var networkState = ref World.Get<NetworkState>(entity);
 
             // Accumulate priority over time
             networkState.AccumulatedPriority += deltaTime;
+
+            if (history is not null && serializer is not null && World is ISnapshotCapability snapshot)
+            {
+                history.Capture(entity, plugin.CurrentTick, snapshot, serializer);
+            }
 
             if (ShouldSendEntity(entity, ref networkState, serializer))
             {

--- a/tests/KeenEyes.Network.Tests/ServerStateHistoryTests.cs
+++ b/tests/KeenEyes.Network.Tests/ServerStateHistoryTests.cs
@@ -1,0 +1,407 @@
+using KeenEyes.Capabilities;
+using KeenEyes.Network.Replication;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Transport;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+// LocalTransport completes synchronously, so Wait() is safe
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// Networked test component recording a one-dimensional position.
+/// </summary>
+public struct HistoryPosition : IComponent
+{
+    /// <summary>The position along the X axis.</summary>
+    public float X;
+}
+
+/// <summary>
+/// Tests for <see cref="ServerStateHistory"/> and its integration with the server
+/// send system: tick-indexed capture, ring eviction, despawn cleanup, at-or-before
+/// lookup, and end-to-end recording across network ticks.
+/// </summary>
+public sealed class ServerStateHistoryTests
+{
+    private static MockNetworkSerializer CreateSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+        serializer.RegisterComponent<HistoryPosition>(
+            serialize: (ref BitWriter w, HistoryPosition c) => w.WriteFloat(c.X),
+            deserialize: (ref BitReader r) => new HistoryPosition { X = r.ReadFloat() });
+        return serializer;
+    }
+
+    private static float PositionAt(IReadOnlyDictionary<Type, object> state) =>
+        ((HistoryPosition)state[typeof(HistoryPosition)]).X;
+
+    #region Ring unit tests
+
+    [Fact]
+    public void Constructor_WithZeroCapacity_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ServerStateHistory(0));
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeCapacity_ThrowsArgumentOutOfRange()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ServerStateHistory(-1));
+    }
+
+    [Fact]
+    public void TryGetState_UnknownEntity_ReturnsFalseWithEmptyState()
+    {
+        var history = new ServerStateHistory(8);
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 1f }).Build();
+
+        var found = history.TryGetState(entity, 1, out var state);
+
+        Assert.False(found);
+        Assert.Empty(state);
+    }
+
+    [Fact]
+    public void Capture_ThenTryGetState_ReturnsRecordedValue()
+    {
+        var history = new ServerStateHistory(8);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 12.5f }).Build();
+
+        history.Capture(entity, 1, world, serializer);
+
+        Assert.True(history.TryGetState(entity, 1, out var state));
+        Assert.Equal(12.5f, PositionAt(state), 0.001f);
+    }
+
+    [Fact]
+    public void Capture_OnlyRecordsNetworkSerializableComponents()
+    {
+        var history = new ServerStateHistory(8);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        // HistoryPosition is registered; NetworkState (added by nothing here) is not present.
+        var entity = world.Spawn().With(new HistoryPosition { X = 3f }).Build();
+
+        history.Capture(entity, 1, world, serializer);
+
+        Assert.True(history.TryGetState(entity, 1, out var state));
+        Assert.Single(state);
+        Assert.True(state.ContainsKey(typeof(HistoryPosition)));
+    }
+
+    [Fact]
+    public void Capture_MultipleTicks_EachTickRetainsItsOwnValue()
+    {
+        var history = new ServerStateHistory(8);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 0f }).Build();
+
+        for (uint tick = 1; tick <= 3; tick++)
+        {
+            ref var pos = ref world.Get<HistoryPosition>(entity);
+            pos.X = tick * 10f;
+            history.Capture(entity, tick, world, serializer);
+        }
+
+        Assert.True(history.TryGetState(entity, 1, out var s1));
+        Assert.True(history.TryGetState(entity, 2, out var s2));
+        Assert.True(history.TryGetState(entity, 3, out var s3));
+        Assert.Equal(10f, PositionAt(s1), 0.001f);
+        Assert.Equal(20f, PositionAt(s2), 0.001f);
+        Assert.Equal(30f, PositionAt(s3), 0.001f);
+    }
+
+    [Fact]
+    public void Capture_BeyondCapacity_EvictsOldestTick()
+    {
+        var history = new ServerStateHistory(4);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 0f }).Build();
+
+        // Capture ticks 1..5 into a capacity-4 ring; tick 5 reuses tick 1's slot.
+        for (uint tick = 1; tick <= 5; tick++)
+        {
+            ref var pos = ref world.Get<HistoryPosition>(entity);
+            pos.X = tick * 100f;
+            history.Capture(entity, tick, world, serializer);
+        }
+
+        Assert.False(history.TryGetState(entity, 1, out _));
+        Assert.True(history.TryGetState(entity, 2, out var s2));
+        Assert.True(history.TryGetState(entity, 5, out var s5));
+        Assert.Equal(200f, PositionAt(s2), 0.001f);
+        Assert.Equal(500f, PositionAt(s5), 0.001f);
+    }
+
+    [Fact]
+    public void Remove_DroppedEntity_ClearsHistory()
+    {
+        var history = new ServerStateHistory(8);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 7f }).Build();
+        history.Capture(entity, 1, world, serializer);
+        Assert.True(history.TryGetState(entity, 1, out _));
+
+        var removed = history.Remove(entity);
+
+        Assert.True(removed);
+        Assert.False(history.TryGetState(entity, 1, out _));
+    }
+
+    [Fact]
+    public void Remove_UnknownEntity_ReturnsFalse()
+    {
+        var history = new ServerStateHistory(8);
+        using var world = new World();
+        var entity = world.Spawn().Build();
+
+        Assert.False(history.Remove(entity));
+    }
+
+    #endregion
+
+    #region TryGetStateAtOrBefore
+
+    [Fact]
+    public void TryGetStateAtOrBefore_ExactTick_ReturnsThatTick()
+    {
+        var history = new ServerStateHistory(64);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 5f }).Build();
+        history.Capture(entity, 20, world, serializer);
+
+        Assert.True(history.TryGetStateAtOrBefore(entity, 20, out var matched, out var state));
+        Assert.Equal(20u, matched);
+        Assert.Equal(5f, PositionAt(state), 0.001f);
+    }
+
+    [Fact]
+    public void TryGetStateAtOrBefore_BetweenTicks_ReturnsEarlierTick()
+    {
+        var history = new ServerStateHistory(64);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 0f }).Build();
+
+        ref var pos = ref world.Get<HistoryPosition>(entity);
+        pos.X = 10f;
+        history.Capture(entity, 10, world, serializer);
+        pos = ref world.Get<HistoryPosition>(entity);
+        pos.X = 20f;
+        history.Capture(entity, 20, world, serializer);
+
+        // Tick 15 falls between recorded ticks 10 and 20; nearest at-or-before is 10.
+        Assert.True(history.TryGetStateAtOrBefore(entity, 15, out var matched, out var state));
+        Assert.Equal(10u, matched);
+        Assert.Equal(10f, PositionAt(state), 0.001f);
+    }
+
+    [Fact]
+    public void TryGetStateAtOrBefore_AfterNewestTick_ReturnsNewest()
+    {
+        var history = new ServerStateHistory(64);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 42f }).Build();
+        history.Capture(entity, 20, world, serializer);
+
+        // Query a tick past the newest recorded tick.
+        Assert.True(history.TryGetStateAtOrBefore(entity, 30, out var matched, out var state));
+        Assert.Equal(20u, matched);
+        Assert.Equal(42f, PositionAt(state), 0.001f);
+    }
+
+    [Fact]
+    public void TryGetStateAtOrBefore_BeforeAllTicks_ReturnsFalse()
+    {
+        var history = new ServerStateHistory(64);
+        var serializer = CreateSerializer();
+        using var world = new World();
+        var entity = world.Spawn().With(new HistoryPosition { X = 1f }).Build();
+        history.Capture(entity, 20, world, serializer);
+
+        Assert.False(history.TryGetStateAtOrBefore(entity, 5, out var matched, out var state));
+        Assert.Equal(0u, matched);
+        Assert.Empty(state);
+    }
+
+    [Fact]
+    public void TryGetStateAtOrBefore_UnknownEntity_ReturnsFalse()
+    {
+        var history = new ServerStateHistory(64);
+        using var world = new World();
+        var entity = world.Spawn().Build();
+
+        Assert.False(history.TryGetStateAtOrBefore(entity, 10, out var matched, out var state));
+        Assert.Equal(0u, matched);
+        Assert.Empty(state);
+    }
+
+    #endregion
+
+    #region Plugin / config integration
+
+    [Fact]
+    public void StateHistory_DefaultConfig_IsDisabled()
+    {
+        var (server, _) = LocalTransport.CreatePair();
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(server, new ServerNetworkConfig { Serializer = CreateSerializer() });
+        world.InstallPlugin(plugin);
+
+        Assert.Null(plugin.StateHistory);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void StateHistory_PositiveConfig_IsEnabledWithCapacity()
+    {
+        var (server, _) = LocalTransport.CreatePair();
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 120,
+        });
+        world.InstallPlugin(plugin);
+
+        Assert.NotNull(plugin.StateHistory);
+        Assert.Equal(120, plugin.StateHistory.Capacity);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task ServerTick_HistoryDisabled_CapturesNothing()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = 50,
+            Serializer = CreateSerializer(),
+        });
+        world.InstallPlugin(plugin);
+
+        await server.ListenAsync(7777);
+        await client.ConnectAsync("localhost", 7777);
+        server.Update();
+        client.Update();
+
+        var entity = world.Spawn().With(new HistoryPosition { X = 1f }).Build();
+        plugin.RegisterNetworkedEntity(entity);
+
+        world.Update(0.02f); // fire one network tick
+
+        Assert.Null(plugin.StateHistory);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task ServerTicks_HistoryEnabled_RecordsHistoricalValuesAcrossTicks()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = 50, // 0.02s per tick, so one tick per Update(0.02f)
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 120,
+        });
+        world.InstallPlugin(plugin);
+
+        await server.ListenAsync(7777);
+        await client.ConnectAsync("localhost", 7777);
+        server.Update();
+        client.Update();
+
+        var entity = world.Spawn().With(new HistoryPosition { X = 0f }).Build();
+        plugin.RegisterNetworkedEntity(entity);
+
+        // Move the entity one unit of 10 per tick and advance three network ticks.
+        for (int i = 1; i <= 3; i++)
+        {
+            ref var pos = ref world.Get<HistoryPosition>(entity);
+            pos.X = i * 10f;
+            world.Update(0.02f);
+        }
+
+        var history = plugin.StateHistory;
+        Assert.NotNull(history);
+
+        // currentTick advanced 1..3; each tick recorded the entity's position at that time.
+        Assert.True(history.TryGetState(entity, 1, out var s1));
+        Assert.True(history.TryGetState(entity, 2, out var s2));
+        Assert.True(history.TryGetState(entity, 3, out var s3));
+
+        var x1 = PositionAt(s1);
+        var x2 = PositionAt(s2);
+        var x3 = PositionAt(s3);
+
+        Assert.Equal(10f, x1, 0.001f);
+        Assert.Equal(20f, x2, 0.001f);
+        Assert.Equal(30f, x3, 0.001f);
+
+        // The whole point of the history: values differ tick-to-tick as the entity moves.
+        Assert.NotEqual(x1, x2);
+        Assert.NotEqual(x2, x3);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task Despawn_HistoryEnabled_DropsEntityHistory()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = 50,
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 120,
+        });
+        world.InstallPlugin(plugin);
+
+        await server.ListenAsync(7777);
+        await client.ConnectAsync("localhost", 7777);
+        server.Update();
+        client.Update();
+
+        var entity = world.Spawn().With(new HistoryPosition { X = 5f }).Build();
+        plugin.RegisterNetworkedEntity(entity);
+
+        world.Update(0.02f); // capture at tick 1
+
+        var history = plugin.StateHistory;
+        Assert.NotNull(history);
+        Assert.True(history.TryGetState(entity, 1, out _));
+
+        world.Despawn(entity);
+
+        Assert.False(history.TryGetState(entity, 1, out _));
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`ServerStateHistory`**: per-entity ring buffer of tick-indexed authoritative component states — the enabler for lag compensation (#584). Capture hooks the send system's existing all-entities iteration (post-simulation, LateUpdate, after owner-state applies), reusing the same boxed struct representation as `lastSentState` — no re-serialization. Ring dictionaries are reused across wraps; steady-state cost is one box per component per tick; O(1) tick lookup.
- **Opt-in via `ServerNetworkConfig.StateHistoryTicks`** (default 0 = disabled → zero cost, zero allocation; ~TickRate ticks ≈ 1 s of history). Exposed as `NetworkServerPlugin.StateHistory` (null when disabled). Despawn drops an entity's history.
- Query API: `TryGetState(entity, tick)` and `TryGetStateAtOrBefore(entity, tick, out matchedTick, ...)` — the matched tick lets #584 interpolate between tick pairs later; no interpolation/rewind built here (that's Phase 3).

## Test plan
- [x] 19 new tests (disabled-by-default no-capture; per-tick values change correctly; ring eviction; despawn cleanup; at-or-before semantics; end-to-end via LocalTransport with a moving entity) — 274 passed / 2 pre-existing skips
- [x] Build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #353 (Phase 2 of the plan), #584 (unblocks lag compensation)