### PR TITLE
feat(replay): Add delta compression for snapshot markers

### DIFF
--- a/src/KeenEyes.Replay/Ghost/GhostExtractor.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostExtractor.cs
@@ -107,6 +107,12 @@ public sealed class GhostExtractor
 
         foreach (var snapshotMarker in replay.Snapshots)
         {
+            // Ghost extraction reads full entity state; delta markers carry no snapshot.
+            if (snapshotMarker.Snapshot is null)
+            {
+                continue;
+            }
+
             // Skip if we haven't passed the minimum interval
             if (MinFrameInterval > TimeSpan.Zero &&
                 snapshotMarker.ElapsedTime - lastFrameTime < MinFrameInterval)
@@ -211,6 +217,12 @@ public sealed class GhostExtractor
 
         foreach (var snapshotMarker in replay.Snapshots)
         {
+            // Ghost extraction reads full entity state; delta markers carry no snapshot.
+            if (snapshotMarker.Snapshot is null)
+            {
+                continue;
+            }
+
             // Skip if we haven't passed the minimum interval
             if (MinFrameInterval > TimeSpan.Zero &&
                 snapshotMarker.ElapsedTime - lastFrameTime < MinFrameInterval)
@@ -311,9 +323,11 @@ public sealed class GhostExtractor
             return result;
         }
 
-        // Find all unique entity names with transforms
+        // Find all unique entity names with transforms. Delta markers carry no full
+        // snapshot, so only keyframe markers contribute entity names here.
         var entityNames = replay.Snapshots
-            .SelectMany(s => s.Snapshot.Entities)
+            .Where(s => s.Snapshot is not null)
+            .SelectMany(s => s.Snapshot!.Entities)
             .Where(e => e.Name is not null &&
                         e.Components.Any(c => c.TypeName.StartsWith(Transform3DTypeName, StringComparison.Ordinal)))
             .Select(e => e.Name!)

--- a/src/KeenEyes.Replay/ReplayData.cs
+++ b/src/KeenEyes.Replay/ReplayData.cs
@@ -35,7 +35,13 @@ public sealed record ReplayData
     /// <summary>
     /// The current version of the replay data format.
     /// </summary>
-    public const int CurrentVersion = 1;
+    /// <remarks>
+    /// Version 2 introduced delta-compressed snapshot markers (see
+    /// <see cref="SnapshotMarker.Delta"/>). Version 1 recordings, whose markers are all
+    /// full keyframes, remain readable: markers lacking delta fields deserialize as
+    /// keyframes.
+    /// </remarks>
+    public const int CurrentVersion = 2;
 
     /// <summary>
     /// Gets or sets the format version of this replay data.

--- a/src/KeenEyes.Replay/ReplayFileFormat.cs
+++ b/src/KeenEyes.Replay/ReplayFileFormat.cs
@@ -45,7 +45,13 @@ public static class ReplayFileFormat
     /// <summary>
     /// Current file format version.
     /// </summary>
-    public const ushort CurrentVersion = 1;
+    /// <remarks>
+    /// Version 2 added delta-compressed snapshot markers to the payload. Version 1 files
+    /// remain readable because the reader accepts any header version at or below
+    /// <see cref="CurrentVersion"/> and the delta fields are absent (all-keyframe) in v1
+    /// payloads.
+    /// </remarks>
+    public const ushort CurrentVersion = 2;
 
     /// <summary>
     /// Default file extension for replay files.

--- a/src/KeenEyes.Replay/ReplayJsonContext.cs
+++ b/src/KeenEyes.Replay/ReplayJsonContext.cs
@@ -19,6 +19,7 @@ namespace KeenEyes.Replay;
 [JsonSerializable(typeof(ReplayFrame))]
 [JsonSerializable(typeof(ReplayEvent))]
 [JsonSerializable(typeof(SnapshotMarker))]
+[JsonSerializable(typeof(Serialization.DeltaSnapshot))]
 [JsonSerializable(typeof(ReplayFileInfo))]
 [JsonSerializable(typeof(IReadOnlyList<ReplayFrame>))]
 [JsonSerializable(typeof(IReadOnlyList<ReplayEvent>))]

--- a/src/KeenEyes.Replay/ReplayOptions.cs
+++ b/src/KeenEyes.Replay/ReplayOptions.cs
@@ -182,4 +182,28 @@ public sealed record ReplayOptions
     /// <seealso cref="ReplayPlayer.AutoValidate"/>
     /// <seealso cref="ReplayPlayer.ValidateCurrentFrame"/>
     public bool RecordChecksums { get; init; }
+
+    /// <summary>
+    /// Gets or sets how often a full-state keyframe snapshot is captured, measured in
+    /// number of snapshot markers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// To reduce file size, snapshots between keyframes are stored as deltas relative to
+    /// the previous marker's state (see <see cref="Serialization.DeltaSnapshot"/>) rather
+    /// than as complete world snapshots. Every <c>KeyframeInterval</c>-th marker is a full
+    /// keyframe, which bounds the length of the delta chain that must be replayed when
+    /// seeking: reconstructing any marker requires restoring the nearest preceding keyframe
+    /// and applying at most <c>KeyframeInterval - 1</c> deltas.
+    /// </para>
+    /// <para>
+    /// The very first marker of every recording is always a full keyframe regardless of
+    /// this value. A value of 1 (or less) disables delta compression entirely, capturing
+    /// every marker as a full keyframe.
+    /// </para>
+    /// <para>
+    /// Default is 10.
+    /// </para>
+    /// </remarks>
+    public int KeyframeInterval { get; init; } = 10;
 }

