### PR TITLE
ci: pin the .NET SDK feature band via global.json across all workflows

### DIFF
--- a/.github/workflows/aot-compatibility.yml
+++ b/.github/workflows/aot-compatibility.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Restore dependencies
@@ -77,7 +77,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Restore dependencies

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Determine benchmark configuration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Restore dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Build (required for source generators)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Install DocFX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: ./global.json
           dotnet-quality: 'preview'
 
       - name: Extract version from tag

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestFeature",
-    "allowPrerelease": true
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Summary
- **Root cause of all four failing workflows on main** (Build and Test, AOT, API Docs, Benchmarks): they fail on 5 `IDE0028` style errors that **no local build reproduces**. `global.json` allowed `rollForward: latestFeature` and every workflow used `dotnet-version: '10.0.x'`, so CI silently adopted a newer SDK feature band whose analyzers added new IDE0028 cases. (This was previously masked by the NU1901 restore failure fixed in #1009 — same onion, next layer.)
- `global.json`: `latestFeature` → `latestPatch`, `allowPrerelease` → false.
- All 8 `setup-dotnet` steps across 6 workflows: `dotnet-version: '10.0.x'` → `global-json-file: ./global.json`, so CI installs the pinned band rather than the newest available.

## Why pin instead of fixing the 5 style sites
The flagged suggestions come from an analyzer we can't run locally (and with `LangVersion=preview`, its preferred rewrites may not even compile on the pinned compiler). Pinning makes builds reproducible; the 5 known sites (`ActionMapProvider.cs:30`, `InputActionMap.cs:35`, `AStarPathfinder.cs:56`, `CollisionEventManager.cs:94`, `ArchetypeChunk.cs:82`) get fixed in the deliberate SDK-bump PR where they can actually be validated.

## Test plan
- [x] `dotnet --version` resolves under the tightened pin locally (10.0.109)
- [x] Full local Release build: zero warnings/errors
- [ ] CI green on this PR — the real proof

Merge ahead of other work; this unblocks all four workflows.