### PR TITLE
feat(animation): Add look-at constraints (LookAtSolver + LookAtSystem)

### DIFF
--- a/src/KeenEyes.Animation/AnimationConfig.cs
+++ b/src/KeenEyes.Animation/AnimationConfig.cs
@@ -34,10 +34,13 @@ public sealed class AnimationConfig
     /// <para>
     /// When enabled, the plugin registers the IK components (<see cref="Components.IKRig"/>,
     /// <see cref="Components.IKChainReference"/>, <see cref="Components.IKTarget"/>,
-    /// <see cref="Components.IKConstraint"/>), exposes an <see cref="IKManager"/> world
-    /// extension preloaded with the TwoBone and FABRIK solvers, and adds
+    /// <see cref="Components.IKConstraint"/>, <see cref="Components.LookAtTarget"/>),
+    /// exposes an <see cref="IKManager"/> world extension preloaded with the TwoBone and
+    /// FABRIK solvers, and adds the IK pipeline systems:
     /// <see cref="Systems.IKSolverSystem"/> at order 57 so IK chains are solved after
-    /// <see cref="Systems.SkeletonPoseSystem"/> writes the FK pose.
+    /// <see cref="Systems.SkeletonPoseSystem"/> writes the FK pose, followed by
+    /// <see cref="Systems.LookAtSystem"/> at order 58 so look-at/aim constraints are
+    /// layered on top of the solved chains.
     /// </para>
     /// <para>
     /// Disabled by default: worlds that do not use IK pay no per-frame cost.

--- a/src/KeenEyes.Animation/AnimationPlugin.cs
+++ b/src/KeenEyes.Animation/AnimationPlugin.cs
@@ -140,6 +140,7 @@ public sealed class AnimationPlugin : IWorldPlugin
             context.RegisterComponent<IKChainReference>();
             context.RegisterComponent<IKTarget>();
             context.RegisterComponent<IKConstraint>();
+            context.RegisterComponent<LookAtTarget>();
 
             // Expose the IK manager with the bundled solvers pre-registered.
             ikManager = new IKManager();
@@ -151,6 +152,12 @@ public sealed class AnimationPlugin : IWorldPlugin
             context.AddSystem<IKSolverSystem>(
                 SystemPhase.Update,
                 order: 57);
+
+            // Look-at constraints run after full-chain IK so aim adjustments
+            // (head/eye tracking) layer on top of the solved pose.
+            context.AddSystem<LookAtSystem>(
+                SystemPhase.Update,
+                order: 58);
         }
 
         // Tweens update after animation state

