### PR TITLE
feat(navigation): Implement true tiled navmesh build in the DotRecast provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
   <ItemGroup Label="Navigation">
     <PackageVersion Include="DotRecast.Core" Version="2026.1.3" />
     <PackageVersion Include="DotRecast.Detour" Version="2026.1.3" />
+    <PackageVersion Include="DotRecast.Detour.Crowd" Version="2026.1.3" />
     <PackageVersion Include="DotRecast.Recast" Version="2026.1.3" />
   </ItemGroup>
   <ItemGroup Label="Audio">

--- a/editor/KeenEyes.Cli/packages.lock.json
+++ b/editor/KeenEyes.Cli/packages.lock.json
@@ -318,6 +318,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -440,6 +441,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -318,6 +318,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -440,6 +441,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/src/KeenEyes.Navigation.Abstractions/Components/CrowdAgent.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Components/CrowdAgent.cs
@@ -1,0 +1,77 @@
+namespace KeenEyes.Navigation.Abstractions.Components;
+
+/// <summary>
+/// Opt-in component that routes a <see cref="NavMeshAgent"/> through crowd
+/// simulation with local avoidance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attach this component alongside <see cref="NavMeshAgent"/> to have the agent
+/// steered by the crowd simulation when the active navigation provider supports
+/// it (see <see cref="ICrowdNavigationProvider"/>). Crowd-managed agents avoid
+/// each other using velocity obstacles and optional separation forces.
+/// </para>
+/// <para>
+/// When the provider does not support crowd simulation, entities with this
+/// component fall back to plain waypoint steering.
+/// </para>
+/// <para>
+/// Override fields set to zero fall back to the values on
+/// <see cref="NavMeshAgent"/> (or provider defaults where noted).
+/// </para>
+/// </remarks>
+public struct CrowdAgent : IComponent
+{
+    /// <summary>
+    /// The avoidance radius override in world units.
+    /// Zero uses <see cref="NavMeshAgent.Settings"/>' radius.
+    /// </summary>
+    public float Radius;
+
+    /// <summary>
+    /// The agent height override in world units.
+    /// Zero uses <see cref="NavMeshAgent.Settings"/>' height.
+    /// </summary>
+    public float Height;
+
+    /// <summary>
+    /// The maximum acceleration override in units per second squared.
+    /// Zero uses <see cref="NavMeshAgent.Acceleration"/>.
+    /// </summary>
+    public float MaxAcceleration;
+
+    /// <summary>
+    /// The maximum speed override in units per second.
+    /// Zero uses <see cref="NavMeshAgent.Speed"/>.
+    /// </summary>
+    public float MaxSpeed;
+
+    /// <summary>
+    /// The obstacle avoidance quality preset, from 0 (fastest) to 3 (highest quality).
+    /// </summary>
+    public int AvoidanceQuality;
+
+    /// <summary>
+    /// The weight of the separation force pushing agents apart.
+    /// Zero disables separation; typical values are 1-3.
+    /// </summary>
+    public float SeparationWeight;
+
+    /// <summary>
+    /// The range in world units within which neighbouring agents and walls are
+    /// considered for avoidance. Zero uses a provider default derived from the
+    /// effective radius.
+    /// </summary>
+    public float CollisionQueryRange;
+
+    /// <summary>
+    /// Creates a crowd agent with recommended default avoidance settings.
+    /// </summary>
+    /// <returns>A new CrowdAgent component.</returns>
+    public static CrowdAgent Create()
+        => new()
+        {
+            AvoidanceQuality = 2,
+            SeparationWeight = 2f
+        };
+}

