### PR TITLE
feat(network): Add interest management / area-of-interest filtering

### DIFF
--- a/src/KeenEyes.Network.Abstractions/AlwaysRelevantInterestManager.cs
+++ b/src/KeenEyes.Network.Abstractions/AlwaysRelevantInterestManager.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.Network;
+
+/// <summary>
+/// Interest manager that treats every entity as relevant to every client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This provides the same visibility semantics as leaving
+/// <see cref="ServerNetworkConfig.InterestManager"/> unset (every client sees
+/// every entity), but exercises the per-client replication path: each client
+/// gets its own dirty tracking, scope bookkeeping, and bandwidth budget.
+/// Leave the config property <see langword="null"/> instead when the shared
+/// broadcast path is sufficient.
+/// </para>
+/// </remarks>
+public sealed class AlwaysRelevantInterestManager : IInterestManager
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Always zero: relevance never changes, so recomputing every tick is free.
+    /// </remarks>
+    public float UpdateFrequencyHz => 0f;
+
+    /// <inheritdoc/>
+    public void BeginUpdate(IWorld world, ReadOnlySpan<int> clientIds)
+    {
+        // No acceleration structures needed; every entity is always relevant.
+    }
+
+    /// <inheritdoc/>
+    public bool IsRelevant(IWorld world, int clientId, Entity entity) => true;
+}

--- a/src/KeenEyes.Network.Abstractions/IInterestManager.cs
+++ b/src/KeenEyes.Network.Abstractions/IInterestManager.cs
@@ -1,0 +1,63 @@
+namespace KeenEyes.Network;
+
+/// <summary>
+/// Decides which networked entities are relevant to each connected client,
+/// enabling area-of-interest filtering of server replication.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When an interest manager is configured via
+/// <see cref="ServerNetworkConfig.InterestManager"/>, the server maintains a
+/// relevance set per client and only replicates entities inside that set.
+/// An entity entering a client's scope is spawned on that client with its
+/// full component state; an entity leaving scope is despawned on that client.
+/// </para>
+/// <para>
+/// The server enforces one invariant on top of any manager: entities owned by
+/// a client are always relevant to that client, regardless of the manager's
+/// verdict. A manager can therefore never scope a client's own entities out.
+/// </para>
+/// <para>
+/// The server calls <see cref="BeginUpdate"/> once per relevance update
+/// (throttled to <see cref="UpdateFrequencyHz"/>), then calls
+/// <see cref="IsRelevant"/> for each (client, entity) pair. Implementations
+/// can use <see cref="BeginUpdate"/> to build acceleration structures so the
+/// per-pair queries are cheap.
+/// </para>
+/// </remarks>
+public interface IInterestManager
+{
+    /// <summary>
+    /// Gets how often per-client relevance sets are recomputed, in updates per second.
+    /// </summary>
+    /// <remarks>
+    /// Values less than or equal to zero recompute relevance on every network tick.
+    /// Between recomputations the server replicates against the cached relevance sets.
+    /// </remarks>
+    float UpdateFrequencyHz { get; }
+
+    /// <summary>
+    /// Prepares the manager for a batch of <see cref="IsRelevant"/> queries.
+    /// </summary>
+    /// <param name="world">The authoritative server world.</param>
+    /// <param name="clientIds">The IDs of all currently connected clients.</param>
+    /// <remarks>
+    /// Called once at the start of every relevance update, before any
+    /// <see cref="IsRelevant"/> call of that update. Implementations should
+    /// refresh any cached spatial structures or per-client viewpoints here.
+    /// </remarks>
+    void BeginUpdate(IWorld world, ReadOnlySpan<int> clientIds);
+
+    /// <summary>
+    /// Determines whether an entity is relevant to a client and should be
+    /// replicated to it.
+    /// </summary>
+    /// <param name="world">The authoritative server world.</param>
+    /// <param name="clientId">The client whose interest is being evaluated.</param>
+    /// <param name="entity">The networked entity to evaluate.</param>
+    /// <returns>
+    /// <see langword="true"/> to replicate the entity to the client;
+    /// <see langword="false"/> to filter it out.
+    /// </returns>
+    bool IsRelevant(IWorld world, int clientId, Entity entity);
+}

--- a/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
+++ b/src/KeenEyes.Network.Abstractions/INetworkPlugin.cs
@@ -190,6 +190,28 @@ public record class ServerNetworkConfig : NetworkPluginConfig
     public Func<OwnershipRequestContext, bool>? OwnershipRequestPolicy { get; set; }
 
     /// <summary>
+    /// Gets or sets the interest manager used for area-of-interest filtering.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see langword="null"/> (the default), no filtering occurs: every
+    /// entity update is broadcast to every client through a single shared
+    /// message stream, exactly as if interest management did not exist.
+    /// </para>
+    /// <para>
+    /// When set, the server replicates per client: it keeps a relevance set,
+    /// dirty-tracking baseline, and bandwidth budget for each client. Entities
+    /// entering a client's scope are spawned on that client with full state,
+    /// entities leaving scope are despawned on that client, and in-scope
+    /// entities receive per-client deltas. A client's own entities are always
+    /// relevant to it. Late joiners are synchronized through scope entry
+    /// (targeted spawns) rather than a broadcast full snapshot, so
+    /// out-of-scope entities are never leaked to them.
+    /// </para>
+    /// </remarks>
+    public IInterestManager? InterestManager { get; set; }
+
+    /// <summary>
     /// Gets or sets the number of network ticks of authoritative entity state to retain
     /// per entity for lag compensation.
     /// </summary>