--- a/src/KeenEyes.Replay/ReplayPlayer.cs
+++ b/src/KeenEyes.Replay/ReplayPlayer.cs
@@ -1676,10 +1676,21 @@ public sealed class ReplayPlayer : IDisposable
     /// </summary>
     private SnapshotMarker? FindNearestSnapshot(int targetFrame)
     {
+        var index = FindNearestSnapshotIndex(targetFrame);
+        return index >= 0 ? replayData!.Snapshots[index] : null;
+    }
+
+    /// <summary>
+    /// Finds the index of the nearest snapshot marker at or before the specified frame
+    /// using binary search, or -1 when none exists.
+    /// Must be called while holding the lock.
+    /// </summary>
+    private int FindNearestSnapshotIndex(int targetFrame)
+    {
         var snapshots = replayData!.Snapshots;
         if (snapshots.Count == 0)
         {
-            return null;
+            return -1;
         }
 
         // Binary search for the snapshot at or before the target frame
@@ -1703,7 +1714,7 @@ public sealed class ReplayPlayer : IDisposable
             }
         }
 
-        return resultIndex >= 0 ? snapshots[resultIndex] : null;
+        return resultIndex;
     }
 
     /// <summary>
@@ -1729,10 +1740,30 @@ public sealed class ReplayPlayer : IDisposable
             return;
         }
 
-        var marker = FindNearestSnapshot(targetFrame);
-        if (marker is null)
+        var targetIndex = FindNearestSnapshotIndex(targetFrame);
+        if (targetIndex < 0)
         {
             return; // No snapshot to restore from - leave the world untouched.
+        }
+
+        var snapshots = replayData!.Snapshots;
+
+        // Walk back to the nearest full keyframe: the target marker may be a delta whose
+        // reconstruction requires restoring the keyframe and replaying intervening deltas.
+        var keyframeIndex = targetIndex;
+        while (keyframeIndex >= 0 && !snapshots[keyframeIndex].IsKeyframe)
+        {
+            keyframeIndex--;
+        }
+
+        if (keyframeIndex < 0)
+        {
+            // A delta chain with no preceding keyframe cannot be reconstructed.
+            throw new ReplayStateRestorationException(
+                targetFrame,
+                snapshots[targetIndex].FrameNumber,
+                new InvalidOperationException(
+                    "No full keyframe snapshot precedes the target delta marker."));
         }
 
         // Back up the current world state so a failed restore can roll back. This keeps
@@ -1747,12 +1778,36 @@ public sealed class ReplayPlayer : IDisposable
         {
             // Broad catch: any failure capturing the backup means we cannot guarantee a
             // safe rollback, so we must not mutate the world at all.
-            throw new ReplayStateRestorationException(targetFrame, marker.FrameNumber, ex);
+            throw new ReplayStateRestorationException(targetFrame, snapshots[keyframeIndex].FrameNumber, ex);
         }
+
+        // Track the frame whose restore/apply is in progress so a failure reports the
+        // exact marker that could not be applied.
+        var failingFrame = snapshots[keyframeIndex].FrameNumber;
 
         try
         {
-            SnapshotManager.RestoreSnapshot(validationWorld, marker.Snapshot, validationSerializer);
+            // Restore the keyframe, then apply the chain of deltas up to the target marker.
+            var entityMap = SnapshotManager.RestoreSnapshot(
+                validationWorld,
+                snapshots[keyframeIndex].Snapshot!,
+                validationSerializer);
+
+            for (var i = keyframeIndex + 1; i <= targetIndex; i++)
+            {
+                var deltaMarker = snapshots[i];
+                if (deltaMarker.Delta is null)
+                {
+                    continue;
+                }
+
+                failingFrame = deltaMarker.FrameNumber;
+                entityMap = DeltaRestorer.ApplyDelta(
+                    validationWorld,
+                    deltaMarker.Delta,
+                    validationSerializer,
+                    entityMap);
+            }
         }
         catch (Exception ex)
         {
@@ -1766,13 +1821,13 @@ public sealed class ReplayPlayer : IDisposable
             catch (Exception rollbackEx)
             {
                 throw new ReplayStateRestorationException(
-                    $"Failed to restore world state from the snapshot at frame {marker.FrameNumber} " +
+                    $"Failed to restore world state from the snapshot at frame {failingFrame} " +
                     $"while seeking to frame {targetFrame}, and rolling back to the previous state also " +
                     "failed. The world may be in an inconsistent state.",
                     rollbackEx);
             }
 
-            throw new ReplayStateRestorationException(targetFrame, marker.FrameNumber, ex);
+            throw new ReplayStateRestorationException(targetFrame, failingFrame, ex);
         }
     }
 