--- a/src/KeenEyes.Navigation.Abstractions/ICrowdNavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Abstractions/ICrowdNavigationProvider.cs
@@ -1,0 +1,92 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Optional capability interface for navigation providers that support crowd
+/// simulation with local avoidance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Providers that implement this interface can steer groups of agents while
+/// avoiding inter-agent collisions. Entities are registered with
+/// <see cref="TryAddCrowdAgent"/>, given targets via
+/// <see cref="RequestCrowdMoveTarget"/>, and advanced once per frame with
+/// <see cref="UpdateCrowd"/>. The simulated position and velocity of each agent
+/// are read back via <see cref="TryGetCrowdAgentState"/>.
+/// </para>
+/// <para>
+/// Providers without crowd support simply do not implement this interface;
+/// callers should fall back to individual agent steering in that case.
+/// </para>
+/// </remarks>
+public interface ICrowdNavigationProvider : INavigationProvider
+{
+    /// <summary>
+    /// Gets the number of agents currently registered in the crowd.
+    /// </summary>
+    int CrowdAgentCount { get; }
+
+    /// <summary>
+    /// Registers an entity as a crowd-simulated agent.
+    /// </summary>
+    /// <param name="entity">The entity to register.</param>
+    /// <param name="position">The agent's current world position.</param>
+    /// <param name="agent">The agent's navigation parameters.</param>
+    /// <param name="crowdAgent">The agent's crowd avoidance parameters.</param>
+    /// <returns>
+    /// True if the agent was added (or already registered); false if the
+    /// position is not on the navigation mesh or the provider is not ready.
+    /// </returns>
+    bool TryAddCrowdAgent(Entity entity, Vector3 position, in NavMeshAgent agent, in CrowdAgent crowdAgent);
+
+    /// <summary>
+    /// Removes an entity from the crowd simulation.
+    /// </summary>
+    /// <param name="entity">The entity to remove. Unknown entities are ignored.</param>
+    void RemoveCrowdAgent(Entity entity);
+
+    /// <summary>
+    /// Requests that a crowd agent move toward the given target position.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <param name="target">The destination in world space.</param>
+    /// <returns>
+    /// True if the request was accepted; false if the entity is not registered
+    /// or the target could not be mapped to the navigation mesh.
+    /// </returns>
+    bool RequestCrowdMoveTarget(Entity entity, Vector3 target);
+
+    /// <summary>
+    /// Cancels a crowd agent's current move target, letting it come to rest.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <returns>True if the agent had its target reset; false if not registered.</returns>
+    bool ResetCrowdMoveTarget(Entity entity);
+
+    /// <summary>
+    /// Advances the crowd simulation by one step.
+    /// </summary>
+    /// <param name="deltaTime">Time elapsed since the last update, in seconds.</param>
+    void UpdateCrowd(float deltaTime);
+
+    /// <summary>
+    /// Gets the simulated state of a crowd agent.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <param name="state">The agent's simulated position and velocities.</param>
+    /// <returns>True if the entity is registered in the crowd.</returns>
+    bool TryGetCrowdAgentState(Entity entity, out CrowdAgentState state);
+}
+
+/// <summary>
+/// The simulated state of a crowd agent as computed by the crowd simulation.
+/// </summary>
+/// <param name="Position">The agent's simulated position on the navigation mesh.</param>
+/// <param name="Velocity">The agent's actual velocity after avoidance and collision resolution.</param>
+/// <param name="DesiredVelocity">The agent's desired velocity before avoidance was applied.</param>
+public readonly record struct CrowdAgentState(
+    Vector3 Position,
+    Vector3 Velocity,
+    Vector3 DesiredVelocity);

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastCrowdManager.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastCrowdManager.cs
@@ -1,0 +1,310 @@
+using System.Numerics;
+using DotRecast.Core.Numerics;
+using DotRecast.Detour.Crowd;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// Manages crowd simulation for entities using DotRecast's <c>DtCrowd</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This manager maps entities to crowd agents, forwards move targets, advances
+/// the simulation each tick, and exposes the simulated position and velocity of
+/// each agent. It is owned by <see cref="DotRecastProvider"/> and accessed
+/// through the <see cref="ICrowdNavigationProvider"/> seam.
+/// </para>
+/// <para>
+/// When the navigation mesh is replaced (for example after a rebuild), the
+/// crowd is recreated on the new mesh and all registered agents are re-added at
+/// their current positions with their previous move targets restored.
+/// </para>
+/// <para>
+/// This class is not thread-safe; it is intended to be driven from the world
+/// update on a single thread.
+/// </para>
+/// </remarks>
+public sealed class DotRecastCrowdManager : IDisposable
+{
+    /// <summary>
+    /// Default collision query range multiplier applied to the agent radius
+    /// when <see cref="CrowdAgent.CollisionQueryRange"/> is zero.
+    /// </summary>
+    private const float CollisionQueryRangeFactor = 12f;
+
+    /// <summary>
+    /// Path optimization range multiplier applied to the agent radius,
+    /// matching the Recast demo's recommended value.
+    /// </summary>
+    private const float PathOptimizationRangeFactor = 30f;
+
+    private sealed class AgentEntry
+    {
+        public required DtCrowdAgent Agent { get; set; }
+        public required DtCrowdAgentParams Parameters { get; init; }
+        public Vector3? Target { get; set; }
+    }
+
+    private readonly Dictionary<Entity, AgentEntry> agents = [];
+    private readonly float maxAgentRadius;
+    private DtCrowd crowd;
+    private bool disposed;
+
+    /// <summary>
+    /// Creates a crowd manager for the given navigation mesh.
+    /// </summary>
+    /// <param name="navMeshData">The navigation mesh to simulate on.</param>
+    /// <param name="maxAgentRadius">
+    /// The maximum radius of any agent that will be added to the crowd. Used to
+    /// size the proximity grid and agent placement queries.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when navMeshData is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when maxAgentRadius is not positive.</exception>
+    public DotRecastCrowdManager(NavMeshData navMeshData, float maxAgentRadius)
+    {
+        ArgumentNullException.ThrowIfNull(navMeshData);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxAgentRadius);
+
+        this.maxAgentRadius = maxAgentRadius;
+        crowd = new DtCrowd(new DtCrowdConfig(maxAgentRadius), navMeshData.InternalNavMesh);
+    }
+
+    /// <summary>
+    /// Gets the number of agents currently registered in the crowd.
+    /// </summary>
+    public int AgentCount => agents.Count;
+
+    /// <summary>
+    /// Replaces the navigation mesh, re-adding all registered agents.
+    /// </summary>
+    /// <param name="navMeshData">The new navigation mesh.</param>
+    /// <exception cref="ArgumentNullException">Thrown when navMeshData is null.</exception>
+    /// <remarks>
+    /// Agents keep their current simulated positions and move targets. Agents
+    /// whose position no longer lies on the new mesh remain registered but stay
+    /// inactive until the mesh covers them again.
+    /// </remarks>
+    public void SetNavMesh(NavMeshData navMeshData)
+    {
+        ArgumentNullException.ThrowIfNull(navMeshData);
+        ThrowIfDisposed();
+
+        // Recreate the crowd rather than swapping the mesh in place: existing
+        // agent corridors hold polygon references into the old mesh.
+        crowd = new DtCrowd(new DtCrowdConfig(maxAgentRadius), navMeshData.InternalNavMesh);
+
+        foreach (var entry in agents.Values)
+        {
+            var position = entry.Agent.npos;
+            entry.Agent = crowd.AddAgent(position, entry.Parameters);
+
+            if (entry.Target is { } target)
+            {
+                RequestMoveTargetCore(entry, target);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers an entity as a crowd agent at the given position.
+    /// </summary>
+    /// <param name="entity">The entity to register.</param>
+    /// <param name="position">The agent's current world position.</param>
+    /// <param name="agent">The agent's navigation parameters.</param>
+    /// <param name="crowdAgent">The agent's crowd avoidance parameters.</param>
+    /// <returns>
+    /// True if the agent was added (or was already registered); false if the
+    /// position could not be placed on the navigation mesh.
+    /// </returns>
+    public bool TryAddAgent(Entity entity, Vector3 position, in NavMeshAgent agent, in CrowdAgent crowdAgent)
+    {
+        ThrowIfDisposed();
+
+        if (agents.ContainsKey(entity))
+        {
+            return true;
+        }
+
+        var parameters = BuildAgentParams(in agent, in crowdAgent);
+        var dtAgent = crowd.AddAgent(ToRcVec3f(position), parameters);
+
+        if (dtAgent.state == DtCrowdAgentState.DT_CROWDAGENT_STATE_INVALID)
+        {
+            crowd.RemoveAgent(dtAgent);
+            return false;
+        }
+
+        agents[entity] = new AgentEntry { Agent = dtAgent, Parameters = parameters };
+        return true;
+    }
+
+    /// <summary>
+    /// Removes an entity from the crowd simulation.
+    /// </summary>
+    /// <param name="entity">The entity to remove. Unknown entities are ignored.</param>
+    public void RemoveAgent(Entity entity)
+    {
+        if (agents.Remove(entity, out var entry))
+        {
+            crowd.RemoveAgent(entry.Agent);
+        }
+    }
+
+    /// <summary>
+    /// Requests that a crowd agent move toward the given target position.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <param name="target">The destination in world space.</param>
+    /// <returns>
+    /// True if the request was accepted; false if the entity is not registered
+    /// or the target could not be mapped to the navigation mesh.
+    /// </returns>
+    public bool RequestMoveTarget(Entity entity, Vector3 target)
+    {
+        ThrowIfDisposed();
+
+        if (!agents.TryGetValue(entity, out var entry))
+        {
+            return false;
+        }
+
+        return RequestMoveTargetCore(entry, target);
+    }
+
+    /// <summary>
+    /// Cancels a crowd agent's current move target, letting it come to rest.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <returns>True if the agent had its target reset; false if not registered.</returns>
+    public bool ResetMoveTarget(Entity entity)
+    {
+        ThrowIfDisposed();
+
+        if (!agents.TryGetValue(entity, out var entry))
+        {
+            return false;
+        }
+
+        entry.Target = null;
+        return crowd.ResetMoveTarget(entry.Agent);
+    }
+
+    /// <summary>
+    /// Advances the crowd simulation by one step.
+    /// </summary>
+    /// <param name="deltaTime">Time elapsed since the last update, in seconds.</param>
+    public void Update(float deltaTime)
+    {
+        ThrowIfDisposed();
+        crowd.Update(deltaTime, null);
+    }
+
+    /// <summary>
+    /// Gets the simulated state of a registered crowd agent.
+    /// </summary>
+    /// <param name="entity">The registered crowd agent entity.</param>
+    /// <param name="state">The agent's simulated position and velocities.</param>
+    /// <returns>True if the entity is registered in the crowd.</returns>
+    public bool TryGetAgentState(Entity entity, out CrowdAgentState state)
+    {
+        if (!agents.TryGetValue(entity, out var entry))
+        {
+            state = default;
+            return false;
+        }
+
+        state = new CrowdAgentState(
+            ToVector3(entry.Agent.npos),
+            ToVector3(entry.Agent.vel),
+            ToVector3(entry.Agent.dvel));
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        foreach (var entry in agents.Values)
+        {
+            crowd.RemoveAgent(entry.Agent);
+        }
+
+        agents.Clear();
+        disposed = true;
+    }
+
+    private bool RequestMoveTargetCore(AgentEntry entry, Vector3 target)
+    {
+        var query = crowd.GetNavMeshQuery();
+        var status = query.FindNearestPoly(
+            ToRcVec3f(target),
+            crowd.GetQueryExtents(),
+            crowd.GetFilter(entry.Parameters.queryFilterType),
+            out var polyRef,
+            out var nearest,
+            out _);
+
+        if (status.Failed() || polyRef == 0)
+        {
+            return false;
+        }
+
+        if (!crowd.RequestMoveTarget(entry.Agent, polyRef, nearest))
+        {
+            return false;
+        }
+
+        entry.Target = target;
+        return true;
+    }
+
+    private static DtCrowdAgentParams BuildAgentParams(in NavMeshAgent agent, in CrowdAgent crowdAgent)
+    {
+        float radius = crowdAgent.Radius > 0f ? crowdAgent.Radius : agent.Settings.Radius;
+        float height = crowdAgent.Height > 0f ? crowdAgent.Height : agent.Settings.Height;
+        float maxAcceleration = crowdAgent.MaxAcceleration > 0f ? crowdAgent.MaxAcceleration : agent.Acceleration;
+        float maxSpeed = crowdAgent.MaxSpeed > 0f ? crowdAgent.MaxSpeed : agent.Speed;
+        float collisionQueryRange = crowdAgent.CollisionQueryRange > 0f
+            ? crowdAgent.CollisionQueryRange
+            : radius * CollisionQueryRangeFactor;
+
+        int updateFlags = DtCrowdAgentUpdateFlags.DT_CROWD_ANTICIPATE_TURNS
+            | DtCrowdAgentUpdateFlags.DT_CROWD_OBSTACLE_AVOIDANCE
+            | DtCrowdAgentUpdateFlags.DT_CROWD_OPTIMIZE_VIS
+            | DtCrowdAgentUpdateFlags.DT_CROWD_OPTIMIZE_TOPO;
+
+        if (crowdAgent.SeparationWeight > 0f)
+        {
+            updateFlags |= DtCrowdAgentUpdateFlags.DT_CROWD_SEPARATION;
+        }
+
+        return new DtCrowdAgentParams
+        {
+            radius = radius,
+            height = height,
+            maxAcceleration = maxAcceleration,
+            maxSpeed = maxSpeed,
+            collisionQueryRange = collisionQueryRange,
+            pathOptimizationRange = radius * PathOptimizationRangeFactor,
+            separationWeight = crowdAgent.SeparationWeight,
+            updateFlags = updateFlags,
+            obstacleAvoidanceType = Math.Clamp(crowdAgent.AvoidanceQuality, 0, 3),
+            queryFilterType = 0
+        };
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+
+    private static Vector3 ToVector3(RcVec3f v) => new(v.X, v.Y, v.Z);
+
+    private static RcVec3f ToRcVec3f(Vector3 v) => new(v.X, v.Y, v.Z);
+}

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
@@ -23,8 +23,12 @@ namespace KeenEyes.Navigation.DotRecast;
 /// <item>Generating polygon mesh and detail mesh</item>
 /// </list>
 /// <para>
-/// For large worlds, use tiled building with the <see cref="NavMeshConfig.UseTiles"/>
-/// option to enable runtime updates and streaming.
+/// For large worlds, enable tiled building with <see cref="NavMeshConfig.UseTiles"/>.
+/// A tiled build partitions the geometry bounds into a grid of square tiles
+/// (<see cref="NavMeshConfig.TileSize"/> cells on a side), builds each tile
+/// independently with a bordered configuration, and installs them into a
+/// multi-tile <see cref="DtNavMesh"/> via <see cref="DtNavMesh.AddTile"/>. This is
+/// the prerequisite for runtime tile streaming and bounded partial rebuilds.
 /// </para>
 /// </remarks>
 public sealed class DotRecastMeshBuilder
@@ -71,10 +75,16 @@ public sealed class DotRecastMeshBuilder
     /// <param name="vertices">The mesh vertices (XYZ triplets).</param>
     /// <param name="indices">The triangle indices.</param>
     /// <param name="areaIds">Optional per-triangle area IDs. If null, all triangles are walkable.</param>
+    /// <param name="overrideTileSize">
+    /// Optional per-surface tile size (in cells) that overrides
+    /// <see cref="NavMeshConfig.TileSize"/> when greater than zero. Mirrors
+    /// <c>NavMeshSurface.OverrideTileSize</c>. Ignored when tiling is disabled.
+    /// </param>
     /// <returns>The built navigation mesh data.</returns>
     /// <exception cref="ArgumentException">Thrown when geometry is invalid.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when overrideTileSize is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mesh building fails.</exception>
-    public NavMeshData Build(ReadOnlySpan<float> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null)
+    public NavMeshData Build(ReadOnlySpan<float> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null, int overrideTileSize = 0)
     {
         if (vertices.Length == 0 || vertices.Length % 3 != 0)
         {
@@ -85,6 +95,8 @@ public sealed class DotRecastMeshBuilder
         {
             throw new ArgumentException("Indices must be triangle triplets", nameof(indices));
         }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(overrideTileSize);
 
         // Convert to arrays for DotRecast
         var vertsArray = vertices.ToArray();
@@ -100,7 +112,7 @@ public sealed class DotRecastMeshBuilder
         // Build the navmesh
         // areaIds reserved for future area marking support
         _ = areaIds;
-        return BuildFromGeometry(geom, bmin, bmax);
+        return BuildFromGeometry(geom, bmin, bmax, overrideTileSize);
     }
 
     /// <summary>
@@ -109,8 +121,12 @@ public sealed class DotRecastMeshBuilder
     /// <param name="vertices">The mesh vertices.</param>
     /// <param name="indices">The triangle indices.</param>
     /// <param name="areaIds">Optional per-triangle area IDs.</param>
+    /// <param name="overrideTileSize">
+    /// Optional per-surface tile size (in cells) that overrides
+    /// <see cref="NavMeshConfig.TileSize"/> when greater than zero.
+    /// </param>
     /// <returns>The built navigation mesh data.</returns>
-    public NavMeshData Build(ReadOnlySpan<Vector3> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null)
+    public NavMeshData Build(ReadOnlySpan<Vector3> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null, int overrideTileSize = 0)
     {
         // Convert Vector3 to float triplets
         var floatVerts = new float[vertices.Length * 3];
@@ -121,7 +137,7 @@ public sealed class DotRecastMeshBuilder
             floatVerts[i * 3 + 2] = vertices[i].Z;
         }
 
-        return Build(floatVerts, indices, areaIds);
+        return Build(floatVerts, indices, areaIds, overrideTileSize);
     }
 
     /// <summary>
@@ -164,8 +180,8 @@ public sealed class DotRecastMeshBuilder
             0, 3, 2,
 
             // Top face (facing up, CCW when viewed from above) - this is the walkable surface
-            4, 5, 6,
-            4, 6, 7,
+            4, 6, 5,
+            4, 7, 6,
 
             // Front face (facing -Z)
             0, 1, 5,
@@ -187,10 +203,17 @@ public sealed class DotRecastMeshBuilder
         return Build(vertices, indices, null);
     }
 
-    private NavMeshData BuildFromGeometry(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax)
+    private NavMeshData BuildFromGeometry(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize)
     {
-        // Create Recast config
-        var rcConfig = CreateRcConfig();
+        return config.UseTiles
+            ? BuildTiled(geom, bmin, bmax, overrideTileSize)
+            : BuildSingleTile(geom, bmin, bmax);
+    }
+
+    private NavMeshData BuildSingleTile(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax)
+    {
+        // Create Recast config (tile size is irrelevant when tiling is disabled)
+        var rcConfig = CreateRcConfig(config.TileSize);
 
         // Create builder config
         var bcfg = new RcBuilderConfig(rcConfig, bmin, bmax);
@@ -203,6 +226,8 @@ public sealed class DotRecastMeshBuilder
             throw new InvalidOperationException("Failed to build navigation mesh");
         }
 
+        MarkWalkablePolys(result.Mesh);
+
         // Create Detour navmesh data from result
         var dtParams = CreateNavMeshParams(result.Mesh, result.MeshDetail, bmin, bmax);
         var meshData = DtNavMeshBuilder.CreateNavMeshData(dtParams);
@@ -212,20 +237,114 @@ public sealed class DotRecastMeshBuilder
             throw new InvalidOperationException("Failed to create navmesh data");
         }
 
-        // Create the navmesh
+        // Create the navmesh with the single-tile Init overload.
         var navMesh = new DtNavMesh();
         navMesh.Init(meshData, config.MaxVertsPerPoly, 0);
 
         return new NavMeshData(navMesh, config.ToAgentSettings());
     }
 
