### PR TITLE
feat(network): Add lag compensation with historical state rewind

### DIFF
--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -39,6 +39,7 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
         config is { StateHistoryTicks: > 0 } cfg ? new ServerStateHistory(cfg.StateHistoryTicks) : null;
 
     private IPluginContext? context;
+    private LagCompensation? lagCompensation;
     private OwnerAuthoritativeComponentSet? ownerAuthTypes;
     private INetworkSerializer? ownerAuthTypesSource;
     private uint currentTick;
@@ -91,6 +92,17 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     public ServerStateHistory? StateHistory => stateHistory;
 
     /// <summary>
+    /// Gets the lag-compensation helper for rewinding to a client's perceived state, or
+    /// <see langword="null"/> when state history is disabled or the plugin is not installed.
+    /// </summary>
+    /// <remarks>
+    /// The helper is available only when <see cref="ServerNetworkConfig.StateHistoryTicks"/>
+    /// is positive (which enables <see cref="StateHistory"/>) and the plugin has been
+    /// installed into a world, since rewinding mutates that world's live components.
+    /// </remarks>
+    public LagCompensation? LagCompensation => lagCompensation;
+
+    /// <summary>
     /// Raised when a client input is received.
     /// </summary>
     /// <remarks>
@@ -116,6 +128,13 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
         // Subscribe to entity events for replication
         entityCreatedSubscription = context.World.OnEntityCreated(OnEntityCreated);
         entityDestroyedSubscription = context.World.OnEntityDestroyed(OnEntityDestroyed);
+
+        // Lag compensation needs both a history to rewind through and a live world to
+        // rewind, so it is created only once installed and only when history is enabled.
+        if (stateHistory is not null)
+        {
+            lagCompensation = new LagCompensation(this, context.World, stateHistory, config);
+        }
     }
 
     /// <inheritdoc/>
@@ -130,6 +149,7 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
         entityCreatedSubscription?.Dispose();
         entityDestroyedSubscription?.Dispose();
 
+        lagCompensation = null;
         this.context = null;
     }
 
@@ -228,6 +248,21 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     {
         return clients.Values;
     }
+
+    /// <summary>
+    /// Gets the most recently measured round-trip time to a client, in milliseconds.
+    /// </summary>
+    /// <param name="clientId">The client to look up.</param>
+    /// <returns>
+    /// The client's round-trip time in milliseconds, or <c>0</c> when the client is not
+    /// connected. A zero value yields no latency compensation for that client.
+    /// </returns>
+    /// <remarks>
+    /// This is the latency input for <see cref="Replication.LagCompensation"/>; the rewind
+    /// helper halves it to estimate the one-way delay of a client's action.
+    /// </remarks>
+    public float GetClientRoundTripTimeMs(int clientId)
+        => clients.TryGetValue(clientId, out var state) ? state.RoundTripTimeMs : 0f;
 
     /// <summary>
     /// Sends a full world snapshot to a client.