--- a/src/KeenEyes.Animation/IK/Solvers/LookAtSolver.cs
+++ b/src/KeenEyes.Animation/IK/Solvers/LookAtSolver.cs
@@ -1,0 +1,121 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.IK.Solvers;
+
+/// <summary>
+/// Pure-math solver for single-bone look-at/aim constraints (head tracking, eye
+/// following, weapon aiming).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The solver computes the shortest-arc rotation that swings the bone's FK forward
+/// direction (the component's forward axis rotated by the FK world rotation) onto the
+/// direction toward the target. That offset rotation is clamped so its angle never
+/// exceeds the maximum angle, meaning the bone can never aim further than the limit
+/// away from its FK forward direction.
+/// </para>
+/// <para>
+/// Smoothing is a frame-rate-independent exponential approach toward the clamped goal
+/// offset: each step interpolates the stored offset by
+/// <c>alpha = 1 - exp(-deltaTime / smoothing)</c>, so the remaining angular error after a
+/// total elapsed time <c>T</c> is <c>exp(-T / smoothing)</c> of the initial error
+/// regardless of how many frames that time is divided into. A smoothing value of zero
+/// (or less) snaps instantly to the goal.
+/// </para>
+/// <para>
+/// The smoothed offset is stored in offset space (relative to the current frame's FK
+/// forward direction), so the constraint layers naturally on top of an animating FK
+/// pose and <see cref="Quaternion.Identity"/> represents "no deviation from FK".
+/// </para>
+/// </remarks>
+internal static class LookAtSolver
+{
+    /// <summary>
+    /// Solves the look-at constraint for a single bone, returning the clamped,
+    /// smoothed world rotation.
+    /// </summary>
+    /// <param name="bonePosition">The bone's world-space position.</param>
+    /// <param name="fkWorldRotation">The bone's FK world-space rotation before the constraint.</param>
+    /// <param name="targetPosition">The world-space position to look at.</param>
+    /// <param name="forwardAxis">The bone's local forward axis (need not be normalized).</param>
+    /// <param name="maxAngleDegrees">Maximum allowed angle, in degrees, between the FK forward direction and the aimed direction.</param>
+    /// <param name="smoothing">Smoothing time constant in seconds; zero or less snaps instantly.</param>
+    /// <param name="deltaTime">Elapsed frame time in seconds.</param>
+    /// <param name="smoothedOffset">
+    /// The persisted smoothed offset rotation relative to the FK forward direction.
+    /// Updated in place; pass <see cref="Quaternion.Identity"/> (or a zero quaternion)
+    /// to start from the unmodified FK pose.
+    /// </param>
+    /// <returns>
+    /// The bone's new world rotation, or <paramref name="fkWorldRotation"/> unchanged when
+    /// the target coincides with the bone position or the forward axis is degenerate.
+    /// </returns>
+    internal static Quaternion Solve(
+        Vector3 bonePosition,
+        Quaternion fkWorldRotation,
+        Vector3 targetPosition,
+        Vector3 forwardAxis,
+        float maxAngleDegrees,
+        float smoothing,
+        float deltaTime,
+        ref Quaternion smoothedOffset)
+    {
+        var toTarget = targetPosition - bonePosition;
+        if (toTarget.LengthSquared().IsApproximatelyZero() ||
+            forwardAxis.LengthSquared().IsApproximatelyZero())
+        {
+            return fkWorldRotation;
+        }
+
+        var desiredDirection = Vector3.Normalize(toTarget);
+        var fkForward = Vector3.Normalize(
+            Vector3.Transform(Vector3.Normalize(forwardAxis), fkWorldRotation));
+
+        var goalOffset = ClampAngle(
+            IKSolverMath.RotationBetween(fkForward, desiredDirection),
+            maxAngleDegrees);
+
+        // A zero quaternion means the offset state was never initialized (default
+        // struct value); treat it as "no deviation from FK".
+        var previousOffset = smoothedOffset.LengthSquared().IsApproximatelyZero()
+            ? Quaternion.Identity
+            : Quaternion.Normalize(smoothedOffset);
+
+        // Frame-rate-independent exponential smoothing: alpha = 1 - exp(-dt / smoothing).
+        var alpha = smoothing <= FloatExtensions.DefaultEpsilon
+            ? 1f
+            : 1f - MathF.Exp(-deltaTime / smoothing);
+
+        smoothedOffset = Quaternion.Normalize(Quaternion.Slerp(previousOffset, goalOffset, alpha));
+
+        return Quaternion.Normalize(smoothedOffset * fkWorldRotation);
+    }
+
+    /// <summary>
+    /// Clamps a rotation so its angle does not exceed the given limit, preserving
+    /// the rotation axis.
+    /// </summary>
+    /// <param name="rotation">The rotation to clamp.</param>
+    /// <param name="maxAngleDegrees">The maximum allowed rotation angle in degrees.</param>
+    /// <returns>The rotation, shortened along its axis if it exceeded the limit.</returns>
+    private static Quaternion ClampAngle(Quaternion rotation, float maxAngleDegrees)
+    {
+        var maxRadians = MathF.Max(maxAngleDegrees, 0f) * (MathF.PI / 180f);
+
+        var shortest = Quaternion.Normalize(rotation);
+        if (shortest.W < 0f)
+        {
+            shortest = -shortest;
+        }
+
+        var angle = 2f * MathF.Acos(Math.Clamp(shortest.W, -1f, 1f));
+        if (angle <= maxRadians || angle.IsApproximatelyZero())
+        {
+            return shortest;
+        }
+
+        return Quaternion.Slerp(Quaternion.Identity, shortest, maxRadians / angle);
+    }
+}

