### PR TITLE
fix(localization): Update IcuFormatter for MessageFormat 8.0.0 API

### DIFF
--- a/src/KeenEyes.Localization/IcuFormatter.cs
+++ b/src/KeenEyes.Localization/IcuFormatter.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
 using Jeffijoe.MessageFormat;
 
 namespace KeenEyes.Localization;
@@ -65,7 +67,8 @@ public sealed class IcuFormatter : IMessageFormatter
 
         try
         {
-            var formatter = new MessageFormatter(useCache: true, locale: locale.Code);
+            var culture = CultureInfo.GetCultureInfo(locale.Code);
+            var formatter = new MessageFormatter(useCache: true, culture: culture);
 
             var argsDict = args switch
             {
@@ -75,7 +78,7 @@ public sealed class IcuFormatter : IMessageFormatter
                 _ => ConvertToDictionary(args)
             };
 
-            result = formatter.FormatMessage(template, argsDict);
+            result = formatter.FormatMessage(template, argsDict, culture);
             return true;
         }
         catch (Exception)


### PR DESCRIPTION
## Summary
- **main does not currently build**: dependabot's MessageFormat 7.1.3→8.0.0 bump (d7e1fb3) broke `KeenEyes.Localization/IcuFormatter.cs` (CS1739 — v8 replaced the `locale:` constructor parameter with `CultureInfo culture` and requires the culture on `FormatMessage`). This was masked until now by the NU1901 restore failure (#1009) — restore failed before compilation could.
- Updates `IcuFormatter` to the v8 API.

## Test plan
- [x] `KeenEyes.Localization` builds (CS1739 confirmed on origin/main, gone with this fix)
- [x] Localization suite: 278/278 passing
- [ ] CI green

**Merge before the IK-gizmos PR** — the editor depends on Localization transitively; that branch temporarily carries this same commit and will dedupe on rebase/merge.

Discovered by the #958 implementation agent (the editor could not build against main).