--- a/src/KeenEyes.Network/Replication/LagCompensation.cs
+++ b/src/KeenEyes.Network/Replication/LagCompensation.cs
@@ -1,0 +1,242 @@
+using KeenEyes.Capabilities;
+using KeenEyes.Network.Serialization;
+
+namespace KeenEyes.Network.Replication;
+
+/// <summary>
+/// Server-side lag compensation: estimates the tick a client acted on and rewinds
+/// authoritative entity state to that tick for hit testing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Players aim at where they see targets, but network latency means those targets have
+/// already moved by the time the action reaches the server. This helper reconstructs the
+/// state the acting client actually saw — from the tick-indexed <see cref="ServerStateHistory"/>
+/// captured each network tick — so interactions resolve fairly.
+/// </para>
+/// <para>
+/// It is obtained from <see cref="NetworkServerPlugin.LagCompensation"/> and is available only
+/// when state history is enabled. It reads the plugin's current tick and per-client round-trip
+/// time live, so estimates track the latest measurements.
+/// </para>
+/// </remarks>
+public sealed class LagCompensation
+{
+    private readonly NetworkServerPlugin server;
+    private readonly IWorld world;
+    private readonly ISnapshotCapability snapshot;
+    private readonly ServerStateHistory history;
+    private readonly ServerNetworkConfig config;
+
+    private static readonly IReadOnlyDictionary<Type, object> emptyState = new Dictionary<Type, object>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LagCompensation"/> class.
+    /// </summary>
+    /// <param name="server">The owning server plugin, queried for current tick and client RTT.</param>
+    /// <param name="world">The live world whose components rewinding swaps.</param>
+    /// <param name="history">The tick-indexed authoritative state history to rewind through.</param>
+    /// <param name="config">The server configuration providing tick rate, interpolation delay, and interpolator.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="world"/> does not support snapshot access.</exception>
+    internal LagCompensation(NetworkServerPlugin server, IWorld world, ServerStateHistory history, ServerNetworkConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(server);
+        ArgumentNullException.ThrowIfNull(world);
+        ArgumentNullException.ThrowIfNull(history);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (world is not ISnapshotCapability snapshotCapability)
+        {
+            throw new ArgumentException("World must support snapshot access for lag compensation.", nameof(world));
+        }
+
+        this.server = server;
+        this.world = world;
+        snapshot = snapshotCapability;
+        this.history = history;
+        this.config = config;
+    }
+
+    /// <summary>
+    /// Estimates the network tick whose state a client perceived when it acted.
+    /// </summary>
+    /// <param name="clientId">The acting client.</param>
+    /// <returns>
+    /// The estimated perceived tick, clamped into the retained history window
+    /// <c>[currentTick - (Capacity - 1), currentTick]</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The estimate walks back from the server's current tick by two latency terms:
+    /// </para>
+    /// <list type="number">
+    /// <item>
+    /// <description>
+    /// <b>One-way latency</b> — half the client's round-trip time
+    /// (<see cref="NetworkServerPlugin.GetClientRoundTripTimeMs"/>). Only the upstream leg
+    /// matters: the action was sampled that long before it arrived. Converted to ticks by
+    /// <c>rttMs / 2 * TickRate / 1000</c>.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <b>Interpolation delay</b> — clients render remote entities
+    /// <see cref="NetworkPluginConfig.InterpolationDelayMs"/> behind server time for smooth
+    /// motion, so the client aimed at state that much further in the past. Converted to ticks
+    /// by <c>InterpolationDelayMs * TickRate / 1000</c>.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// The two terms are summed, rounded to whole ticks, and subtracted from the current tick.
+    /// The result is clamped into the retained window: it can never predate the oldest recorded
+    /// tick (nothing older survives to rewind to) nor exceed the current tick. Clamping also
+    /// caps how far a client can rewind, which bounds the anti-cheat surface.
+    /// </para>
+    /// </remarks>
+    public uint EstimateClientPerceivedTick(int clientId)
+    {
+        var currentTick = server.CurrentTick;
+        var tickRate = config.TickRate;
+
+        // One-way (upstream) latency in ticks: half the round trip, scaled from ms to ticks.
+        var oneWayLatencyTicks = server.GetClientRoundTripTimeMs(clientId) * 0.5f * tickRate / 1000f;
+
+        // Interpolation delay the client renders behind, in ticks.
+        var interpolationDelayTicks = config.InterpolationDelayMs * tickRate / 1000f;
+
+        var offsetTicks = (uint)MathF.Round(oneWayLatencyTicks + interpolationDelayTicks);
+
+        // Walk back from the current tick, guarding against unsigned underflow.
+        var perceived = offsetTicks >= currentTick ? 0u : currentTick - offsetTicks;
+
+        // Clamp into the retained history window [oldest, currentTick].
+        var capacity = (uint)history.Capacity;
+        var oldest = currentTick + 1 > capacity ? currentTick + 1 - capacity : 0u;
+        if (perceived < oldest)
+        {
+            perceived = oldest;
+        }
+
+        if (perceived > currentTick)
+        {
+            perceived = currentTick;
+        }
+
+        return perceived;
+    }
+
+    /// <summary>
+    /// Gets an entity's recorded state at a tick, interpolating between the surrounding
+    /// recorded ticks for components that support it.
+    /// </summary>
+    /// <param name="entity">The entity to query.</param>
+    /// <param name="tick">The tick to reconstruct state for.</param>
+    /// <param name="state">
+    /// When this method returns <see langword="true"/>, the reconstructed component values
+    /// keyed by type; otherwise an empty dictionary.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if any retained state at or before <paramref name="tick"/> exists
+    /// for the entity; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// When the exact tick is recorded, its state is returned as-is. Otherwise the state at or
+    /// before the tick is bracketed with the next recorded tick and each component is blended by
+    /// the fractional position of <paramref name="tick"/> between them: interpolatable components
+    /// (per the configured <see cref="INetworkInterpolator"/>) are interpolated; all others snap
+    /// to the at-or-before value. When there is no later recorded tick, the at-or-before state is
+    /// returned unchanged.
+    /// </para>
+    /// </remarks>
+    public bool TryGetStateAt(Entity entity, uint tick, out IReadOnlyDictionary<Type, object> state)
+    {
+        if (!history.TryGetStateAtOrBefore(entity, tick, out var beforeTick, out var beforeState))
+        {
+            state = emptyState;
+            return false;
+        }
+
+        // Exact hit, or no later sample to interpolate toward: use the at-or-before state.
+        if (beforeTick == tick
+            || !history.TryGetStateAtOrAfter(entity, tick, out var afterTick, out var afterState)
+            || afterTick <= beforeTick)
+        {
+            state = beforeState;
+            return true;
+        }
+
+        // tick falls strictly between beforeTick and afterTick; blend by its fractional position.
+        var factor = (float)(tick - beforeTick) / (afterTick - beforeTick);
+        var interpolator = config.Interpolator;
+        var result = new Dictionary<Type, object>(beforeState.Count);
+
+        foreach (var (type, fromValue) in beforeState)
+        {
+            if (interpolator is not null
+                && interpolator.IsInterpolatable(type)
+                && afterState.TryGetValue(type, out var toValue))
+            {
+                var interpolated = interpolator.Interpolate(type, fromValue, toValue, factor);
+                result[type] = interpolated ?? fromValue;
+            }
+            else
+            {
+                // Non-interpolatable (or no matching later value): snap to the at-or-before value.
+                result[type] = fromValue;
+            }
+        }
+
+        state = result;
+        return true;
+    }
+
+    /// <summary>
+    /// Temporarily rewinds the given entities' live components to their state at a tick.
+    /// </summary>
+    /// <param name="entities">The entities to rewind (typically hit-test candidates).</param>
+    /// <param name="tick">The tick to rewind to, usually from <see cref="EstimateClientPerceivedTick"/>.</param>
+    /// <returns>
+    /// A <see cref="RewindScope"/> that restores the originals when disposed. Consume it with a
+    /// <c>using</c> statement and perform hit testing against the live world inside the scope.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entities"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Entities that are not alive or have no retained state at the tick are skipped, leaving
+    /// their live components untouched; skipping one entity never affects the others. Only
+    /// components the entity currently has and that are present in the recorded state are
+    /// swapped, so restoration is exact.
+    /// </remarks>
+    public RewindScope Rewind(IEnumerable<Entity> entities, uint tick)
+    {
+        ArgumentNullException.ThrowIfNull(entities);
+
+        // Build the swap list up front. Reading the historical state (which may interpolate)
+        // happens before any live mutation, so the captured live values are pristine.
+        var swaps = new List<(Entity Entity, Type Type, object Live, object Historical)>();
+        foreach (var entity in entities)
+        {
+            if (!world.IsAlive(entity))
+            {
+                continue;
+            }
+
+            if (!TryGetStateAt(entity, tick, out var historical) || historical.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var (type, liveValue) in snapshot.GetComponents(entity))
+            {
+                if (historical.TryGetValue(type, out var historicalValue))
+                {
+                    swaps.Add((entity, type, liveValue, historicalValue));
+                }
+            }
+        }
+
+        return new RewindScope(world, swaps);
+    }
+}