-    private RcConfig CreateRcConfig()
+    private NavMeshData BuildTiled(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize)
     {
-        // RcConfig constructor takes agent parameters in world units
+        // Effective tile size honours a per-surface override (NavMeshSurface.OverrideTileSize)
+        // when positive, otherwise falls back to the global config value.
+        int tileSize = overrideTileSize > 0 ? overrideTileSize : config.TileSize;
+        var rcConfig = CreateRcConfig(tileSize);
+
+        // Partition the bounds into a grid of tiles: tw x th tiles of tileSize cells each.
+        RcRecast.CalcTileCount(bmin, bmax, config.CellSize, rcConfig.TileSizeX, rcConfig.TileSizeZ, out int tw, out int th);
+
+        // Size the navmesh so tile + poly indices fit in the reference bit budget.
+        // DotRecast packs the polygon reference as salt|tile|poly; the tile and poly
+        // indices together use 22 bits. Allocate as many bits to the tile index as the
+        // grid needs (capped at 14 to leave room for salt), and give the rest to polys.
+        int tileColumns = Math.Max(1, tw * th);
+        int tileBits = Math.Min(BitOperations.Log2(BitOperations.RoundUpToPowerOf2((uint)tileColumns)), 14);
+        int polyBits = 22 - tileBits;
+        int maxTiles = 1 << tileBits;
+        int maxPolysPerTile = 1 << polyBits;
+
+        // Tile footprint in world units.
+        float tileWorldSize = rcConfig.TileSizeX * config.CellSize;
+
+        var navMeshParams = new DtNavMeshParams
+        {
+            orig = bmin,
+            tileWidth = tileWorldSize,
+            tileHeight = tileWorldSize,
+            maxTiles = maxTiles,
+            maxPolys = maxPolysPerTile
+        };
+
+        var navMesh = new DtNavMesh();
+        navMesh.Init(navMeshParams, config.MaxVertsPerPoly);
+
+        // BuildTiles walks the whole tw x th grid and returns one result per tile.
+        var results = builder.BuildTiles(geom, rcConfig, false, true);
+
+        int tilesAdded = 0;
+        foreach (var result in results)
+        {
+            // Skip empty tiles (no walkable geometry landed in this cell).
+            if (result?.Mesh == null || result.Mesh.npolys == 0)
+            {
+                continue;
+            }
+
+            MarkWalkablePolys(result.Mesh);
+
+            var dtParams = CreateNavMeshParams(
+                result.Mesh,
+                result.MeshDetail,
+                result.Mesh.bmin,
+                result.Mesh.bmax,
+                result.TileX,
+                result.TileZ);
+
+            var meshData = DtNavMeshBuilder.CreateNavMeshData(dtParams);
+            if (meshData == null)
+            {
+                continue;
+            }
+
+            navMesh.AddTile(meshData, 0, 0, out _);
+            tilesAdded++;
+        }
+
+        if (tilesAdded == 0)
+        {
+            throw new InvalidOperationException("Failed to build navigation mesh");
+        }
+
+        return new NavMeshData(navMesh, config.ToAgentSettings());
+    }
+
+    /// <summary>
+    /// Assigns a walkable polygon flag to every non-null-area polygon so the default
+    /// Detour query filter (which requires at least one include flag bit set) can
+    /// traverse them.
+    /// </summary>
+    private static void MarkWalkablePolys(RcPolyMesh mesh)
+    {
+        for (int i = 0; i < mesh.npolys; i++)
+        {
+            if (mesh.areas[i] != RcRecast.RC_NULL_AREA)
+            {
+                mesh.flags[i] = 1;
+            }
+        }
+    }
+
+    private RcConfig CreateRcConfig(int tileSize)
+    {
+        // RcConfig constructor takes agent parameters in world units.
+        // The walkable area modification must resolve to a non-null area
+        // (RC_WALKABLE_AREA); mapping it to RC_NULL_AREA (0) would make Recast treat
+        // every span as unwalkable and produce an empty mesh.
         return new RcConfig(
             useTiles: config.UseTiles,
-            tileSizeX: config.TileSize,
-            tileSizeZ: config.TileSize,
+            tileSizeX: tileSize,
+            tileSizeZ: tileSize,
             borderSize: config.MaxVertsPerPoly + 3,
             partition: RcPartition.WATERSHED,
             cellSize: config.CellSize,
@@ -244,7 +363,7 @@ public sealed class DotRecastMeshBuilder
             filterLowHangingObstacles: config.FilterLowHangingObstacles,
             filterLedgeSpans: config.FilterLedgeSpans,
             filterWalkableLowHeightSpans: config.FilterWalkableLowHeightSpans,
-            walkableAreaMod: new RcAreaModification(0, 0x3f),
+            walkableAreaMod: new RcAreaModification(RcRecast.RC_WALKABLE_AREA),
             buildMeshDetail: true);
     }
 

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using DotRecast.Core.Numerics;
 using DotRecast.Detour;
 using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
 
 namespace KeenEyes.Navigation.DotRecast;
 
@@ -19,9 +20,10 @@ namespace KeenEyes.Navigation.DotRecast;
 /// <item>Raycast line-of-sight queries</item>
 /// <item>Area-based cost modifiers</item>
 /// <item>Thread-safe query pooling</item>
+/// <item>Crowd simulation with local avoidance via <see cref="ICrowdNavigationProvider"/></item>
 /// </list>
 /// </remarks>
-public sealed class DotRecastProvider : INavigationProvider
+public sealed class DotRecastProvider : ICrowdNavigationProvider
 {
     private readonly NavMeshConfig config;
     private readonly Queue<DotRecastPathRequest> pendingRequests;
@@ -30,6 +32,7 @@ public sealed class DotRecastProvider : INavigationProvider
 
     private NavMeshData? activeMesh;
     private NavMeshQueryPool? queryPool;
+    private DotRecastCrowdManager? crowdManager;
     private bool disposed;
 
     /// <summary>
@@ -120,6 +123,9 @@ public sealed class DotRecastProvider : INavigationProvider
 
         activeMesh = navMeshData;
         queryPool = new NavMeshQueryPool(navMeshData.InternalNavMesh);
+
+        // Rebuild the crowd on the new mesh, re-adding registered agents
+        crowdManager?.SetNavMesh(navMeshData);
     }
 
     #region Pathfinding
@@ -482,6 +488,66 @@ public sealed class DotRecastProvider : INavigationProvider
 
     #endregion
 
+    #region Crowd Simulation
+
+    /// <inheritdoc/>
+    public int CrowdAgentCount => crowdManager?.AgentCount ?? 0;
+
+    /// <inheritdoc/>
+    public bool TryAddCrowdAgent(Entity entity, Vector3 position, in NavMeshAgent agent, in CrowdAgent crowdAgent)
+    {
+        ThrowIfDisposed();
+
+        if (activeMesh == null)
+        {
+            return false;
+        }
+
+        crowdManager ??= new DotRecastCrowdManager(activeMesh, config.AgentRadius);
+        return crowdManager.TryAddAgent(entity, position, in agent, in crowdAgent);
+    }
+
+    /// <inheritdoc/>
+    public void RemoveCrowdAgent(Entity entity)
+    {
+        crowdManager?.RemoveAgent(entity);
+    }
+
+    /// <inheritdoc/>
+    public bool RequestCrowdMoveTarget(Entity entity, Vector3 target)
+    {
+        ThrowIfDisposed();
+        return crowdManager?.RequestMoveTarget(entity, target) ?? false;
+    }
+
+    /// <inheritdoc/>
+    public bool ResetCrowdMoveTarget(Entity entity)
+    {
+        ThrowIfDisposed();
+        return crowdManager?.ResetMoveTarget(entity) ?? false;
+    }
+
+    /// <inheritdoc/>
+    public void UpdateCrowd(float deltaTime)
+    {
+        ThrowIfDisposed();
+        crowdManager?.Update(deltaTime);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetCrowdAgentState(Entity entity, out CrowdAgentState state)
+    {
+        if (crowdManager == null)
+        {
+            state = default;
+            return false;
+        }
+
+        return crowdManager.TryGetAgentState(entity, out state);
+    }
+
+    #endregion
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -500,6 +566,7 @@ public sealed class DotRecastProvider : INavigationProvider
             }
         }
 