--- a/src/KeenEyes.Replay/ReplayRecorder.cs
+++ b/src/KeenEyes.Replay/ReplayRecorder.cs
@@ -58,6 +58,11 @@ public sealed class ReplayRecorder : IInputRecorder
     private string? recordingName;
     private IReadOnlyDictionary<string, object>? recordingMetadata;
 
+    // Full world state of the most recently captured marker, used as the baseline for
+    // computing the next marker's delta. Reconstructed to the exact state at that marker
+    // regardless of whether the marker was stored as a keyframe or a delta.
+    private WorldSnapshot? previousMarkerSnapshot;
+
     // Ring buffer support
     private int ringBufferStart;
 
@@ -155,6 +160,7 @@ public sealed class ReplayRecorder : IInputRecorder
         snapshots.Clear();
         currentFrameEvents.Clear();
         currentFrameInputs.Clear();
+        previousMarkerSnapshot = null;
         ringBufferStart = 0;
 
         // Initialize recording state
@@ -208,9 +214,11 @@ public sealed class ReplayRecorder : IInputRecorder
             }
             finalFrames = actualFrames;
 
-            // Filter snapshots to only include those within the ring buffer window
+            // Filter snapshots to only include those within the ring buffer window. Delta
+            // markers cannot be reconstructed without their preceding keyframe, so extend
+            // the window backward to the keyframe that governs the first retained marker.
             var minFrameNumber = actualFrames.Count > 0 ? actualFrames[0].FrameNumber : 0;
-            finalSnapshots = snapshots.Where(s => s.FrameNumber >= minFrameNumber).ToList();
+            finalSnapshots = FilterSnapshotsForWindow(minFrameNumber);
         }
         else
         {
@@ -232,6 +240,39 @@ public sealed class ReplayRecorder : IInputRecorder
     }
 
     /// <summary>
+    /// Returns the snapshot markers whose frame number is at or after
+    /// <paramref name="minFrameNumber"/>, extended backward to include the keyframe that
+    /// governs the first retained delta marker so the delta chain remains reconstructable.
+    /// </summary>
+    private List<SnapshotMarker> FilterSnapshotsForWindow(int minFrameNumber)
+    {
+        // Find the first marker at or after the window start.
+        var startIndex = -1;
+        for (var i = 0; i < snapshots.Count; i++)
+        {
+            if (snapshots[i].FrameNumber >= minFrameNumber)
+            {
+                startIndex = i;
+                break;
+            }
+        }
+
+        if (startIndex < 0)
+        {
+            return [];
+        }
+
+        // Walk back to the keyframe governing the first retained marker so any retained
+        // delta can still be applied on top of a full snapshot.
+        while (startIndex > 0 && !snapshots[startIndex].IsKeyframe)
+        {
+            startIndex--;
+        }
+
+        return snapshots.GetRange(startIndex, snapshots.Count - startIndex);
+    }
+
+    /// <summary>
     /// Cancels the current recording without returning data.
     /// </summary>
     /// <remarks>
@@ -245,6 +286,7 @@ public sealed class ReplayRecorder : IInputRecorder
         snapshots.Clear();
         currentFrameEvents.Clear();
         currentFrameInputs.Clear();
+        previousMarkerSnapshot = null;
     }
 
     /// <summary>
@@ -558,24 +600,61 @@ public sealed class ReplayRecorder : IInputRecorder
             return; // Can't create snapshot without concrete World
         }
 
+        // Always compute the full current state: it is either stored directly (keyframe)
+        // or diffed against the previous marker (delta), and it becomes the baseline for
+        // the next marker's delta either way.
         var snapshot = SnapshotManager.CreateSnapshot(concreteWorld, serializer);
 
-        // Calculate checksum if enabled
+        // Calculate checksum if enabled. The checksum always reflects the full world state
+        // at this marker so reconstructed state (keyframe + delta chain) can be validated.
         uint? checksum = null;
         if (options.RecordChecksums)
         {
             checksum = WorldChecksum.Calculate(concreteWorld, serializer);
         }
 
-        var marker = new SnapshotMarker
+        // The first marker is always a keyframe; thereafter every KeyframeInterval-th marker
+        // is a keyframe and the rest are deltas. An interval of 1 or less disables deltas.
+        var markerIndex = snapshots.Count;
+        var isKeyframe =
+            markerIndex == 0 ||
+            options.KeyframeInterval <= 1 ||
+            markerIndex % options.KeyframeInterval == 0 ||
+            previousMarkerSnapshot is null;
+
+        SnapshotMarker marker;
+        if (isKeyframe)
         {
-            FrameNumber = frameNumber,
-            ElapsedTime = elapsedTime,
-            Snapshot = snapshot,
-            Checksum = checksum
-        };
+            marker = new SnapshotMarker
+            {
+                FrameNumber = frameNumber,
+                ElapsedTime = elapsedTime,
+                Snapshot = snapshot,
+                Checksum = checksum
+            };
+        }
+        else
+        {
+            var baselineMarker = snapshots[^1];
+            var delta = DeltaDiffer.CreateDelta(
+                concreteWorld,
+                previousMarkerSnapshot!,
+                serializer,
+                baselineMarker.FrameNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                markerIndex);
+
+            marker = new SnapshotMarker
+            {
+                FrameNumber = frameNumber,
+                ElapsedTime = elapsedTime,
+                Delta = delta,
+                BaselineFrameNumber = baselineMarker.FrameNumber,
+                Checksum = checksum
+            };
+        }
 
         snapshots.Add(marker);