--- a/src/KeenEyes.Network/Replication/RewindScope.cs
+++ b/src/KeenEyes.Network/Replication/RewindScope.cs
@@ -1,0 +1,117 @@
+namespace KeenEyes.Network.Replication;
+
+/// <summary>
+/// A disposable scope that temporarily swaps live entity components to their historical
+/// values for lag-compensated hit testing, restoring the originals on dispose.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Obtain a scope from <see cref="LagCompensation.Rewind"/>. Inside the scope the listed
+/// entities read as they did at the rewound tick, so hit detection against the live world
+/// resolves against the state the acting client actually saw. Disposing the scope restores
+/// every swapped component to the exact boxed value it held before the swap.
+/// </para>
+/// <para>
+/// This is a <see langword="ref"/> struct: it lives on the stack and must be consumed with a
+/// <c>using</c> statement in the same method. Because <c>using</c> compiles to a
+/// <c>try</c>/<c>finally</c>, restoration runs even when an exception is thrown inside the
+/// scope. Restoration is also self-guarded: if applying the historical values fails partway,
+/// the constructor rolls back what it already changed before rethrowing.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var tick = lagCompensation.EstimateClientPerceivedTick(attackerClientId);
+/// using (lagCompensation.Rewind(targets, tick))
+/// {
+///     // Positions now read as the attacker saw them; resolve the shot here.
+///     var hit = RaycastAgainstLiveWorld(world, ray);
+/// }
+/// // Live positions are restored exactly here.
+/// </code>
+/// </example>
+public ref struct RewindScope
+{
+    private readonly IWorld world;
+    private readonly List<(Entity Entity, Type Type, object Original)> originals;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new <see cref="RewindScope"/>, capturing the live values it is about to
+    /// overwrite and then applying the historical values.
+    /// </summary>
+    /// <param name="world">The live world whose components are swapped.</param>
+    /// <param name="swaps">
+    /// The per-component swaps to perform: the entity, the component type, its current live
+    /// (boxed) value, and the historical (boxed) value to apply. Only components the entity
+    /// currently has are included, so every applied value has a captured original.
+    /// </param>
+    internal RewindScope(IWorld world, List<(Entity Entity, Type Type, object Live, object Historical)> swaps)
+    {
+        this.world = world;
+        originals = new List<(Entity, Type, object)>(swaps.Count);
+
+        // Phase 1: record the exact live boxed values first, so restore is byte-for-byte.
+        foreach (var (entity, type, live, _) in swaps)
+        {
+            originals.Add((entity, type, live));
+        }
+
+        // Phase 2: apply the historical values. If any application throws, undo the ones
+        // already applied (newest first) before propagating, so the world is never left
+        // in a partially rewound state.
+        var applied = 0;
+        try
+        {
+            foreach (var (entity, type, _, historical) in swaps)
+            {
+                world.SetComponent(entity, type, historical);
+                applied++;
+            }
+        }
+        catch
+        {
+            for (var i = applied - 1; i >= 0; i--)
+            {
+                var (entity, type, original) = originals[i];
+                if (world.IsAlive(entity))
+                {
+                    world.SetComponent(entity, type, original);
+                }
+            }
+
+            disposed = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Restores every swapped component to its original live value.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent: calling more than once (or after a failed construction rollback) does
+    /// nothing further. Components on entities that were despawned inside the scope are
+    /// skipped rather than resurrected.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // Restore in reverse application order to mirror the swap sequence exactly.
+        for (var i = originals.Count - 1; i >= 0; i--)
+        {
+            var (entity, type, original) = originals[i];
+            if (world.IsAlive(entity))
+            {
+                world.SetComponent(entity, type, original);
+            }
+        }
+
+        originals.Clear();
+    }
+}

--- a/src/KeenEyes.Network/Replication/ServerStateHistory.cs
+++ b/src/KeenEyes.Network/Replication/ServerStateHistory.cs
@@ -142,6 +142,41 @@ public sealed class ServerStateHistory
     }
 
     /// <summary>