+        crowdManager?.Dispose();
         queryPool?.Dispose();
         disposed = true;
     }

--- a/src/KeenEyes.Navigation.DotRecast/KeenEyes.Navigation.DotRecast.csproj
+++ b/src/KeenEyes.Navigation.DotRecast/KeenEyes.Navigation.DotRecast.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotRecast.Detour" />
+    <PackageReference Include="DotRecast.Detour.Crowd" />
     <PackageReference Include="DotRecast.Recast" />
   </ItemGroup>
 

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using DotRecast.Core;
 using DotRecast.Core.Numerics;
 using DotRecast.Detour;
+using DotRecast.Detour.Io;
 using KeenEyes.Navigation.Abstractions;
 
 namespace KeenEyes.Navigation.DotRecast;
@@ -22,6 +23,10 @@ namespace KeenEyes.Navigation.DotRecast;
 /// </remarks>
 public sealed class NavMeshData : INavigationMesh
 {
+    // Serialized format version. Bumped to 2 when the tile payload switched to
+    // DotRecast's mesh-set format (full multi-tile topology, BV tree, detail meshes).
+    private const int FormatVersion = 2;
+
     private readonly DtNavMesh navMesh;
     private readonly AgentSettings builtForAgent;
     private readonly string id;
@@ -215,25 +220,12 @@ public sealed class NavMeshData : INavigationMesh
     /// <inheritdoc/>
     public byte[] Serialize()
     {
-        var tiles = new List<byte[]>();
-        int maxTiles = navMesh.GetMaxTiles();
-
-        for (int i = 0; i < maxTiles; i++)
-        {
-            var tile = navMesh.GetTile(i);
-            if (tile?.data != null)
-            {
-                tiles.Add(SerializeTile(tile));
-            }
-        }
-
-        // Write header + all tiles
         using var ms = new MemoryStream();
         using var writer = new BinaryWriter(ms);
 
         // Magic number and version
         writer.Write(0x4B454E4D); // "KENM" - KeenEyes NavMesh
-        writer.Write(1); // Version
+        writer.Write(FormatVersion);
 
         // Agent settings
         writer.Write(builtForAgent.Radius);
@@ -241,28 +233,29 @@ public sealed class NavMeshData : INavigationMesh
         writer.Write(builtForAgent.MaxSlopeAngle);
         writer.Write(builtForAgent.StepHeight);
 
-        // NavMesh params
-        navMesh.ComputeBounds(out var bmin, out var bmax);
-        writer.Write(bmin.X);
-        writer.Write(bmin.Y);
-        writer.Write(bmin.Z);
-        writer.Write(bmax.X);
-        writer.Write(bmax.Y);
-        writer.Write(bmax.Z);
+        // Max vertices per polygon (required to re-read the mesh set)
         writer.Write(navMesh.GetMaxVertsPerPoly());
 
-        // Tile count and data
-        writer.Write(tiles.Count);
-        foreach (var tileData in tiles)
-        {
-            writer.Write(tileData.Length);
-            writer.Write(tileData);
-        }
+        // Serialize the full navmesh (params + every tile, including BV tree and detail
+        // meshes) with DotRecast's own mesh-set writer. This preserves multi-tile
+        // topology so cross-tile links are rebuilt on load.
+        byte[] meshSet = SerializeNavMesh();
+        writer.Write(meshSet.Length);
+        writer.Write(meshSet);
 
         // ID
         writer.Write(id);
 
         return ms.ToArray();
+    }
+
+    private byte[] SerializeNavMesh()
+    {
+        using var meshStream = new MemoryStream();
+        using var meshWriter = new BinaryWriter(meshStream);
+        new DtMeshSetWriter().Write(meshWriter, navMesh, RcByteOrder.LITTLE_ENDIAN, false);
+        meshWriter.Flush();
+        return meshStream.ToArray();
     }
 
     /// <inheritdoc/>
@@ -311,7 +304,7 @@ public sealed class NavMeshData : INavigationMesh
         }
 
         int version = reader.ReadInt32();
-        if (version != 1)
+        if (version != FormatVersion)
         {
             throw new InvalidDataException($"Unsupported NavMesh version: {version}");
         }
@@ -323,36 +316,12 @@ public sealed class NavMeshData : INavigationMesh
         float stepHeight = reader.ReadSingle();
         var agentSettings = new AgentSettings(agentRadius, agentHeight, maxSlope, stepHeight);
 
-        // NavMesh params
-        var bmin = new RcVec3f(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        var bmax = new RcVec3f(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
         int maxVertsPerPoly = reader.ReadInt32();
 
-        // Create navmesh with params
-        var navMeshParams = new DtNavMeshParams
-        {
-            orig = bmin,
-            tileWidth = bmax.X - bmin.X,
-            tileHeight = bmax.Z - bmin.Z,
-            maxTiles = 1024, // Reasonable default
-            maxPolys = 65535
-        };
-
-        var navMesh = new DtNavMesh();
-        navMesh.Init(navMeshParams, maxVertsPerPoly);
-
-        // Read tiles
-        int tileCount = reader.ReadInt32();
-        for (int i = 0; i < tileCount; i++)
-        {
-            int tileLength = reader.ReadInt32();
-            byte[] tileData = reader.ReadBytes(tileLength);
-            var meshData = DeserializeTile(tileData);
-            if (meshData != null)
-            {
-                navMesh.AddTile(meshData, 0, 0, out _);
-            }
-        }
+        // Read the mesh-set body and rebuild the full multi-tile navmesh.
+        int meshSetLength = reader.ReadInt32();
+        byte[] meshSet = reader.ReadBytes(meshSetLength);
+        var navMesh = DeserializeNavMesh(meshSet, maxVertsPerPoly);
 
         // ID
         string id = reader.ReadString();
@@ -360,145 +329,11 @@ public sealed class NavMeshData : INavigationMesh
         return new NavMeshData(navMesh, agentSettings, id);
     }
 
-    private static byte[] SerializeTile(DtMeshTile tile)
+    private static DtNavMesh DeserializeNavMesh(byte[] meshSet, int maxVertsPerPoly)
     {
-        // Serialize tile data to bytes
-        // This is a simplified serialization - full implementation would use DtNavMeshDataWriter
-        using var ms = new MemoryStream();
-        using var writer = new BinaryWriter(ms);
-
-        var header = tile.data.header;
-
-        // Write header
-        writer.Write(header.magic);
-        writer.Write(header.version);
-        writer.Write(header.x);
-        writer.Write(header.y);
-        writer.Write(header.layer);
-        writer.Write(header.userId);
-        writer.Write(header.polyCount);
-        writer.Write(header.vertCount);
-        writer.Write(header.maxLinkCount);
-        writer.Write(header.detailMeshCount);
-        writer.Write(header.detailVertCount);
-        writer.Write(header.detailTriCount);
-        writer.Write(header.bvNodeCount);
-        writer.Write(header.offMeshConCount);
-        writer.Write(header.offMeshBase);
-        writer.Write(header.walkableHeight);
-        writer.Write(header.walkableRadius);
-        writer.Write(header.walkableClimb);
-        writer.Write(header.bmin.X);
-        writer.Write(header.bmin.Y);
-        writer.Write(header.bmin.Z);
-        writer.Write(header.bmax.X);
-        writer.Write(header.bmax.Y);
-        writer.Write(header.bmax.Z);
-        writer.Write(header.bvQuantFactor);
-
-        // Write vertices
-        foreach (float v in tile.data.verts)
-        {
-            writer.Write(v);
-        }
-
-        // Write polygons
-        foreach (var poly in tile.data.polys)
-        {
-            writer.Write(poly.firstLink);
-            for (int i = 0; i < poly.verts.Length; i++)
-            {
-                writer.Write(poly.verts[i]);
-            }
-            for (int i = 0; i < poly.neis.Length; i++)
-            {
-                writer.Write(poly.neis[i]);
-            }
-            writer.Write(poly.flags);
-            writer.Write(poly.vertCount);
-            writer.Write((byte)poly.areaAndtype);
-        }
-
-        return ms.ToArray();
-    }
-
-    private static DtMeshData? DeserializeTile(byte[] data)
-    {
-        // Simplified deserialization - full implementation would use DtNavMeshDataReader
-        using var ms = new MemoryStream(data);
-        using var reader = new BinaryReader(ms);
-
-        var meshData = new DtMeshData
-        {
-            header = new DtMeshHeader()
-        };
-
-        meshData.header.magic = reader.ReadInt32();
-        meshData.header.version = reader.ReadInt32();
-        meshData.header.x = reader.ReadInt32();
-        meshData.header.y = reader.ReadInt32();
-        meshData.header.layer = reader.ReadInt32();
-        meshData.header.userId = reader.ReadInt32();
-        meshData.header.polyCount = reader.ReadInt32();
-        meshData.header.vertCount = reader.ReadInt32();
-        meshData.header.maxLinkCount = reader.ReadInt32();
-        meshData.header.detailMeshCount = reader.ReadInt32();
-        meshData.header.detailVertCount = reader.ReadInt32();
-        meshData.header.detailTriCount = reader.ReadInt32();
-        meshData.header.bvNodeCount = reader.ReadInt32();
-        meshData.header.offMeshConCount = reader.ReadInt32();
-        meshData.header.offMeshBase = reader.ReadInt32();
-        meshData.header.walkableHeight = reader.ReadSingle();
-        meshData.header.walkableRadius = reader.ReadSingle();
-        meshData.header.walkableClimb = reader.ReadSingle();
-        meshData.header.bmin = new RcVec3f(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        meshData.header.bmax = new RcVec3f(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-        meshData.header.bvQuantFactor = reader.ReadSingle();
-
-        // Read vertices
-        meshData.verts = new float[meshData.header.vertCount * 3];
-        for (int i = 0; i < meshData.verts.Length; i++)
-        {
-            meshData.verts[i] = reader.ReadSingle();
-        }
-
-        // Read polygons
-        meshData.polys = new DtPoly[meshData.header.polyCount];
-        for (int i = 0; i < meshData.header.polyCount; i++)
-        {
-            int firstLink = reader.ReadInt32();
-
-            // Read vert indices
-            ushort[] verts = new ushort[6];
-            for (int j = 0; j < 6; j++)
-            {
-                verts[j] = reader.ReadUInt16();
-            }
-
-            // Read neighbor indices
-            ushort[] neis = new ushort[6];
-            for (int j = 0; j < 6; j++)
-            {
-                neis[j] = reader.ReadUInt16();
-            }
-
-            int flags = reader.ReadInt32();
-            byte vertCount = reader.ReadByte();
-            byte areaAndtype = reader.ReadByte();
-
-            var poly = new DtPoly(i, 6)
-            {
-                firstLink = firstLink,
-                flags = flags,
-                vertCount = vertCount,
-                areaAndtype = areaAndtype
-            };
-            Array.Copy(verts, poly.verts, 6);
-            Array.Copy(neis, poly.neis, 6);
-            meshData.polys[i] = poly;
-        }
-
-        return meshData;
+        using var meshStream = new MemoryStream(meshSet);
+        using var meshReader = new BinaryReader(meshStream);
+        return new DtMeshSetReader().Read(meshReader, maxVertsPerPoly);
     }
 
     private static IDtQueryFilter CreateFilter(NavAreaMask areaMask)

--- a/src/KeenEyes.Navigation.DotRecast/packages.lock.json
+++ b/src/KeenEyes.Navigation.DotRecast/packages.lock.json
@@ -11,6 +11,15 @@
           "DotRecast.Core": "2026.1.3"
         }
       },
+      "DotRecast.Detour.Crowd": {
+        "type": "Direct",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
+        }
+      },
       "DotRecast.Recast": {
         "type": "Direct",
         "requested": "[2026.1.3, )",

--- a/src/KeenEyes.Navigation/NavigationPlugin.cs
+++ b/src/KeenEyes.Navigation/NavigationPlugin.cs
@@ -14,6 +14,8 @@ namespace KeenEyes.Navigation;
 /// <list type="bullet">
 /// <item><description>Asynchronous pathfinding via <see cref="PathRequestSystem"/></description></item>
 /// <item><description>Agent movement along paths via <see cref="NavMeshAgentSystem"/></description></item>
+/// <item><description>Crowd simulation with local avoidance via <see cref="CrowdSteeringSystem"/>
+/// when the provider implements <see cref="ICrowdNavigationProvider"/></description></item>
 /// <item><description>Dynamic obstacle handling via <see cref="ObstacleUpdateSystem"/></description></item>
 /// </list>
 /// <para>
@@ -53,6 +55,7 @@ public sealed class NavigationPlugin : IWorldPlugin
     private INavigationProvider? provider;
     private EventSubscription? agentAddedSubscription;
     private EventSubscription? agentRemovedSubscription;
+    private EventSubscription? crowdAgentRemovedSubscription;
     private EventSubscription? obstacleAddedSubscription;
     private EventSubscription? obstacleRemovedSubscription;
     private EventSubscription? entityDestroyedSubscription;
@@ -89,6 +92,7 @@ public sealed class NavigationPlugin : IWorldPlugin
     {
         // Register components
         context.RegisterComponent<NavMeshAgent>();
+        context.RegisterComponent<CrowdAgent>();
         context.RegisterComponent<NavMeshObstacle>();
 
         // Get or create navigation provider
@@ -115,12 +119,14 @@ public sealed class NavigationPlugin : IWorldPlugin
         // Unsubscribe from events
         agentAddedSubscription?.Dispose();
         agentRemovedSubscription?.Dispose();
+        crowdAgentRemovedSubscription?.Dispose();
         obstacleAddedSubscription?.Dispose();
         obstacleRemovedSubscription?.Dispose();
         entityDestroyedSubscription?.Dispose();
 
         agentAddedSubscription = null;
         agentRemovedSubscription = null;
+        crowdAgentRemovedSubscription = null;
         obstacleAddedSubscription = null;
         obstacleRemovedSubscription = null;
         entityDestroyedSubscription = null;
@@ -181,6 +187,13 @@ public sealed class NavigationPlugin : IWorldPlugin
             context.AddSystem<NavMeshAgentSystem>(
                 SystemPhase.Update,
                 order: 0);
+
+            // CrowdSteeringSystem - steers crowd-simulated agents
+            // Runs after NavMeshAgentSystem; no-op when the provider
+            // lacks crowd support
+            context.AddSystem<CrowdSteeringSystem>(
+                SystemPhase.Update,
+                order: 10);
         }
 
         // ObstacleUpdateSystem - syncs dynamic obstacles
@@ -198,6 +211,9 @@ public sealed class NavigationPlugin : IWorldPlugin
         // Subscribe to NavMeshAgent component added/removed
         agentAddedSubscription = context.World.OnComponentAdded<NavMeshAgent>(OnAgentAdded);
         agentRemovedSubscription = context.World.OnComponentRemoved<NavMeshAgent>(OnAgentRemoved);
+
+        // Subscribe to CrowdAgent removal to unregister from the crowd simulation
+        crowdAgentRemovedSubscription = context.World.OnComponentRemoved<CrowdAgent>(OnCrowdAgentRemoved);
 
         // Subscribe to NavMeshObstacle component added/removed
         obstacleAddedSubscription = context.World.OnComponentAdded<NavMeshObstacle>(OnObstacleAdded);
@@ -219,6 +235,13 @@ public sealed class NavigationPlugin : IWorldPlugin
         navigationContext?.RemoveAgent(entity);
     }
 
