### PR TITLE
feat(editor): Add IK debug gizmo renderer

### DIFF
--- a/editor/KeenEyes.Editor/Animation/AnimationEditorPlugin.cs
+++ b/editor/KeenEyes.Editor/Animation/AnimationEditorPlugin.cs
@@ -1,0 +1,59 @@
+using KeenEyes.Editor.Abstractions;
+using KeenEyes.Editor.Abstractions.Capabilities;
+
+namespace KeenEyes.Editor.Animation;
+
+/// <summary>
+/// Editor plugin that registers the animation debug gizmo renderers in the viewport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This plugin wires up the skeleton and IK chain visualizers so their debug gizmos appear in
+/// the viewport for the loaded scene:
+/// <list type="bullet">
+///   <item><description><see cref="SkeletonGizmoRenderer"/> - bone hierarchy visualization.</description></item>
+///   <item><description><see cref="IKGizmoRenderer"/> - IK chains, targets, and pole vectors.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class AnimationEditorPlugin : EditorPluginBase
+{
+    private SkeletonGizmoRenderer? skeletonGizmo;
+    private IKGizmoRenderer? ikGizmo;
+
+    /// <inheritdoc/>
+    public override string Name => "Animation";
+
+    /// <inheritdoc/>
+    public override string? Description => "Skeleton and IK chain visualization gizmos";
+
+    /// <inheritdoc/>
+    protected override void OnInitialize(IEditorContext context)
+    {
+        if (context.TryGetCapability<IViewportCapability>(out var viewport) && viewport != null)
+        {
+            skeletonGizmo = new SkeletonGizmoRenderer();
+            viewport.AddGizmoRenderer(skeletonGizmo);
+
+            ikGizmo = new IKGizmoRenderer();
+            viewport.AddGizmoRenderer(ikGizmo);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnShutdown()
+    {
+        if (Context != null && Context.TryGetCapability<IViewportCapability>(out var viewport) && viewport != null)
+        {
+            if (skeletonGizmo != null)
+            {
+                viewport.RemoveGizmoRenderer(skeletonGizmo);
+            }
+
+            if (ikGizmo != null)
+            {
+                viewport.RemoveGizmoRenderer(ikGizmo);
+            }
+        }
+    }
+}

--- a/editor/KeenEyes.Editor/Animation/IKGizmoRenderer.cs
+++ b/editor/KeenEyes.Editor/Animation/IKGizmoRenderer.cs
@@ -1,0 +1,355 @@
+using System.Numerics;
+
+using KeenEyes.Animation;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK;
+using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
+
+namespace KeenEyes.Editor.Animation;
+
+/// <summary>
+/// Gizmo renderer that visualizes IK chains, targets, and pole vectors in the viewport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For every end effector entity carrying an <see cref="IKChainReference"/>, this renderer
+/// resolves the chain definition from the <see cref="IKManager"/> world extension, collects
+/// the chain's bone entities by walking the entity hierarchy up from the end effector, and
+/// draws:
+/// <list type="bullet">
+///   <item><description>Chain bones as blue lines with a sphere at each joint.</description></item>
+///   <item><description>The target position as a green sphere (red when unreachable).</description></item>
+///   <item><description>The target rotation as RGB axis lines when the target uses rotation.</description></item>
+///   <item><description>The pole vector as a yellow line from the chain's mid joint.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The effective blend weight (<c>IKRig.GlobalWeight × IKChainReference.Weight ×
+/// IKTarget.Weight</c>, clamped to [0, 1]) modulates the opacity of every element, and a target
+/// whose distance from the chain root exceeds the total chain length is highlighted in red.
+/// </para>
+/// <para>
+/// The renderer degrades gracefully: worlds without an <see cref="IKManager"/> extension, dead
+/// or missing targets, unregistered chain IDs, and incomplete bone hierarchies are skipped
+/// without drawing anything and without throwing.
+/// </para>
+/// </remarks>
+public sealed class IKGizmoRenderer : IGizmoRenderer
+{
+    private static readonly Vector4 ChainLineColor = new(0.2f, 0.4f, 1.0f, 1.0f);   // Blue
+    private static readonly Vector4 JointColor = new(0.3f, 0.6f, 1.0f, 1.0f);       // Blue
+    private static readonly Vector4 TargetColor = new(0.2f, 0.9f, 0.3f, 1.0f);      // Green
+    private static readonly Vector4 UnreachableColor = new(1.0f, 0.2f, 0.2f, 1.0f); // Red
+    private static readonly Vector4 PoleColor = new(1.0f, 0.9f, 0.2f, 1.0f);        // Yellow
+    private static readonly Vector4 AxisXColor = new(1.0f, 0.2f, 0.2f, 1.0f);       // Red
+    private static readonly Vector4 AxisYColor = new(0.2f, 1.0f, 0.2f, 1.0f);       // Green
+    private static readonly Vector4 AxisZColor = new(0.2f, 0.4f, 1.0f, 1.0f);       // Blue
+
+    private const float JointSphereRadius = 0.03f;
+    private const float TargetSphereRadius = 0.05f;
+    private const float LineWidth = 2.0f;
+    private const float AxisLength = 0.15f;
+    private const float JointPointSize = 6.0f;
+
+    /// <inheritdoc />
+    public string Id => "ik-gizmo";
+
+    /// <inheritdoc />
+    public string DisplayName => "IK Chains";
+
+    /// <inheritdoc />
+    public bool IsEnabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public int Order => 101; // Render just after the skeleton gizmo (100)
+
+    /// <inheritdoc />
+    public void Render(GizmoRenderContext context)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        var world = context.SceneWorld;
+
+        // IK is optional; worlds without the manager extension simply draw nothing.
+        if (!world.TryGetExtension<IKManager>(out var manager) || manager is null)
+        {
+            return;
+        }
+
+        // Component IDs reference entities by ID, so build per-frame lookups keyed by ID.
+        var targets = new Dictionary<int, IKTarget>();
+        var poleNeeded = false;
+        foreach (var entity in world.Query<IKTarget>())
+        {
+            ref readonly var target = ref world.Get<IKTarget>(entity);
+            targets[entity.Id] = target;
+            if (target.PoleTargetEntityId >= 0)
+            {
+                poleNeeded = true;
+            }
+        }
+
+        var rigs = new Dictionary<int, IKRig>();
+        foreach (var entity in world.Query<IKRig>())
+        {
+            rigs[entity.Id] = world.Get<IKRig>(entity);
+        }
+
+        // Pole targets are referenced by entity ID; only resolve entity handles when needed.
+        Dictionary<int, Entity>? transformsById = null;
+        if (poleNeeded)
+        {
+            transformsById = [];
+            foreach (var entity in world.Query<Transform3D>())
+            {
+                transformsById[entity.Id] = entity;
+            }
+        }
+
+        foreach (var endEffector in world.Query<IKChainReference, BoneReference, Transform3D>())
+        {
+            DrawChain(context, manager, endEffector, targets, rigs, transformsById);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool ShouldRender(Entity entity, IWorld sceneWorld)
+    {
+        // Render for entities participating in IK: chain end effectors, rigs, or targets.
+        return sceneWorld.Has<IKChainReference>(entity) ||
+               sceneWorld.Has<IKRig>(entity) ||
+               sceneWorld.Has<IKTarget>(entity);
+    }
+
+    private static void DrawChain(
+        GizmoRenderContext context,
+        IKManager manager,
+        Entity endEffector,
+        Dictionary<int, IKTarget> targets,
+        Dictionary<int, IKRig> rigs,
+        Dictionary<int, Entity>? transformsById)
+    {
+        var world = context.SceneWorld;
+
+        ref readonly var chainRef = ref world.Get<IKChainReference>(endEffector);
+        if (!chainRef.Enabled || chainRef.ChainId < 0)
+        {
+            return;
+        }
+
+        if (!manager.TryGetChain(chainRef.ChainId, out var chain) || chain is null)
+        {
+            return;
+        }
+
+        // The rig (if any) lives on the skeleton root referenced by the end effector's bone.
+        var globalWeight = 1f;
+        ref readonly var boneRef = ref world.Get<BoneReference>(endEffector);
+        if (rigs.TryGetValue(boneRef.SkeletonRootId, out var rig))
+        {
+            if (!rig.Enabled)
+            {
+                return;
+            }
+
+            globalWeight = rig.GlobalWeight;
+        }
+
+        if (chainRef.TargetEntityId < 0 ||
+            !targets.TryGetValue(chainRef.TargetEntityId, out var target))
+        {
+            return;
+        }
+
+        var weight = ComputeEffectiveWeight(globalWeight, chainRef.Weight, target.Weight);
+        if (weight.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        if (!TryCollectChainBones(world, endEffector, chain, out var bones))
+        {
+            return;
+        }
+
+        var joints = new Vector3[bones.Length];
+        for (var i = 0; i < bones.Length; i++)
+        {
+            joints[i] = GetWorldPosition(world, bones[i]);
+        }
+
+        var chainLength = ComputeChainLength(joints);
+        var targetDistance = Vector3.Distance(joints[0], target.Position);
+        var unreachable = IsUnreachable(chainLength, targetDistance);
+
+        // Chain bones: blue lines with a joint sphere at each bone.
+        var jointColor = WithAlpha(JointColor, weight);
+        var lineColor = WithAlpha(ChainLineColor, weight);
+        for (var i = 0; i < joints.Length; i++)
+        {
+            context.DrawPoint(joints[i], jointColor, JointPointSize);
+            context.Drawer.DrawWireSphere(joints[i], JointSphereRadius, jointColor);
+
+            if (i > 0)
+            {
+                context.DrawLine(joints[i - 1], joints[i], lineColor, LineWidth);
+            }
+        }
+
+        // Target position: green sphere, or red when the target is out of reach.
+        var targetColor = WithAlpha(unreachable ? UnreachableColor : TargetColor, weight);
+        context.Drawer.DrawWireSphere(target.Position, TargetSphereRadius, targetColor);
+
+        // Target rotation: RGB axis lines from the target position.
+        if (target.UseRotation)
+        {
+            DrawRotationAxes(context, target.Position, target.Rotation, weight);
+        }
+
+        // Pole vector: yellow line from the chain's mid joint toward the pole target.
+        if (target.PoleTargetEntityId >= 0 &&
+            transformsById is not null &&
+            transformsById.TryGetValue(target.PoleTargetEntityId, out var poleEntity) &&
+            world.IsAlive(poleEntity))
+        {
+            var polePosition = GetWorldPosition(world, poleEntity);
+            var midJoint = joints[joints.Length / 2];
+            context.DrawLine(midJoint, polePosition, WithAlpha(PoleColor, weight), LineWidth);
+        }
+    }
+
+    private static void DrawRotationAxes(
+        GizmoRenderContext context, Vector3 origin, Quaternion rotation, float weight)
+    {
+        var axisX = Vector3.Transform(Vector3.UnitX, rotation);
+        var axisY = Vector3.Transform(Vector3.UnitY, rotation);
+        var axisZ = Vector3.Transform(Vector3.UnitZ, rotation);
+
+        context.DrawLine(origin, origin + (axisX * AxisLength), WithAlpha(AxisXColor, weight), LineWidth);
+        context.DrawLine(origin, origin + (axisY * AxisLength), WithAlpha(AxisYColor, weight), LineWidth);
+        context.DrawLine(origin, origin + (axisZ * AxisLength), WithAlpha(AxisZColor, weight), LineWidth);
+    }
+
+    /// <summary>
+    /// Computes the effective IK blend weight, clamped to the range [0, 1].
+    /// </summary>
+    /// <param name="globalWeight">The rig's global weight.</param>
+    /// <param name="chainWeight">The per-chain weight multiplier.</param>
+    /// <param name="targetWeight">The target's blend weight.</param>
+    /// <returns>The clamped product of the three weights.</returns>
+    internal static float ComputeEffectiveWeight(float globalWeight, float chainWeight, float targetWeight)
+        => Math.Clamp(globalWeight * chainWeight * targetWeight, 0f, 1f);
+
+    /// <summary>
+    /// Sums the distances between consecutive chain joints to obtain the total chain length.
+    /// </summary>
+    /// <param name="joints">World-space joint positions ordered root to tip.</param>
+    /// <returns>The total length of the chain, or zero for fewer than two joints.</returns>
+    internal static float ComputeChainLength(IReadOnlyList<Vector3> joints)
+    {
+        var length = 0f;
+        for (var i = 1; i < joints.Count; i++)
+        {
+            length += Vector3.Distance(joints[i - 1], joints[i]);
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    /// Determines whether a target is unreachable, i.e. farther from the chain root than the
+    /// chain can extend.
+    /// </summary>
+    /// <param name="chainLength">The total length of the chain.</param>
+    /// <param name="targetDistance">The distance from the chain root to the target.</param>
+    /// <returns><see langword="true"/> when the target lies beyond the chain's reach.</returns>
+    internal static bool IsUnreachable(float chainLength, float targetDistance)
+        => targetDistance > chainLength;
+
+    /// <summary>
+    /// Collects the chain's bone entities by walking the hierarchy up from the end effector,
+    /// validating each bone against the chain definition's bone names.
+    /// </summary>
+    /// <param name="world">The world containing the bones.</param>
+    /// <param name="endEffector">The chain's tip (end effector) entity.</param>
+    /// <param name="chain">The chain definition describing the expected bones.</param>
+    /// <param name="bones">The collected bone entities ordered root to tip, on success.</param>
+    /// <returns><see langword="true"/> when a complete, matching bone chain was collected.</returns>
+    internal static bool TryCollectChainBones(
+        IWorld world, Entity endEffector, IKChainDefinition chain, out Entity[] bones)
+    {
+        bones = [];
+        if (chain.BoneCount < 2)
+        {
+            return false;
+        }
+
+        var collected = new Entity[chain.BoneCount];
+        var current = endEffector;
+        for (var i = chain.BoneCount - 1; i >= 0; i--)
+        {
+            if (!current.IsValid ||
+                !world.IsAlive(current) ||
+                !world.Has<Transform3D>(current) ||
+                !world.Has<BoneReference>(current))
+            {
+                return false;
+            }
+
+            ref readonly var boneRef = ref world.Get<BoneReference>(current);
+            if (!string.Equals(boneRef.BoneName, chain.BoneNames[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            collected[i] = current;
+            current = world.GetParent(current);
+        }
+
+        bones = collected;
+        return true;
+    }
+
+    /// <summary>
+    /// Computes the world-space position of an entity by composing local transforms up the
+    /// entity hierarchy. Bone <see cref="Transform3D"/> components store parent-relative values.
+    /// </summary>
+    /// <param name="world">The world containing the entity.</param>
+    /// <param name="entity">The entity to locate.</param>
+    /// <returns>The world-space position, or <see cref="Vector3.Zero"/> when unavailable.</returns>
+    internal static Vector3 GetWorldPosition(IWorld world, Entity entity)
+    {
+        if (!entity.IsValid || !world.IsAlive(entity) || !world.Has<Transform3D>(entity))
+        {
+            return Vector3.Zero;
+        }
+
+        return GetWorldTransform(world, entity).Position;
+    }
+
+    private static (Vector3 Position, Quaternion Rotation, Vector3 Scale) GetWorldTransform(
+        IWorld world, Entity entity)
+    {
+        ref readonly var local = ref world.Get<Transform3D>(entity);
+        var parent = world.GetParent(entity);
+
+        if (!parent.IsValid || !world.IsAlive(parent) || !world.Has<Transform3D>(parent))
+        {
+            return (local.Position, local.Rotation, local.Scale);
+        }
+
+        var (parentPos, parentRot, parentScale) = GetWorldTransform(world, parent);
+
+        return (
+            parentPos + Vector3.Transform(parentScale * local.Position, parentRot),
+            Quaternion.Normalize(parentRot * local.Rotation),
+            parentScale * local.Scale);
+    }
+
+    private static Vector4 WithAlpha(Vector4 color, float alpha)
+        => new(color.X, color.Y, color.Z, color.W * alpha);
+}

--- a/tests/KeenEyes.Editor.Tests/Animation/IKGizmoRendererTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Animation/IKGizmoRendererTests.cs
@@ -1,0 +1,421 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Numerics;
+
+using KeenEyes.Animation;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK;
+using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Animation;
+
+namespace KeenEyes.Editor.Tests.Animation;
+
+public class IKGizmoRendererTests
+{
+    #region Property Tests
+
+    [Fact]
+    public void Id_ReturnsExpectedValue()
+    {
+        var renderer = new IKGizmoRenderer();
+
+        Assert.Equal("ik-gizmo", renderer.Id);
+    }
+
+    [Fact]
+    public void DisplayName_ReturnsIKChains()
+    {
+        var renderer = new IKGizmoRenderer();
+
+        Assert.Equal("IK Chains", renderer.DisplayName);
+    }
+
+    [Fact]
+    public void IsEnabled_DefaultsToTrue()
+    {
+        var renderer = new IKGizmoRenderer();
+
+        Assert.True(renderer.IsEnabled);
+    }
+
+    [Fact]
+    public void IsEnabled_CanBeSet()
+    {
+        var renderer = new IKGizmoRenderer { IsEnabled = false };
+
+        Assert.False(renderer.IsEnabled);
+    }
+
+    [Fact]
+    public void Order_RendersAfterSkeletonGizmo()
+    {
+        var renderer = new IKGizmoRenderer();
+
+        Assert.Equal(101, renderer.Order);
+    }
+
+    #endregion
+
+    #region ShouldRender Tests
+
+    [Fact]
+    public void ShouldRender_WithChainReference_ReturnsTrue()
+    {
+        using var world = new World();
+        var entity = world.Spawn().With(IKChainReference.Default).Build();
+        var renderer = new IKGizmoRenderer();
+
+        Assert.True(renderer.ShouldRender(entity, world));
+    }
+
+    [Fact]
+    public void ShouldRender_WithRig_ReturnsTrue()
+    {
+        using var world = new World();
+        var entity = world.Spawn().With(IKRig.Default).Build();
+        var renderer = new IKGizmoRenderer();
+
+        Assert.True(renderer.ShouldRender(entity, world));
+    }
+
+    [Fact]
+    public void ShouldRender_WithTarget_ReturnsTrue()
+    {
+        using var world = new World();
+        var entity = world.Spawn().With(IKTarget.Default).Build();
+        var renderer = new IKGizmoRenderer();
+
+        Assert.True(renderer.ShouldRender(entity, world));
+    }
+
+    [Fact]
+    public void ShouldRender_WithUnrelatedEntity_ReturnsFalse()
+    {
+        using var world = new World();
+        var entity = world.Spawn().With(Transform3D.Identity).Build();
+        var renderer = new IKGizmoRenderer();
+
+        Assert.False(renderer.ShouldRender(entity, world));
+    }
+
+    #endregion
+
+    #region ComputeEffectiveWeight Tests
+
+    [Fact]
+    public void ComputeEffectiveWeight_MultipliesWeights()
+    {
+        var weight = IKGizmoRenderer.ComputeEffectiveWeight(0.5f, 0.5f, 1f);
+
+        Assert.Equal(0.25f, weight, 5);
+    }
+
+    [Fact]
+    public void ComputeEffectiveWeight_ClampsAboveOne()
+    {
+        var weight = IKGizmoRenderer.ComputeEffectiveWeight(2f, 1f, 1f);
+
+        Assert.Equal(1f, weight, 5);
+    }
+
+    [Fact]
+    public void ComputeEffectiveWeight_ClampsBelowZero()
+    {
+        var weight = IKGizmoRenderer.ComputeEffectiveWeight(-1f, 1f, 1f);
+
+        Assert.Equal(0f, weight, 5);
+    }
+
+    #endregion
+
+    #region ComputeChainLength Tests
+
+    [Fact]
+    public void ComputeChainLength_SumsSegmentLengths()
+    {
+        var joints = new[]
+        {
+            Vector3.Zero,
+            new Vector3(1f, 0f, 0f),
+            new Vector3(1f, 2f, 0f),
+        };
+
+        var length = IKGizmoRenderer.ComputeChainLength(joints);
+
+        Assert.Equal(3f, length, 5);
+    }
+
+    [Fact]
+    public void ComputeChainLength_WithSingleJoint_ReturnsZero()
+    {
+        var joints = new[] { Vector3.Zero };
+
+        var length = IKGizmoRenderer.ComputeChainLength(joints);
+
+        Assert.Equal(0f, length, 5);
+    }
+
+    #endregion
+
+    #region IsUnreachable Tests
+
+    [Fact]
+    public void IsUnreachable_WhenTargetBeyondReach_ReturnsTrue()
+    {
+        Assert.True(IKGizmoRenderer.IsUnreachable(chainLength: 2f, targetDistance: 5f));
+    }
+
+    [Fact]
+    public void IsUnreachable_WhenTargetWithinReach_ReturnsFalse()
+    {
+        Assert.False(IKGizmoRenderer.IsUnreachable(chainLength: 2f, targetDistance: 1.5f));
+    }
+
+    #endregion
+
+    #region GetWorldPosition Tests
+
+    [Fact]
+    public void GetWorldPosition_ComposesHierarchy()
+    {
+        using var world = new World();
+        var root = world.Spawn()
+            .With(new Transform3D(new Vector3(1f, 0f, 0f), Quaternion.Identity, Vector3.One))
+            .Build();
+        var child = world.Spawn()
+            .With(new Transform3D(new Vector3(1f, 0f, 0f), Quaternion.Identity, Vector3.One))
+            .Build();
+        world.SetParent(child, root);
+
+        var position = IKGizmoRenderer.GetWorldPosition(world, child);
+
+        Assert.Equal(2f, position.X, 5);
+        Assert.Equal(0f, position.Y, 5);
+    }
+
+    [Fact]
+    public void GetWorldPosition_WithDeadEntity_ReturnsZero()
+    {
+        using var world = new World();
+        var entity = world.Spawn().With(Transform3D.Identity).Build();
+        world.Despawn(entity);
+
+        var position = IKGizmoRenderer.GetWorldPosition(world, entity);
+
+        Assert.Equal(Vector3.Zero, position);
+    }
+
+    #endregion
+
+    #region TryCollectChainBones Tests
+
+    [Fact]
+    public void TryCollectChainBones_WithMatchingHierarchy_CollectsRootToTip()
+    {
+        using var world = new World();
+        var (_, upper, lower, hand) = CreateArmSkeleton(world);
+        var chain = IKChainDefinition.TwoBone("Arm", "Upper", "Lower", "Hand", Vector3.UnitZ);
+
+        var collected = IKGizmoRenderer.TryCollectChainBones(world, hand, chain, out var bones);
+
+        Assert.True(collected);
+        Assert.Equal(3, bones.Length);
+        Assert.Equal(upper.Id, bones[0].Id);
+        Assert.Equal(lower.Id, bones[1].Id);
+        Assert.Equal(hand.Id, bones[2].Id);
+    }
+
+    [Fact]
+    public void TryCollectChainBones_WithBoneNameMismatch_ReturnsFalse()
+    {
+        using var world = new World();
+        var (_, _, _, hand) = CreateArmSkeleton(world);
+        var chain = IKChainDefinition.TwoBone("Arm", "Upper", "Forearm", "Hand", Vector3.UnitZ);
+
+        var collected = IKGizmoRenderer.TryCollectChainBones(world, hand, chain, out var bones);
+
+        Assert.False(collected);
+        Assert.Empty(bones);
+    }
+
+    [Fact]
+    public void TryCollectChainBones_WithSingleBoneChain_ReturnsFalse()
+    {
+        using var world = new World();
+        var (_, _, _, hand) = CreateArmSkeleton(world);
+        var chain = new IKChainDefinition { Name = "Tip", BoneNames = ["Hand"] };
+
+        var collected = IKGizmoRenderer.TryCollectChainBones(world, hand, chain, out var bones);
+
+        Assert.False(collected);
+        Assert.Empty(bones);
+    }
+
+    #endregion
+
+    #region Render Tests
+
+    [Fact]
+    public void Render_WithNoIKManager_DrawsNothing()
+    {
+        using var world = new World();
+        world.Spawn().With(IKChainReference.Default).With(Transform3D.Identity).Build();
+        var drawer = new RecordingGizmoDrawer();
+        var renderer = new IKGizmoRenderer();
+
+        renderer.Render(CreateContext(world, drawer));
+
+        Assert.Empty(drawer.Spheres);
+        Assert.Empty(drawer.Lines);
+    }
+
+    [Fact]
+    public void Render_WhenDisabled_DrawsNothing()
+    {
+        using var world = CreateIKWorld(out var hand, out _, new Vector3(1.5f, 0f, 0f));
+        var drawer = new RecordingGizmoDrawer();
+        var renderer = new IKGizmoRenderer { IsEnabled = false };
+
+        renderer.Render(CreateContext(world, drawer));
+
+        Assert.Empty(drawer.Spheres);
+        Assert.Empty(drawer.Lines);
+        Assert.NotEqual(0, hand.Id); // guard: hand was created
+    }
+
+    [Fact]
+    public void Render_WithReachableChain_DrawsChainLinesAndGreenTarget()
+    {
+        using var world = CreateIKWorld(out _, out var target, new Vector3(1.5f, 0f, 0f));
+        var drawer = new RecordingGizmoDrawer();
+        var renderer = new IKGizmoRenderer();
+
+        renderer.Render(CreateContext(world, drawer));
+
+        // Two bone segments across three joints produce two chain lines at minimum.
+        Assert.True(drawer.Lines.Count >= 2);
+
+        // The target sphere is drawn green (dominant green channel) at the target position.
+        Assert.Contains(drawer.Spheres, s =>
+            Vector3.Distance(s.Center, target) < 1e-4f &&
+            s.Color.Y > 0.5f &&
+            s.Color.X < 0.5f);
+    }
+
+    [Fact]
+    public void Render_WithUnreachableTarget_DrawsRedTarget()
+    {
+        using var world = CreateIKWorld(out _, out var target, new Vector3(10f, 0f, 0f));
+        var drawer = new RecordingGizmoDrawer();
+        var renderer = new IKGizmoRenderer();
+
+        renderer.Render(CreateContext(world, drawer));
+
+        // The unreachable target sphere is drawn red (dominant red channel).
+        Assert.Contains(drawer.Spheres, s =>
+            Vector3.Distance(s.Center, target) < 1e-4f &&
+            s.Color.X > 0.5f &&
+            s.Color.Y < 0.5f);
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    private static (Entity Root, Entity Upper, Entity Lower, Entity Hand) CreateArmSkeleton(World world)
+    {
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(IKRig.Default)
+            .Build();
+
+        var upper = CreateBone(world, "Upper", root, Vector3.Zero, root.Id);
+        var lower = CreateBone(world, "Lower", upper, Vector3.UnitX, root.Id);
+        var hand = CreateBone(world, "Hand", lower, Vector3.UnitX, root.Id);
+
+        return (root, upper, lower, hand);
+    }
+
+    private static Entity CreateBone(World world, string name, Entity parent, Vector3 localPosition, int skeletonRootId)
+    {
+        var bone = world.Spawn()
+            .With(new Transform3D(localPosition, Quaternion.Identity, Vector3.One))
+            .With(BoneReference.Create(name, skeletonRootId))
+            .Build();
+
+        world.SetParent(bone, parent);
+        return bone;
+    }
+
+    /// <summary>
+    /// Builds a world with the AnimationPlugin (IK enabled), a three-bone arm chain whose end
+    /// effector references a target placed at <paramref name="targetPosition"/>.
+    /// </summary>
+    private static World CreateIKWorld(out Entity hand, out Vector3 targetPosition, Vector3 target)
+    {
+        var world = new World();
+        world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableIK = true }));
+
+        var (_, _, _, effector) = CreateArmSkeleton(world);
+
+        var targetEntity = world.Spawn()
+            .With(IKTarget.AtPosition(target))
+            .With(new Transform3D(target, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        var manager = world.GetExtension<IKManager>();
+        var chainId = manager.RegisterChain(
+            IKChainDefinition.TwoBone("Arm", "Upper", "Lower", "Hand", Vector3.UnitZ));
+
+        world.Add(effector, IKChainReference.ForChain(chainId, targetEntity.Id));
+
+        hand = effector;
+        targetPosition = target;
+        return world;
+    }
+
+    private static GizmoRenderContext CreateContext(World world, IGizmoDrawer drawer) => new()
+    {
+        SceneWorld = world,
+        SelectedEntities = [],
+        ViewMatrix = Matrix4x4.Identity,
+        ProjectionMatrix = Matrix4x4.Identity,
+        CameraPosition = Vector3.Zero,
+        Bounds = new ViewportBounds(0f, 0f, 800f, 600f),
+        Drawer = drawer,
+    };
+
+    private sealed class RecordingGizmoDrawer : IGizmoDrawer
+    {
+        public List<(Vector3 Center, float Radius, Vector4 Color)> Spheres { get; } = [];
+
+        public List<(Vector3 Start, Vector3 End, Vector4 Color)> Lines { get; } = [];
+
+        public List<(Vector3 Position, Vector4 Color)> Points { get; } = [];
+
+        public void DrawTriangle(Vector3 v0, Vector3 v1, Vector3 v2, Vector4 color)
+        {
+        }
+
+        public void DrawLine(Vector3 start, Vector3 end, Vector4 color, float width = 1f)
+            => Lines.Add((start, end, color));
+
+        public void DrawPoint(Vector3 position, Vector4 color, float size = 4f)
+            => Points.Add((position, color));
+
+        public void DrawWireBox(Vector3 min, Vector3 max, Vector4 color, float lineWidth = 1f)
+        {
+        }
+
+        public void DrawWireSphere(Vector3 center, float radius, Vector4 color, int segments = 16)
+            => Spheres.Add((center, radius, color));
+
+        public void DrawText(Vector3 position, string text, Vector4 color)
+        {
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`IKGizmoRenderer`** (`Id="ik-gizmo"`, order 101, right after the skeleton gizmo): draws IK chains per the issue's visual table — blue chain lines + joint spheres, green target sphere, RGB target-rotation axes, yellow pole line from the mid joint; effective weight (`rig × chain × target`) modulates opacity; unreachable targets (distance > total chain length) render red. Reads `IKManager` + chain components from the scene world using the same hierarchy-walk/world-composition helpers as `IKSolverSystem`; degrades gracefully (no IK in world / dead targets → draws nothing).
- **Registration home:** neither `SkeletonGizmoRenderer` nor this one had a registration site (the skeleton gizmo was orphaned!), so following the `NavigationEditorPlugin` precedent this adds **`AnimationEditorPlugin : EditorPluginBase`** registering both via `IViewportCapability.AddGizmoRenderer` (removed on shutdown). Note: like `NavigationEditorPlugin`, it isn't auto-installed by `EditorApplication` — consistent with the existing pattern; wiring editor plugins into startup is a separate decision.
- One issue-table deviation: "dashed sphere" for unreachable → solid red wire sphere (`IGizmoDrawer` has no dashed primitive; color carries the signal).

## Test plan
- [x] 25 new tests (weight clamping, chain-length/unreachable math, bone collection match/mismatch, world-position hierarchy compose, dead entities, and Render integration via a recording `IGizmoDrawer`) — editor suite 1251/1251
- [x] Build zero warnings; `dotnet format` clean; re-verified after rebase (the temporary Localization fix commit deduped once #1016 merged)
- [ ] CI green

## Related Issues
Refs #958 — completes the #959 IK epic. 🎉