### PR TITLE
feat(animation): Add root motion extraction and application

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -247,6 +247,31 @@ Each frame, `IKSolverSystem` queries entities with `IKChainReference` + `BoneRef
 
 Note that the `CCD` and `LookAt` solver types have no bundled implementations yet; chains configured with them fall back to FABRIK (register your own `IIKSolver` with `IKManager.RegisterSolver` to override). `LookAtTarget` is likewise not yet driven by any bundled system.
 
+### Root Motion
+
+Root motion extracts the movement of a designated root bone (typically "Root" or "Hips") from the playing animation and delivers it to the skeleton root entity, so walk/run/turn clips drive the character through the world instead of playing in place.
+
+Root motion is opt-in: install the plugin with `AnimationConfig.EnableRootMotion = true` and the plugin registers the `RootMotion` component and adds `RootMotionSystem` at order 56 — directly after `SkeletonPoseSystem` (order 55) writes the FK pose and before IK (order 57) consumes bone transforms.
+
+```csharp
+world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableRootMotion = true }));
+
+var character = world.Spawn()
+    .With(Transform3D.Identity)
+    .With(AnimationPlayer.ForClip(walkClipId))
+    .With(RootMotion.ForBone("Root"))
+    .Build();
+```
+
+Each frame, `RootMotionSystem` samples the root bone's track at the previous and current playback times and computes the frame delta (position by difference, rotation as `current * inverse(previous)`). The delta is transformed into the entity's space using its current orientation, scaled by `PositionScale`/`RotationScale`, and delivered according to `Mode`:
+
+- **`RootMotionMode.ApplyToEntity`** (default): the delta is applied directly to the entity's `Transform3D`.
+- **`RootMotionMode.ExposeDelta`**: the entity is left untouched and the delta is written to `RootMotion.DeltaPosition`/`DeltaRotation` for a character controller or physics system to consume (the fields are populated in both modes).
+
+The root bone's animated local translation (and rotation, when `ApplyRotation` is set) is suppressed after extraction so the motion isn't applied twice. With `PlanarOnly`, the delta is restricted to the XZ plane and the bone keeps its animated Y translation — vertical motion (crouching, bobbing) stays in the skeleton while horizontal motion drives the entity. `ApplyPosition`/`ApplyRotation` select which channels are extracted at all.
+
+Looping is handled seamlessly: when `WrapMode.Loop` playback wraps between frames, the delta accumulates `[previousTime → clip end]` plus `[clip start → currentTime]`, so the loop seam produces continuous motion with no teleport back. Under an `Animator` crossfade, both clips' root deltas are blended with the same weight (`TransitionProgress`) that the pose blend uses, so root velocity matches the blended pose and feet don't slide during transitions.
+
 ## Performance
 
 - **Per-frame caching:** `SkeletonPoseSystem` builds a per-frame `Dictionary` cache of active `AnimationPlayer`/`Animator` states before iterating bones, so sampling cost for a skeleton's clip is paid once regardless of bone count.

--- a/src/KeenEyes.Animation/AnimationConfig.cs
+++ b/src/KeenEyes.Animation/AnimationConfig.cs
@@ -49,6 +49,25 @@ public sealed class AnimationConfig
     public bool EnableIK { get; set; }
 
     /// <summary>
+    /// Gets or sets whether root motion support is enabled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, the plugin registers the <see cref="Components.RootMotion"/> component
+    /// and adds <see cref="Systems.RootMotionSystem"/> at order 56, directly after
+    /// <see cref="Systems.SkeletonPoseSystem"/> (order 55). The system extracts the root
+    /// bone's per-frame movement from the playing clip(s), suppresses the root bone's
+    /// animated local translation, and either applies the delta to the skeleton root
+    /// entity's Transform3D or exposes it for character controllers, depending on
+    /// <see cref="Components.RootMotion.Mode"/>.
+    /// </para>
+    /// <para>
+    /// Disabled by default: worlds that do not use root motion pay no per-frame cost.
+    /// </para>
+    /// </remarks>
+    public bool EnableRootMotion { get; set; }
+
+    /// <summary>
     /// Gets or sets whether GPU skinning support is enabled.
     /// </summary>
     /// <remarks>

--- a/src/KeenEyes.Animation/AnimationPlugin.cs
+++ b/src/KeenEyes.Animation/AnimationPlugin.cs
@@ -134,6 +134,17 @@ public sealed class AnimationPlugin : IWorldPlugin
             SystemPhase.Update,
             order: 55);
 
+        if (Config.EnableRootMotion)
+        {
+            context.RegisterComponent<RootMotion>();
+
+            // Root motion extraction runs directly after the FK pose has been
+            // written (order 55) and before IK (order 57) consumes bone transforms.
+            context.AddSystem<RootMotionSystem>(
+                SystemPhase.Update,
+                order: 56);
+        }
+
         if (Config.EnableIK)
         {
             context.RegisterComponent<IKRig>();

--- a/src/KeenEyes.Animation/Components/Animator.cs
+++ b/src/KeenEyes.Animation/Components/Animator.cs
@@ -70,6 +70,18 @@ public partial struct Animator
     public float NextStateTime;
 
     /// <summary>
+    /// The previous frame's playback time in the current state (for root motion delta extraction).
+    /// </summary>
+    [BuilderIgnore]
+    public float PreviousStateTime;
+
+    /// <summary>
+    /// The previous frame's playback time in the next state (for root motion delta extraction).
+    /// </summary>
+    [BuilderIgnore]
+    public float PreviousNextStateTime;
+
+    /// <summary>
     /// Whether the animator is currently enabled.
     /// </summary>
     public bool Enabled;
@@ -97,6 +109,8 @@ public partial struct Animator
         TransitionProgress = 0f,
         TransitionDuration = 0f,
         NextStateTime = 0f,
+        PreviousStateTime = 0f,
+        PreviousNextStateTime = 0f,
         Enabled = true,
         Speed = 1f,
         TriggerStateHash = 0

--- a/src/KeenEyes.Animation/Components/RootMotion.cs
+++ b/src/KeenEyes.Animation/Components/RootMotion.cs
@@ -1,0 +1,144 @@
+using System.Numerics;
+
+namespace KeenEyes.Animation.Components;
+
+/// <summary>
+/// Defines how extracted root motion is delivered.
+/// </summary>
+public enum RootMotionMode
+{
+    /// <summary>
+    /// The extracted delta is applied directly to the skeleton root entity's Transform3D.
+    /// </summary>
+    ApplyToEntity,
+
+    /// <summary>
+    /// The extracted delta is written to <see cref="RootMotion.DeltaPosition"/> and
+    /// <see cref="RootMotion.DeltaRotation"/> without touching the entity's Transform3D,
+    /// so a character controller or physics system can consume it.
+    /// </summary>
+    ExposeDelta
+}
+
+/// <summary>
+/// Component that enables root motion extraction for a skeleton root entity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Root motion extracts the per-frame movement of a designated root bone from the
+/// playing animation clip(s) and delivers it as an entity-space delta, so animations
+/// like walking or turning drive the character through the world instead of playing
+/// in place. The root bone's animated local translation (and rotation, when
+/// <see cref="ApplyRotation"/> is set) is suppressed so the motion is not applied twice.
+/// </para>
+/// <para>
+/// Attach this component to the same entity that carries the
+/// <see cref="AnimationPlayer"/> or <see cref="Animator"/>. Requires
+/// <see cref="AnimationConfig.EnableRootMotion"/> to be set when installing the
+/// <see cref="AnimationPlugin"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var character = world.Spawn()
+///     .With(Transform3D.Identity)
+///     .With(AnimationPlayer.ForClip(walkClipId))
+///     .With(RootMotion.ForBone("Root"))
+///     .Build();
+/// </code>
+/// </example>
+[Component]
+public partial struct RootMotion
+{
+    /// <summary>
+    /// Whether root motion extraction is active for this entity.
+    /// </summary>
+    public bool Enabled;
+
+    /// <summary>
+    /// The name of the bone to extract root motion from (typically "Root" or "Hips").
+    /// </summary>
+    public string RootBoneName;
+
+    /// <summary>
+    /// How the extracted delta is delivered.
+    /// </summary>
+    public RootMotionMode Mode;
+
+    /// <summary>
+    /// Whether to extract and deliver position deltas.
+    /// </summary>
+    public bool ApplyPosition;
+
+    /// <summary>
+    /// Whether to extract and deliver rotation deltas.
+    /// </summary>
+    public bool ApplyRotation;
+
+    /// <summary>
+    /// Whether to restrict the delivered position delta to the XZ plane.
+    /// </summary>
+    /// <remarks>
+    /// When set, the entity-space Y component of the delta is suppressed and the root
+    /// bone keeps its animated Y translation, so vertical motion (crouching, bobbing)
+    /// stays in the skeleton while horizontal motion drives the entity.
+    /// </remarks>
+    public bool PlanarOnly;
+
+    /// <summary>
+    /// Multiplier for the extracted position delta (e.g. 1.5 for faster movement).
+    /// </summary>
+    public float PositionScale;
+
+    /// <summary>
+    /// Multiplier for the extracted rotation delta (e.g. 0.5 for slower turning).
+    /// </summary>
+    public float RotationScale;
+
+    /// <summary>
+    /// The position delta extracted this frame, in the skeleton root entity's parent space.
+    /// </summary>
+    /// <remarks>
+    /// Written by the root motion system every frame in both modes. In
+    /// <see cref="RootMotionMode.ExposeDelta"/> mode this is the value a character
+    /// controller should consume.
+    /// </remarks>
+    [BuilderIgnore]
+    public Vector3 DeltaPosition;
+
+    /// <summary>
+    /// The rotation delta extracted this frame.
+    /// </summary>
+    /// <remarks>
+    /// Written by the root motion system every frame in both modes.
+    /// </remarks>
+    [BuilderIgnore]
+    public Quaternion DeltaRotation;
+
+    /// <summary>
+    /// Creates a default root motion configuration.
+    /// </summary>
+    public static RootMotion Default => new()
+    {
+        Enabled = true,
+        RootBoneName = "Root",
+        Mode = RootMotionMode.ApplyToEntity,
+        ApplyPosition = true,
+        ApplyRotation = true,
+        PlanarOnly = false,
+        PositionScale = 1f,
+        RotationScale = 1f,
+        DeltaPosition = Vector3.Zero,
+        DeltaRotation = Quaternion.Identity
+    };
+
+    /// <summary>
+    /// Creates a root motion configuration for the specified root bone.
+    /// </summary>
+    /// <param name="rootBoneName">The name of the root bone.</param>
+    /// <returns>A configured root motion component.</returns>
+    public static RootMotion ForBone(string rootBoneName) => Default with
+    {
+        RootBoneName = rootBoneName
+    };
+}

--- a/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
@@ -63,6 +63,11 @@ public sealed class AnimatorSystem : SystemBase
                 continue;
             }
 
+            // Record the previous sample times before advancing so downstream systems
+            // (e.g. root motion) can compute per-frame deltas.
+            animator.PreviousStateTime = animator.StateTime;
+            animator.PreviousNextStateTime = animator.NextStateTime;
+
             // Process triggered state change
             if (animator.TriggerStateHash != 0)
             {
@@ -86,12 +91,14 @@ public sealed class AnimatorSystem : SystemBase
                         animator.TransitionDuration = transition.Value.Duration;
                         animator.TransitionProgress = 0f;
                         animator.NextStateTime = 0f;
+                        animator.PreviousNextStateTime = 0f;
                     }
                     else
                     {
                         // Immediate transition (no defined crossfade)
                         animator.CurrentStateHash = animator.TriggerStateHash;
                         animator.StateTime = 0f;
+                        animator.PreviousStateTime = 0f;
                         animator.NextStateHash = 0;
                     }
                 }
@@ -111,12 +118,15 @@ public sealed class AnimatorSystem : SystemBase
 
                 if (animator.TransitionProgress >= 1f)
                 {
-                    // Complete transition
+                    // Complete transition; the next state's times carry over as the
+                    // current state's times so per-frame deltas remain continuous.
                     animator.CurrentStateHash = animator.NextStateHash;
                     animator.StateTime = animator.NextStateTime;
+                    animator.PreviousStateTime = animator.PreviousNextStateTime;
                     animator.NextStateHash = 0;
                     animator.TransitionProgress = 0f;
                     animator.NextStateTime = 0f;
+                    animator.PreviousNextStateTime = 0f;
                 }
             }
 
@@ -155,6 +165,7 @@ public sealed class AnimatorSystem : SystemBase
                 animator.TransitionDuration = transition.Duration;
                 animator.TransitionProgress = 0f;
                 animator.NextStateTime = 0f;
+                animator.PreviousNextStateTime = 0f;
                 break;
             }
         }

--- a/src/KeenEyes.Animation/Systems/RootMotionSystem.cs
+++ b/src/KeenEyes.Animation/Systems/RootMotionSystem.cs
@@ -1,0 +1,285 @@
+using System.Numerics;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.Data;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Systems;
+
+/// <summary>
+/// System that extracts root motion from playing animations and delivers it to the
+/// skeleton root entity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For each entity with <see cref="RootMotion"/>, the system samples the root bone's
+/// track at the previous and current playback times and computes the frame delta
+/// (position: difference of samples; rotation: current times inverse of previous).
+/// When looping playback wrapped between frames, the delta is computed as the segment
+/// from the previous time to the clip end plus the segment from the clip start to the
+/// current time, so looping produces continuous motion with no teleport back.
+/// </para>
+/// <para>
+/// Under an <see cref="Animator"/> crossfade, the two clips' deltas are blended with
+/// the same weight (<see cref="Animator.TransitionProgress"/>) that
+/// <see cref="SkeletonPoseSystem"/> uses for the pose blend, so root velocity matches
+/// the blended pose and feet do not slide during transitions.
+/// </para>
+/// <para>
+/// The root bone's animated local translation (and rotation, when
+/// <see cref="RootMotion.ApplyRotation"/> is set) is suppressed after extraction; with
+/// <see cref="RootMotion.PlanarOnly"/> the bone keeps its animated Y translation. The
+/// system runs at order 56, directly after <see cref="SkeletonPoseSystem"/> (order 55)
+/// wrote the frame's pose and before IK (order 57) and skinning consume bone transforms.
+/// </para>
+/// <para>
+/// Wrap compensation applies to forward <see cref="WrapMode.Loop"/> playback. Reverse
+/// playback and <see cref="WrapMode.PingPong"/> use the direct sample difference, and
+/// <see cref="Animator"/> state times are unwrapped so they never require compensation.
+/// </para>
+/// </remarks>
+public sealed class RootMotionSystem : SystemBase
+{
+    private AnimationManager? manager;
+
+    // Per-frame cache of skeleton roots whose root bone must be suppressed:
+    // skeleton root entity id -> suppression settings.
+    private readonly Dictionary<int, (string RootBoneName, bool SuppressPosition, bool KeepY, bool SuppressRotation)> suppressionCache = [];
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        World.TryGetExtension(out manager);
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        manager ??= World.TryGetExtension<AnimationManager>(out var m) ? m : null;
+        if (manager == null)
+        {
+            return;
+        }
+
+        suppressionCache.Clear();
+
+        foreach (var entity in World.Query<RootMotion, Transform3D>())
+        {
+            ref var rootMotion = ref World.Get<RootMotion>(entity);
+
+            if (!rootMotion.Enabled || string.IsNullOrEmpty(rootMotion.RootBoneName))
+            {
+                continue;
+            }
+
+            if (!TryExtractDelta(entity, in rootMotion, out var deltaPosition, out var deltaRotation))
+            {
+                continue;
+            }
+
+            ref var transform = ref World.Get<Transform3D>(entity);
+
+            // Transform the local-space position delta into the entity's parent space
+            // using the entity's current orientation, then scale and filter it.
+            var entityDelta = Vector3.Zero;
+            if (rootMotion.ApplyPosition)
+            {
+                entityDelta = Vector3.Transform(deltaPosition * rootMotion.PositionScale, transform.Rotation);
+                if (rootMotion.PlanarOnly)
+                {
+                    entityDelta.Y = 0f;
+                }
+            }
+
+            var entityDeltaRotation = Quaternion.Identity;
+            if (rootMotion.ApplyRotation)
+            {
+                entityDeltaRotation = rootMotion.RotationScale.ApproximatelyEquals(1f)
+                    ? deltaRotation
+                    : Quaternion.Slerp(Quaternion.Identity, deltaRotation, rootMotion.RotationScale);
+            }
+
+            // Expose the extracted delta in both modes.
+            rootMotion.DeltaPosition = entityDelta;
+            rootMotion.DeltaRotation = entityDeltaRotation;
+
+            if (rootMotion.Mode == RootMotionMode.ApplyToEntity)
+            {
+                transform.Position += entityDelta;
+                if (rootMotion.ApplyRotation)
+                {
+                    transform.Rotation = Quaternion.Normalize(entityDeltaRotation * transform.Rotation);
+                }
+            }
+
+            // The motion has been transferred to the entity (or exposed for a
+            // controller), so the root bone's animated transform must be suppressed
+            // to avoid applying it twice.
+            suppressionCache[entity.Id] = (
+                rootMotion.RootBoneName,
+                rootMotion.ApplyPosition,
+                rootMotion.PlanarOnly,
+                rootMotion.ApplyRotation);
+        }
+
+        if (suppressionCache.Count == 0)
+        {
+            return;
+        }
+
+        // Suppress the root bones' animated local transforms written by SkeletonPoseSystem.
+        foreach (var entity in World.Query<BoneReference, Transform3D>())
+        {
+            ref readonly var boneRef = ref World.Get<BoneReference>(entity);
+
+            if (!suppressionCache.TryGetValue(boneRef.SkeletonRootId, out var info) ||
+                !string.Equals(boneRef.BoneName, info.RootBoneName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            ref var transform = ref World.Get<Transform3D>(entity);
+
+            if (info.SuppressPosition)
+            {
+                transform.Position = info.KeepY
+                    ? new Vector3(0f, transform.Position.Y, 0f)
+                    : Vector3.Zero;
+            }
+
+            if (info.SuppressRotation)
+            {
+                transform.Rotation = Quaternion.Identity;
+            }
+        }
+    }
+
+    private bool TryExtractDelta(Entity entity, in RootMotion rootMotion, out Vector3 deltaPosition, out Quaternion deltaRotation)
+    {
+        deltaPosition = Vector3.Zero;
+        deltaRotation = Quaternion.Identity;
+
+        // Single-clip playback path.
+        if (World.Has<AnimationPlayer>(entity))
+        {
+            ref readonly var player = ref World.Get<AnimationPlayer>(entity);
+
+            if (player.ClipId < 0 ||
+                !manager!.TryGetClip(player.ClipId, out var clip) || clip == null ||
+                !clip.TryGetBoneTrack(rootMotion.RootBoneName, out var track) || track == null)
+            {
+                return false;
+            }
+
+            var wrapMode = player.WrapModeOverride ?? clip.WrapMode;
+            var playingForward = player.Speed * clip.Speed >= 0f;
+            var wrapped = wrapMode == WrapMode.Loop && playingForward && player.Time < player.PreviousTime;
+
+            ComputeTrackDelta(track, clip.Duration, player.PreviousTime, player.Time, wrapped,
+                out deltaPosition, out deltaRotation);
+            return true;
+        }
+
+        // Animator (state machine) path with crossfade blending.
+        if (World.Has<Animator>(entity))
+        {
+            ref readonly var animator = ref World.Get<Animator>(entity);
+
+            if (!animator.Enabled || animator.ControllerId < 0 ||
+                !manager!.TryGetController(animator.ControllerId, out var controller) || controller == null)
+            {
+                return false;
+            }
+
+            AnimationClip? currentClip = null;
+            if (controller.TryGetState(animator.CurrentStateHash, out var currentState) && currentState != null)
+            {
+                manager.TryGetClip(currentState.ClipId, out currentClip);
+            }
+
+            AnimationClip? nextClip = null;
+            if (animator.NextStateHash != 0 &&
+                controller.TryGetState(animator.NextStateHash, out var nextState) && nextState != null)
+            {
+                manager.TryGetClip(nextState.ClipId, out nextClip);
+            }
+
+            var hasCurrentDelta = false;
+            var currentDelta = Vector3.Zero;
+            var currentDeltaRotation = Quaternion.Identity;
+
+            if (currentClip != null &&
+                currentClip.TryGetBoneTrack(rootMotion.RootBoneName, out var currentTrack) && currentTrack != null)
+            {
+                // Animator state times are unwrapped, so no loop compensation is needed.
+                ComputeTrackDelta(currentTrack, currentClip.Duration,
+                    animator.PreviousStateTime, animator.StateTime, wrapped: false,
+                    out currentDelta, out currentDeltaRotation);
+                hasCurrentDelta = true;
+            }
+
+            // Mirror the SkeletonPoseSystem crossfade: blend the two clips' deltas
+            // with the same weight the pose blend uses (TransitionProgress).
+            if (nextClip != null && animator.TransitionProgress > 0f &&
+                nextClip.TryGetBoneTrack(rootMotion.RootBoneName, out var nextTrack) && nextTrack != null)
+            {
+                ComputeTrackDelta(nextTrack, nextClip.Duration,
+                    animator.PreviousNextStateTime, animator.NextStateTime, wrapped: false,
+                    out var nextDelta, out var nextDeltaRotation);
+
+                if (hasCurrentDelta)
+                {
+                    var t = animator.TransitionProgress;
+                    deltaPosition = Vector3.Lerp(currentDelta, nextDelta, t);
+                    deltaRotation = Quaternion.Slerp(currentDeltaRotation, nextDeltaRotation, t);
+                }
+                else
+                {
+                    deltaPosition = nextDelta;
+                    deltaRotation = nextDeltaRotation;
+                }
+
+                return true;
+            }
+
+            if (hasCurrentDelta)
+            {
+                deltaPosition = currentDelta;
+                deltaRotation = currentDeltaRotation;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void ComputeTrackDelta(
+        BoneTrack track,
+        float duration,
+        float previousTime,
+        float currentTime,
+        bool wrapped,
+        out Vector3 deltaPosition,
+        out Quaternion deltaRotation)
+    {
+        track.Sample(previousTime, out var previousPosition, out var previousRotation, out _);
+        track.Sample(currentTime, out var currentPosition, out var currentRotation, out _);
+
+        if (wrapped)
+        {
+            // Playback wrapped between frames: accumulate [previousTime -> end]
+            // plus [start -> currentTime] so the loop seam produces no teleport.
+            track.Sample(duration, out var endPosition, out var endRotation, out _);
+            track.Sample(0f, out var startPosition, out var startRotation, out _);
+
+            deltaPosition = (endPosition - previousPosition) + (currentPosition - startPosition);
+            deltaRotation = Quaternion.Normalize(
+                (currentRotation * Quaternion.Inverse(startRotation)) *
+                (endRotation * Quaternion.Inverse(previousRotation)));
+        }
+        else
+        {
+            deltaPosition = currentPosition - previousPosition;
+            deltaRotation = Quaternion.Normalize(currentRotation * Quaternion.Inverse(previousRotation));
+        }
+    }
+}

--- a/tests/KeenEyes.Animation.Tests/RootMotionTests.cs
+++ b/tests/KeenEyes.Animation.Tests/RootMotionTests.cs
@@ -1,0 +1,502 @@
+using System.Numerics;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.Data;
+using KeenEyes.Animation.Systems;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests;
+
+/// <summary>
+/// Tests for the RootMotion component and RootMotionSystem.
+/// </summary>
+public class RootMotionTests : IDisposable
+{
+    private World? world;
+
+    public void Dispose()
+    {
+        world?.Dispose();
+    }
+
+    #region Helpers
+
+    private World CreateWorldWithRootMotion()
+    {
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableRootMotion = true }));
+        return world;
+    }
+
+    private static AnimationClip CreateLinearPositionClip(
+        string name, float duration, Vector3 endPosition, WrapMode wrapMode, string boneName = "Root")
+    {
+        var positionCurve = new Vector3Curve();
+        positionCurve.AddKeyframe(0f, Vector3.Zero);
+        positionCurve.AddKeyframe(duration, endPosition);
+
+        var clip = new AnimationClip { Name = name, Duration = duration, WrapMode = wrapMode };
+        clip.AddBoneTrack(new BoneTrack { BoneName = boneName, PositionCurve = positionCurve });
+        return clip;
+    }
+
+    private static AnimationClip CreateLinearYawClip(
+        string name, float duration, float endYawRadians, WrapMode wrapMode, string boneName = "Root")
+    {
+        var rotationCurve = new QuaternionCurve();
+        rotationCurve.AddKeyframe(0f, Quaternion.Identity);
+        rotationCurve.AddKeyframe(duration, Quaternion.CreateFromAxisAngle(Vector3.UnitY, endYawRadians));
+
+        var clip = new AnimationClip { Name = name, Duration = duration, WrapMode = wrapMode };
+        clip.AddBoneTrack(new BoneTrack { BoneName = boneName, RotationCurve = rotationCurve });
+        return clip;
+    }
+
+    #endregion
+
+    #region AnimationPlayer Extraction Tests
+
+    [Fact]
+    public void Update_ForwardWalkClipFullPlaythrough_MovesEntityByClipDisplacement()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 2f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root"))
+            .Build();
+
+        var bone = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 10; i++)
+        {
+            playerSystem.Update(0.1f);
+            poseSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        // Sum of per-frame deltas equals the clip's total root displacement
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.X.ShouldBe(0f, 0.001f);
+        transform.Position.Y.ShouldBe(0f, 0.001f);
+        transform.Position.Z.ShouldBe(2f, 0.001f);
+
+        // Root bone's animated translation is fully suppressed
+        ref readonly var boneTransform = ref world.Get<Transform3D>(bone);
+        boneTransform.Position.Length().IsApproximatelyZero().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Update_LoopWrapBetweenFrames_ProducesContinuousMotion()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 1f), WrapMode.Loop));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root"))
+            .Build();
+
+        world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(rootMotionSystem);
+
+        // dt = 0.4: the third frame wraps (1.2 -> 0.2) and must not teleport back
+        var previousZ = 0f;
+        for (var i = 0; i < 3; i++)
+        {
+            playerSystem.Update(0.4f);
+            rootMotionSystem.Update(0.4f);
+
+            ref readonly var transform = ref world.Get<Transform3D>(root);
+            var frameDelta = transform.Position.Z - previousZ;
+            frameDelta.ShouldBe(0.4f, 0.001f);
+            previousZ = transform.Position.Z;
+        }
+
+        previousZ.ShouldBe(1.2f, 0.001f);
+    }
+
+    [Fact]
+    public void Update_PlanarMode_LeavesEntityYUnchangedWhileBoneYAnimates()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("WalkRamp", 1f, new Vector3(0f, 3f, 2f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root") with { PlanarOnly = true })
+            .Build();
+
+        var bone = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 5; i++)
+        {
+            playerSystem.Update(0.1f);
+            poseSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        // Entity: horizontal motion applied, vertical motion suppressed
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.Y.IsApproximatelyZero().ShouldBeTrue();
+        transform.Position.Z.ShouldBe(1f, 0.001f);
+
+        // Bone: keeps its animated Y translation, X/Z zeroed
+        ref readonly var boneTransform = ref world.Get<Transform3D>(bone);
+        boneTransform.Position.X.IsApproximatelyZero().ShouldBeTrue();
+        boneTransform.Position.Y.ShouldBe(1.5f, 0.001f);
+        boneTransform.Position.Z.IsApproximatelyZero().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Update_ExposeMode_PopulatesDeltaFieldsWithoutMovingEntity()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 2f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root") with { Mode = RootMotionMode.ExposeDelta })
+            .Build();
+
+        world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 3; i++)
+        {
+            playerSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+
+            // Delta fields populated each frame; entity untouched
+            ref readonly var rootMotion = ref world.Get<RootMotion>(root);
+            rootMotion.DeltaPosition.Z.ShouldBe(0.2f, 0.001f);
+
+            ref readonly var transform = ref world.Get<Transform3D>(root);
+            transform.Position.Length().IsApproximatelyZero().ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void Update_ApplyModeWithRotation_RotatesEntityByClipYaw()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearYawClip("Turn", 1f, MathF.PI / 2f, WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root"))
+            .Build();
+
+        var bone = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 10; i++)
+        {
+            playerSystem.Update(0.1f);
+            poseSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        // Accumulated rotation deltas equal the clip's total 90-degree yaw
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        var expected = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2f);
+        MathF.Abs(Quaternion.Dot(transform.Rotation, expected)).ShouldBeGreaterThan(0.9999f);
+
+        // Root bone's animated rotation is suppressed to identity
+        ref readonly var boneTransform = ref world.Get<Transform3D>(bone);
+        MathF.Abs(Quaternion.Dot(boneTransform.Rotation, Quaternion.Identity)).ShouldBeGreaterThan(0.9999f);
+    }
+
+    [Fact]
+    public void Update_EntityRotated_TransformsDeltaIntoEntitySpace()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 1f), WrapMode.Once));
+
+        // Entity faces +90 degrees yaw: local +Z motion becomes world +X motion
+        var initialRotation = Quaternion.CreateFromAxisAngle(Vector3.UnitY, MathF.PI / 2f);
+        var root = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, initialRotation, Vector3.One))
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root") with { ApplyRotation = false })
+            .Build();
+
+        world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 10; i++)
+        {
+            playerSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.X.ShouldBe(1f, 0.001f);
+        transform.Position.Y.ShouldBe(0f, 0.001f);
+        transform.Position.Z.ShouldBe(0f, 0.001f);
+    }
+
+    [Fact]
+    public void Update_PositionScale_ScalesDisplacement()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 1f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root") with { PositionScale = 2f })
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(rootMotionSystem);
+
+        playerSystem.Update(0.1f);
+        rootMotionSystem.Update(0.1f);
+
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.Z.ShouldBe(0.2f, 0.001f);
+    }
+
+    #endregion
+
+    #region Animator Crossfade Tests
+
+    [Fact]
+    public void Update_AnimatorCrossfade_BlendsDeltasByTransitionWeight()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+
+        // Walk: 1 unit/s along Z. Run: 3 units/s along Z.
+        var walkClipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 2f, new Vector3(0f, 0f, 2f), WrapMode.Loop));
+        var runClipId = manager.RegisterClip(
+            CreateLinearPositionClip("Run", 2f, new Vector3(0f, 0f, 6f), WrapMode.Loop));
+
+        var controller = new AnimatorController { Name = "Locomotion" };
+        var walkState = new AnimatorState { Name = "Walk", ClipId = walkClipId };
+        walkState.AddTransition("Run", duration: 1f);
+        var runState = new AnimatorState { Name = "Run", ClipId = runClipId };
+        controller.AddState(walkState, isDefault: true);
+        controller.AddState(runState);
+        var controllerId = manager.RegisterController(controller);
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(Animator.ForController(controllerId))
+            .With(RootMotion.ForBone("Root"))
+            .Build();
+
+        world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var animatorSystem = new AnimatorSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(animatorSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        // Frame 1: pure walk (1 unit/s * 0.1s)
+        animatorSystem.Update(0.1f);
+        poseSystem.Update(0.1f);
+        rootMotionSystem.Update(0.1f);
+
+        ref readonly var afterWalk = ref world.Get<Transform3D>(root);
+        afterWalk.Position.Z.ShouldBe(0.1f, 0.001f);
+
+        // Frame 2: crossfading to run with TransitionProgress = 0.1
+        ref var animator = ref world.Get<Animator>(root);
+        animator.TriggerStateHash = Animator.GetStateHash("Run");
+
+        animatorSystem.Update(0.1f);
+        poseSystem.Update(0.1f);
+        rootMotionSystem.Update(0.1f);
+
+        // Blended delta = lerp(walkDelta, runDelta, 0.1) = lerp(0.1, 0.3, 0.1) = 0.12,
+        // the same weight the pose crossfade uses
+        ref readonly var afterBlend = ref world.Get<Transform3D>(root);
+        afterBlend.Position.Z.ShouldBe(0.22f, 0.001f);
+    }
+
+    #endregion
+
+    #region Disabled / Opt-Out Tests
+
+    [Fact]
+    public void Update_DisabledComponent_DoesNotMoveEntityOrSuppressBone()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 2f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .With(RootMotion.ForBone("Root") with { Enabled = false })
+            .Build();
+
+        var bone = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 5; i++)
+        {
+            playerSystem.Update(0.1f);
+            poseSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        // Entity untouched, bone keeps its animated translation
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.Length().IsApproximatelyZero().ShouldBeTrue();
+
+        ref readonly var boneTransform = ref world.Get<Transform3D>(bone);
+        boneTransform.Position.Z.ShouldBe(1f, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithoutRootMotionComponent_LeavesEntityAndBoneUntouched()
+    {
+        world = CreateWorldWithRootMotion();
+        var manager = world.GetExtension<AnimationManager>();
+        var clipId = manager.RegisterClip(
+            CreateLinearPositionClip("Walk", 1f, new Vector3(0f, 0f, 2f), WrapMode.Once));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(AnimationPlayer.ForClip(clipId))
+            .Build();
+
+        var bone = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("Root", root.Id))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        var rootMotionSystem = new RootMotionSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(poseSystem);
+        world.AddSystem(rootMotionSystem);
+
+        for (var i = 0; i < 5; i++)
+        {
+            playerSystem.Update(0.1f);
+            poseSystem.Update(0.1f);
+            rootMotionSystem.Update(0.1f);
+        }
+
+        ref readonly var transform = ref world.Get<Transform3D>(root);
+        transform.Position.Length().IsApproximatelyZero().ShouldBeTrue();
+
+        ref readonly var boneTransform = ref world.Get<Transform3D>(bone);
+        boneTransform.Position.Z.ShouldBe(1f, 0.001f);
+    }
+
+    [Fact]
+    public void Update_WithNoManager_DoesNotCrash()
+    {
+        world = new World();
+        // Don't install animation plugin
+
+        var system = new RootMotionSystem();
+        world.AddSystem(system);
+
+        // Should not throw
+        system.Update(1f / 60f);
+    }
+
+    [Fact]
+    public void AnimationConfig_Default_RootMotionDisabled()
+    {
+        var config = AnimationConfig.Default;
+
+        config.EnableRootMotion.ShouldBeFalse();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`RootMotion` component + `RootMotionSystem` (order 56** — between the FK pose write at 55 and IK at 57): extracts the designated root bone's motion from clip tracks and either applies it to the skeleton-root entity's `Transform3D` (`ApplyToEntity`) or exposes per-frame `DeltaPosition`/`DeltaRotation` for character controllers/physics (`ExposeDelta`). Planar (XZ-only) option; position/rotation scales per the issue's sketch. Opt-in via `AnimationConfig.EnableRootMotion` (default off — existing 336 tests pass unmodified).
- **Design improvement over the issue's sketch:** deltas come from **clip-track sampling** (`Sample(Time) − Sample(PreviousTime)`), not from diffing stored bone transforms — making loop-wrap handling exact (seam = end-segment + start-segment, composed rotations) and eliminating the sketch's snap-back problem entirely.
- **Crossfade-correct:** `Animator` gained previous-time bookkeeping so root deltas blend with **exactly the same weights as the pose crossfade** (verified: 1 u/s vs 3 u/s clips at 10% transition → 0.12/frame delta). No foot-sliding during transitions.
- Root-bone suppression (zeroed, or Y-preserved in planar mode) runs in both modes so deltas are never double-applied; entity-space transform rotates the local delta by the entity's current rotation (tested with a 90°-yawed entity).
- `docs/animation.md` updated.

## Test plan
- [x] 12 new tests: full-playthrough displacement, loop-wrap continuity (constant per-frame delta across the seam), planar Y isolation, expose-mode purity, rotation application, crossfade weight blending, disabled-flag zero-change — 348/348 passing
- [x] Release build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #522

Documented limitations (in XML docs): reverse playback and PingPong use direct deltas (no seam compensation); `Animator` state times are unwrapped upstream and never need it.