+    private void OnCrowdAgentRemoved(Entity entity)
+    {
+        // Unregister from the crowd simulation; the entity falls back to
+        // plain waypoint steering if it still has a NavMeshAgent
+        (provider as ICrowdNavigationProvider)?.RemoveCrowdAgent(entity);
+    }
+
     private void OnObstacleAdded(Entity entity, NavMeshObstacle obstacle)
     {
         // Obstacle added - obstacle system will handle updates
@@ -234,5 +257,6 @@ public sealed class NavigationPlugin : IWorldPlugin
     {
         // Clean up any navigation state for destroyed entity
         navigationContext?.RemoveAgent(entity);
+        (provider as ICrowdNavigationProvider)?.RemoveCrowdAgent(entity);
     }
 }

--- a/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
@@ -1,0 +1,161 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.Systems;
+
+/// <summary>
+/// System that steers crowd-simulated agents using the provider's crowd simulation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This system processes entities with <see cref="NavMeshAgent"/>,
+/// <see cref="CrowdAgent"/>, and <see cref="Transform3D"/> components. Agents
+/// are registered with the crowd, their destinations forwarded as move targets,
+/// and after advancing the simulation once per frame their simulated positions
+/// and velocities are written back to the components.
+/// </para>
+/// <para>
+/// If the active navigation provider does not implement
+/// <see cref="ICrowdNavigationProvider"/>, this system is a no-op and crowd
+/// agents fall back to plain waypoint steering in <see cref="NavMeshAgentSystem"/>.
+/// </para>
+/// </remarks>
+internal sealed class CrowdSteeringSystem : SystemBase
+{
+    private readonly Dictionary<Entity, Vector3> requestedTargets = [];
+    private readonly List<Entity> staleTargets = [];
+    private ICrowdNavigationProvider? crowdProvider;
+
+    /// <inheritdoc/>
+    protected override void OnInitialize()
+    {
+        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        {
+            throw new InvalidOperationException("CrowdSteeringSystem requires NavigationContext extension.");
+        }
+
+        // Crowd support is optional; without it this system does nothing and
+        // crowd agents degrade to plain waypoint steering.
+        crowdProvider = ctx.Provider as ICrowdNavigationProvider;
+    }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        if (crowdProvider is not { IsReady: true })
+        {
+            return;
+        }
+
+        RegisterAgentsAndTargets();
+
+        if (crowdProvider.CrowdAgentCount == 0)
+        {
+            return;
+        }
+
+        crowdProvider.UpdateCrowd(deltaTime);
+
+        WriteBackSimulationResults();
+        PruneStaleTargets();
+    }
+
+    private void RegisterAgentsAndTargets()
+    {
+        foreach (var entity in World.Query<NavMeshAgent, CrowdAgent, Transform3D>())
+        {
+            ref var agent = ref World.Get<NavMeshAgent>(entity);
+            ref readonly var crowdAgent = ref World.Get<CrowdAgent>(entity);
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+
+            // Register with the crowd on first sight
+            if (!crowdProvider!.TryGetCrowdAgentState(entity, out _))
+            {
+                if (!crowdProvider.TryAddCrowdAgent(entity, transform.Position, in agent, in crowdAgent))
+                {
+                    continue;
+                }
+
+                agent.IsOnNavMesh = true;
+            }
+
+            if (agent.IsStopped)
+            {
+                // Cancel the crowd move target once when the agent stops
+                if (requestedTargets.Remove(entity))
+                {
+                    crowdProvider.ResetCrowdMoveTarget(entity);
+                }
+
+                continue;
+            }
+
+            // Forward the destination when it changes
+            bool destinationChanged = !requestedTargets.TryGetValue(entity, out var target) ||
+                Vector3.DistanceSquared(target, agent.Destination) > 1e-6f;
+
+            if (destinationChanged && crowdProvider.RequestCrowdMoveTarget(entity, agent.Destination))
+            {
+                requestedTargets[entity] = agent.Destination;
+            }
+        }
+    }
+
+    private void WriteBackSimulationResults()
+    {
+        foreach (var entity in World.Query<NavMeshAgent, CrowdAgent, Transform3D>())
+        {
+            ref var agent = ref World.Get<NavMeshAgent>(entity);
+
+            if (agent.IsStopped || !crowdProvider!.TryGetCrowdAgentState(entity, out var state))
+            {
+                continue;
+            }
+
+            ref var transform = ref World.Get<Transform3D>(entity);
+            transform.Position = state.Position;
+            agent.DesiredVelocity = state.Velocity;
+            agent.SteeringTarget = state.Position + state.DesiredVelocity;
+            agent.RemainingDistance = Vector3.Distance(state.Position, agent.Destination);
+
+            if (agent.RemainingDistance <= agent.StoppingDistance)
+            {
+                CompleteNavigation(entity, ref agent);
+            }
+        }
+    }
+
+    private void CompleteNavigation(Entity entity, ref NavMeshAgent agent)
+    {
+        agent.HasPath = false;
+        agent.PathPending = false;
+        agent.IsStopped = true;
+        agent.DesiredVelocity = Vector3.Zero;
+        agent.RemainingDistance = 0f;
+
+        requestedTargets.Remove(entity);
+        crowdProvider!.ResetCrowdMoveTarget(entity);
+    }
+
+    private void PruneStaleTargets()
+    {
+        // Entities removed from the crowd (destroyed or component removed)
+        // must not leak requested-target entries.
+        foreach (var entity in requestedTargets.Keys)
+        {
+            if (!crowdProvider!.TryGetCrowdAgentState(entity, out _))
+            {
+                staleTargets.Add(entity);
+            }
+        }
+
+        foreach (var entity in staleTargets)
+        {
+            requestedTargets.Remove(entity);
+        }
+
+        staleTargets.Clear();
+    }
+}