+        previousMarkerSnapshot = snapshot;
 
         // Record snapshot event
         currentFrameEvents.Add(new ReplayEvent

--- a/src/KeenEyes.Replay/SnapshotMarker.cs
+++ b/src/KeenEyes.Replay/SnapshotMarker.cs
@@ -7,15 +7,26 @@ namespace KeenEyes.Replay;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Snapshots are periodic captures of the complete world state during recording.
-/// They enable efficient seeking by providing restoration points throughout
-/// the replay timeline.
+/// Snapshots are periodic captures of world state during recording. They enable
+/// efficient seeking by providing restoration points throughout the replay timeline.
 /// </para>
 /// <para>
-/// The snapshot marker stores metadata about when the snapshot was taken
-/// (frame number and elapsed time) along with the actual snapshot data.
-/// During playback, the system can restore any snapshot and replay forward
-/// from that point.
+/// A marker is one of two kinds, distinguished by <see cref="IsKeyframe"/>:
+/// <list type="bullet">
+/// <item><description>
+/// A <b>keyframe</b> carries a complete <see cref="Snapshot"/> of the world state and
+/// no delta. Keyframes are self-contained restore points.
+/// </description></item>
+/// <item><description>
+/// A <b>delta marker</b> carries only the changes since the previous marker's state
+/// (<see cref="Delta"/>) and references that marker via <see cref="BaselineFrameNumber"/>.
+/// Reconstructing a delta marker requires restoring the nearest preceding keyframe and
+/// applying the intervening deltas in order.
+/// </description></item>
+/// </list>
+/// Storing deltas between keyframes (controlled by
+/// <see cref="ReplayOptions.KeyframeInterval"/>) substantially reduces recording size
+/// when most entities are unchanged between snapshots.
 /// </para>
 /// </remarks>
 /// <example>
@@ -55,20 +66,58 @@ public sealed record SnapshotMarker
     public required TimeSpan ElapsedTime { get; init; }
 
     /// <summary>
-    /// Gets or sets the complete world state captured at this point.
+    /// Gets the complete world state captured at this point, or <c>null</c> when this
+    /// marker is a delta (see <see cref="Delta"/>).
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The snapshot contains all entities, components, hierarchy relationships,
-    /// and singletons. It can be restored using
-    /// <see cref="SnapshotManager.RestoreSnapshot"/>.
+    /// When present, the snapshot contains all entities, components, hierarchy
+    /// relationships, and singletons, and can be restored using
+    /// <see cref="SnapshotManager.RestoreSnapshot"/>. This is populated only for
+    /// keyframe markers; delta markers leave it <c>null</c> and store their changes in
+    /// <see cref="Delta"/> instead.
     /// </para>
     /// <para>
     /// Snapshots are created using the configured <see cref="IComponentSerializer"/>
     /// to ensure AOT compatibility.
     /// </para>
     /// </remarks>
-    public required WorldSnapshot Snapshot { get; init; }
+    public WorldSnapshot? Snapshot { get; init; }
+
+    /// <summary>
+    /// Gets the incremental changes relative to the baseline marker identified by
+    /// <see cref="BaselineFrameNumber"/>, or <c>null</c> when this marker is a keyframe
+    /// (see <see cref="Snapshot"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A delta stores only entities and components that changed since the previous
+    /// marker's state. To reconstruct the world at this marker, restore the nearest
+    /// preceding keyframe's <see cref="Snapshot"/> and apply each subsequent marker's
+    /// delta in order using <see cref="DeltaRestorer.ApplyDelta"/>.
+    /// </para>
+    /// </remarks>
+    public DeltaSnapshot? Delta { get; init; }
+
+    /// <summary>
+    /// Gets the frame number of the marker this marker's <see cref="Delta"/> is relative
+    /// to, or <c>null</c> for keyframe markers.
+    /// </summary>
+    /// <remarks>
+    /// The baseline is always the immediately preceding marker in the recording, so the
+    /// delta chain from a keyframe up to any delta marker can be replayed in order.
+    /// </remarks>
+    public int? BaselineFrameNumber { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this marker is a full-state keyframe.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>true</c> when <see cref="Snapshot"/> is present (a self-contained
+    /// restore point) and <c>false</c> when the marker carries only a <see cref="Delta"/>.
+    /// </remarks>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsKeyframe => Snapshot is not null;
 
     /// <summary>
     /// Gets or sets the world state checksum when this snapshot was captured.

--- a/tests/KeenEyes.Replay.Tests/DeltaCompressionTests.cs
+++ b/tests/KeenEyes.Replay.Tests/DeltaCompressionTests.cs
@@ -1,0 +1,494 @@
+using System.Text.Json;
+using KeenEyes.Serialization;
+
+namespace KeenEyes.Replay.Tests;
+
+/// <summary>
+/// Tests for delta-compressed snapshot markers: recording as keyframe/delta chains,
+/// reconstructing state by replaying deltas during navigation, file-format versioning,
+/// and the resulting size reduction (see issue #531).
+/// </summary>
+public class DeltaCompressionTests
+{
+    private const float FrameDelta = 0.1f;
+
+    #region Recording / Keyframe Interval Tests
+
+    [Fact]
+    public void CaptureSnapshot_FirstMarker_IsAlwaysKeyframe()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 6);
+
+        Assert.NotEmpty(replay.Snapshots);
+        Assert.True(replay.Snapshots[0].IsKeyframe);
+        Assert.NotNull(replay.Snapshots[0].Snapshot);
+        Assert.Null(replay.Snapshots[0].Delta);
+    }
+
+    [Fact]
+    public void CaptureSnapshot_WithKeyframeInterval_HonorsIntervalForKeyframesAndDeltas()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 6);
+
+        // Markers: idx 0,3,6 are keyframes; 1,2,4,5 are deltas.
+        for (int i = 0; i < replay.Snapshots.Count; i++)
+        {
+            var marker = replay.Snapshots[i];
+            if (i % 3 == 0)
+            {
+                Assert.True(marker.IsKeyframe, $"Marker {i} should be a keyframe.");
+                Assert.NotNull(marker.Snapshot);
+                Assert.Null(marker.Delta);
+                Assert.Null(marker.BaselineFrameNumber);
+            }
+            else
+            {
+                Assert.False(marker.IsKeyframe, $"Marker {i} should be a delta.");
+                Assert.Null(marker.Snapshot);
+                Assert.NotNull(marker.Delta);
+                Assert.Equal(replay.Snapshots[i - 1].FrameNumber, marker.BaselineFrameNumber);
+            }
+        }
+    }
+
+    [Fact]
+    public void CaptureSnapshot_WithKeyframeIntervalOne_CapturesAllKeyframes()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 1, snapshotFrames: 6);
+
+        Assert.All(replay.Snapshots, m => Assert.True(m.IsKeyframe));
+        Assert.All(replay.Snapshots, m => Assert.Null(m.Delta));
+    }
+
+    [Fact]
+    public void ReplayData_CurrentVersion_IsTwo()
+    {
+        Assert.Equal(2, ReplayData.CurrentVersion);
+    }
+
+    #endregion
+
+    #region Delta Chain Reconstruction Tests
+
+    [Fact]
+    public void SeekToFrame_DeltaMarker_ReconstructsStateFromKeyframePlusDeltaChain()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 9);
+
+        // Frame 8's marker is a delta whose chain roots at the keyframe on frame 6.
+        var marker8 = replay.Snapshots.Single(s => s.FrameNumber == 8);
+        Assert.False(marker8.IsKeyframe);
+
+        using var playbackWorld = new World();
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replay);
+        player.SetValidationContext(playbackWorld, serializer);
+        player.EnableStateRestoration = true;
+
+        player.SeekToFrame(8);
+
+        // Timeline advances to the exact target frame.
+        Assert.Equal(8, player.CurrentFrame);
+
+        // The recorded value at frame f is 100 + f, so the delta chain must reconstruct 108.
+        Assert.Equal(3, playbackWorld.Query<RestorableHealth>().Count());
+        Assert.All(
+            playbackWorld.Query<RestorableHealth>(),
+            e => Assert.Equal(108, playbackWorld.Get<RestorableHealth>(e).Current));
+
+        // Checksum-verified: reconstructed state matches the marker's recorded checksum.
+        Assert.Equal(marker8.Checksum, WorldChecksum.Calculate(playbackWorld, serializer));
+    }
+
+    [Fact]
+    public void SeekToFrame_DeltaMarkerImmediatelyAfterKeyframe_ReconstructsState()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 9);
+
+        // Frame 4's marker is the first delta after the keyframe on frame 3.
+        var marker4 = replay.Snapshots.Single(s => s.FrameNumber == 4);
+        Assert.False(marker4.IsKeyframe);
+
+        using var playbackWorld = new World();
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replay);
+        player.SetValidationContext(playbackWorld, serializer);
+        player.EnableStateRestoration = true;
+
+        player.SeekToFrame(4);
+
+        Assert.All(
+            playbackWorld.Query<RestorableHealth>(),
+            e => Assert.Equal(104, playbackWorld.Get<RestorableHealth>(e).Current));
+        Assert.Equal(marker4.Checksum, WorldChecksum.Calculate(playbackWorld, serializer));
+    }
+
+    [Fact]
+    public void SeekToFrame_KeyframeMarker_RestoresDirectlyWithoutDeltas()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 9);
+
+        var marker6 = replay.Snapshots.Single(s => s.FrameNumber == 6);
+        Assert.True(marker6.IsKeyframe);
+
+        using var playbackWorld = new World();
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replay);
+        player.SetValidationContext(playbackWorld, serializer);
+        player.EnableStateRestoration = true;
+
+        player.SeekToFrame(6);
+
+        Assert.All(
+            playbackWorld.Query<RestorableHealth>(),
+            e => Assert.Equal(106, playbackWorld.Get<RestorableHealth>(e).Current));
+        Assert.Equal(marker6.Checksum, WorldChecksum.Calculate(playbackWorld, serializer));
+    }
+
+    #endregion
+
+    #region File Format Versioning Tests
+
+    [Fact]
+    public void ReplayFileFormat_CurrentVersion_IsTwo()
+    {
+        Assert.Equal((ushort)2, ReplayFileFormat.CurrentVersion);
+    }
+
+    [Fact]
+    public void LoadReplay_Version1File_LoadsAsAllKeyframeMarkers()
+    {
+        // Build a version-1 style recording: all markers are full keyframes and the
+        // payload carries no delta fields, exactly as a pre-delta writer would produce.
+        var v1Bytes = CreateVersion1FileBytes();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(v1Bytes, validateChecksum: true);
+
+        Assert.NotNull(player.LoadedReplay);
+        Assert.Equal(1, player.LoadedReplay!.Version);
+        Assert.Equal(2, player.LoadedReplay.Snapshots.Count);
+
+        // Absent delta fields deserialize as keyframes.
+        Assert.All(player.LoadedReplay.Snapshots, m => Assert.True(m.IsKeyframe));
+        Assert.All(player.LoadedReplay.Snapshots, m => Assert.Null(m.Delta));
+    }
+
+    [Fact]
+    public void WriteThenRead_DeltaCompressedReplay_RoundTripsMarkerKinds()
+    {
+        var serializer = CreateSerializer();
+        var replay = RecordSession(serializer, keyframeInterval: 3, snapshotFrames: 6);
+
+        var bytes = ReplayFileFormat.Write(replay);
+        var (_, restored) = ReplayFileFormat.Read(bytes);
+
+        Assert.Equal(2, restored.Version);
+        Assert.Equal(replay.Snapshots.Count, restored.Snapshots.Count);
+
+        for (int i = 0; i < restored.Snapshots.Count; i++)
+        {
+            Assert.Equal(replay.Snapshots[i].IsKeyframe, restored.Snapshots[i].IsKeyframe);
+            Assert.Equal(replay.Snapshots[i].BaselineFrameNumber, restored.Snapshots[i].BaselineFrameNumber);
+        }
+    }
+
+    #endregion
+
+    #region Corrupt Delta Safety Tests
+
+    [Fact]
+    public void SeekToFrame_CorruptDeltaInChain_RollsBackWorldAndThrows()
+    {
+        var serializer = CreateSerializer();
+        var replay = CreateReplayWithCorruptDelta(serializer);
+
+        using var playbackWorld = new World();
+        playbackWorld.Spawn("Survivor").With(new RestorableHealth { Current = 42, Max = 42 }).Build();
+        playbackWorld.Spawn("AlsoSurvivor").With(new RestorableHealth { Current = 42, Max = 42 }).Build();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replay);
+        player.SetValidationContext(playbackWorld, serializer);
+        player.EnableStateRestoration = true;
+
+        var checksumBefore = WorldChecksum.Calculate(playbackWorld, serializer);
+        var countBefore = playbackWorld.GetAllEntities().Count();
+        var frameBefore = player.CurrentFrame;
+
+        // Frame 1's marker is a delta with malformed component data; its chain root is the
+        // keyframe at frame 0. The keyframe restores fine, then the delta apply fails.
+        var ex = Assert.Throws<ReplayStateRestorationException>(() => player.SeekToFrame(1));
+
+        // The failure references the delta marker (frame 1), not the keyframe.
+        Assert.Equal(1, ex.FrameNumber);
+        Assert.Equal(1, ex.SnapshotFrameNumber);
+
+        // World is rolled back to its pre-seek state, not left half-mutated by the
+        // successful keyframe restore that preceded the failed delta.
+        Assert.Equal(countBefore, playbackWorld.GetAllEntities().Count());
+        Assert.Equal(checksumBefore, WorldChecksum.Calculate(playbackWorld, serializer));
+        Assert.All(
+            playbackWorld.Query<RestorableHealth>(),
+            e => Assert.Equal(42, playbackWorld.Get<RestorableHealth>(e).Current));
+
+        // Timeline position is unchanged because the frame index only advances after a
+        // successful restore.
+        Assert.Equal(frameBefore, player.CurrentFrame);
+    }
+
+    #endregion
+
+    #region Size Comparison Tests
+
+    [Fact]
+    public void DeltaCompression_ManyEntitiesFewChanges_ProducesMateriallySmallerRecording()
+    {
+        var serializer = CreateSerializer();
+
+        // Scale entity count high so the delta's fixed structural overhead cannot approach
+        // the full-snapshot size (see the DeltaSave lesson in AutoSaveSystemTests).
+        const int entityCount = 500;
+        const int snapshotFrames = 10;
+
+        var deltaReplay = RecordLargeSession(serializer, entityCount, snapshotFrames, keyframeInterval: 100);
+        var fullReplay = RecordLargeSession(serializer, entityCount, snapshotFrames, keyframeInterval: 1);
+
+        // Compare uncompressed serialized size so the structural payload is measured
+        // directly rather than the stream compressor's ability to dedupe repetition.
+        var options = new ReplayFileOptions { Compression = CompressionMode.None, IncludeChecksum = false };
+        var deltaSize = ReplayFileFormat.Write(deltaReplay, options).Length;
+        var fullSize = ReplayFileFormat.Write(fullReplay, options).Length;
+
+        // Sanity: both recordings captured the same number of markers.
+        Assert.Equal(fullReplay.Snapshots.Count, deltaReplay.Snapshots.Count);
+
+        Assert.True(
+            deltaSize < fullSize,
+            $"Delta recording ({deltaSize} bytes) should be smaller than all-full ({fullSize} bytes).");
+
+        // With 1 of 500 entities changing per snapshot, deltas should be far under half
+        // the all-full size. Threshold is deliberately loose to survive serializer drift.
+        Assert.True(
+            deltaSize < fullSize * 0.5,
+            $"Delta recording ({deltaSize} bytes) should be under 50% of all-full ({fullSize} bytes); " +
+            $"reduction was {(1.0 - (double)deltaSize / fullSize) * 100:F1}%.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static RestorationTestSerializer CreateSerializer()
+        => new RestorationTestSerializer().WithComponent<RestorableHealth>();
+
+    /// <summary>
+    /// Records a session with three entities whose health is set to <c>100 + frame</c>
+    /// each frame, capturing one snapshot per frame from frame 1 onward (frame 0's marker
+    /// is the recorder's automatic initial snapshot).
+    /// </summary>
+    private static ReplayData RecordSession(
+        RestorationTestSerializer serializer,
+        int keyframeInterval,
+        int snapshotFrames)
+    {
+        using var recordingWorld = new World();
+        var entities = new[]
+        {
+            recordingWorld.Spawn("Player").With(new RestorableHealth { Current = 100, Max = 100 }).Build(),
+            recordingWorld.Spawn("Enemy1").With(new RestorableHealth { Current = 100, Max = 100 }).Build(),
+            recordingWorld.Spawn("Enemy2").With(new RestorableHealth { Current = 100, Max = 100 }).Build(),
+        };
+
+        var recorder = new ReplayRecorder(
+            recordingWorld,
+            serializer,
+            new ReplayOptions
+            {
+                RecordChecksums = true,
+                SnapshotInterval = TimeSpan.Zero, // Snapshots captured explicitly below.
+                KeyframeInterval = keyframeInterval,
+            });
+
+        recorder.StartRecording("Delta Session");
+
+        for (int frame = 0; frame <= snapshotFrames; frame++)
+        {
+            recorder.BeginFrame(FrameDelta);
+
+            foreach (var entity in entities)
+            {
+                ref var health = ref recordingWorld.Get<RestorableHealth>(entity);
+                health.Current = 100 + frame;
+            }
+
+            // Frame 0 already has the automatic initial snapshot; capture the rest.
+            if (frame > 0)
+            {
+                recorder.CaptureSnapshot();
+            }
+
+            recorder.EndFrame(FrameDelta);
+        }
+
+        var data = recorder.StopRecording();
+        Assert.NotNull(data);
+        return data!;
+    }
+
+    /// <summary>
+    /// Records a session with many entities where exactly one entity changes per snapshot,
+    /// capturing one snapshot per frame.
+    /// </summary>
+    private static ReplayData RecordLargeSession(
+        RestorationTestSerializer serializer,
+        int entityCount,
+        int snapshotFrames,
+        int keyframeInterval)
+    {
+        using var recordingWorld = new World();
+        var entities = new Entity[entityCount];
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities[i] = recordingWorld.Spawn($"Entity{i}")
+                .With(new RestorableHealth { Current = i, Max = 100 })
+                .Build();
+        }
+
+        var recorder = new ReplayRecorder(
+            recordingWorld,
+            serializer,
+            new ReplayOptions
+            {
+                RecordChecksums = false,
+                SnapshotInterval = TimeSpan.Zero,
+                KeyframeInterval = keyframeInterval,
+            });
+
+        recorder.StartRecording("Large Session");
+
+        for (int frame = 0; frame < snapshotFrames; frame++)
+        {
+            recorder.BeginFrame(FrameDelta);
+
+            // Change exactly one entity per frame.
+            ref var health = ref recordingWorld.Get<RestorableHealth>(entities[frame % entityCount]);
+            health.Current += 1000;
+
+            if (frame > 0)
+            {
+                recorder.CaptureSnapshot();
+            }
+
+            recorder.EndFrame(FrameDelta);
+        }
+
+        var data = recorder.StopRecording();
+        Assert.NotNull(data);
+        return data!;
+    }
+
+    /// <summary>
+    /// Builds the raw bytes of a version-1 .kreplay file: a full-keyframe recording whose
+    /// container header advertises version 1 and whose markers carry no delta fields.
+    /// </summary>
+    private static byte[] CreateVersion1FileBytes()
+    {
+        var serializer = CreateSerializer();
+
+        using var world = new World();
+        world.Spawn("Hero").With(new RestorableHealth { Current = 100, Max = 100 }).Build();
+        var snapshotA = SnapshotManager.CreateSnapshot(world, serializer);
+
+        world.Spawn("Villain").With(new RestorableHealth { Current = 50, Max = 50 }).Build();
+        var snapshotB = SnapshotManager.CreateSnapshot(world, serializer);
+
+        var replay = new ReplayData
+        {
+            Version = 1,
+            RecordingStarted = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(2 * FrameDelta),
+            FrameCount = 2,
+            Frames =
+            [
+                new ReplayFrame { FrameNumber = 0, DeltaTime = TimeSpan.FromSeconds(FrameDelta), ElapsedTime = TimeSpan.Zero, Events = [], PrecedingSnapshotIndex = 0 },
+                new ReplayFrame { FrameNumber = 1, DeltaTime = TimeSpan.FromSeconds(FrameDelta), ElapsedTime = TimeSpan.FromSeconds(FrameDelta), Events = [], PrecedingSnapshotIndex = 1 },
+            ],
+            Snapshots =
+            [
+                new SnapshotMarker { FrameNumber = 0, ElapsedTime = TimeSpan.Zero, Snapshot = snapshotA },
+                new SnapshotMarker { FrameNumber = 1, ElapsedTime = TimeSpan.FromSeconds(FrameDelta), Snapshot = snapshotB },
+            ],
+        };
+
+        var bytes = ReplayFileFormat.Write(replay);
+
+        // Patch the container header version (ushort at offset 4) from the current version
+        // down to 1 to produce a genuine version-1 file. The stored CRC32 covers only the
+        // compressed payload, so the header edit does not invalidate it.
+        bytes[4] = 1;
+        bytes[5] = 0;
+        return bytes;
+    }
+
+    /// <summary>
+    /// Builds a replay with a valid keyframe at frame 0 followed by a delta marker at
+    /// frame 1 whose modified-component data is malformed, forcing the delta apply to
+    /// throw during reconstruction.
+    /// </summary>
+    private static ReplayData CreateReplayWithCorruptDelta(RestorationTestSerializer serializer)
+    {
+        using var world = new World();
+        world.Spawn("Recorded").With(new RestorableHealth { Current = 1, Max = 1 }).Build();
+        var keyframe = SnapshotManager.CreateSnapshot(world, serializer);
+
+        // Delta references entity id 0 (the sole entity in the keyframe) but supplies a
+        // string where the "current" int field is expected, which throws on deserialize.
+        var badDelta = new DeltaSnapshot
+        {
+            BaselineSlotName = "0",
+            ModifiedEntities =
+            [
+                new EntityDelta
+                {
+                    EntityId = 0,
+                    ModifiedComponents =
+                    [
+                        new SerializedComponent
+                        {
+                            TypeName = typeof(RestorableHealth).FullName!,
+                            Data = JsonDocument.Parse("{\"current\":\"not-an-int\",\"max\":1}").RootElement.Clone(),
+                            IsTag = false,
+                            Version = 1,
+                        }
+                    ]
+                }
+            ]
+        };
+
+        return new ReplayData
+        {
+            RecordingStarted = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(2 * FrameDelta),
+            FrameCount = 2,
+            Frames =
+            [
+                new ReplayFrame { FrameNumber = 0, DeltaTime = TimeSpan.FromSeconds(FrameDelta), ElapsedTime = TimeSpan.Zero, Events = [], PrecedingSnapshotIndex = 0 },
+                new ReplayFrame { FrameNumber = 1, DeltaTime = TimeSpan.FromSeconds(FrameDelta), ElapsedTime = TimeSpan.FromSeconds(FrameDelta), Events = [], PrecedingSnapshotIndex = 1 },
+            ],
+            Snapshots =
+            [
+                new SnapshotMarker { FrameNumber = 0, ElapsedTime = TimeSpan.Zero, Snapshot = keyframe },
+                new SnapshotMarker { FrameNumber = 1, ElapsedTime = TimeSpan.FromSeconds(FrameDelta), Delta = badDelta, BaselineFrameNumber = 0 },
+            ],
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **Delta markers between keyframes**: recording now stores a full `WorldSnapshot` every `ReplayOptions.KeyframeInterval`-th marker (default 10; ≤1 disables) and `DeltaSnapshot`s (via Core's proven `DeltaDiffer`) in between. Seek/restore rebuilds state by restoring the governing keyframe then replaying the delta chain via `DeltaRestorer`, all inside #1028's atomic backup/rollback.
- **Measured: 89.3% size reduction** (500 entities, 1 change/snapshot: 126.5 KB delta vs 1,181 KB all-full, uncompressed).
- **Zero-cost v1 compatibility**: single `SnapshotMarker` type with nullable `Snapshot`/`Delta` fields + `WhenWritingNull` serialization means a keyframe's serialized form is byte-identical to v1 — old files load with no reader changes (data-format versioning, `ReplayData`/`ReplayFileFormat` → v2).
- Ring-buffer retention extends back to the governing keyframe so retained chains stay reconstructable; `GhostExtractor` reads keyframes only (guard, no ghost feature work).

## Test plan
- [x] 12 new tests: delta-chain reconstruction (checksum + component asserts), keyframe interval honored, v1 round-trip, corrupt delta → rollback + typed exception with failing frame, size-reduction threshold (500-entity scale per the DeltaSave lesson) — 577/577 passing
- [x] Release build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #531 (plan on #98). **Stacked on #1028** — merge that first; this diff is the delta-compression commit only.