--- a/src/KeenEyes.Network.Abstractions/KeenEyes.Network.Abstractions.csproj
+++ b/src/KeenEyes.Network.Abstractions/KeenEyes.Network.Abstractions.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Network.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/KeenEyes.Network.Abstractions/SpatialInterestManager.cs
+++ b/src/KeenEyes.Network.Abstractions/SpatialInterestManager.cs
@@ -1,0 +1,222 @@
+using System.Numerics;
+using KeenEyes.Network.Components;
+
+namespace KeenEyes.Network;
+
+/// <summary>
+/// Interest manager that filters replication by distance using an internal
+/// uniform spatial grid.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An entity is relevant to a client when it lies within
+/// <see cref="ViewDistance"/> of any of the client's viewpoints. Entities for
+/// which <see cref="PositionProvider"/> returns <see langword="null"/> have no
+/// position and are treated as globally relevant (for example match state or
+/// score entities).
+/// </para>
+/// <para>
+/// <b>Viewpoint rule:</b> a client's viewpoints are the positions of the
+/// entities it owns, as resolved by <see cref="PositionProvider"/>. When
+/// <see cref="ViewpointProvider"/> is set and returns a non-null position for
+/// a client, that position replaces the owned-entity viewpoints entirely
+/// (useful for spectators or free-flying cameras). A client with no positioned
+/// owned entities and no override only receives globally relevant entities and
+/// its own entities (the server always replicates a client's own entities to it).
+/// </para>
+/// <para>
+/// The grid buckets entity positions into cubic cells of <see cref="CellSize"/>
+/// units. During a relevance update, occupied cells outside the cell-level
+/// radius of every viewpoint are rejected wholesale; entities in the remaining
+/// cells are checked against the exact <see cref="ViewDistance"/>.
+/// </para>
+/// </remarks>
+public sealed class SpatialInterestManager : IInterestManager
+{
+    private readonly Dictionary<(int X, int Y, int Z), List<Entity>> grid = [];
+    private readonly Dictionary<Entity, Vector3> positions = [];
+    private readonly HashSet<Entity> globallyRelevant = [];
+    private readonly Dictionary<int, List<Vector3>> ownedViewpoints = [];
+    private readonly Dictionary<int, HashSet<Entity>> relevantByClient = [];
+
+    /// <summary>
+    /// Gets the edge length of a spatial grid cell, in world units.
+    /// </summary>
+    /// <remarks>
+    /// Choose a value in the same order of magnitude as <see cref="ViewDistance"/>
+    /// (for example a quarter to a half of it) so cell-level rejection stays coarse
+    /// but effective. Must be positive.
+    /// </remarks>
+    public float CellSize { get; init; } = 100f;
+
+    /// <summary>
+    /// Gets the maximum distance from a client viewpoint at which entities are
+    /// replicated, in world units.
+    /// </summary>
+    /// <remarks>Must be positive.</remarks>
+    public float ViewDistance { get; init; } = 500f;
+
+    /// <summary>
+    /// Gets how often per-client relevance sets are recomputed, in updates per second.
+    /// </summary>
+    /// <remarks>
+    /// Values less than or equal to zero recompute on every network tick.
+    /// </remarks>
+    public float UpdateFrequencyHz { get; init; } = 10f;
+
+    /// <summary>
+    /// Gets the callback that resolves an entity's world position.
+    /// </summary>
+    /// <remarks>
+    /// Return <see langword="null"/> for entities without a spatial position;
+    /// such entities are treated as globally relevant. The networking layer has
+    /// no dependency on any particular transform component, so games supply
+    /// this mapping explicitly.
+    /// </remarks>
+    public required Func<IWorld, Entity, Vector3?> PositionProvider { get; init; }
+
+    /// <summary>
+    /// Gets the optional per-client viewpoint override.
+    /// </summary>
+    /// <remarks>
+    /// When set and returning a non-null position for a client, that position
+    /// is used as the client's sole viewpoint instead of the positions of the
+    /// entities it owns. Return <see langword="null"/> to fall back to the
+    /// owned-entity rule for that client.
+    /// </remarks>
+    public Func<IWorld, int, Vector3?>? ViewpointProvider { get; init; }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="CellSize"/> or <see cref="ViewDistance"/> is not positive.
+    /// </exception>
+    public void BeginUpdate(IWorld world, ReadOnlySpan<int> clientIds)
+    {
+        if (CellSize <= 0f)
+        {
+            throw new InvalidOperationException("SpatialInterestManager.CellSize must be positive.");
+        }
+
+        if (ViewDistance <= 0f)
+        {
+            throw new InvalidOperationException("SpatialInterestManager.ViewDistance must be positive.");
+        }
+
+        grid.Clear();
+        positions.Clear();
+        globallyRelevant.Clear();
+        ownedViewpoints.Clear();
+        relevantByClient.Clear();
+
+        // Single pass: bucket positioned entities into the grid and collect
+        // owned-entity positions as candidate viewpoints per owning client.
+        foreach (var entity in world.Query<NetworkId>())
+        {
+            var position = PositionProvider(world, entity);
+            if (position is null)
+            {
+                globallyRelevant.Add(entity);
+                continue;
+            }
+
+            positions[entity] = position.Value;
+
+            var cell = GetCell(position.Value, CellSize);
+            if (!grid.TryGetValue(cell, out var cellEntities))
+            {
+                cellEntities = [];
+                grid[cell] = cellEntities;
+            }
+
+            cellEntities.Add(entity);
+
+            if (world.Has<NetworkOwner>(entity))
+            {
+                var ownerId = world.Get<NetworkOwner>(entity).ClientId;
+                if (ownerId != NetworkOwner.ServerClientId)
+                {
+                    if (!ownedViewpoints.TryGetValue(ownerId, out var viewpoints))
+                    {
+                        viewpoints = [];
+                        ownedViewpoints[ownerId] = viewpoints;
+                    }
+
+                    viewpoints.Add(position.Value);
+                }
+            }
+        }
+
+        foreach (var clientId in clientIds)
+        {
+            relevantByClient[clientId] = ComputeRelevantSet(ResolveViewpoints(world, clientId));
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsRelevant(IWorld world, int clientId, Entity entity)
+        => globallyRelevant.Contains(entity)
+            || (relevantByClient.TryGetValue(clientId, out var relevant) && relevant.Contains(entity));
+
+    private List<Vector3> ResolveViewpoints(IWorld world, int clientId)
+    {
+        var overridePosition = ViewpointProvider?.Invoke(world, clientId);
+        if (overridePosition is not null)
+        {
+            return [overridePosition.Value];
+        }
+
+        return ownedViewpoints.TryGetValue(clientId, out var viewpoints) ? viewpoints : [];
+    }
+
+    private HashSet<Entity> ComputeRelevantSet(List<Vector3> viewpoints)
+    {
+        var result = new HashSet<Entity>();
+        var cellRadius = GetCellRadius(ViewDistance, CellSize);
+        var maxDistanceSquared = ViewDistance * ViewDistance;
+
+        foreach (var viewpoint in viewpoints)
+        {
+            var viewCell = GetCell(viewpoint, CellSize);
+
+            foreach (var (cell, cellEntities) in grid)
+            {
+                if (!IsWithinCellRadius(cell, viewCell, cellRadius))
+                {
+                    continue;
+                }
+
+                foreach (var entity in cellEntities)
+                {
+                    if (Vector3.DistanceSquared(positions[entity], viewpoint) <= maxDistanceSquared)
+                    {
+                        result.Add(entity);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Computes the grid cell containing a position, flooring toward negative infinity.
+    /// </summary>
+    internal static (int X, int Y, int Z) GetCell(Vector3 position, float cellSize)
+        => ((int)MathF.Floor(position.X / cellSize),
+            (int)MathF.Floor(position.Y / cellSize),
+            (int)MathF.Floor(position.Z / cellSize));
+
+    /// <summary>
+    /// Computes the cell-level search radius that conservatively covers a view distance.
+    /// </summary>
+    internal static int GetCellRadius(float viewDistance, float cellSize)
+        => (int)MathF.Ceiling(viewDistance / cellSize);
+
+    /// <summary>
+    /// Checks whether a cell lies within a Chebyshev radius of a center cell.
+    /// </summary>
+    internal static bool IsWithinCellRadius((int X, int Y, int Z) cell, (int X, int Y, int Z) center, int radius)
+        => Math.Abs(cell.X - center.X) <= radius
+            && Math.Abs(cell.Y - center.Y) <= radius
+            && Math.Abs(cell.Z - center.Z) <= radius;
+}

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -670,4 +670,33 @@ public sealed class ClientState
     /// Gets or sets the round-trip time in milliseconds.
     /// </summary>
     public float RoundTripTimeMs { get; set; }
+
+    /// <summary>
+    /// Whether this client's interest relevance set has been computed at least once.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="ServerNetworkConfig.InterestManager"/> is set.
+    /// Uninitialized clients force an immediate relevance update so late joiners
+    /// do not wait for the next scheduled recomputation.
+    /// </remarks>
+    internal bool InterestInitialized { get; set; }
+
+    /// <summary>
+    /// The entities currently in scope for this client.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="ServerNetworkConfig.InterestManager"/> is set.
+    /// Rebuilt by the send system at the interest manager's update frequency.
+    /// </remarks>
+    internal HashSet<Entity> RelevantEntities { get; } = [];
+
+    /// <summary>
+    /// Per-entity component baselines of the state last sent to this client.
+    /// </summary>
+    /// <remarks>
+    /// Only used when <see cref="ServerNetworkConfig.InterestManager"/> is set.
+    /// An entity without an entry receives a full <c>EntitySpawn</c>; entries are
+    /// removed on scope exit so re-entry re-sends full state.
+    /// </remarks>
+    internal Dictionary<Entity, Dictionary<Type, object>> LastSentState { get; } = [];
 }

--- a/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using KeenEyes.Capabilities;
 using KeenEyes.Network.Components;
 using KeenEyes.Network.Protocol;
@@ -11,13 +12,22 @@ namespace KeenEyes.Network.Systems;
 /// Server system that sends state updates to clients.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Runs in LateUpdate phase after game logic has executed.
+/// </para>
+/// <para>
+/// Without an interest manager configured, updates are built once per tick and
+/// broadcast to all clients. With <see cref="ServerNetworkConfig.InterestManager"/>
+/// set, replication is per client: each client has its own relevance set, dirty
+/// tracking baseline, and bandwidth budget, with scope enter/exit translated
+/// into targeted entity spawn/despawn messages.
+/// </para>
 /// </remarks>
 public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : SystemBase
 {
     private readonly byte[] sendBuffer = new byte[4096];
 
-    // Track last sent component values per entity for delta detection
+    // Track last sent component values per entity for delta detection (broadcast path).
     private readonly Dictionary<Entity, Dictionary<Type, object>> lastSentState = [];
 
     // Track bytes sent this tick for bandwidth limiting
@@ -30,15 +40,40 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
     // Pre-allocated list to avoid per-tick allocations
     private readonly List<(Entity entity, float priority, bool needsFullSync)> entitiesToUpdate = [];
 
+    // Interest management state (only used when an interest manager is configured).
+    private float interestAccumulator;
+    private readonly List<int> clientIdScratch = [];
+    private readonly HashSet<Entity> relevanceScratch = [];
+    private readonly List<Entity> scopeExitScratch = [];
+    private readonly HashSet<Entity> sentEntitiesScratch = [];
+
     /// <inheritdoc/>
     public override void Update(float deltaTime)
     {
+        // Time toward the next relevance recomputation passes regardless of
+        // whether this frame lands on a network tick.
+        interestAccumulator += deltaTime;
+
         // Advance tick
         if (!plugin.Tick(deltaTime))
         {
             return; // Not time for a network tick yet
         }
 
+        if (plugin.Config.InterestManager is { } interestManager)
+        {
+            UpdateFiltered(deltaTime, interestManager);
+        }
+        else
+        {
+            UpdateBroadcast(deltaTime);
+        }
+    }
+
+    #region Broadcast path (no interest manager)
+
+    private void UpdateBroadcast(float deltaTime)
+    {
         // Check for clients that need full snapshots
         foreach (var client in plugin.GetConnectedClients())
         {
@@ -246,7 +281,7 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
     private void SendClientOwnedDelta(Entity entity, NetworkId networkId, int ownerId, INetworkSerializer serializer)
     {
         var ownerAuth = GetOwnerAuthTypes(serializer);
-        var changed = CollectChangedComponents(entity, serializer);
+        var changed = CollectChangedComponents(entity, serializer, lastSentState);
 
         var toOwnerAndOthers = new List<(Type type, object current, object? baseline)>();
         var toOthersOnly = new List<(Type type, object current, object? baseline)>();
@@ -278,6 +313,291 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             plugin.SendToAll(span, DeliveryMode.UnreliableSequenced);
         }
     }
+
+    #endregion
+
+    #region Filtered path (interest manager configured)
+
+    private void UpdateFiltered(float deltaTime, IInterestManager interestManager)
+    {
+        var serializer = plugin.Config.Serializer;
+        var config = plugin.Config;
+
+        // The bandwidth budget applies per client in filtered mode.
+        var bytesPerTick = config.EnableBandwidthLimiting
+            ? config.MaxBandwidthBytesPerSecond / config.TickRate
+            : int.MaxValue;
+
+        // Late joiners are synchronized through scope entry (a targeted
+        // EntitySpawn per relevant entity) instead of the broadcast full
+        // snapshot, which would leak out-of-scope entities.
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            client.NeedsFullSnapshot = false;
+        }
+
+        // Capture lag-compensation history and accumulate priority exactly as
+        // the broadcast path does, reusing the same single iteration.
+        var history = plugin.StateHistory;
+        entitiesToUpdate.Clear();
+
+        foreach (var entity in World.Query<NetworkId, NetworkState>())
+        {
+            ref var networkState = ref World.Get<NetworkState>(entity);
+            networkState.AccumulatedPriority += deltaTime;
+
+            if (history is not null && serializer is not null && World is ISnapshotCapability snapshot)
+            {
+                history.Capture(entity, plugin.CurrentTick, snapshot, serializer);
+            }
+
+            entitiesToUpdate.Add((entity, networkState.AccumulatedPriority, false));
+        }
+
+        RecomputeRelevanceIfDue(interestManager);
+
+        // Sort by priority (higher first). Per-client full syncs are implied by a
+        // missing per-client baseline, so no separate full-sync ordering is needed.
+        entitiesToUpdate.Sort(static (a, b) => b.priority.CompareTo(a.priority));
+
+        sentEntitiesScratch.Clear();
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            SendUpdatesToClient(client, serializer, bytesPerTick);
+        }
+
+        // Reset priority for entities that produced at least one message this tick.
+        foreach (var entity in sentEntitiesScratch)
+        {
+            ref var networkState = ref World.Get<NetworkState>(entity);
+            networkState.LastSentTick = plugin.CurrentTick;
+            networkState.AccumulatedPriority = 0;
+            networkState.NeedsFullSync = false;
+        }
+
+        // Pump the transport to flush outgoing data
+        plugin.Transport.Update();
+    }
+
+    private void RecomputeRelevanceIfDue(IInterestManager interestManager)
+    {
+        var due = interestManager.UpdateFrequencyHz <= 0f
+            || interestAccumulator >= 1f / interestManager.UpdateFrequencyHz;
+
+        if (!due)
+        {
+            // New clients get an immediate relevance set so initial replication
+            // does not wait for the next scheduled update.
+            foreach (var client in plugin.GetConnectedClients())
+            {
+                if (!client.InterestInitialized)
+                {
+                    due = true;
+                    break;
+                }
+            }
+        }
+
+        if (!due)
+        {
+            return;
+        }
+
+        interestAccumulator = 0f;
+
+        clientIdScratch.Clear();
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            clientIdScratch.Add(client.ClientId);
+        }
+
+        interestManager.BeginUpdate(World, CollectionsMarshal.AsSpan(clientIdScratch));
+
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            RecomputeClientRelevance(client, interestManager);
+        }
+    }
+
+    private void RecomputeClientRelevance(ClientState client, IInterestManager interestManager)
+    {
+        relevanceScratch.Clear();
+
+        foreach (var (entity, _, _) in entitiesToUpdate)
+        {
+            var ownerId = World.Has<NetworkOwner>(entity)
+                ? World.Get<NetworkOwner>(entity).ClientId
+                : NetworkOwner.ServerClientId;
+
+            // Invariant: a client's own entities are always relevant to it,
+            // regardless of the interest manager's verdict.
+            if (ownerId == client.ClientId || interestManager.IsRelevant(World, client.ClientId, entity))
+            {
+                relevanceScratch.Add(entity);
+            }
+        }
+
+        // Entities leaving scope are despawned on this client. Entities entering
+        // scope need no explicit action: having no per-client baseline, they get
+        // a full EntitySpawn in the send phase.
+        scopeExitScratch.Clear();
+        foreach (var entity in client.RelevantEntities)
+        {
+            if (!relevanceScratch.Contains(entity))
+            {
+                scopeExitScratch.Add(entity);
+            }
+        }
+
+        foreach (var entity in scopeExitScratch)
+        {
+            SendScopeExit(client, entity);
+        }
+
+        client.RelevantEntities.Clear();
+        client.RelevantEntities.UnionWith(relevanceScratch);
+        client.InterestInitialized = true;
+    }
+
+    private void SendScopeExit(ClientState client, Entity entity)
+    {
+        // Drop the per-client baseline so a later re-entry re-sends full state.
+        client.LastSentState.Remove(entity);
+
+        if (!plugin.NetworkIds.TryGetNetworkId(entity, out var networkId))
+        {
+            // Entity was destroyed; the plugin already broadcast its despawn.
+            return;
+        }
+
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.EntityDespawn, plugin.CurrentTick);
+        writer.WriteEntityDespawn(networkId.Value);
+        plugin.SendToClient(client.ClientId, writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+    }
+
+    private void SendUpdatesToClient(ClientState client, INetworkSerializer? serializer, int bytesPerTick)
+    {
+        var limiting = plugin.Config.EnableBandwidthLimiting;
+        var bytesSent = 0;
+
+        foreach (var (entity, _, _) in entitiesToUpdate)
+        {
+            // Per-client bandwidth budget: stop sending to this client once
+            // exhausted; unsent changes remain dirty against this client's
+            // baseline and go out on later ticks.
+            if (limiting && bytesSent >= bytesPerTick)
+            {
+                break;
+            }
+
+            if (!client.RelevantEntities.Contains(entity))
+            {
+                continue;
+            }
+
+            // No baseline means the entity is new to this client (scope entry,
+            // registration, or re-entry after exit): send a full spawn.
+            var sent = client.LastSentState.ContainsKey(entity)
+                ? SendDeltaToClient(client, entity, serializer)
+                : SendSpawnToClient(client, entity, serializer);
+
+            if (sent > 0)
+            {
+                bytesSent += sent;
+                sentEntitiesScratch.Add(entity);
+            }
+        }
+    }
+
+    private int SendSpawnToClient(ClientState client, Entity entity, INetworkSerializer? serializer)
+    {
+        ref readonly var networkId = ref World.Get<NetworkId>(entity);
+
+        var owner = World.Has<NetworkOwner>(entity)
+            ? World.Get<NetworkOwner>(entity)
+            : NetworkOwner.Server;
+
+        var writer = new NetworkMessageWriter(sendBuffer);
+        writer.WriteHeader(MessageType.EntitySpawn, plugin.CurrentTick);
+        writer.WriteEntitySpawn(networkId.Value, owner.ClientId);
+        WriteReplicatedComponentsFull(entity, ref writer, serializer);
+
+        var span = writer.GetWrittenSpan();
+
+        // Scope transitions must arrive: a dropped spawn would leave the entity
+        // invisible to this client until it re-enters scope.
+        plugin.SendToClient(client.ClientId, span, DeliveryMode.ReliableOrdered);
+
+        SaveSentStateForClient(client, entity, serializer);
+        return span.Length;
+    }
+
+    private int SendDeltaToClient(ClientState client, Entity entity, INetworkSerializer? serializer)
+    {
+        if (serializer is null)
+        {
+            return 0; // Without a serializer only spawn/despawn replicate.
+        }
+
+        var changed = CollectChangedComponents(entity, serializer, client.LastSentState);
+        if (changed.Count == 0)
+        {
+            return 0;
+        }
+
+        var owner = World.Has<NetworkOwner>(entity)
+            ? World.Get<NetworkOwner>(entity)
+            : NetworkOwner.Server;
+
+        // Echo suppression: owner-authoritative components are never sent back
+        // to the owning client (its own state is authoritative for them).
+        if (owner.ClientId == client.ClientId && owner.ClientId != NetworkOwner.ServerClientId)
+        {
+            var ownerAuth = GetOwnerAuthTypes(serializer);
+            changed.RemoveAll(component => ownerAuth.Contains(component.type));
+            if (changed.Count == 0)
+            {
+                return 0;
+            }
+        }
+
+        ref readonly var networkId = ref World.Get<NetworkId>(entity);
+        var span = WriteDeltaMessage(networkId, changed, serializer);
+        plugin.SendToClient(client.ClientId, span, DeliveryMode.UnreliableSequenced);
+
+        SaveSentStateForClient(client, entity, serializer);
+        return span.Length;
+    }
+
+    private void SaveSentStateForClient(ClientState client, Entity entity, INetworkSerializer? serializer)
+    {
+        if (!client.LastSentState.TryGetValue(entity, out var entityState))
+        {
+            // Record the entity even without a serializer so the spawn is not resent.
+            entityState = [];
+            client.LastSentState[entity] = entityState;
+        }
+
+        if (serializer is null)
+        {
+            return;
+        }
+
+        if (World is ISnapshotCapability snapshot)
+        {
+            foreach (var (type, value) in snapshot.GetComponents(entity))
+            {
+                if (serializer.IsNetworkSerializable(type))
+                {
+                    entityState[type] = value;
+                }
+            }
+        }
+    }
+
+    #endregion
 
     private ReadOnlySpan<byte> WriteDeltaMessage(
         NetworkId networkId,
@@ -327,14 +647,17 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             return;
         }
 
-        var toSend = CollectChangedComponents(entity, serializer);
+        var toSend = CollectChangedComponents(entity, serializer, lastSentState);
         WriteDeltaComponents(ref writer, toSend, serializer);
     }
 
-    private List<(Type type, object current, object? baseline)> CollectChangedComponents(Entity entity, INetworkSerializer serializer)
+    private List<(Type type, object current, object? baseline)> CollectChangedComponents(
+        Entity entity,
+        INetworkSerializer serializer,
+        Dictionary<Entity, Dictionary<Type, object>> sentStates)
     {
         // Get last sent state for delta comparison
-        lastSentState.TryGetValue(entity, out var entityLastState);
+        sentStates.TryGetValue(entity, out var entityLastState);
 
         // Collect components that have changed
         var toSend = new List<(Type type, object current, object? baseline)>();
@@ -446,5 +769,11 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
     public void ClearEntityState(Entity entity)
     {
         lastSentState.Remove(entity);
+
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            client.LastSentState.Remove(entity);
+            client.RelevantEntities.Remove(entity);
+        }
     }
 }

--- a/tests/KeenEyes.Network.Tests/InterestManagementTests.cs
+++ b/tests/KeenEyes.Network.Tests/InterestManagementTests.cs
@@ -1,0 +1,604 @@
+using System.Numerics;
+using KeenEyes.Network.Components;
+using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Transport;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+// LocalTransport completes synchronously, so Wait() is safe
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// Replicated position component used to drive spatial interest decisions.
+/// </summary>
+public struct InterestPosition : IComponent
+{
+    /// <summary>The X coordinate.</summary>
+    public float X;
+
+    /// <summary>The Y coordinate.</summary>
+    public float Y;
+
+    /// <summary>The Z coordinate.</summary>
+    public float Z;
+}
+
+/// <summary>
+/// Replicated server-authoritative value component for delta assertions.
+/// </summary>
+public struct InterestHealth : IComponent
+{
+    /// <summary>The server-controlled value.</summary>
+    public float Value;
+}
+
+/// <summary>
+/// Owner-authoritative component used to verify echo suppression on the filtered path.
+/// </summary>
+public struct InterestOwnerInput : IComponent
+{
+    /// <summary>The owner-controlled value.</summary>
+    public float Value;
+}
+
+/// <summary>
+/// Tests for interest management / area-of-interest filtering (issue #585):
+/// the per-client replication path, <see cref="SpatialInterestManager"/> scope
+/// enter/exit behavior, owner relevance invariants, relevance-update throttling,
+/// and the spatial grid math.
+/// </summary>
+public sealed class InterestManagementTests
+{
+    private const int TickRate = 60;
+    private const float TickDelta = 0.02f;
+
+    #region Harness
+
+    private sealed class Harness : IDisposable
+    {
+        public required LocalTransport ServerTransport { get; init; }
+        public required LocalTransport ClientTransport { get; init; }
+        public required World ServerWorld { get; init; }
+        public required World ClientWorld { get; init; }
+        public required NetworkServerPlugin ServerPlugin { get; init; }
+        public required NetworkClientPlugin ClientPlugin { get; init; }
+        public required int ClientId { get; init; }
+
+        public void Dispose()
+        {
+            ClientWorld.UninstallPlugin("NetworkClient");
+            ServerWorld.UninstallPlugin("NetworkServer");
+            ClientTransport.Dispose();
+            ServerTransport.Dispose();
+            ClientWorld.Dispose();
+            ServerWorld.Dispose();
+        }
+    }
+
+    private static MockNetworkSerializer CreateSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+
+        serializer.RegisterComponent<InterestPosition>(
+            serialize: (ref BitWriter w, InterestPosition c) =>
+            {
+                w.WriteFloat(c.X);
+                w.WriteFloat(c.Y);
+                w.WriteFloat(c.Z);
+            },
+            deserialize: (ref BitReader r) => new InterestPosition
+            {
+                X = r.ReadFloat(),
+                Y = r.ReadFloat(),
+                Z = r.ReadFloat(),
+            },
+            new NetworkComponentInfo
+            {
+                Type = typeof(InterestPosition),
+                NetworkTypeId = 1,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+
+        serializer.RegisterComponent<InterestHealth>(
+            serialize: (ref BitWriter w, InterestHealth c) => w.WriteFloat(c.Value),
+            deserialize: (ref BitReader r) => new InterestHealth { Value = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(InterestHealth),
+                NetworkTypeId = 2,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+
+        serializer.RegisterComponent<InterestOwnerInput>(
+            serialize: (ref BitWriter w, InterestOwnerInput c) => w.WriteFloat(c.Value),
+            deserialize: (ref BitReader r) => new InterestOwnerInput { Value = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(InterestOwnerInput),
+                NetworkTypeId = 3,
+                Strategy = SyncStrategy.OwnerAuthoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+
+        return serializer;
+    }
+
+    private static Vector3? GetPosition(IWorld world, Entity entity)
+    {
+        if (!world.Has<InterestPosition>(entity))
+        {
+            return null;
+        }
+
+        ref readonly var position = ref world.Get<InterestPosition>(entity);
+        return new Vector3(position.X, position.Y, position.Z);
+    }
+
+    private static SpatialInterestManager CreateSpatialManager(
+        float updateFrequencyHz = 0f,
+        Func<IWorld, int, Vector3?>? viewpointProvider = null)
+        => new()
+        {
+            CellSize = 50f,
+            ViewDistance = 100f,
+            UpdateFrequencyHz = updateFrequencyHz,
+            PositionProvider = GetPosition,
+            ViewpointProvider = viewpointProvider,
+        };
+
+    private static Harness CreateConnectedHarness(IInterestManager? interestManager)
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        var serverWorld = new World();
+        var clientWorld = new World();
+
+        // The client applies incoming components by Type, which requires the
+        // types to be registered in the client world up front.
+        clientWorld.Components.Register<InterestPosition>();
+        clientWorld.Components.Register<InterestHealth>();
+        clientWorld.Components.Register<InterestOwnerInput>();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreateSerializer(),
+            InterestManager = interestManager,
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreateSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        server.ListenAsync(7777).Wait();
+        clientPlugin.ConnectAsync().Wait();
+        server.Update();
+        client.Update();
+
+        return new Harness
+        {
+            ServerTransport = server,
+            ClientTransport = client,
+            ServerWorld = serverWorld,
+            ClientWorld = clientWorld,
+            ServerPlugin = serverPlugin,
+            ClientPlugin = clientPlugin,
+            ClientId = clientPlugin.LocalClientId,
+        };
+    }
+
+    /// <summary>
+    /// Runs one server network tick and delivers its messages to the client.
+    /// </summary>
+    private static void Step(Harness harness, float deltaTime = TickDelta)
+    {
+        harness.ServerWorld.Update(deltaTime);
+        harness.ClientTransport.Update();
+        harness.ServerTransport.Update();
+    }
+
+    private static (Entity Entity, uint NetId) SpawnAt(
+        Harness harness,
+        float x,
+        int ownerId = NetworkOwner.ServerClientId,
+        float health = 0f)
+    {
+        var entity = harness.ServerWorld.Spawn()
+            .With(new InterestPosition { X = x })
+            .With(new InterestHealth { Value = health })
+            .Build();
+        var netId = harness.ServerPlugin.RegisterNetworkedEntity(entity, ownerId);
+        return (entity, netId.Value);
+    }
+
+    private static bool TryGetClientEntity(World clientWorld, uint netId, out Entity found)
+    {
+        foreach (var entity in clientWorld.Query<NetworkId>())
+        {
+            if (clientWorld.Get<NetworkId>(entity).Value == netId)
+            {
+                found = entity;
+                return true;
+            }
+        }
+
+        found = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Counts messages about a single network ID arriving at a transport.
+    /// </summary>
+    private sealed class MessageCounter
+    {
+        public int Spawns { get; private set; }
+        public int Despawns { get; private set; }
+        public int Deltas { get; private set; }
+
+        public MessageCounter(LocalTransport transport, uint netId)
+        {
+            transport.DataReceived += (_, data) =>
+            {
+                var reader = new NetworkMessageReader(data);
+                reader.ReadHeader(out var type, out uint _);
+                switch (type)
+                {
+                    case MessageType.EntitySpawn:
+                        reader.ReadEntitySpawn(out var spawnId, out _);
+                        if (spawnId == netId)
+                        {
+                            Spawns++;
+                        }
+                        break;
+
+                    case MessageType.EntityDespawn:
+                        reader.ReadEntityDespawn(out var despawnId);
+                        if (despawnId == netId)
+                        {
+                            Despawns++;
+                        }
+                        break;
+
+                    case MessageType.ComponentDelta:
+                        if (reader.ReadNetworkId() == netId)
+                        {
+                            Deltas++;
+                        }
+                        break;
+                }
+            };
+        }
+    }
+
+    #endregion
+
+    #region Null interest manager (broadcast path)
+
+    [Fact]
+    public void Send_NullInterestManager_FarEntityStillReplicatedToClient()
+    {
+        using var harness = CreateConnectedHarness(interestManager: null);
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (_, farNetId) = SpawnAt(harness, x: 10_000f, health: 3f);
+
+        Step(harness);
+
+        // Without an interest manager everything is broadcast, distance is ignored.
+        Assert.True(TryGetClientEntity(harness.ClientWorld, farNetId, out var clientEntity));
+        Assert.Equal(3f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+    }
+
+    #endregion
+
+    #region Spatial relevance
+
+    [Fact]
+    public void Send_SpatialInterestManager_NearEntity_ReplicatedToClient()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (_, nearNetId) = SpawnAt(harness, x: 10f, health: 5f);
+
+        Step(harness);
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, nearNetId, out var clientEntity));
+        Assert.Equal(5f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+    }
+
+    [Fact]
+    public void Send_SpatialInterestManager_FarEntity_NeverArrivesAtClient()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (_, farNetId) = SpawnAt(harness, x: 10_000f);
+        var counter = new MessageCounter(harness.ClientTransport, farNetId);
+
+        for (var i = 0; i < 5; i++)
+        {
+            Step(harness);
+        }
+
+        Assert.False(TryGetClientEntity(harness.ClientWorld, farNetId, out _));
+        Assert.Equal(0, counter.Spawns);
+        Assert.Equal(0, counter.Deltas);
+    }
+
+    [Fact]
+    public void Send_SpatialInterestManager_EntityWithoutPosition_AlwaysReplicated()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        // No owned entity and no viewpoint: only globally relevant entities replicate.
+        var entity = harness.ServerWorld.Spawn().With(new InterestHealth { Value = 3f }).Build();
+        var netId = harness.ServerPlugin.RegisterNetworkedEntity(entity);
+
+        Step(harness);
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId.Value, out var clientEntity));
+        Assert.Equal(3f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+    }
+
+    [Fact]
+    public void Send_AlwaysRelevantInterestManager_FarEntityReplicatedToClient()
+    {
+        using var harness = CreateConnectedHarness(new AlwaysRelevantInterestManager());
+
+        var (_, farNetId) = SpawnAt(harness, x: 10_000f, health: 7f);
+
+        Step(harness);
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, farNetId, out var clientEntity));
+        Assert.Equal(7f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+    }
+
+    #endregion
+
+    #region Scope transitions
+
+    [Fact]
+    public void Send_SpatialInterestManager_EntityEnteringScope_ClientReceivesSpawnThenDeltas()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (serverEntity, netId) = SpawnAt(harness, x: 10_000f, health: 1f);
+        var counter = new MessageCounter(harness.ClientTransport, netId);
+
+        Step(harness);
+        Step(harness);
+        Assert.False(TryGetClientEntity(harness.ClientWorld, netId, out _));
+
+        // Entity moves into view distance.
+        harness.ServerWorld.Set(serverEntity, new InterestPosition { X = 10f });
+        Step(harness);
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out var clientEntity));
+        Assert.Equal(1f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+        Assert.Equal(1, counter.Spawns);
+
+        // Subsequent changes arrive as deltas against the per-client baseline.
+        harness.ServerWorld.Set(serverEntity, new InterestHealth { Value = 2f });
+        Step(harness);
+
+        Assert.Equal(2f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+        Assert.Equal(1, counter.Spawns);
+        Assert.Equal(1, counter.Deltas);
+    }
+
+    [Fact]
+    public void Send_SpatialInterestManager_EntityLeavingScope_ClientReceivesDespawnAndNoFurtherDeltas()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (serverEntity, netId) = SpawnAt(harness, x: 10f, health: 1f);
+
+        Step(harness);
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out _));
+
+        var counter = new MessageCounter(harness.ClientTransport, netId);
+
+        // Entity moves out of view distance.
+        harness.ServerWorld.Set(serverEntity, new InterestPosition { X = 10_000f });
+        Step(harness);
+
+        Assert.False(TryGetClientEntity(harness.ClientWorld, netId, out _));
+        Assert.Equal(1, counter.Despawns);
+
+        // Changes while out of scope produce no traffic for this client.
+        harness.ServerWorld.Set(serverEntity, new InterestHealth { Value = 2f });
+        for (var i = 0; i < 3; i++)
+        {
+            Step(harness);
+        }
+
+        Assert.Equal(0, counter.Deltas);
+        Assert.Equal(0, counter.Spawns);
+    }
+
+    [Fact]
+    public void Send_SpatialInterestManager_ReEntry_ResendsFullStateWithFreshValues()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (serverEntity, netId) = SpawnAt(harness, x: 10f, health: 1f);
+        var counter = new MessageCounter(harness.ClientTransport, netId);
+
+        Step(harness);
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out var clientEntity));
+        Assert.Equal(1f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+
+        // Leave scope, then change state while the client cannot see the entity.
+        harness.ServerWorld.Set(serverEntity, new InterestPosition { X = 10_000f });
+        Step(harness);
+        Assert.False(TryGetClientEntity(harness.ClientWorld, netId, out _));
+
+        harness.ServerWorld.Set(serverEntity, new InterestHealth { Value = 99f });
+        Step(harness);
+
+        // Re-enter scope: stale per-client baseline was invalidated on exit,
+        // so the client receives a fresh full spawn with the new value.
+        harness.ServerWorld.Set(serverEntity, new InterestPosition { X = 10f });
+        Step(harness);
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out clientEntity));
+        Assert.Equal(99f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+        Assert.Equal(2, counter.Spawns);
+    }
+
+    #endregion
+
+    #region Owner invariants
+
+    [Fact]
+    public void Send_SpatialInterestManager_OwnedEntityOutsideViewDistance_StillReplicatedToOwner()
+    {
+        // Pin the client's viewpoint at the origin so distance is judged from there.
+        using var harness = CreateConnectedHarness(
+            CreateSpatialManager(viewpointProvider: (_, _) => Vector3.Zero));
+
+        var (_, ownedNetId) = SpawnAt(harness, x: 10_000f, ownerId: harness.ClientId, health: 4f);
+        var (_, strangerNetId) = SpawnAt(harness, x: 10_010f);
+
+        Step(harness);
+
+        // The owned entity is far from the viewpoint but must always replicate to
+        // its owner; the equally-far non-owned entity proves the manager did
+        // consider that region out of range.
+        Assert.True(TryGetClientEntity(harness.ClientWorld, ownedNetId, out var clientEntity));
+        Assert.Equal(4f, harness.ClientWorld.Get<InterestHealth>(clientEntity).Value, 0.001f);
+        Assert.False(TryGetClientEntity(harness.ClientWorld, strangerNetId, out _));
+    }
+
+    [Fact]
+    public void Send_SpatialInterestManager_OwnerAuthoritativeComponent_NotEchoedToOwner()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager());
+
+        var serverEntity = harness.ServerWorld.Spawn()
+            .With(new InterestPosition { X = 0f })
+            .With(new InterestHealth { Value = 1f })
+            .With(new InterestOwnerInput { Value = 1f })
+            .Build();
+        var netId = harness.ServerPlugin.RegisterNetworkedEntity(serverEntity, harness.ClientId);
+
+        Step(harness);
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId.Value, out _));
+
+        var counter = new MessageCounter(harness.ClientTransport, netId.Value);
+
+        // Owner-authoritative change: suppressed toward the owner.
+        harness.ServerWorld.Set(serverEntity, new InterestOwnerInput { Value = 5f });
+        Step(harness);
+        Assert.Equal(0, counter.Deltas);
+
+        // Server-authoritative change on the same entity still reaches the owner.
+        harness.ServerWorld.Set(serverEntity, new InterestHealth { Value = 7f });
+        Step(harness);
+        Assert.Equal(1, counter.Deltas);
+    }
+
+    #endregion
+
+    #region Update frequency throttling
+
+    [Fact]
+    public void Send_SpatialInterestManager_UpdateFrequency_ThrottlesRelevanceRecomputation()
+    {
+        using var harness = CreateConnectedHarness(CreateSpatialManager(updateFrequencyHz: 1f));
+
+        SpawnAt(harness, x: 0f, ownerId: harness.ClientId);
+        var (serverEntity, netId) = SpawnAt(harness, x: 10f);
+
+        // First tick forces an initial relevance computation for the new client.
+        Step(harness);
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out _));
+
+        // Move out of range; at 1 Hz the relevance set is not recomputed on the
+        // next few ticks, so the entity stays in scope.
+        harness.ServerWorld.Set(serverEntity, new InterestPosition { X = 10_000f });
+        for (var i = 0; i < 5; i++)
+        {
+            Step(harness);
+        }
+
+        Assert.True(TryGetClientEntity(harness.ClientWorld, netId, out _));
+
+        // Once a full update interval has elapsed, the recompute runs and the
+        // client receives the despawn.
+        Step(harness, deltaTime: 1.1f);
+
+        Assert.False(TryGetClientEntity(harness.ClientWorld, netId, out _));
+    }
+
+    #endregion
+
+    #region Grid math
+
+    [Fact]
+    public void GetCell_PositionInsideCell_ReturnsContainingCell()
+    {
+        var cell = SpatialInterestManager.GetCell(new Vector3(150f, 250f, 50f), 100f);
+
+        Assert.Equal((1, 2, 0), cell);
+    }
+
+    [Fact]
+    public void GetCell_NegativeCoordinates_FloorsTowardNegativeInfinity()
+    {
+        var cell = SpatialInterestManager.GetCell(new Vector3(-0.5f, -100.1f, -200f), 100f);
+
+        Assert.Equal((-1, -2, -2), cell);
+    }
+
+    [Fact]
+    public void GetCell_ExactBoundary_AssignsToUpperCell()
+    {
+        var cell = SpatialInterestManager.GetCell(new Vector3(100f, 0f, 0f), 100f);
+
+        Assert.Equal((1, 0, 0), cell);
+    }
+
+    [Fact]
+    public void GetCellRadius_NonDivisibleDistance_RoundsUp()
+    {
+        Assert.Equal(3, SpatialInterestManager.GetCellRadius(250f, 100f));
+        Assert.Equal(2, SpatialInterestManager.GetCellRadius(200f, 100f));
+    }
+
+    [Fact]
+    public void IsWithinCellRadius_UsesChebyshevDistance()
+    {
+        Assert.True(SpatialInterestManager.IsWithinCellRadius((2, 2, 2), (0, 0, 0), 2));
+        Assert.True(SpatialInterestManager.IsWithinCellRadius((-2, 1, 0), (0, 0, 0), 2));
+        Assert.False(SpatialInterestManager.IsWithinCellRadius((3, 0, 0), (0, 0, 0), 2));
+        Assert.False(SpatialInterestManager.IsWithinCellRadius((0, 0, -3), (0, 0, 0), 2));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`IInterestManager`** abstraction + two implementations: `AlwaysRelevantInterestManager` and **`SpatialInterestManager`** (cell size, view distance, update-frequency Hz; internal uniform grid — `KeenEyes.Spatial` is not referenced by Network, so no new cross-package dependency; positions via a required `PositionProvider` delegate).
- **Per-client replication** when configured: relevance sets + per-client component baselines in `ClientState`; "no per-client baseline" uniformly signals full-sync (registration, scope entry, re-entry); entry → targeted `EntitySpawn` (ReliableOrdered), exit → targeted `EntityDespawn`; per-client deltas and bandwidth budgets; relevance recompute throttled by `UpdateFrequencyHz`.
- **Invariants:** `InterestManager = null` (default) keeps the original broadcast path bit-identical (all pre-existing tests pass unmodified); owner-auth echo suppression preserved; **owned entities always relevant to their owner** — enforced in the send system, so it holds for any custom manager.
- Documented filtered-mode behavior change: late joiners sync via scope-entry spawns rather than the broadcast full snapshot (which would leak out-of-scope entities).

## Test plan
- [x] 16 new tests (near/far, boundary in/out, owner-always-relevant, re-entry full re-sync, frequency throttling, grid math, null-manager equivalence) — 308 passed / 2 pre-existing skips
- [x] Builds zero warnings (CS1591 enforced); `dotnet format` clean; re-verified after rebase onto main
- [ ] CI green

## Related Issues
Refs #585 — completes the #353 networking plan (Phase 4 of 4). 🎉