--- a/src/KeenEyes.Animation/Systems/LookAtSystem.cs
+++ b/src/KeenEyes.Animation/Systems/LookAtSystem.cs
@@ -1,0 +1,200 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK.Solvers;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Systems;
+
+/// <summary>
+/// System that applies <see cref="LookAtTarget"/> constraints so bones aim at
+/// entity or world-position targets.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system runs at order 58, after <see cref="IKSolverSystem"/> (order 57) and
+/// before <see cref="TweenSystem"/> (order 60), so look-at adjustments (head tracking,
+/// eye following, weapon aiming) are layered on top of both the sampled FK pose and any
+/// solved IK chains.
+/// </para>
+/// <para>
+/// For each entity carrying a <see cref="LookAtTarget"/> and a <see cref="Transform3D"/>,
+/// the system resolves the target position (a tracked entity's world position when
+/// <see cref="LookAtTarget.TargetEntityId"/> is set, otherwise
+/// <see cref="LookAtTarget.WorldTarget"/>), computes the clamped, smoothed world rotation
+/// via <see cref="LookAtSolver"/>, blends it against the FK rotation using
+/// <see cref="LookAtTarget.Weight"/>, and writes the result back as a LOCAL
+/// (parent-relative) rotation. The smoothed offset state persists in
+/// <see cref="LookAtTarget.CurrentRotation"/>.
+/// </para>
+/// <para>
+/// The max-angle clamp and weight blend are always measured against the bone's FK
+/// rotation. When animation re-poses the bone every frame the current transform IS the
+/// FK pose; for bones nothing re-poses, the system remembers the world rotation it wrote
+/// and the FK rotation that produced it, so the constraint never compounds its own
+/// output from previous frames.
+/// </para>
+/// <para>
+/// Invalid configurations degrade gracefully: constraints with dead or missing target
+/// entities, zero weight, degenerate forward axes, or targets coinciding with the bone
+/// position are skipped without modifying the FK pose.
+/// </para>
+/// </remarks>
+public sealed class LookAtSystem : SystemBase
+{
+    // Per-frame cache of target world positions keyed by entity ID
+    // (LookAtTarget references target entities by ID).
+    private readonly Dictionary<int, Vector3> targetPositionCache = [];
+    private readonly HashSet<int> requiredTargetIds = [];
+
+    // Persistent per-entity record of the world rotation this system wrote and the FK
+    // world rotation it was derived from. When a bone's current rotation still matches
+    // the written value (nothing re-posed it since), the stored FK rotation is reused as
+    // the clamp/blend reference instead of treating our own output as the FK pose.
+    private readonly Dictionary<int, AppliedRotation> appliedRotations = [];
+    private readonly HashSet<int> activeEntityIds = [];
+    private readonly List<int> staleEntityIds = [];
+
+    private readonly record struct AppliedRotation(Quaternion Written, Quaternion Fk);
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        BuildTargetCache();
+
+        activeEntityIds.Clear();
+        foreach (var entity in World.Query<LookAtTarget, Transform3D>())
+        {
+            activeEntityIds.Add(entity.Id);
+            ApplyLookAt(entity, deltaTime);
+        }
+
+        PruneStaleState();
+    }
+
+    private void BuildTargetCache()
+    {
+        targetPositionCache.Clear();
+        requiredTargetIds.Clear();
+
+        foreach (var entity in World.Query<LookAtTarget>())
+        {
+            ref readonly var lookAt = ref World.Get<LookAtTarget>(entity);
+            if (lookAt.TargetEntityId >= 0)
+            {
+                requiredTargetIds.Add(lookAt.TargetEntityId);
+            }
+        }
+
+        // Targets are referenced by entity ID; resolve their world positions in a
+        // single pass only when at least one constraint tracks an entity.
+        if (requiredTargetIds.Count > 0)
+        {
+            foreach (var entity in World.Query<Transform3D>())
+            {
+                if (requiredTargetIds.Contains(entity.Id))
+                {
+                    targetPositionCache[entity.Id] =
+                        IKSolverMath.GetWorldTransform(World, entity).Position;
+                }
+            }
+        }
+    }
+
+    private void ApplyLookAt(Entity entity, float deltaTime)
+    {
+        ref var lookAt = ref World.Get<LookAtTarget>(entity);
+
+        var weight = Math.Clamp(lookAt.Weight, 0f, 1f);
+        if (weight.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        Vector3 targetPosition;
+        if (lookAt.TargetEntityId >= 0)
+        {
+            // Dead or missing target entities leave the FK pose untouched.
+            if (!targetPositionCache.TryGetValue(lookAt.TargetEntityId, out targetPosition))
+            {
+                return;
+            }
+        }
+        else
+        {
+            targetPosition = lookAt.WorldTarget;
+        }
+
+        // Bone Transform3D components are LOCAL (parent-relative); compose the parent's
+        // world transform so the solved world rotation can be written back locally.
+        var parentPosition = Vector3.Zero;
+        var parentRotation = Quaternion.Identity;
+        var parentScale = Vector3.One;
+
+        var parent = World.GetParent(entity);
+        if (parent.IsValid && World.Has<Transform3D>(parent))
+        {
+            (parentPosition, parentRotation, parentScale) =
+                IKSolverMath.GetWorldTransform(World, parent);
+        }
+
+        ref var transform = ref World.Get<Transform3D>(entity);
+        var currentWorldRotation = Quaternion.Normalize(parentRotation * transform.Rotation);
+        var bonePosition = parentPosition +
+            Vector3.Transform(parentScale * transform.Position, parentRotation);
+
+        // If the bone still holds exactly what this system wrote last frame, nothing has
+        // re-posed it since, so the stored FK rotation remains the constraint reference.
+        var fkWorldRotation = currentWorldRotation;
+        if (appliedRotations.TryGetValue(entity.Id, out var applied) &&
+            MathF.Abs(Quaternion.Dot(currentWorldRotation, applied.Written)) > 1f - FloatExtensions.DefaultEpsilon)
+        {
+            fkWorldRotation = applied.Fk;
+        }
+
+        var smoothedOffset = lookAt.CurrentRotation;
+        var solvedWorldRotation = LookAtSolver.Solve(
+            bonePosition,
+            fkWorldRotation,
+            targetPosition,
+            lookAt.ForwardAxis,
+            lookAt.MaxAngle,
+            lookAt.Smoothing,
+            deltaTime,
+            ref smoothedOffset);
+        lookAt.CurrentRotation = smoothedOffset;
+
+        var finalWorldRotation = solvedWorldRotation;
+        if (weight < 1f && !weight.ApproximatelyEquals(1f))
+        {
+            finalWorldRotation = Quaternion.Slerp(fkWorldRotation, solvedWorldRotation, weight);
+        }
+
+        finalWorldRotation = Quaternion.Normalize(finalWorldRotation);
+        transform.Rotation = Quaternion.Normalize(
+            Quaternion.Inverse(parentRotation) * finalWorldRotation);
+        appliedRotations[entity.Id] = new AppliedRotation(finalWorldRotation, fkWorldRotation);
+    }
+
+    private void PruneStaleState()
+    {
+        if (appliedRotations.Count == activeEntityIds.Count)
+        {
+            return;
+        }
+
+        staleEntityIds.Clear();
+        foreach (var id in appliedRotations.Keys)
+        {
+            if (!activeEntityIds.Contains(id))
+            {
+                staleEntityIds.Add(id);
+            }
+        }
+
+        foreach (var id in staleEntityIds)
+        {
+            appliedRotations.Remove(id);
+        }
+    }
+}