+    /// Gets the recorded state of an entity at the earliest tick at or after the given tick.
+    /// </summary>
+    /// <param name="entity">The entity to query.</param>
+    /// <param name="tick">The lower bound tick (inclusive).</param>
+    /// <param name="matchedTick">
+    /// When this method returns <see langword="true"/>, the actual tick whose state was
+    /// returned; otherwise zero.
+    /// </param>
+    /// <param name="state">
+    /// When this method returns <see langword="true"/>, the recorded component states for
+    /// <paramref name="matchedTick"/>; otherwise an empty dictionary.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if any retained state at or after <paramref name="tick"/>
+    /// exists for the entity; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// This is the forward-looking counterpart to <see cref="TryGetStateAtOrBefore"/>.
+    /// Lag compensation pairs the two to bracket a client's action time and interpolate
+    /// between the surrounding recorded ticks.
+    /// </remarks>
+    public bool TryGetStateAtOrAfter(Entity entity, uint tick, out uint matchedTick, out IReadOnlyDictionary<Type, object> state)
+    {
+        if (histories.TryGetValue(entity, out var ring) && ring.TryGetAtOrAfter(tick, out matchedTick, out var slot))
+        {
+            state = slot;
+            return true;
+        }
+
+        matchedTick = 0;
+        state = EmptyState.Instance;
+        return false;
+    }
+
+    /// <summary>
     /// Drops all recorded history for an entity. Call when the entity despawns.
     /// </summary>
     /// <param name="entity">The entity whose history should be dropped.</param>