--- a/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
 using KeenEyes.Navigation.Abstractions.Components;
 
 namespace KeenEyes.Navigation.Systems;
@@ -27,6 +28,7 @@ internal sealed class NavMeshAgentSystem : SystemBase
 {
     private NavigationContext? context;
     private NavigationConfig? config;
+    private bool crowdSupported;
 
     /// <inheritdoc/>
     protected override void OnInitialize()
@@ -38,6 +40,10 @@ internal sealed class NavMeshAgentSystem : SystemBase
 
         context = ctx;
         config = ctx.Config;
+
+        // When the provider supports crowd simulation, entities with a
+        // CrowdAgent component are steered by CrowdSteeringSystem instead.
+        crowdSupported = ctx.Provider is ICrowdNavigationProvider;
     }
 
     /// <inheritdoc/>
@@ -51,6 +57,12 @@ internal sealed class NavMeshAgentSystem : SystemBase
         // Process all agents with paths
         foreach (var entity in World.Query<NavMeshAgent, Transform3D>())
         {
+            // Crowd-simulated agents are handled by CrowdSteeringSystem
+            if (crowdSupported && World.Has<CrowdAgent>(entity))
+            {
+                continue;
+            }
+
             ref var agent = ref World.Get<NavMeshAgent>(entity);
             ref var transform = ref World.Get<Transform3D>(entity);
 

--- a/tests/KeenEyes.Cli.Tests/packages.lock.json
+++ b/tests/KeenEyes.Cli.Tests/packages.lock.json
@@ -503,6 +503,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -625,6 +626,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
@@ -496,6 +496,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -618,6 +619,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Editor.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Tests/packages.lock.json
@@ -496,6 +496,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -618,6 +619,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/CrowdSteeringSystemTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/CrowdSteeringSystemTests.cs
@@ -1,0 +1,293 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// World-level integration tests for crowd steering: entities with
+/// <see cref="CrowdAgent"/> are simulated by the crowd when the provider
+/// supports it, plain agents keep waypoint steering, and worlds with a
+/// non-crowd provider degrade gracefully.
+/// </summary>
+public class CrowdSteeringSystemTests
+{
+    private const float SlabSize = 40f;
+    private const float TimeStep = 0.05f;
+
+    #region Helpers
+
+    private static DotRecastProvider CreateSlabProvider()
+    {
+        var builder = TestHelper.CreateTestBuilder();
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var mesh = builder.Build(vertices, indices);
+        return new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+    }
+
+    private static World CreateNavigationWorld(INavigationProvider provider)
+    {
+        var world = new World();
+        world.InstallPlugin(new NavigationPlugin(new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = provider
+        }));
+        return world;
+    }
+
+    private static Entity SpawnAgent(World world, Vector3 position, bool crowd)
+    {
+        var agent = NavMeshAgent.Create();
+        agent.StoppingDistance = 0.5f;
+
+        var spawn = world.Spawn()
+            .With(new Transform3D(position, Quaternion.Identity, Vector3.One))
+            .With(agent);
+
+        if (crowd)
+        {
+            var crowdAgent = CrowdAgent.Create();
+            crowdAgent.Radius = 0.6f;
+            spawn = spawn.With(crowdAgent);
+        }
+
+        return spawn.Build();
+    }
+
+    #endregion
+
+    #region Crowd Steering Tests
+
+    [Fact]
+    public void Update_CrowdAgent_ReachesDestinationViaCrowdSimulation()
+    {
+        using var provider = CreateSlabProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var entity = SpawnAgent(world, new Vector3(10f, 0f, 10f), crowd: true);
+        var destination = new Vector3(30f, 0f, 30f);
+        world.GetExtension<NavigationContext>().SetDestination(entity, destination);
+
+        for (int i = 0; i < 800; i++)
+        {
+            world.Update(TimeStep);
+            if (world.Get<NavMeshAgent>(entity).IsStopped)
+            {
+                break;
+            }
+        }
+
+        // The crowd simulation registered and moved the entity
+        provider.CrowdAgentCount.ShouldBe(1);
+
+        ref readonly var transform = ref world.Get<Transform3D>(entity);
+        Vector3.Distance(transform.Position, destination).ShouldBeLessThanOrEqualTo(0.75f);
+
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.IsStopped.ShouldBeTrue();
+        agent.DesiredVelocity.Length().ShouldBe(0f, 1e-3f);
+    }
+
+    [Fact]
+    public void Update_TwoOpposingCrowdAgents_DoNotInterpenetrate()
+    {
+        using var provider = CreateSlabProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var left = SpawnAgent(world, new Vector3(10f, 0f, 20f), crowd: true);
+        var right = SpawnAgent(world, new Vector3(30f, 0f, 20.05f), crowd: true);
+
+        var navigation = world.GetExtension<NavigationContext>();
+        navigation.SetDestination(left, new Vector3(30f, 0f, 20f));
+        navigation.SetDestination(right, new Vector3(10f, 0f, 20f));
+
+        float minSeparation = float.MaxValue;
+        for (int i = 0; i < 400; i++)
+        {
+            world.Update(TimeStep);
+
+            var leftPos = world.Get<Transform3D>(left).Position;
+            var rightPos = world.Get<Transform3D>(right).Position;
+            minSeparation = MathF.Min(minSeparation, Vector3.Distance(leftPos, rightPos));
+        }
+
+        minSeparation.ShouldBeGreaterThanOrEqualTo((0.6f + 0.6f) * 0.8f);
+    }
+
+    [Fact]
+    public void Update_CrowdAgentComponentRemoved_UnregistersFromCrowd()
+    {
+        using var provider = CreateSlabProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var entity = SpawnAgent(world, new Vector3(10f, 0f, 10f), crowd: true);
+        world.GetExtension<NavigationContext>().SetDestination(entity, new Vector3(30f, 0f, 30f));
+
+        world.Update(TimeStep);
+        provider.CrowdAgentCount.ShouldBe(1);
+
+        world.Remove<CrowdAgent>(entity);
+
+        provider.CrowdAgentCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Update_CrowdAgentEntityDespawned_UnregistersFromCrowd()
+    {
+        using var provider = CreateSlabProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var entity = SpawnAgent(world, new Vector3(10f, 0f, 10f), crowd: true);
+        world.GetExtension<NavigationContext>().SetDestination(entity, new Vector3(30f, 0f, 30f));
+
+        world.Update(TimeStep);
+        provider.CrowdAgentCount.ShouldBe(1);
+
+        world.Despawn(entity);
+
+        provider.CrowdAgentCount.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region Non-Crowd Steering Tests
+
+    [Fact]
+    public void Update_PlainAgentWithCrowdCapableProvider_UsesWaypointSteering()
+    {
+        using var provider = CreateSlabProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var entity = SpawnAgent(world, new Vector3(10f, 0f, 10f), crowd: false);
+        var destination = new Vector3(30f, 0f, 30f);
+        world.GetExtension<NavigationContext>().SetDestination(entity, destination);
+
+        float startDistance = Vector3.Distance(new Vector3(10f, 0f, 10f), destination);
+        for (int i = 0; i < 400; i++)
+        {
+            world.Update(TimeStep);
+        }
+
+        // The plain agent never touched the crowd simulation
+        provider.CrowdAgentCount.ShouldBe(0);
+
+        // But it still moved toward its destination via waypoint steering
+        ref readonly var transform = ref world.Get<Transform3D>(entity);
+        Vector3.Distance(transform.Position, destination).ShouldBeLessThan(startDistance * 0.5f);
+    }
+
+    [Fact]
+    public void Update_ProviderWithoutCrowdSupport_CrowdAgentFallsBackToPlainSteering()
+    {
+        using var provider = new StubPathProvider();
+        using var world = CreateNavigationWorld(provider);
+
+        var entity = SpawnAgent(world, new Vector3(0f, 0f, 0f), crowd: true);
+        var destination = new Vector3(10f, 0f, 10f);
+        world.GetExtension<NavigationContext>().SetDestination(entity, destination);
+
+        float startDistance = Vector3.Distance(Vector3.Zero, destination);
+
+        // Must not throw even though the provider has no crowd concept
+        for (int i = 0; i < 200; i++)
+        {
+            world.Update(TimeStep);
+        }
+
+        // The agent moved toward its destination via plain waypoint steering
+        ref readonly var transform = ref world.Get<Transform3D>(entity);
+        Vector3.Distance(transform.Position, destination).ShouldBeLessThan(startDistance * 0.5f);
+    }
+
+    #endregion
+
+    #region Stub Provider
+
+    /// <summary>
+    /// Minimal navigation provider without crowd support that returns direct
+    /// straight-line paths.
+    /// </summary>
+    private sealed class StubPathProvider : INavigationProvider
+    {
+        public NavigationStrategy Strategy => NavigationStrategy.Custom;
+
+        public bool IsReady => true;
+
+        public INavigationMesh? ActiveMesh => null;
+
+        public NavPath FindPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+            => new([new NavPoint(start), new NavPoint(end)], true, Vector3.Distance(start, end));
+
+        public IPathRequest RequestPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+            => new StubPathRequest(start, end, agent);
+
+        public void CancelAllRequests()
+        {
+        }
+
+        public bool Raycast(Vector3 start, Vector3 end, out Vector3 hitPosition)
+        {
+            hitPosition = end;
+            return false;
+        }
+
+        public bool Raycast(Vector3 start, Vector3 end, NavAreaMask areaMask, out Vector3 hitPosition, out NavAreaType hitAreaType)
+        {
+            hitPosition = end;
+            hitAreaType = NavAreaType.Walkable;
+            return false;
+        }
+
+        public NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f) => new NavPoint(position);
+
+        public bool IsNavigable(Vector3 position, AgentSettings agent) => true;
+
+        public Vector3? ProjectToNavMesh(Vector3 position, float maxDistance = 5f) => position;
+
+        public float GetAreaCost(NavAreaType areaType) => 1f;
+
+        public void SetAreaCost(NavAreaType areaType, float cost)
+        {
+        }
+
+        public void Update(float deltaTime)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Path request that completes immediately with a straight-line path.
+    /// </summary>
+    private sealed class StubPathRequest(Vector3 start, Vector3 end, AgentSettings agent) : IPathRequest
+    {
+        public int Id => 1;
+
+        public PathRequestStatus Status { get; private set; } = PathRequestStatus.Completed;
+
+        public Vector3 Start => start;
+
+        public Vector3 End => end;
+
+        public AgentSettings Agent => agent;
+
+        public NavPath Result { get; } = new([new NavPoint(start), new NavPoint(end)], true, Vector3.Distance(start, end));
+
+        public void Cancel() => Status = PathRequestStatus.Cancelled;
+
+        public bool Wait(TimeSpan timeout) => true;
+
+        public Task<NavPath> AsTask() => Task.FromResult(Result);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastCrowdTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastCrowdTests.cs
@@ -1,0 +1,269 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for crowd simulation via <see cref="DotRecastCrowdManager"/> exposed
+/// through the <see cref="ICrowdNavigationProvider"/> seam on <see cref="DotRecastProvider"/>.
+/// </summary>
+public class DotRecastCrowdTests : IDisposable
+{
+    private const float SlabSize = 40f;
+    private const float AgentRadius = 0.6f;
+    private const float TimeStep = 0.05f;
+
+    private readonly DotRecastProvider provider;
+
+    public DotRecastCrowdTests()
+    {
+        provider = CreateSlabProvider();
+    }
+
+    public void Dispose()
+    {
+        provider.Dispose();
+    }
+
+    #region Helpers
+
+    private static DotRecastProvider CreateSlabProvider()
+    {
+        var builder = TestHelper.CreateTestBuilder();
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var mesh = builder.Build(vertices, indices);
+        return new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+    }
+
+    private static NavMeshAgent CreateNavAgent() => NavMeshAgent.Create();
+
+    private static CrowdAgent CreateCrowdAgent()
+    {
+        var crowdAgent = CrowdAgent.Create();
+        crowdAgent.Radius = AgentRadius;
+        return crowdAgent;
+    }
+
+    private bool AddAgent(Entity entity, Vector3 position)
+    {
+        var agent = CreateNavAgent();
+        var crowdAgent = CreateCrowdAgent();
+        return provider.TryAddCrowdAgent(entity, position, in agent, in crowdAgent);
+    }
+
+    private Vector3 GetPosition(Entity entity)
+    {
+        provider.TryGetCrowdAgentState(entity, out var state).ShouldBeTrue();
+        return state.Position;
+    }
+
+    #endregion
+
+    #region Registration Tests
+
+    [Fact]
+    public void TryAddCrowdAgent_OnNavMesh_RegistersAgent()
+    {
+        var entity = new Entity(1, 0);
+
+        AddAgent(entity, new Vector3(10f, 0f, 10f)).ShouldBeTrue();
+
+        provider.CrowdAgentCount.ShouldBe(1);
+        provider.TryGetCrowdAgentState(entity, out var state).ShouldBeTrue();
+        Vector3.Distance(state.Position, new Vector3(10f, 0f, 10f)).ShouldBeLessThan(0.5f);
+    }
+
+    [Fact]
+    public void TryAddCrowdAgent_OffNavMesh_ReturnsFalse()
+    {
+        var entity = new Entity(1, 0);
+
+        AddAgent(entity, new Vector3(500f, 0f, 500f)).ShouldBeFalse();
+
+        provider.CrowdAgentCount.ShouldBe(0);
+        provider.TryGetCrowdAgentState(entity, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryAddCrowdAgent_AlreadyRegistered_ReturnsTrueWithoutDuplicate()
+    {
+        var entity = new Entity(1, 0);
+
+        AddAgent(entity, new Vector3(10f, 0f, 10f)).ShouldBeTrue();
+        AddAgent(entity, new Vector3(12f, 0f, 12f)).ShouldBeTrue();
+
+        provider.CrowdAgentCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemoveCrowdAgent_RegisteredAgent_RemovesFromCrowd()
+    {
+        var entity = new Entity(1, 0);
+        AddAgent(entity, new Vector3(10f, 0f, 10f));
+
+        provider.RemoveCrowdAgent(entity);
+
+        provider.CrowdAgentCount.ShouldBe(0);
+        provider.TryGetCrowdAgentState(entity, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RequestCrowdMoveTarget_UnknownEntity_ReturnsFalse()
+    {
+        provider.RequestCrowdMoveTarget(new Entity(99, 0), new Vector3(20f, 0f, 20f)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ResetCrowdMoveTarget_UnknownEntity_ReturnsFalse()
+    {
+        provider.ResetCrowdMoveTarget(new Entity(99, 0)).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Simulation Tests
+
+    [Fact]
+    public void UpdateCrowd_SingleAgent_ReachesTarget()
+    {
+        var entity = new Entity(1, 0);
+        var target = new Vector3(32f, 0f, 32f);
+        AddAgent(entity, new Vector3(8f, 0f, 8f)).ShouldBeTrue();
+        provider.RequestCrowdMoveTarget(entity, target).ShouldBeTrue();
+
+        float distance = float.MaxValue;
+        for (int i = 0; i < 800; i++)
+        {
+            provider.UpdateCrowd(TimeStep);
+            distance = Vector3.Distance(GetPosition(entity), target);
+            if (distance <= 0.5f)
+            {
+                break;
+            }
+        }
+
+        distance.ShouldBeLessThanOrEqualTo(0.5f);
+    }
+
+    [Fact]
+    public void UpdateCrowd_TwoOpposingAgents_DeviateWithoutInterpenetrating()
+    {
+        var left = new Entity(1, 0);
+        var right = new Entity(2, 0);
+        var leftStart = new Vector3(10f, 0f, 20f);
+        var rightStart = new Vector3(30f, 0f, 20.05f);
+
+        AddAgent(left, leftStart).ShouldBeTrue();
+        AddAgent(right, rightStart).ShouldBeTrue();
+        provider.RequestCrowdMoveTarget(left, new Vector3(30f, 0f, 20f)).ShouldBeTrue();
+        provider.RequestCrowdMoveTarget(right, new Vector3(10f, 0f, 20f)).ShouldBeTrue();
+
+        float minSeparation = float.MaxValue;
+        float maxDeviation = 0f;
+
+        for (int i = 0; i < 400; i++)
+        {
+            provider.UpdateCrowd(TimeStep);
+
+            var leftPos = GetPosition(left);
+            var rightPos = GetPosition(right);
+            minSeparation = MathF.Min(minSeparation, Vector3.Distance(leftPos, rightPos));
+            maxDeviation = MathF.Max(maxDeviation, MathF.Abs(leftPos.Z - 20f));
+            maxDeviation = MathF.Max(maxDeviation, MathF.Abs(rightPos.Z - 20f));
+        }
+
+        // Agents must never interpenetrate: separation stays at or above the
+        // sum of their radii, with tolerance for soft collision resolution.
+        minSeparation.ShouldBeGreaterThanOrEqualTo((AgentRadius + AgentRadius) * 0.8f);
+
+        // Avoidance must have steered them off the straight corridor line
+        maxDeviation.ShouldBeGreaterThan(0.1f);
+
+        // Both agents must still have crossed to their respective targets
+        Vector3.Distance(GetPosition(left), new Vector3(30f, 0f, 20f)).ShouldBeLessThan(2f);
+        Vector3.Distance(GetPosition(right), new Vector3(10f, 0f, 20f)).ShouldBeLessThan(2f);
+    }
+
+    [Fact]
+    public void UpdateCrowd_ManyAgentsToOneTarget_DoNotStack()
+    {
+        const int agentCount = 6;
+        var center = new Vector3(20f, 0f, 20f);
+        var entities = new Entity[agentCount];
+
+        for (int i = 0; i < agentCount; i++)
+        {
+            float angle = i * MathF.Tau / agentCount;
+            var start = center + new Vector3(MathF.Cos(angle) * 8f, 0f, MathF.Sin(angle) * 8f);
+
+            entities[i] = new Entity(i + 1, 0);
+            AddAgent(entities[i], start).ShouldBeTrue();
+            provider.RequestCrowdMoveTarget(entities[i], center).ShouldBeTrue();
+        }
+
+        for (int step = 0; step < 400; step++)
+        {
+            provider.UpdateCrowd(TimeStep);
+        }
+
+        // Every agent should have made progress toward the shared target
+        foreach (var entity in entities)
+        {
+            Vector3.Distance(GetPosition(entity), center).ShouldBeLessThan(5f);
+        }
+
+        // No two agents may occupy the same spot: pairwise separation stays
+        // near the sum of radii even when crowding a single target.
+        for (int i = 0; i < agentCount; i++)
+        {
+            for (int j = i + 1; j < agentCount; j++)
+            {
+                float separation = Vector3.Distance(GetPosition(entities[i]), GetPosition(entities[j]));
+                separation.ShouldBeGreaterThanOrEqualTo((AgentRadius + AgentRadius) * 0.6f);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Mesh Replacement Tests
+
+    [Fact]
+    public void SetNavMesh_WithRegisteredAgents_PreservesAgentsAndTargets()
+    {
+        var entity = new Entity(1, 0);
+        var target = new Vector3(30f, 0f, 20f);
+        AddAgent(entity, new Vector3(10f, 0f, 20f)).ShouldBeTrue();
+        provider.RequestCrowdMoveTarget(entity, target).ShouldBeTrue();
+
+        // Let the agent start moving, then replace the mesh mid-run
+        for (int i = 0; i < 40; i++)
+        {
+            provider.UpdateCrowd(TimeStep);
+        }
+
+        var builder = TestHelper.CreateTestBuilder();
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        provider.SetNavMesh(builder.Build(vertices, indices));
+
+        provider.CrowdAgentCount.ShouldBe(1);
+        provider.TryGetCrowdAgentState(entity, out _).ShouldBeTrue();
+
+        // The move target must survive the mesh swap without a new request
+        float distance = float.MaxValue;
+        for (int i = 0; i < 600; i++)
+        {
+            provider.UpdateCrowd(TimeStep);
+            distance = Vector3.Distance(GetPosition(entity), target);
+            if (distance <= 0.5f)
+            {
+                break;
+            }
+        }
+
+        distance.ShouldBeLessThanOrEqualTo(0.5f);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastTiledBuildTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastTiledBuildTests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.DotRecast;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for the tiled navigation mesh build path in <see cref="DotRecastMeshBuilder"/>.
+/// </summary>
+/// <remarks>
+/// These tests build real navigation meshes from a slab (a floor with vertical extent),
+/// which Recast can voxelize reliably - unlike the zero-thickness planes used by the
+/// legacy skipped tests. The slab is large enough to span multiple tiles.
+/// </remarks>
+public class DotRecastTiledBuildTests
+{
+    private const float SlabSize = 120f;
+    private static readonly Vector3 start = new(15f, 0f, 15f);
+    private static readonly Vector3 end = new(105f, 0f, 105f);
+
+    #region Helpers
+
+    private static int CountTiles(NavMeshData mesh)
+    {
+        var navMesh = mesh.InternalNavMesh;
+        int count = 0;
+        for (int i = 0; i < navMesh.GetMaxTiles(); i++)
+        {
+            var tile = navMesh.GetTile(i);
+            if (tile?.data != null)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    // Counts how many distinct grid tiles the path's waypoints fall into, derived from
+    // the navmesh tile grid (origin + tile footprint). This does not rely on the
+    // waypoint polygon refs, which the provider stores as a lossy uint cast.
+    private static int CountDistinctTilesAlongPath(NavMeshData mesh, NavPath path)
+    {
+        ref readonly var navParams = ref mesh.InternalNavMesh.GetParams();
+        var tiles = new HashSet<(int X, int Z)>();
+
+        for (int i = 0; i < path.Count; i++)
+        {
+            var pos = path[i].Position;
+            int tileX = (int)MathF.Floor((pos.X - navParams.orig.X) / navParams.tileWidth);
+            int tileZ = (int)MathF.Floor((pos.Z - navParams.orig.Z) / navParams.tileHeight);
+            tiles.Add((tileX, tileZ));
+        }
+
+        return tiles.Count;
+    }
+
+    #endregion
+
+    [Fact]
+    public void Build_WithTilesEnabled_ProducesMultipleTiles()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+
+        var mesh = builder.Build(vertices, indices);
+
+        Assert.True(CountTiles(mesh) > 1, "A tiled build over a multi-tile slab should install more than one tile.");
+    }
+
+    [Fact]
+    public void Build_WithTilesDisabled_ProducesSingleTile()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var config = TestHelper.CreateTestConfig();  // UseTiles = false
+        var builder = new DotRecastMeshBuilder(config);
+
+        var mesh = builder.Build(vertices, indices);
+
+        Assert.Equal(1, CountTiles(mesh));
+    }
+
+    [Fact]
+    public void Build_TiledCrossTilePath_MatchesSingleTilePathLength()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+
+        var singleConfig = TestHelper.CreateTestConfig();  // UseTiles = false
+        var singleMesh = new DotRecastMeshBuilder(singleConfig).Build(vertices, indices);
+        using var singleProvider = new DotRecastProvider(singleMesh, singleConfig);
+        var singlePath = singleProvider.FindPath(start, end, AgentSettings.Default);
+
+        var tiledConfig = TestHelper.CreateTiledTestConfig();
+        var tiledMesh = new DotRecastMeshBuilder(tiledConfig).Build(vertices, indices);
+        using var tiledProvider = new DotRecastProvider(tiledMesh, tiledConfig);
+        var tiledPath = tiledProvider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(singlePath.IsValid, "Single-tile path should be found.");
+        Assert.True(tiledPath.IsValid, "Tiled path should be found.");
+
+        // The tiled path must actually cross tile boundaries (otherwise the comparison
+        // is meaningless).
+        Assert.True(
+            CountDistinctTilesAlongPath(tiledMesh, tiledPath) > 1,
+            "The tiled path should traverse more than one tile.");
+
+        // Path length through the tiled mesh must match the single-tile mesh within a
+        // small tolerance (tiled builds add borders per tile which can perturb geometry).
+        float tolerance = System.Math.Max(0.5f, singlePath.Length * 0.05f);
+        Assert.True(
+            singlePath.Length.ApproximatelyEquals(tiledPath.Length, tolerance),
+            $"Tiled path length {tiledPath.Length} should approximately equal single-tile length {singlePath.Length}.");
+    }
+
+    [Fact]
+    public void Build_WithSmallerOverrideTileSize_ProducesMoreTiles()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var config = TestHelper.CreateTiledTestConfig(tileSize: 48);
+        var builder = new DotRecastMeshBuilder(config);
+
+        var defaultMesh = builder.Build(vertices, indices);
+        var overriddenMesh = builder.Build(vertices, indices, areaIds: null, overrideTileSize: 24);
+
+        int defaultTiles = CountTiles(defaultMesh);
+        int overriddenTiles = CountTiles(overriddenMesh);
+
+        Assert.True(defaultTiles > 1, "Default tile size should still produce multiple tiles.");
+        Assert.True(
+            overriddenTiles > defaultTiles,
+            $"A smaller override tile size ({overriddenTiles} tiles) should produce more tiles than the default ({defaultTiles} tiles).");
+    }
+
+    [Fact]
+    public void Build_WithNegativeOverrideTileSize_ThrowsArgumentOutOfRange()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            builder.Build(vertices, indices, areaIds: null, overrideTileSize: -1));
+    }
+
+    [Fact]
+    public void Serialize_MultiTileMesh_RoundTripPreservesTileCountAndPath()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var config = TestHelper.CreateTiledTestConfig();
+        var mesh = new DotRecastMeshBuilder(config).Build(vertices, indices);
+
+        int originalTiles = CountTiles(mesh);
+        Assert.True(originalTiles > 1, "Precondition: mesh should be multi-tile.");
+
+        using var originalProvider = new DotRecastProvider(mesh, config);
+        var originalPath = originalProvider.FindPath(start, end, AgentSettings.Default);
+        Assert.True(originalPath.IsValid);
+
+        var bytes = mesh.Serialize();
+        var restored = NavMeshData.Deserialize(bytes);
+
+        Assert.Equal(originalTiles, CountTiles(restored));
+        Assert.Equal(mesh.PolygonCount, restored.PolygonCount);
+
+        using var restoredProvider = new DotRecastProvider(restored, config);
+        var restoredPath = restoredProvider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(restoredPath.IsValid, "Path through the restored mesh should be found.");
+        Assert.True(
+            originalPath.Length.ApproximatelyEquals(restoredPath.Length, System.Math.Max(0.5f, originalPath.Length * 0.05f)),
+            $"Restored path length {restoredPath.Length} should match original {originalPath.Length}.");
+    }
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/KeenEyes.Navigation.DotRecast.Tests.csproj
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/KeenEyes.Navigation.DotRecast.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Navigation\KeenEyes.Navigation.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Navigation.DotRecast\KeenEyes.Navigation.DotRecast.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
   </ItemGroup>

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/TestHelper.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/TestHelper.cs
@@ -121,4 +121,70 @@ internal static class TestHelper
 
         return builder.Build(vertices.ToArray(), indices.ToArray());
     }
+
+    /// <summary>
+    /// Creates a NavMeshConfig with tiled building enabled for tiled-build tests.
+    /// </summary>
+    /// <param name="tileSize">The tile size in cells.</param>
+    public static NavMeshConfig CreateTiledTestConfig(int tileSize = 48)
+    {
+        var config = CreateTestConfig();
+        config.UseTiles = true;
+        config.TileSize = tileSize;
+        return config;
+    }
+
+    /// <summary>
+    /// Builds a flat square slab (a thick floor) centered on the origin plane at Y=0.
+    /// </summary>
+    /// <remarks>
+    /// Unlike a zero-thickness plane, the slab spans a small vertical extent so Recast
+    /// can voxelize it into walkable spans. The top face (Y=0) is wound so its normal
+    /// points up, making it the walkable surface. A large slab spans multiple tiles.
+    /// </remarks>
+    /// <param name="size">The side length of the slab in world units.</param>
+    /// <returns>The vertices (XYZ triplets) and triangle indices of the slab.</returns>
+    public static (float[] Vertices, int[] Indices) BuildSlabGeometry(float size)
+    {
+        const float top = 0f;
+        const float bottom = -1f;
+
+        var vertices = new[]
+        {
+            // Bottom face
+            0f, bottom, 0f,
+            size, bottom, 0f,
+            size, bottom, size,
+            0f, bottom, size,
+
+            // Top face (walkable surface)
+            0f, top, 0f,
+            size, top, 0f,
+            size, top, size,
+            0f, top, size
+        };
+
+        var indices = new[]
+        {
+            // Bottom (normal down)
+            0, 2, 1,
+            0, 3, 2,
+
+            // Top (normal up - walkable)
+            4, 6, 5,
+            4, 7, 6,
+
+            // Sides
+            0, 1, 5,
+            0, 5, 4,
+            2, 3, 7,
+            2, 7, 6,
+            0, 4, 7,
+            0, 7, 3,
+            1, 2, 6,
+            1, 6, 5
+        };
+
+        return (vertices, indices);
+    }
 }

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/packages.lock.json
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/packages.lock.json
@@ -225,6 +225,13 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.navigation.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -235,6 +242,7 @@
         "type": "Project",
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -286,6 +294,15 @@
         "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
         "dependencies": {
           "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
         }
       },
       "DotRecast.Recast": {


### PR DESCRIPTION
## Summary
- **Real tiled builds**: `UseTiles=true` (the default) was a dead config hook — `BuildFromGeometry` always produced a single-tile mesh. Now `BuildTiled` uses DotRecast's canonical `RcBuilder.BuildTiles` (bordered per-tile configs via `RcBuilderConfig`), installs each non-empty tile via `DtNavMesh.AddTile` with **real `TileX`/`TileZ`** (were hardcoded 0,0), and initializes with a proper multi-tile `DtNavMeshParams` (maxTiles capped at 14 bits, canonical 22-bit tile+poly split). `UseTiles=false` keeps the exact single-tile flow. `NavMeshSurface.OverrideTileSize` is now honored via a new builder parameter (per-surface plumbing from the editor collector is out of scope — noted).
- **Serialization upgraded**: hand-rolled lossy tile serialization replaced with DotRecast's `DtMeshSetWriter`/`Reader` (preserves params, BV trees, detail meshes, multi-tile topology); format v2.
- **Two latent bugs fixed — pathfinding never actually worked**: (1) `walkableAreaMod` was `RcAreaModification(0, 0x3f)`, remapping `RC_WALKABLE_AREA(63)` → `RC_NULL_AREA(0)`, so every build produced an empty mesh; (2) walkable polys carried no flags, so the default Detour filter (`includeFlags` needs a nonzero bit) rejected all of them. Both masked by the 52 legacy tests that fully skip. Built against the verified 2026.1.3 API (packages decompiled to confirm signatures).

## Test plan
- [x] 6 new tests: multi-tile build (196 tiles on a 200×200 slab), cross-tile path length equals single-tile path (exactly, e.g. 226.27), UseTiles=false single-tile, smaller override → more tiles, negative override throws, multi-tile serialize/deserialize round-trip — 54 passed / 52 pre-existing skips / 0 failed
- [x] Release build zero warnings; `dotnet format` clean
- [x] `Navigation.Tests`' 13 failures are **pre-existing on clean main** (ObjectDisposedException test-isolation bug in `NavigationContextTests`, no DotRecast reference) — follow-up issue being filed
- [ ] CI green

## Related Issues
Refs #1000, part of #643 — prerequisite for streaming (#1003); crowds (#1001) and off-mesh links (#1002) now unblocked.