--- a/tests/KeenEyes.Animation.Tests/IK/LookAtTests.cs
+++ b/tests/KeenEyes.Animation.Tests/IK/LookAtTests.cs
@@ -1,0 +1,485 @@
+using System.Numerics;
+
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK.Solvers;
+using KeenEyes.Animation.Systems;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests.IK;
+
+/// <summary>
+/// Tests for <see cref="LookAtSolver"/> clamp/smoothing math and for
+/// <see cref="LookAtSystem"/> running inside a world with <see cref="AnimationPlugin"/>
+/// installed with IK enabled.
+/// </summary>
+public class LookAtTests
+{
+    private const float DeltaTime = 1f / 60f;
+    private const float AngleTolerance = 0.01f;
+
+    private static AnimationConfig IKEnabledConfig => new() { EnableIK = true };
+
+    private static float AngleBetween(Vector3 a, Vector3 b)
+        => MathF.Acos(Math.Clamp(
+            Vector3.Dot(Vector3.Normalize(a), Vector3.Normalize(b)), -1f, 1f));
+
+    private static float DegreesToRadians(float degrees) => degrees * MathF.PI / 180f;
+
+    /// <summary>
+    /// Computes the world-space forward direction (+Z rotated by the world rotation)
+    /// of an entity.
+    /// </summary>
+    private static Vector3 WorldForward(World world, Entity entity)
+        => Vector3.Transform(
+            Vector3.UnitZ,
+            IKSolverTestHelpers.GetWorldTransform(world, entity).Rotation);
+
+    /// <summary>
+    /// Creates a head bone parented under a root entity, both with identity local
+    /// transforms, so the head's FK forward direction is +Z.
+    /// </summary>
+    private static (Entity Root, Entity Head) CreateHead(World world)
+    {
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .Build();
+
+        var head = world.Spawn()
+            .With(Transform3D.Identity)
+            .Build();
+        world.SetParent(head, root);
+
+        return (root, head);
+    }
+
+    #region Plugin Wiring Tests
+
+    [Fact]
+    public void Install_WithDefaultConfig_DoesNotRegisterLookAtSystem()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        world.GetSystem<LookAtSystem>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Install_WithEnableIK_RegistersLookAtSystem()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        world.GetSystem<LookAtSystem>().ShouldNotBeNull();
+    }
+
+    #endregion
+
+    #region Target Resolution Tests
+
+    [Fact]
+    public void Update_WithEntityTarget_RotatesForwardTowardTarget()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        var target = world.Spawn()
+            .With(new Transform3D(new Vector3(5f, 0f, 5f), Quaternion.Identity, Vector3.One))
+            .Build();
+        world.Add(head, LookAtTarget.AtEntity(target.Id) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        var forward = WorldForward(world, head);
+        AngleBetween(forward, new Vector3(1f, 0f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithWorldPositionTarget_RotatesForwardTowardTarget()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 3f, 3f)) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        var forward = WorldForward(world, head);
+        AngleBetween(forward, new Vector3(0f, 1f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithMovingEntityTarget_ForwardFollowsTargetEachFrame()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        var target = world.Spawn()
+            .With(new Transform3D(new Vector3(5f, 0f, 5f), Quaternion.Identity, Vector3.One))
+            .Build();
+        world.Add(head, LookAtTarget.AtEntity(target.Id) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        // Move the target; the constraint must re-aim on the next frame.
+        world.Get<Transform3D>(target).Position = new Vector3(-5f, 0f, 5f);
+        world.Update(DeltaTime);
+
+        var forward = WorldForward(world, head);
+        AngleBetween(forward, new Vector3(-1f, 0f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithRotatedParent_WritesLocalRotationRelativeToParent()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        // Parent rotated 90 degrees about Y: the head's FK world forward becomes +X.
+        var root = world.Spawn()
+            .With(new Transform3D(
+                Vector3.Zero,
+                Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2f),
+                Vector3.One))
+            .Build();
+
+        var head = world.Spawn()
+            .With(Transform3D.Identity)
+            .Build();
+        world.SetParent(head, root);
+
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(5f, 5f, 0f)) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        var forward = WorldForward(world, head);
+        AngleBetween(forward, new Vector3(1f, 1f, 0f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    #endregion
+
+    #region Max Angle Clamp Tests
+
+    [Fact]
+    public void Update_WithTargetBehindBone_ClampsRotationToMaxAngle()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+
+        // Target directly behind (180 degrees from FK forward), limit 60 degrees.
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 0f, -5f)) with
+        {
+            Smoothing = 0f,
+            MaxAngle = 60f,
+        });
+
+        world.Update(DeltaTime);
+
+        var deviation = AngleBetween(WorldForward(world, head), Vector3.UnitZ);
+        deviation.ShouldBe(DegreesToRadians(60f), AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithTargetBehindBoneOverManyFrames_DeviationStaysAtMaxAngle()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 0f, -5f)) with
+        {
+            Smoothing = 0f,
+            MaxAngle = 60f,
+        });
+
+        // The clamp is relative to the FK pose: repeated updates must not compound
+        // the constraint's own output and creep past the limit.
+        for (var frame = 0; frame < 10; frame++)
+        {
+            world.Update(DeltaTime);
+        }
+
+        var deviation = AngleBetween(WorldForward(world, head), Vector3.UnitZ);
+        deviation.ShouldBe(DegreesToRadians(60f), AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithTargetWithinMaxAngle_ReachesTargetExactly()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+
+        // 45 degrees away with a 90 degree limit: no clamping.
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 5f, 5f)) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        var forward = WorldForward(world, head);
+        AngleBetween(forward, new Vector3(0f, 1f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    #endregion
+
+    #region Smoothing Tests
+
+    [Fact]
+    public void Update_WithSmoothing_ApproachesTargetMonotonicallyWithoutSnapping()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        var desiredDirection = new Vector3(0f, 1f, 1f);
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 5f, 5f)) with { Smoothing = 0.2f });
+
+        var initialError = AngleBetween(Vector3.UnitZ, desiredDirection);
+
+        // The first frame must move toward the target but not snap onto it.
+        world.Update(DeltaTime);
+        var previousError = AngleBetween(WorldForward(world, head), desiredDirection);
+        previousError.ShouldBeLessThan(initialError);
+        previousError.ShouldBeGreaterThan(AngleTolerance);
+
+        // Each subsequent frame keeps shrinking the error.
+        for (var frame = 0; frame < 8; frame++)
+        {
+            world.Update(DeltaTime);
+            var error = AngleBetween(WorldForward(world, head), desiredDirection);
+            error.ShouldBeLessThan(previousError);
+            previousError = error;
+        }
+
+        // After enough simulated time the constraint converges onto the target.
+        for (var frame = 0; frame < 300; frame++)
+        {
+            world.Update(DeltaTime);
+        }
+
+        AngleBetween(WorldForward(world, head), desiredDirection).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Update_WithSameElapsedTimeAtDifferentFrameRates_ConvergesToSameRotation()
+    {
+        // Simulate 0.5 seconds at 30 FPS and at 60 FPS; the exponential smoothing
+        // formula alpha = 1 - exp(-dt / smoothing) must make the residual error depend
+        // only on total elapsed time, not on the step count.
+        var errorAt30 = SimulateSmoothing(steps: 15, deltaTime: 1f / 30f);
+        var errorAt60 = SimulateSmoothing(steps: 30, deltaTime: 1f / 60f);
+
+        errorAt30.ShouldBe(errorAt60, 0.001f);
+    }
+
+    private static float SimulateSmoothing(int steps, float deltaTime)
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        var desiredDirection = new Vector3(0f, 5f, 5f);
+        world.Add(head, LookAtTarget.AtPosition(desiredDirection) with { Smoothing = 0.3f });
+
+        for (var frame = 0; frame < steps; frame++)
+        {
+            world.Update(deltaTime);
+        }
+
+        return AngleBetween(WorldForward(world, head), desiredDirection);
+    }
+
+    #endregion
+
+    #region Weight Blending Tests
+
+    [Fact]
+    public void Update_WithZeroWeight_LeavesFkRotationUntouched()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 5f, 5f)) with
+        {
+            Smoothing = 0f,
+            Weight = 0f,
+        });
+
+        world.Update(DeltaTime);
+
+        var rotation = world.Get<Transform3D>(head).Rotation;
+        MathF.Abs(Quaternion.Dot(rotation, Quaternion.Identity)).ShouldBeGreaterThan(1f - 1e-6f);
+    }
+
+    [Fact]
+    public void Update_WithHalfWeight_RotatesHalfwayTowardTarget()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+
+        // Target 45 degrees from FK forward; half weight must rotate 22.5 degrees.
+        world.Add(head, LookAtTarget.AtPosition(new Vector3(0f, 5f, 5f)) with
+        {
+            Smoothing = 0f,
+            Weight = 0.5f,
+        });
+
+        world.Update(DeltaTime);
+
+        var deviation = AngleBetween(WorldForward(world, head), Vector3.UnitZ);
+        deviation.ShouldBe(DegreesToRadians(22.5f), AngleTolerance);
+    }
+
+    #endregion
+
+    #region Graceful Degradation Tests
+
+    [Fact]
+    public void Update_WithDeadTargetEntity_PreservesFkPoseWithoutThrowing()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        var target = world.Spawn()
+            .With(new Transform3D(new Vector3(5f, 0f, 5f), Quaternion.Identity, Vector3.One))
+            .Build();
+        world.Add(head, LookAtTarget.AtEntity(target.Id) with { Smoothing = 0f });
+        world.Despawn(target);
+
+        world.Update(DeltaTime);
+
+        var rotation = world.Get<Transform3D>(head).Rotation;
+        MathF.Abs(Quaternion.Dot(rotation, Quaternion.Identity)).ShouldBeGreaterThan(1f - 1e-6f);
+    }
+
+    [Fact]
+    public void Update_WithMissingTargetEntityId_PreservesFkPose()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AnimationPlugin(IKEnabledConfig));
+
+        var (_, head) = CreateHead(world);
+        world.Add(head, LookAtTarget.AtEntity(99999) with { Smoothing = 0f });
+
+        world.Update(DeltaTime);
+
+        var rotation = world.Get<Transform3D>(head).Rotation;
+        MathF.Abs(Quaternion.Dot(rotation, Quaternion.Identity)).ShouldBeGreaterThan(1f - 1e-6f);
+    }
+
+    #endregion
+
+    #region LookAtSolver Unit Tests
+
+    [Fact]
+    public void Solve_WithTargetWithinLimit_RotatesForwardOntoTargetDirection()
+    {
+        var offset = Quaternion.Identity;
+
+        var rotation = LookAtSolver.Solve(
+            Vector3.Zero, Quaternion.Identity, new Vector3(0f, 5f, 5f),
+            Vector3.UnitZ, maxAngleDegrees: 90f, smoothing: 0f,
+            deltaTime: DeltaTime, ref offset);
+
+        var forward = Vector3.Transform(Vector3.UnitZ, rotation);
+        AngleBetween(forward, new Vector3(0f, 1f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Solve_WithTargetBeyondLimit_ClampsRotationToMaxAngle()
+    {
+        var offset = Quaternion.Identity;
+
+        // Target is 180 degrees behind the forward direction; the clamp must stop
+        // the rotation at exactly the 45 degree limit.
+        var rotation = LookAtSolver.Solve(
+            Vector3.Zero, Quaternion.Identity, new Vector3(0f, 0f, -5f),
+            Vector3.UnitZ, maxAngleDegrees: 45f, smoothing: 0f,
+            deltaTime: DeltaTime, ref offset);
+
+        var forward = Vector3.Transform(Vector3.UnitZ, rotation);
+        AngleBetween(forward, Vector3.UnitZ).ShouldBe(DegreesToRadians(45f), AngleTolerance);
+    }
+
+    [Fact]
+    public void Solve_WithZeroMaxAngle_ReturnsFkRotation()
+    {
+        var offset = Quaternion.Identity;
+        var fkRotation = Quaternion.CreateFromAxisAngle(Vector3.UnitY, 0.3f);
+
+        var rotation = LookAtSolver.Solve(
+            Vector3.Zero, fkRotation, new Vector3(5f, 0f, 0f),
+            Vector3.UnitZ, maxAngleDegrees: 0f, smoothing: 0f,
+            deltaTime: DeltaTime, ref offset);
+
+        MathF.Abs(Quaternion.Dot(rotation, fkRotation)).ShouldBeGreaterThan(1f - 1e-6f);
+    }
+
+    [Fact]
+    public void Solve_WithTargetAtBonePosition_ReturnsFkRotationUnchanged()
+    {
+        var offset = Quaternion.Identity;
+        var fkRotation = Quaternion.CreateFromAxisAngle(Vector3.UnitX, 0.5f);
+        var bonePosition = new Vector3(1f, 2f, 3f);
+
+        var rotation = LookAtSolver.Solve(
+            bonePosition, fkRotation, bonePosition,
+            Vector3.UnitZ, maxAngleDegrees: 90f, smoothing: 0f,
+            deltaTime: DeltaTime, ref offset);
+
+        MathF.Abs(Quaternion.Dot(rotation, fkRotation)).ShouldBeGreaterThan(1f - 1e-6f);
+    }
+
+    [Fact]
+    public void Solve_WithZeroSmoothedOffsetState_TreatsStateAsIdentity()
+    {
+        // A default-initialized component field is a zero quaternion; the solver
+        // must seed it as identity instead of producing NaNs.
+        var offset = default(Quaternion);
+
+        var rotation = LookAtSolver.Solve(
+            Vector3.Zero, Quaternion.Identity, new Vector3(0f, 5f, 5f),
+            Vector3.UnitZ, maxAngleDegrees: 90f, smoothing: 0f,
+            deltaTime: DeltaTime, ref offset);
+
+        var forward = Vector3.Transform(Vector3.UnitZ, rotation);
+        AngleBetween(forward, new Vector3(0f, 1f, 1f)).ShouldBeLessThan(AngleTolerance);
+    }
+
+    [Fact]
+    public void Solve_WithSameElapsedTimeAtDifferentSteps_ProducesSameResidualError()
+    {
+        var desiredDirection = new Vector3(5f, 0f, 0f);
+
+        var errorCoarse = SolveRepeatedly(desiredDirection, steps: 10, deltaTime: 1f / 20f);
+        var errorFine = SolveRepeatedly(desiredDirection, steps: 30, deltaTime: 1f / 60f);
+
+        errorCoarse.ShouldBe(errorFine, 0.001f);
+    }
+
+    private static float SolveRepeatedly(Vector3 targetPosition, int steps, float deltaTime)
+    {
+        var offset = Quaternion.Identity;
+        var rotation = Quaternion.Identity;
+
+        for (var i = 0; i < steps; i++)
+        {
+            rotation = LookAtSolver.Solve(
+                Vector3.Zero, Quaternion.Identity, targetPosition,
+                Vector3.UnitZ, maxAngleDegrees: 180f, smoothing: 0.25f,
+                deltaTime: deltaTime, ref offset);
+        }
+
+        return AngleBetween(Vector3.Transform(Vector3.UnitZ, rotation), targetPosition);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`LookAtSolver`** (internal, pure math): shortest-arc aim from FK forward to target direction, axis-preserving clamp to `MaxAngle` measured from FK forward, then frame-rate-independent exponential smoothing (`alpha = 1 − exp(−dt / Smoothing)`; residual error after time T is `exp(−T/Smoothing)` regardless of step count; `Smoothing ≤ 0` snaps).
- **`LookAtSystem`** (order 58, between IKSolverSystem 57 and Tween 60), registered under the existing `EnableIK` flag: entity or world-position targets, weight-blended against FK via slerp, written back as local rotation via the shared IK world/local helpers. Dead targets, zero weight, and degenerate axes skip gracefully with FK preserved.
- **Feedback-loop guard:** for bones nothing re-poses each frame, the system tracks what it last wrote vs the FK it derived from — otherwise its own output compounds as "FK" and the clamp creeps past `MaxAngle`. Regression-tested (`Update_WithTargetBehindBoneOverManyFrames_DeviationStaysAtMaxAngle`). Smoothing state lives in the existing system-managed `LookAtTarget.CurrentRotation` field.
- `LookAtTarget.UpAxis` intentionally unused (shortest-arc aim per the issue; roll control would be speculative).

## Test plan
- [x] 21 new tests: entity + world-position tracking, max-angle clamp with target behind, smoothing convergence + frame-rate independence (verified at dt 1/20, 1/30, 1/60), weight blending (0 / 0.5 / 1), dead-target grace, solver clamp math, the feedback-loop regression — 336/336 passing
- [x] Build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #956 (part of #959). Rebased onto main after #1012 merged mid-task.