@@ -213,6 +248,33 @@ public sealed class ServerStateHistory
                 for (uint offset = 0; offset < (uint)capacity && offset <= start; offset++)
                 {
                     var candidate = start - offset;
+                    var index = (int)(candidate % (uint)capacity);
+                    if (occupied[index] && ticks[index] == candidate)
+                    {
+                        matchedTick = candidate;
+                        slot = slots[index];
+                        return true;
+                    }
+                }
+            }
+
+            matchedTick = 0;
+            slot = null!;
+            return false;
+        }
+
+        public bool TryGetAtOrAfter(uint tick, out uint matchedTick, out Dictionary<Type, object> slot)
+        {
+            // Nothing at or after a tick beyond the newest recorded one.
+            if (hasAny && tick <= newestTick)
+            {
+                // The ring retains ticks in (newestTick - capacity, newestTick]; never search
+                // below that window or an evicted slot could produce a false match. Bounding
+                // the start there also caps the walk at one full ring pass.
+                var oldest = newestTick + 1 > (uint)capacity ? newestTick + 1 - (uint)capacity : 0u;
+                var start = tick > oldest ? tick : oldest;
+                for (var candidate = start; candidate <= newestTick; candidate++)
+                {
                     var index = (int)(candidate % (uint)capacity);
                     if (occupied[index] && ticks[index] == candidate)
                     {

--- a/tests/KeenEyes.Network.Tests/LagCompensationTests.cs
+++ b/tests/KeenEyes.Network.Tests/LagCompensationTests.cs
@@ -1,0 +1,604 @@
+using KeenEyes.Network.Replication;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Transport;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+// LocalTransport completes synchronously, so awaiting its tasks never blocks a real socket.
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// One-dimensional interpolatable position used to exercise lag-compensated rewinding.
+/// </summary>
+public struct LagPosition : IComponent
+{
+    /// <summary>The position along the X axis.</summary>
+    public float X;
+}
+
+/// <summary>
+/// A non-interpolatable networked value used to verify snap-to-at-or-before behavior.
+/// </summary>
+public struct LagTeam : IComponent
+{
+    /// <summary>The team identifier.</summary>
+    public int Value;
+}
+
+/// <summary>
+/// Test interpolator that linearly blends <see cref="LagPosition"/> and refuses everything else.
+/// </summary>
+public sealed class LagPositionInterpolator : INetworkInterpolator
+{
+    /// <inheritdoc/>
+    public bool IsInterpolatable(Type type) => type == typeof(LagPosition);
+
+    /// <inheritdoc/>
+    public object? Interpolate(Type type, object from, object to, float factor)
+    {
+        if (type != typeof(LagPosition))
+        {
+            return null;
+        }
+
+        var a = (LagPosition)from;
+        var b = (LagPosition)to;
+        return new LagPosition { X = a.X + ((b.X - a.X) * factor) };
+    }
+}
+
+/// <summary>
+/// Tests for <see cref="LagCompensation"/>: perceived-tick estimation, interpolated historical
+/// state, rewind/restore exactness, and end-to-end lag-compensated hit detection.
+/// </summary>
+public sealed class LagCompensationTests
+{
+    private static MockNetworkSerializer CreateSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+        serializer.RegisterComponent<LagPosition>(
+            serialize: (ref BitWriter w, LagPosition c) => w.WriteFloat(c.X),
+            deserialize: (ref BitReader r) => new LagPosition { X = r.ReadFloat() });
+        serializer.RegisterComponent<LagTeam>(
+            serialize: (ref BitWriter w, LagTeam c) => w.WriteUInt32((uint)c.Value),
+            deserialize: (ref BitReader r) => new LagTeam { Value = (int)r.ReadUInt32() });
+        return serializer;
+    }
+
+    private static float XOf(IReadOnlyDictionary<Type, object> state) =>
+        ((LagPosition)state[typeof(LagPosition)]).X;
+
+    private static int TeamOf(IReadOnlyDictionary<Type, object> state) =>
+        ((LagTeam)state[typeof(LagTeam)]).Value;
+
+    /// <summary>
+    /// Installs a server plugin (no client connection) and returns it with its transport.
+    /// </summary>
+    private static (NetworkServerPlugin Plugin, LocalTransport Server) InstallServer(World world, ServerNetworkConfig config)
+    {
+        var (server, _) = LocalTransport.CreatePair();
+        var plugin = new NetworkServerPlugin(server, config);
+        world.InstallPlugin(plugin);
+        return (plugin, server);
+    }
+
+    /// <summary>
+    /// Installs a server plugin and connects a single client, returning the client id.
+    /// </summary>
+    private static async Task<(NetworkServerPlugin Plugin, LocalTransport Server, LocalTransport Client, int ClientId)>
+        InstallServerWithClientAsync(World world, ServerNetworkConfig config)
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        var plugin = new NetworkServerPlugin(server, config);
+        world.InstallPlugin(plugin);
+
+        await server.ListenAsync(7777);
+        await client.ConnectAsync("localhost", 7777);
+        server.Update();
+        client.Update();
+
+        var clientId = plugin.GetConnectedClients().First().ClientId;
+        return (plugin, server, client, clientId);
+    }
+
+    private static void AdvanceTo(NetworkServerPlugin plugin, uint targetTick)
+    {
+        // Each Tick(1f) advances exactly one network tick regardless of tick rate.
+        while (plugin.CurrentTick < targetTick)
+        {
+            plugin.Tick(1f);
+        }
+    }
+
+    #region Availability
+
+    [Fact]
+    public void LagCompensation_HistoryDisabled_IsNull()
+    {
+        using var world = new World();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig { Serializer = CreateSerializer() });
+
+        Assert.Null(plugin.StateHistory);
+        Assert.Null(plugin.LagCompensation);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void LagCompensation_HistoryEnabledAndInstalled_IsAvailable()
+    {
+        using var world = new World();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 64,
+        });
+
+        Assert.NotNull(plugin.StateHistory);
+        Assert.NotNull(plugin.LagCompensation);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void LagCompensation_AfterUninstall_IsNullAgain()
+    {
+        using var world = new World();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 64,
+        });
+        Assert.NotNull(plugin.LagCompensation);
+
+        world.UninstallPlugin("NetworkServer");
+
+        Assert.Null(plugin.LagCompensation);
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region EstimateClientPerceivedTick
+
+    [Fact]
+    public async Task EstimateClientPerceivedTick_WithRttAndInterpolationDelay_SubtractsBothTerms()
+    {
+        using var world = new World();
+        var (plugin, server, client, clientId) = await InstallServerWithClientAsync(world, new ServerNetworkConfig
+        {
+            TickRate = 50,           // 20 ms per tick
+            InterpolationDelayMs = 100f, // 5 ticks
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 128,
+        });
+
+        // RTT 200 ms -> one-way 100 ms -> 5 ticks. Plus 5 ticks interpolation delay = 10 ticks back.
+        plugin.GetConnectedClients().First().RoundTripTimeMs = 200f;
+        AdvanceTo(plugin, 20);
+
+        var perceived = plugin.LagCompensation!.EstimateClientPerceivedTick(clientId);
+
+        Assert.Equal(10u, perceived);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task EstimateClientPerceivedTick_ZeroLatencyAndNoDelay_ReturnsCurrentTick()
+    {
+        using var world = new World();
+        var (plugin, server, client, clientId) = await InstallServerWithClientAsync(world, new ServerNetworkConfig
+        {
+            TickRate = 50,
+            InterpolationDelayMs = 0f,
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 128,
+        });
+
+        plugin.GetConnectedClients().First().RoundTripTimeMs = 0f;
+        AdvanceTo(plugin, 20);
+
+        var perceived = plugin.LagCompensation!.EstimateClientPerceivedTick(clientId);
+
+        Assert.Equal(20u, perceived);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task EstimateClientPerceivedTick_ExcessiveLatency_ClampsToOldestRetainedTick()
+    {
+        using var world = new World();
+        var (plugin, server, client, clientId) = await InstallServerWithClientAsync(world, new ServerNetworkConfig
+        {
+            TickRate = 50,
+            InterpolationDelayMs = 0f,
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 8, // window keeps ticks (currentTick - 7 .. currentTick)
+        });
+
+        // Absurd RTT would rewind far past the retained window; must clamp to the oldest tick.
+        plugin.GetConnectedClients().First().RoundTripTimeMs = 100_000f;
+        AdvanceTo(plugin, 20);
+
+        var perceived = plugin.LagCompensation!.EstimateClientPerceivedTick(clientId);
+
+        // Oldest retained = currentTick + 1 - capacity = 20 + 1 - 8 = 13.
+        Assert.Equal(13u, perceived);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public void EstimateClientPerceivedTick_UnknownClient_UsesZeroRttGracefully()
+    {
+        using var world = new World();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            TickRate = 50,
+            InterpolationDelayMs = 100f, // 5 ticks, no RTT term for an unknown client
+            Serializer = CreateSerializer(),
+            StateHistoryTicks = 128,
+        });
+        AdvanceTo(plugin, 20);
+
+        // Client 999 was never connected: RTT resolves to 0, only interpolation delay applies.
+        var perceived = plugin.LagCompensation!.EstimateClientPerceivedTick(999);
+
+        Assert.Equal(15u, perceived);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region TryGetStateAt
+
+    [Fact]
+    public void TryGetStateAt_ExactRecordedTick_ReturnsRecordedValue()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagPosition { X = 7f }).Build();
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+
+        Assert.True(plugin.LagCompensation!.TryGetStateAt(entity, 10, out var state));
+        Assert.Equal(7f, XOf(state), 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void TryGetStateAt_BetweenTicks_InterpolatableComponent_Blends()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagPosition { X = 0f }).Build();
+
+        ref var pos = ref world.Get<LagPosition>(entity);
+        pos.X = 0f;
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+        pos = ref world.Get<LagPosition>(entity);
+        pos.X = 100f;
+        plugin.StateHistory.Capture(entity, 20, world, serializer);
+
+        // Tick 15 is halfway between 10 and 20, so X blends to 50.
+        Assert.True(plugin.LagCompensation!.TryGetStateAt(entity, 15, out var state));
+        Assert.Equal(50f, XOf(state), 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void TryGetStateAt_BetweenTicks_NonInterpolatableComponent_SnapsToAtOrBefore()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagTeam { Value = 1 }).Build();
+
+        ref var team = ref world.Get<LagTeam>(entity);
+        team.Value = 1;
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+        team = ref world.Get<LagTeam>(entity);
+        team.Value = 2;
+        plugin.StateHistory.Capture(entity, 20, world, serializer);
+
+        // LagTeam is not interpolatable, so tick 15 snaps to the tick-10 value.
+        Assert.True(plugin.LagCompensation!.TryGetStateAt(entity, 15, out var state));
+        Assert.Equal(1, TeamOf(state));
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void TryGetStateAt_BetweenTicks_NoInterpolatorConfigured_SnapsToAtOrBefore()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = null, // interpolation disabled
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagPosition { X = 0f }).Build();
+
+        ref var pos = ref world.Get<LagPosition>(entity);
+        pos.X = 0f;
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+        pos = ref world.Get<LagPosition>(entity);
+        pos.X = 100f;
+        plugin.StateHistory.Capture(entity, 20, world, serializer);
+
+        Assert.True(plugin.LagCompensation!.TryGetStateAt(entity, 15, out var state));
+        Assert.Equal(0f, XOf(state), 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void TryGetStateAt_NoLaterTick_ReturnsAtOrBeforeUnchanged()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagPosition { X = 42f }).Build();
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+
+        // Tick 15 is after the newest recorded tick 10; nothing to interpolate toward.
+        Assert.True(plugin.LagCompensation!.TryGetStateAt(entity, 15, out var state));
+        Assert.Equal(42f, XOf(state), 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void TryGetStateAt_UnknownEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = CreateSerializer(),
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+        var entity = world.Spawn().With(new LagPosition { X = 1f }).Build();
+
+        Assert.False(plugin.LagCompensation!.TryGetStateAt(entity, 10, out var state));
+        Assert.Empty(state);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region Rewind
+
+    [Fact]
+    public void Rewind_SwapsLiveComponentsToHistoricalValues_WithinScope()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+
+        var entity = world.Spawn().With(new LagPosition { X = 10f }).Build();
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+
+        // Move the live entity away from the recorded position.
+        world.Get<LagPosition>(entity).X = 99f;
+        Assert.Equal(99f, world.Get<LagPosition>(entity).X, 0.001f);
+
+        using (plugin.LagCompensation!.Rewind([entity], 10))
+        {
+            Assert.Equal(10f, world.Get<LagPosition>(entity).X, 0.001f);
+        }
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void Rewind_OnDispose_RestoresOriginalLiveValuesExactly()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+
+        var entity = world.Spawn().With(new LagPosition { X = 10f }).Build();
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+        world.Get<LagPosition>(entity).X = 99f;
+
+        using (plugin.LagCompensation!.Rewind([entity], 10))
+        {
+            Assert.Equal(10f, world.Get<LagPosition>(entity).X, 0.001f);
+        }
+
+        Assert.Equal(99f, world.Get<LagPosition>(entity).X, 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void Rewind_ExceptionThrownInsideScope_StillRestoresLiveValues()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+
+        var entity = world.Spawn().With(new LagPosition { X = 10f }).Build();
+        plugin.StateHistory!.Capture(entity, 10, world, serializer);
+        world.Get<LagPosition>(entity).X = 99f;
+
+        var threw = false;
+        try
+        {
+            using (plugin.LagCompensation!.Rewind([entity], 10))
+            {
+                Assert.Equal(10f, world.Get<LagPosition>(entity).X, 0.001f);
+                throw new InvalidOperationException("hit resolution failed");
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            threw = true;
+        }
+
+        Assert.True(threw);
+        Assert.Equal(99f, world.Get<LagPosition>(entity).X, 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    [Fact]
+    public void Rewind_EntityWithoutHistory_IsSkippedWithoutAffectingOthers()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server) = InstallServer(world, new ServerNetworkConfig
+        {
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 64,
+        });
+
+        var withHistory = world.Spawn().With(new LagPosition { X = 10f }).Build();
+        plugin.StateHistory!.Capture(withHistory, 10, world, serializer);
+        world.Get<LagPosition>(withHistory).X = 99f;
+
+        // Never captured, so it has no retained state at tick 10.
+        var withoutHistory = world.Spawn().With(new LagPosition { X = 77f }).Build();
+
+        using (plugin.LagCompensation!.Rewind([withHistory, withoutHistory], 10))
+        {
+            Assert.Equal(10f, world.Get<LagPosition>(withHistory).X, 0.001f);   // rewound
+            Assert.Equal(77f, world.Get<LagPosition>(withoutHistory).X, 0.001f); // untouched
+        }
+
+        Assert.Equal(99f, world.Get<LagPosition>(withHistory).X, 0.001f);
+        Assert.Equal(77f, world.Get<LagPosition>(withoutHistory).X, 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region End-to-end hit detection
+
+    [Fact]
+    public async Task LagCompensatedHitTest_RewoundPositionHits_WhereLivePositionMisses()
+    {
+        using var world = new World();
+        var serializer = CreateSerializer();
+        var (plugin, server, client, clientId) = await InstallServerWithClientAsync(world, new ServerNetworkConfig
+        {
+            TickRate = 50,               // 20 ms per tick
+            InterpolationDelayMs = 100f, // 5 ticks behind
+            Serializer = serializer,
+            Interpolator = new LagPositionInterpolator(),
+            StateHistoryTicks = 128,
+        });
+
+        // RTT 200 ms -> one-way 5 ticks; plus 5 ticks interpolation delay = 10 ticks back.
+        plugin.GetConnectedClients().First().RoundTripTimeMs = 200f;
+
+        // Target moves one unit per tick along X. Record its authoritative position each tick.
+        var target = world.Spawn().With(new LagPosition { X = 0f }).Build();
+        for (uint tick = 1; tick <= 20; tick++)
+        {
+            world.Get<LagPosition>(target).X = tick;
+            plugin.StateHistory!.Capture(target, tick, world, serializer);
+            AdvanceTo(plugin, tick);
+        }
+
+        // Live target now sits at X = 20; the attacker fired at where they saw it: X = 10.
+        const float aimX = 10f;
+        const float hitRadius = 0.5f;
+        Assert.Equal(20f, world.Get<LagPosition>(target).X, 0.001f);
+
+        static bool IsHit(World w, Entity e, float aim, float radius) =>
+            MathF.Abs(w.Get<LagPosition>(e).X - aim) <= radius;
+
+        // Testing against the live position misses (|20 - 10| = 10).
+        Assert.False(IsHit(world, target, aimX, hitRadius));
+
+        var perceivedTick = plugin.LagCompensation!.EstimateClientPerceivedTick(clientId);
+        Assert.Equal(10u, perceivedTick);
+
+        bool hit;
+        using (plugin.LagCompensation.Rewind([target], perceivedTick))
+        {
+            // Rewound to tick 10 where X = 10, so the shot connects.
+            hit = IsHit(world, target, aimX, hitRadius);
+        }
+
+        Assert.True(hit);
+
+        // Live state is exactly restored after the scope ends.
+        Assert.Equal(20f, world.Get<LagPosition>(target).X, 0.001f);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`LagCompensation`** (exposed as `NetworkServerPlugin.LagCompensation`, null unless state history is enabled): `EstimateClientPerceivedTick(clientId)` = current tick − (RTT/2 + client interpolation delay) in ticks, clamped into the retained history window (which doubles as the anti-cheat rewind bound); `TryGetStateAt` with **linear interpolation between bracketing ticks** via the existing `INetworkInterpolator` (non-interpolatable components snap to at-or-before).
- **`RewindScope`** (`ref struct`, `using`-consumed): swaps listed entities' live components to historical values for hit-testing and restores the exact boxed originals on dispose — exception-safe by construction (all throwing work happens before any mutation; partial application rolls back; `Dispose` idempotent, despawn-tolerant).
- `ServerStateHistory.TryGetStateAtOrAfter` added (forward counterpart needed to bracket ticks; ring-walking stays in the ring type). Plus a per-client RTT accessor on the server plugin.

## Test plan
- [x] 18 new tests: perceived-tick math (RTT/interp-delay/clamp cases), interpolated vs snap lookup, rewind/restore exactness incl. exception-inside-scope, disabled-history null, no-history entity skipped — and the end-to-end proof: a shot **hits the rewound position where testing live position misses**, with live state exactly restored after
- [x] Full network suite 292/294 (2 pre-existing env skips; the UDP socket test reported flaky by the implementer passed in-suite and in isolation on my verification run)
- [x] Build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #584 (Phase 3 of the plan on #353). Rebased onto main after #1013 merged mid-task.