### PR TITLE
feat(particles): Add texture-sheet animation, ParticleSpace, and new emission shapes

### DIFF
--- a/docs/particles.md
+++ b/docs/particles.md
@@ -70,12 +70,41 @@ Adding a `ParticleEmitter` component fires `World.OnComponentAdded<ParticleEmitt
 - **Burst emission** - `BurstCount` particles every `BurstInterval` seconds; `BurstInterval = 0` fires a single one-shot burst instead of repeating.
 - **Spawn ranges** - `LifetimeMin`/`LifetimeMax`, `StartSizeMin`/`StartSizeMax`, `StartSpeedMin`/`StartSpeedMax`, `StartRotationMin`/`StartRotationMax` are all sampled uniformly at random per particle.
 - **Shape** - `Shape` (an `EmissionShape`) controls where particles spawn and their initial direction.
-- **Visuals** - `Texture` (a `TextureHandle`; particles render as filled circles when it's not valid), `StartColor`, and `BlendMode`.
+- **Space** - `Space` (a `ParticleSpace`) selects world- or local-space simulation (see [Simulation Space](#simulation-space-world-vs-local) below); defaults to `ParticleSpace.World`.
+- **Visuals** - `Texture` (a `TextureHandle`; particles render as filled circles when it's not valid), `StartColor`, `BlendMode`, and `TextureSheetColumns`/`TextureSheetRows` for sprite-sheet animation (see [Texture Sheet Animation](#texture-sheet-animation) below).
 - **Playback** - `IsPlaying` toggles emission on and off without removing the component.
 
 `ParticleEmitter.Default` provides sensible starting values, and `ParticleEmitter.Burst(count, lifetime)` / `ParticleEmitter.Continuous(rate, lifetime)` are convenience factories for the two emission modes.
 
-`EmissionShape` supports four shapes via static factories: `EmissionShape.Point`, `EmissionShape.Sphere(radius)`, `EmissionShape.Cone(radius, angle)` / `EmissionShape.Cone(radius, angle, direction)`, and `EmissionShape.Box(width, height)`.
+`EmissionShape` supports these shapes via static factories:
+
+- `EmissionShape.Point` - all particles emit from the emitter origin.
+- `EmissionShape.Sphere(radius)` - a filled disc (the sphere flattened to 2D); direction is radial outward.
+- `EmissionShape.Cone(radius, angle)` / `EmissionShape.Cone(radius, angle, direction)` - a spread arc around `direction`.
+- `EmissionShape.Box(width, height)` - a filled rectangle; direction is random.
+- `EmissionShape.Hemisphere(radius)` / `EmissionShape.Hemisphere(radius, direction)` - **2D interpretation:** a filled half-disc. Positions and initial directions span the 180-degree arc centered on `direction` (default `Vector2.UnitY`), mirroring how `Sphere` flattens a sphere to a disc.
+- `EmissionShape.Edge(length)` / `EmissionShape.Edge(extent)` - a straight line segment centered on the emitter (spanning `-extent/2` to `+extent/2`; `Edge(length)` lies along the X axis). Direction is random. The extent is stored in `Size`.
+- `EmissionShape.Circle(radius)` - the **perimeter** of a ring (not a filled disc): positions lie exactly at distance `radius`, with an outward radial direction.
+
+#### Simulation Space (World vs Local)
+
+`ParticleEmitter.Space` chooses the coordinate space particles are simulated in:
+
+- `ParticleSpace.World` (default) - particles spawn at the emitter's current world position and are stored in world coordinates. Once spawned they are independent, so moving the emitter afterwards leaves existing particles where they are. This is the original behavior.
+- `ParticleSpace.Local` - particles are stored relative to the emitter. Their world position is resolved each frame by adding the emitter's current position, so moving the emitter carries all of its live particles with it. Velocity is still integrated in the emitter's local frame.
+
+#### Texture Sheet Animation
+
+Set `TextureSheetColumns` and `TextureSheetRows` to treat `Texture` as a grid of animation frames laid out left-to-right, top-to-bottom. When `TextureSheetColumns * TextureSheetRows` is greater than 1, `ParticleRenderSystem` selects the frame from each particle's normalized age: frame `0` at spawn advancing to the final frame at end of life (`frame = clamp((int)(normalizedAge * frameCount), 0, frameCount - 1)`), and draws only that frame's UV sub-rectangle. A value of `0` or `1` for either dimension disables sheet animation and draws the whole texture.
+
+```csharp
+var explosion = ParticleEffects.Explosion() with
+{
+    Texture = explosionSheet, // e.g. a 4x4 grid of 16 frames
+    TextureSheetColumns = 4,
+    TextureSheetRows = 4
+};
+```
 
 ### `ParticleEmitterModifiers`
 

--- a/src/KeenEyes.Graphics.Abstractions/Rendering2D/I2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Rendering2D/I2DRenderer.cs
@@ -270,6 +270,17 @@ public interface I2DRenderer : IDisposable
     /// <param name="tint">Optional color tint (default: white/no tint).</param>
     void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, float rotation, Vector2 origin, Vector4? tint = null);
 
+    /// <summary>
+    /// Draws a rotated region of a texture (for rotated sprite-sheet/atlas frames).
+    /// </summary>
+    /// <param name="texture">The texture handle.</param>
+    /// <param name="destRect">The destination rectangle on screen.</param>
+    /// <param name="sourceRect">The source rectangle in texture coordinates (0-1 range).</param>
+    /// <param name="rotation">The rotation angle in radians.</param>
+    /// <param name="origin">The rotation origin (relative to destRect, 0-1 range).</param>
+    /// <param name="tint">Optional color tint (default: white/no tint).</param>
+    void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, in Rectangle sourceRect, float rotation, Vector2 origin, Vector4? tint = null);
+
     #endregion
 
     #region Clipping

--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -653,6 +653,14 @@ public sealed class Silk2DRenderer : I2DRenderer
     }
 
     /// <inheritdoc />
+    public void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, in Rectangle sourceRect, float rotation, Vector2 origin, Vector4? tint = null)
+    {
+        // Simplified: rotation is not yet applied by this renderer (matches the rotation-only
+        // overload above); draw the requested sub-region so sprite-sheet frames select correctly.
+        DrawTextureRegion(texture, destRect, sourceRect, tint);
+    }
+
+    /// <inheritdoc />
     public void PushClip(in Rectangle rect)
     {
         Flush(); // Flush before changing scissor

--- a/src/KeenEyes.Particles/Components/ParticleEmitter.cs
+++ b/src/KeenEyes.Particles/Components/ParticleEmitter.cs
@@ -58,6 +58,16 @@ public partial struct ParticleEmitter
     /// </summary>
     public EmissionShape Shape;
 
+    /// <summary>
+    /// The coordinate space particles are simulated in.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ParticleSpace.World"/> (the default) spawns particles at the emitter's
+    /// world position and leaves them behind when the emitter moves.
+    /// <see cref="ParticleSpace.Local"/> attaches particles to the emitter so they move with it.
+    /// </remarks>
+    public ParticleSpace Space;
+
     #endregion
 
     #region Particle Properties
@@ -122,6 +132,27 @@ public partial struct ParticleEmitter
     /// </summary>
     public BlendMode BlendMode;
 
+    /// <summary>
+    /// Number of columns in the particle's texture sheet (sprite sheet).
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="TextureSheetColumns"/> multiplied by <see cref="TextureSheetRows"/>
+    /// is greater than 1, the emitter's <see cref="Texture"/> is treated as a grid of
+    /// animation frames laid out left-to-right, top-to-bottom. The displayed frame advances
+    /// with each particle's normalized age (0 at spawn, the final frame at end of life).
+    /// A value of 0 or 1 disables sheet animation and draws the whole texture.
+    /// </remarks>
+    public int TextureSheetColumns;
+
+    /// <summary>
+    /// Number of rows in the particle's texture sheet (sprite sheet).
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="TextureSheetColumns"/> for how the grid is interpreted. A value of
+    /// 0 or 1 (combined with the column count) disables sheet animation.
+    /// </remarks>
+    public int TextureSheetRows;
+
     #endregion
 
     #region State (managed by system)
@@ -160,6 +191,7 @@ public partial struct ParticleEmitter
         BurstCount = 0,
         BurstInterval = 0f,
         Shape = EmissionShape.Point,
+        Space = ParticleSpace.World,
         LifetimeMin = 1f,
         LifetimeMax = 2f,
         StartSizeMin = 8f,
@@ -171,6 +203,8 @@ public partial struct ParticleEmitter
         Texture = TextureHandle.Invalid,
         StartColor = Vector4.One,
         BlendMode = BlendMode.Additive,
+        TextureSheetColumns = 1,
+        TextureSheetRows = 1,
         IsPlaying = true,
         EmissionAccumulator = 0f,
         BurstTimer = 0f,

--- a/src/KeenEyes.Particles/Data/EmissionShape.cs
+++ b/src/KeenEyes.Particles/Data/EmissionShape.cs
@@ -17,7 +17,24 @@ public enum EmissionShapeType
     Cone,
 
     /// <summary>Particles emit from within a rectangular box.</summary>
-    Box
+    Box,
+
+    /// <summary>
+    /// Particles emit from within a half-disc.
+    /// </summary>
+    /// <remarks>
+    /// The particle pool is 2D (X/Y only), so a "hemisphere" is interpreted as the 2D
+    /// flattening of a hemisphere: a filled half-disc. Emission is restricted to the
+    /// 180-degree arc centered on <see cref="EmissionShape.Direction"/>, mirroring the way
+    /// <see cref="EmissionShapeType.Sphere"/> flattens a sphere to a filled disc.
+    /// </remarks>
+    Hemisphere,
+
+    /// <summary>Particles emit along a straight line segment.</summary>
+    Edge,
+
+    /// <summary>Particles emit on the perimeter of a circle (a ring, not a filled disc).</summary>
+    Circle
 }
 
 /// <summary>
@@ -105,5 +122,84 @@ public readonly record struct EmissionShape
     {
         Type = EmissionShapeType.Box,
         Size = new Vector2(width, height)
+    };
+
+    /// <summary>
+    /// Creates a hemisphere emission shape pointing along the default upward direction.
+    /// </summary>
+    /// <param name="radius">The radius of the hemisphere.</param>
+    /// <returns>A hemisphere emission shape.</returns>
+    /// <remarks>
+    /// In the 2D particle pool this emits from a filled half-disc: positions and initial
+    /// directions are sampled across the 180-degree arc centered on
+    /// <see cref="Direction"/> (defaulting to <see cref="Vector2.UnitY"/>), consistent with
+    /// how <see cref="Sphere"/> flattens a sphere to a filled disc.
+    /// </remarks>
+    public static EmissionShape Hemisphere(float radius) => new()
+    {
+        Type = EmissionShapeType.Hemisphere,
+        Radius = radius,
+        Direction = Vector2.UnitY
+    };
+
+    /// <summary>
+    /// Creates a hemisphere emission shape oriented along a custom direction.
+    /// </summary>
+    /// <param name="radius">The radius of the hemisphere.</param>
+    /// <param name="direction">The direction the flat side of the hemisphere faces away from (will be normalized).</param>
+    /// <returns>A hemisphere emission shape.</returns>
+    /// <remarks>
+    /// In the 2D particle pool this emits from a filled half-disc: positions and initial
+    /// directions are sampled across the 180-degree arc centered on <paramref name="direction"/>.
+    /// </remarks>
+    public static EmissionShape Hemisphere(float radius, Vector2 direction) => new()
+    {
+        Type = EmissionShapeType.Hemisphere,
+        Radius = radius,
+        Direction = Vector2.Normalize(direction)
+    };
+
+    /// <summary>
+    /// Creates an edge (line segment) emission shape along the X axis.
+    /// </summary>
+    /// <param name="length">The full length of the segment; particles spawn between <c>-length/2</c> and <c>+length/2</c> on the X axis, relative to the emitter.</param>
+    /// <returns>An edge emission shape.</returns>
+    /// <remarks>
+    /// The segment extent is stored in <see cref="Size"/> as <c>(length, 0)</c>. Particles
+    /// spawn uniformly along the segment with a random initial direction.
+    /// </remarks>
+    public static EmissionShape Edge(float length) => new()
+    {
+        Type = EmissionShapeType.Edge,
+        Size = new Vector2(length, 0f)
+    };
+
+    /// <summary>
+    /// Creates an edge (line segment) emission shape spanning the given extent vector.
+    /// </summary>
+    /// <param name="extent">The full segment vector; particles spawn between <c>-extent/2</c> and <c>+extent/2</c>, relative to the emitter.</param>
+    /// <returns>An edge emission shape.</returns>
+    /// <remarks>
+    /// Particles spawn uniformly along the segment with a random initial direction.
+    /// </remarks>
+    public static EmissionShape Edge(Vector2 extent) => new()
+    {
+        Type = EmissionShapeType.Edge,
+        Size = extent
+    };
+
+    /// <summary>
+    /// Creates a circle (ring perimeter) emission shape.
+    /// </summary>
+    /// <param name="radius">The radius of the ring.</param>
+    /// <returns>A circle emission shape.</returns>
+    /// <remarks>
+    /// Particles spawn exactly on the ring's perimeter (distance <paramref name="radius"/>
+    /// from the emitter), not within a filled disc, with an outward radial initial direction.
+    /// </remarks>
+    public static EmissionShape Circle(float radius) => new()
+    {
+        Type = EmissionShapeType.Circle,
+        Radius = radius
     };
 }

--- a/src/KeenEyes.Particles/Data/ParticleSpace.cs
+++ b/src/KeenEyes.Particles/Data/ParticleSpace.cs
@@ -1,0 +1,25 @@
+namespace KeenEyes.Particles.Data;
+
+/// <summary>
+/// The coordinate space in which an emitter's particles are simulated.
+/// </summary>
+/// <remarks>
+/// This controls whether particles are anchored to world coordinates at spawn time
+/// or remain attached to the emitter and move with it.
+/// </remarks>
+public enum ParticleSpace
+{
+    /// <summary>
+    /// Particles are spawned at the emitter's world position and stored in world
+    /// coordinates. Once spawned they are independent of the emitter, so moving the
+    /// emitter afterwards has no effect on existing particles. This is the default.
+    /// </summary>
+    World,
+
+    /// <summary>
+    /// Particles are stored relative to the emitter (local coordinates). Their world
+    /// position is resolved each frame by adding the emitter's current position, so
+    /// moving the emitter moves all of its live particles with it.
+    /// </summary>
+    Local
+}

--- a/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using KeenEyes.Common;
 using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Particles.Components;
 using KeenEyes.Particles.Data;
@@ -15,7 +16,9 @@ namespace KeenEyes.Particles.Systems;
 /// batching.
 /// </para>
 /// <para>
-/// If a particle has a valid texture, it uses <see cref="I2DRenderer.DrawTextureRotated"/>.
+/// If a particle has a valid texture, it uses
+/// <see cref="I2DRenderer.DrawTextureRotated(TextureHandle, in Rectangle, float, Vector2, Vector4?)"/>
+/// (or the sprite-sheet overload when a texture sheet is configured).
 /// Otherwise, it falls back to <see cref="I2DRenderer.FillCircle"/>.
 /// </para>
 /// </remarks>
@@ -63,10 +66,10 @@ public sealed class ParticleRenderSystem : SystemBase
 
         // Group emitters by blend mode for efficient batching
         // We'll render transparent first, then additive (so glow effects overlay)
-        var transparentEmitters = new List<(Entity, ParticlePool, ParticleEmitter)>();
-        var additiveEmitters = new List<(Entity, ParticlePool, ParticleEmitter)>();
-        var multiplyEmitters = new List<(Entity, ParticlePool, ParticleEmitter)>();
-        var premultipliedEmitters = new List<(Entity, ParticlePool, ParticleEmitter)>();
+        var transparentEmitters = new List<RenderEntry>();
+        var additiveEmitters = new List<RenderEntry>();
+        var multiplyEmitters = new List<RenderEntry>();
+        var premultipliedEmitters = new List<RenderEntry>();
 
         foreach (var entity in World.Query<ParticleEmitter>())
         {
@@ -77,19 +80,27 @@ public sealed class ParticleRenderSystem : SystemBase
                 continue;
             }
 
+            // Local-space particles are stored relative to the emitter, so translate them
+            // by the emitter's current position at render time. World-space particles use
+            // absolute coordinates and need no offset.
+            var offset = emitter.Space == ParticleSpace.Local
+                ? ResolveEmitterPosition(entity)
+                : Vector2.Zero;
+            var entry = new RenderEntry(pool, emitter, offset);
+
             switch (emitter.BlendMode)
             {
                 case BlendMode.Transparent:
-                    transparentEmitters.Add((entity, pool, emitter));
+                    transparentEmitters.Add(entry);
                     break;
                 case BlendMode.Additive:
-                    additiveEmitters.Add((entity, pool, emitter));
+                    additiveEmitters.Add(entry);
                     break;
                 case BlendMode.Multiply:
-                    multiplyEmitters.Add((entity, pool, emitter));
+                    multiplyEmitters.Add(entry);
                     break;
                 case BlendMode.Premultiplied:
-                    premultipliedEmitters.Add((entity, pool, emitter));
+                    premultipliedEmitters.Add(entry);
                     break;
             }
         }
@@ -102,7 +113,7 @@ public sealed class ParticleRenderSystem : SystemBase
         RenderBatch(r, additiveEmitters);
     }
 
-    private static void RenderBatch(I2DRenderer renderer, List<(Entity, ParticlePool, ParticleEmitter)> emitters)
+    private static void RenderBatch(I2DRenderer renderer, List<RenderEntry> emitters)
     {
         if (emitters.Count == 0)
         {
@@ -111,25 +122,32 @@ public sealed class ParticleRenderSystem : SystemBase
 
         // Calculate total particles for batch hint
         var totalParticles = 0;
-        foreach (var (_, pool, _) in emitters)
+        foreach (var entry in emitters)
         {
-            totalParticles += pool.ActiveCount;
+            totalParticles += entry.Pool.ActiveCount;
         }
 
         renderer.Begin();
         renderer.SetBatchHint(totalParticles);
 
-        foreach (var (_, pool, emitter) in emitters)
+        foreach (var entry in emitters)
         {
-            RenderPool(renderer, pool, emitter.Texture);
+            RenderPool(renderer, entry.Pool, in entry.Emitter, entry.Offset);
         }
 
         renderer.End();
     }
 
-    private static void RenderPool(I2DRenderer renderer, ParticlePool pool, TextureHandle texture)
+    private static void RenderPool(I2DRenderer renderer, ParticlePool pool, in ParticleEmitter emitter, Vector2 offset)
     {
+        var texture = emitter.Texture;
         var hasTexture = texture.IsValid;
+
+        // A texture sheet is only active when the grid describes more than one frame.
+        var columns = Math.Max(1, emitter.TextureSheetColumns);
+        var rows = Math.Max(1, emitter.TextureSheetRows);
+        var frameCount = columns * rows;
+        var animated = hasTexture && frameCount > 1;
 
         for (var i = 0; i < pool.Capacity; i++)
         {
@@ -146,32 +164,95 @@ public sealed class ParticleRenderSystem : SystemBase
 
             var size = pool.Sizes[i];
             var halfSize = size / 2f;
+            var posX = pool.PositionsX[i] + offset.X;
+            var posY = pool.PositionsY[i] + offset.Y;
 
             if (hasTexture)
             {
                 var destRect = new Rectangle(
-                    pool.PositionsX[i] - halfSize,
-                    pool.PositionsY[i] - halfSize,
+                    posX - halfSize,
+                    posY - halfSize,
                     size,
                     size);
 
-                renderer.DrawTextureRotated(
-                    texture,
-                    in destRect,
-                    pool.Rotations[i],
-                    new Vector2(0.5f, 0.5f),
-                    color);
+                if (animated)
+                {
+                    var sourceRect = FrameSourceRect(pool.NormalizedAges[i], columns, rows, frameCount);
+                    renderer.DrawTextureRotated(
+                        texture,
+                        in destRect,
+                        in sourceRect,
+                        pool.Rotations[i],
+                        new Vector2(0.5f, 0.5f),
+                        color);
+                }
+                else
+                {
+                    renderer.DrawTextureRotated(
+                        texture,
+                        in destRect,
+                        pool.Rotations[i],
+                        new Vector2(0.5f, 0.5f),
+                        color);
+                }
             }
             else
             {
                 // Fallback: draw as filled circle
                 renderer.FillCircle(
-                    pool.PositionsX[i],
-                    pool.PositionsY[i],
+                    posX,
+                    posY,
                     halfSize,
                     color,
                     segments: 8);
             }
         }
+    }
+
+    /// <summary>
+    /// Computes the UV sub-rectangle for the sprite-sheet frame at the given normalized age.
+    /// </summary>
+    private static Rectangle FrameSourceRect(float normalizedAge, int columns, int rows, int frameCount)
+    {
+        var frame = (int)(normalizedAge * frameCount);
+        if (frame < 0)
+        {
+            frame = 0;
+        }
+        else if (frame >= frameCount)
+        {
+            frame = frameCount - 1;
+        }
+
+        var col = frame % columns;
+        var row = frame / columns;
+        var frameWidth = 1f / columns;
+        var frameHeight = 1f / rows;
+
+        return new Rectangle(col * frameWidth, row * frameHeight, frameWidth, frameHeight);
+    }
+
+    private Vector2 ResolveEmitterPosition(Entity entity)
+    {
+        if (World.Has<Transform2D>(entity))
+        {
+            ref readonly var transform = ref World.Get<Transform2D>(entity);
+            return transform.Position;
+        }
+
+        if (World.Has<Transform3D>(entity))
+        {
+            ref readonly var transform3D = ref World.Get<Transform3D>(entity);
+            return new Vector2(transform3D.Position.X, transform3D.Position.Y);
+        }
+
+        return Vector2.Zero;
+    }
+
+    private readonly struct RenderEntry(ParticlePool pool, ParticleEmitter emitter, Vector2 offset)
+    {
+        public readonly ParticlePool Pool = pool;
+        public readonly ParticleEmitter Emitter = emitter;
+        public readonly Vector2 Offset = offset;
     }
 }

--- a/src/KeenEyes.Particles/Systems/ParticleSpawnSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleSpawnSystem.cs
@@ -96,10 +96,13 @@ public sealed class ParticleSpawnSystem : SystemBase
                 }
             }
 
-            // Spawn particles
+            // Spawn particles. In Local space, positions are stored relative to the
+            // emitter (origin zero) and translated by the emitter position at render time;
+            // in World space, positions are anchored at the emitter's current position.
+            var origin = emitter.Space == ParticleSpace.Local ? Vector2.Zero : transform.Position;
             for (var i = 0; i < toSpawn; i++)
             {
-                SpawnParticle(pool, in emitter, in transform, pm.Config.MaxParticlesPerEmitter);
+                SpawnParticle(pool, in emitter, origin, pm.Config.MaxParticlesPerEmitter);
             }
         }
 
@@ -164,14 +167,15 @@ public sealed class ParticleSpawnSystem : SystemBase
                 }
             }
 
+            var origin = emitter.Space == ParticleSpace.Local ? Vector2.Zero : transform.Position;
             for (var i = 0; i < toSpawn; i++)
             {
-                SpawnParticle(pool, in emitter, in transform, pm.Config.MaxParticlesPerEmitter);
+                SpawnParticle(pool, in emitter, origin, pm.Config.MaxParticlesPerEmitter);
             }
         }
     }
 
-    private void SpawnParticle(ParticlePool pool, in ParticleEmitter emitter, in Transform2D transform, int maxParticles)
+    private void SpawnParticle(ParticlePool pool, in ParticleEmitter emitter, Vector2 origin, int maxParticles)
     {
         var index = pool.Allocate();
         if (index < 0)
@@ -188,8 +192,8 @@ public sealed class ParticleSpawnSystem : SystemBase
         // Calculate spawn position and direction based on shape
         var (posOffset, direction) = CalculateSpawnPosition(emitter.Shape);
 
-        pool.PositionsX[index] = transform.Position.X + posOffset.X;
-        pool.PositionsY[index] = transform.Position.Y + posOffset.Y;
+        pool.PositionsX[index] = origin.X + posOffset.X;
+        pool.PositionsY[index] = origin.Y + posOffset.Y;
 
         // Calculate velocity
         var speed = Lerp(emitter.StartSpeedMin, emitter.StartSpeedMax, World.NextFloat());
@@ -244,6 +248,30 @@ public sealed class ParticleSpawnSystem : SystemBase
                 var x = Lerp(-shape.Size.X / 2, shape.Size.X / 2, World.NextFloat());
                 var y = Lerp(-shape.Size.Y / 2, shape.Size.Y / 2, World.NextFloat());
                 return (new Vector2(x, y), RandomDirection());
+
+            case EmissionShapeType.Hemisphere:
+                // 2D interpretation: a filled half-disc. Directions (and positions) span the
+                // 180-degree arc centered on the shape direction, mirroring how Sphere fills a disc.
+                var hemiBase = shape.Direction;
+                if (hemiBase == Vector2.Zero)
+                {
+                    hemiBase = Vector2.UnitY;
+                }
+                var hemiBaseAngle = MathF.Atan2(hemiBase.Y, hemiBase.X);
+                var hemiAngle = hemiBaseAngle + Lerp(-MathF.PI / 2f, MathF.PI / 2f, World.NextFloat());
+                var hemiDir = new Vector2(MathF.Cos(hemiAngle), MathF.Sin(hemiAngle));
+                var hemiDist = World.NextFloat() * shape.Radius;
+                return (hemiDir * hemiDist, hemiDir);
+
+            case EmissionShapeType.Edge:
+                // Uniformly sample a point along the segment spanning -Size/2 .. +Size/2.
+                var edgeT = World.NextFloat() - 0.5f;
+                return (shape.Size * edgeT, RandomDirection());
+
+            case EmissionShapeType.Circle:
+                // Ring perimeter: position lies exactly on the circle, direction points outward.
+                var circleDir = RandomDirection();
+                return (circleDir * shape.Radius, circleDir);
 
             default:
                 return (Vector2.Zero, Vector2.UnitY);

--- a/src/KeenEyes.Testing/Graphics/Mock2DRenderer.cs
+++ b/src/KeenEyes.Testing/Graphics/Mock2DRenderer.cs
@@ -260,6 +260,12 @@ public sealed class Mock2DRenderer : I2DRenderer
         RecordCommand(new DrawTextureRotatedCommand(texture, destRect, rotation, origin, tint ?? Vector4.One));
     }
 
+    /// <inheritdoc />
+    public void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, in Rectangle sourceRect, float rotation, Vector2 origin, Vector4? tint = null)
+    {
+        RecordCommand(new DrawTextureRotatedRegionCommand(texture, destRect, sourceRect, rotation, origin, tint ?? Vector4.One));
+    }
+
     #endregion
 
     #region Clipping
@@ -480,6 +486,17 @@ public sealed record DrawTextureRegionCommand(TextureHandle Texture, Rectangle D
 /// <param name="Origin">The rotation origin.</param>
 /// <param name="Tint">The color tint.</param>
 public sealed record DrawTextureRotatedCommand(TextureHandle Texture, Rectangle DestRect, float Rotation, Vector2 Origin, Vector4 Tint) : Draw2DCommand;
+
+/// <summary>
+/// A rotated texture region draw command (for sprite-sheet/atlas frames).
+/// </summary>
+/// <param name="Texture">The texture handle.</param>
+/// <param name="DestRect">The destination rectangle.</param>
+/// <param name="SourceRect">The source rectangle in texture coordinates.</param>
+/// <param name="Rotation">The rotation angle in radians.</param>
+/// <param name="Origin">The rotation origin.</param>
+/// <param name="Tint">The color tint.</param>
+public sealed record DrawTextureRotatedRegionCommand(TextureHandle Texture, Rectangle DestRect, Rectangle SourceRect, float Rotation, Vector2 Origin, Vector4 Tint) : Draw2DCommand;
 
 /// <summary>
 /// A push clip command.

--- a/tests/KeenEyes.Particles.Tests/EmissionShapeTests.cs
+++ b/tests/KeenEyes.Particles.Tests/EmissionShapeTests.cs
@@ -154,6 +154,95 @@ public class EmissionShapeTests
 
     #endregion
 
+    #region Hemisphere Shape Tests
+
+    [Fact]
+    public void Hemisphere_HasHemisphereType()
+    {
+        var shape = EmissionShape.Hemisphere(10f);
+
+        Assert.Equal(EmissionShapeType.Hemisphere, shape.Type);
+    }
+
+    [Fact]
+    public void Hemisphere_HasCorrectRadius()
+    {
+        var shape = EmissionShape.Hemisphere(25f);
+
+        Assert.Equal(25f, shape.Radius);
+    }
+
+    [Fact]
+    public void Hemisphere_DefaultsToUpwardDirection()
+    {
+        var shape = EmissionShape.Hemisphere(10f);
+
+        Assert.Equal(Vector2.UnitY, shape.Direction);
+    }
+
+    [Fact]
+    public void Hemisphere_WithDirection_NormalizesDirection()
+    {
+        var shape = EmissionShape.Hemisphere(10f, new Vector2(3f, 4f)); // Length 5
+
+        var normalized = Vector2.Normalize(new Vector2(3f, 4f));
+        Assert.Equal(normalized.X, shape.Direction.X, 4);
+        Assert.Equal(normalized.Y, shape.Direction.Y, 4);
+    }
+
+    #endregion
+
+    #region Edge Shape Tests
+
+    [Fact]
+    public void Edge_HasEdgeType()
+    {
+        var shape = EmissionShape.Edge(100f);
+
+        Assert.Equal(EmissionShapeType.Edge, shape.Type);
+    }
+
+    [Fact]
+    public void Edge_Length_StoresExtentOnXAxis()
+    {
+        var shape = EmissionShape.Edge(200f);
+
+        Assert.Equal(200f, shape.Size.X);
+        Assert.Equal(0f, shape.Size.Y);
+    }
+
+    [Fact]
+    public void Edge_Extent_StoresExtentVector()
+    {
+        var extent = new Vector2(50f, 120f);
+        var shape = EmissionShape.Edge(extent);
+
+        Assert.Equal(EmissionShapeType.Edge, shape.Type);
+        Assert.Equal(extent, shape.Size);
+    }
+
+    #endregion
+
+    #region Circle Shape Tests
+
+    [Fact]
+    public void Circle_HasCircleType()
+    {
+        var shape = EmissionShape.Circle(10f);
+
+        Assert.Equal(EmissionShapeType.Circle, shape.Type);
+    }
+
+    [Fact]
+    public void Circle_HasCorrectRadius()
+    {
+        var shape = EmissionShape.Circle(42f);
+
+        Assert.Equal(42f, shape.Radius);
+    }
+
+    #endregion
+
     #region Record Struct Behavior Tests
 
     [Fact]

--- a/tests/KeenEyes.Particles.Tests/ParticleSpaceTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleSpaceTests.cs
@@ -1,0 +1,159 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Particles.Components;
+using KeenEyes.Particles.Data;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.Particles.Tests;
+
+/// <summary>
+/// Tests for <see cref="ParticleSpace"/> World/Local simulation behavior.
+/// </summary>
+public class ParticleSpaceTests : IDisposable
+{
+    private World? world;
+    private Mock2DRenderer? mockRenderer;
+
+    public void Dispose()
+    {
+        mockRenderer?.Dispose();
+        world?.Dispose();
+    }
+
+    private static int FirstAlive(ParticlePool pool)
+    {
+        for (var i = 0; i < pool.Capacity; i++)
+        {
+            if (pool.Alive[i])
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    [Fact]
+    public void WorldSpace_IsTheDefault()
+    {
+        Assert.Equal(ParticleSpace.World, default(ParticleEmitter).Space);
+        Assert.Equal(ParticleSpace.World, ParticleEmitter.Default.Space);
+    }
+
+    [Fact]
+    public void WorldSpace_EmitterMovesMidLife_ParticlesStayInWorldCoordinates()
+    {
+        world = new World();
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var start = new Vector2(100f, 100f);
+        var emitter = ParticleEmitter.Burst(1, 10f) with
+        {
+            Space = ParticleSpace.World,
+            Shape = EmissionShape.Point,
+            StartSpeedMin = 0f,
+            StartSpeedMax = 0f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(start, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var manager = world.GetExtension<ParticleManager>();
+        var pool = manager.GetPool(entity)!;
+        var idx = FirstAlive(pool);
+        Assert.True(idx >= 0);
+
+        var spawnedX = pool.PositionsX[idx];
+        var spawnedY = pool.PositionsY[idx];
+        Assert.True(spawnedX.ApproximatelyEquals(start.X, 0.01f));
+        Assert.True(spawnedY.ApproximatelyEquals(start.Y, 0.01f));
+
+        // Move the emitter well away from the spawn location.
+        ref var transform = ref world.Get<Transform2D>(entity);
+        transform.Position = new Vector2(500f, 400f);
+
+        world.Update(1f / 60f);
+
+        // World-space particles are anchored at spawn time and must not follow the emitter.
+        Assert.True(pool.PositionsX[idx].ApproximatelyEquals(spawnedX, 0.01f));
+        Assert.True(pool.PositionsY[idx].ApproximatelyEquals(spawnedY, 0.01f));
+    }
+
+    [Fact]
+    public void LocalSpace_ParticlesStoredRelativeToEmitter()
+    {
+        world = new World();
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var start = new Vector2(100f, 100f);
+        var emitter = ParticleEmitter.Burst(1, 10f) with
+        {
+            Space = ParticleSpace.Local,
+            Shape = EmissionShape.Point,
+            StartSpeedMin = 0f,
+            StartSpeedMax = 0f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(start, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var manager = world.GetExtension<ParticleManager>();
+        var pool = manager.GetPool(entity)!;
+        var idx = FirstAlive(pool);
+        Assert.True(idx >= 0);
+
+        // Stored positions are local (relative to the emitter), not the world position.
+        Assert.True(pool.PositionsX[idx].IsApproximatelyZero(0.01f));
+        Assert.True(pool.PositionsY[idx].IsApproximatelyZero(0.01f));
+    }
+
+    [Fact]
+    public void LocalSpace_EmitterMovesMidLife_RenderedParticlesFollowEmitter()
+    {
+        world = new World();
+        mockRenderer = new Mock2DRenderer();
+        world.SetExtension<I2DRenderer>(mockRenderer);
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var start = new Vector2(100f, 100f);
+        var emitter = ParticleEmitter.Burst(1, 10f) with
+        {
+            Space = ParticleSpace.Local,
+            Shape = EmissionShape.Point,
+            StartSpeedMin = 0f,
+            StartSpeedMax = 0f,
+            StartSizeMin = 10f,
+            StartSizeMax = 10f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(start, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        // The particle renders at the emitter's current world position (local offset + emitter pos).
+        var beforeCircle = Assert.Single(mockRenderer.Commands.OfType<FillCircleCommand>());
+        Assert.True(beforeCircle.Center.X.ApproximatelyEquals(start.X, 0.5f));
+        Assert.True(beforeCircle.Center.Y.ApproximatelyEquals(start.Y, 0.5f));
+
+        // Move the emitter; the same particle should now render at the new position.
+        var moved = new Vector2(500f, 400f);
+        ref var transform = ref world.Get<Transform2D>(entity);
+        transform.Position = moved;
+
+        mockRenderer.ClearCommands();
+        world.Update(1f / 60f);
+
+        var afterCircle = Assert.Single(mockRenderer.Commands.OfType<FillCircleCommand>());
+        Assert.True(afterCircle.Center.X.ApproximatelyEquals(moved.X, 0.5f));
+        Assert.True(afterCircle.Center.Y.ApproximatelyEquals(moved.Y, 0.5f));
+    }
+}

--- a/tests/KeenEyes.Particles.Tests/ParticleSpawnSystemTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleSpawnSystemTests.cs
@@ -541,6 +541,131 @@ public class ParticleSpawnSystemTests : IDisposable
         }
     }
 
+    [Fact]
+    public void SpawnSystem_EdgeShape_SpawnsAlongSegment()
+    {
+        world = new World();
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var center = new Vector2(100f, 100f);
+        var length = 200f;
+        var emitter = ParticleEmitter.Burst(100, 1f) with
+        {
+            Shape = EmissionShape.Edge(length), // Horizontal segment on the X axis
+            StartSpeedMin = 0f,
+            StartSpeedMax = 0f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(center, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var manager = world.GetExtension<ParticleManager>();
+        var pool = manager.GetPool(entity);
+        Assert.NotNull(pool);
+
+        var alive = FindAllAlive(pool);
+        Assert.Equal(100, alive.Count);
+
+        var halfLength = length / 2f;
+        foreach (var idx in alive)
+        {
+            var dx = pool.PositionsX[idx] - center.X;
+            var dy = pool.PositionsY[idx] - center.Y;
+
+            // Within the segment bounds on X
+            Assert.InRange(dx, -halfLength - 1f, halfLength + 1f);
+            // Collinear: all points lie on the horizontal line through the emitter
+            Assert.True(MathF.Abs(dy).IsApproximatelyZero(0.001f),
+                $"Particle Y offset {dy} is not collinear with the horizontal edge");
+        }
+    }
+
+    [Fact]
+    public void SpawnSystem_CircleShape_SpawnsOnRingPerimeter()
+    {
+        world = new World();
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var center = new Vector2(150f, 150f);
+        var radius = 60f;
+        var emitter = ParticleEmitter.Burst(100, 1f) with
+        {
+            Shape = EmissionShape.Circle(radius),
+            StartSpeedMin = 0f,
+            StartSpeedMax = 0f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(center, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var manager = world.GetExtension<ParticleManager>();
+        var pool = manager.GetPool(entity);
+        Assert.NotNull(pool);
+
+        var alive = FindAllAlive(pool);
+        Assert.Equal(100, alive.Count);
+
+        // Every particle sits on the ring perimeter (distance == radius, not merely <= radius)
+        foreach (var idx in alive)
+        {
+            var dx = pool.PositionsX[idx] - center.X;
+            var dy = pool.PositionsY[idx] - center.Y;
+            var dist = MathF.Sqrt(dx * dx + dy * dy);
+            Assert.True(dist.ApproximatelyEquals(radius, 0.01f),
+                $"Particle distance {dist} is not on the ring of radius {radius}");
+        }
+    }
+
+    [Fact]
+    public void SpawnSystem_HemisphereShape_SpawnsWithinSemicircle()
+    {
+        world = new World();
+        world.InstallPlugin(new ParticlesPlugin());
+
+        var center = Vector2.Zero;
+        var radius = 50f;
+        // Default hemisphere direction is +Y, so emission spans the arc where sin(angle) >= 0.
+        var emitter = ParticleEmitter.Burst(200, 1f) with
+        {
+            Shape = EmissionShape.Hemisphere(radius),
+            StartSpeedMin = 50f,
+            StartSpeedMax = 50f
+        };
+        var entity = world.Spawn()
+            .With(new Transform2D(center, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var manager = world.GetExtension<ParticleManager>();
+        var pool = manager.GetPool(entity);
+        Assert.NotNull(pool);
+
+        var alive = FindAllAlive(pool);
+        Assert.Equal(200, alive.Count);
+
+        foreach (var idx in alive)
+        {
+            // Positions lie within the half-disc on the +Y side.
+            var dx = pool.PositionsX[idx] - center.X;
+            var dy = pool.PositionsY[idx] - center.Y;
+            var dist = MathF.Sqrt(dx * dx + dy * dy);
+            Assert.True(dist <= radius + 1f, $"Particle distance {dist} exceeds radius {radius}");
+            Assert.True(dy >= -0.01f, $"Particle Y offset {dy} falls outside the +Y semicircle");
+
+            // Initial direction stays within the same 180-degree arc (velocity Y >= 0).
+            Assert.True(pool.VelocitiesY[idx] >= -0.01f,
+                $"Particle velocity Y {pool.VelocitiesY[idx]} points outside the hemisphere arc");
+        }
+    }
+
     #endregion
 
     #region Edge Cases

--- a/tests/KeenEyes.Particles.Tests/ParticleTextureSheetTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleTextureSheetTests.cs
@@ -1,0 +1,154 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Particles.Components;
+using KeenEyes.Particles.Data;
+using KeenEyes.Particles.Systems;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.Particles.Tests;
+
+/// <summary>
+/// Tests for age-driven texture-sheet (sprite) animation in <see cref="ParticleRenderSystem"/>.
+/// </summary>
+public class ParticleTextureSheetTests : IDisposable
+{
+    private World? world;
+    private Mock2DRenderer? mockRenderer;
+
+    public void Dispose()
+    {
+        mockRenderer?.Dispose();
+        world?.Dispose();
+    }
+
+    /// <summary>
+    /// Sets up a render-only world with a single manually-controlled particle at the
+    /// given normalized age, so the exact sprite-sheet frame can be asserted.
+    /// </summary>
+    private ParticleManager SetupSingleParticle(ParticleEmitter emitter, float normalizedAge)
+    {
+        world = new World();
+
+        var manager = new ParticleManager(world, new ParticlesConfig());
+        world.SetExtension(manager);
+
+        mockRenderer = new Mock2DRenderer();
+        world.SetExtension<I2DRenderer>(mockRenderer);
+
+        world.AddSystem(new ParticleRenderSystem(), SystemPhase.Render);
+
+        var entity = world.Spawn()
+            .With(new Transform2D(Vector2.Zero, 0f, Vector2.One))
+            .With(emitter)
+            .Build();
+
+        ref var stored = ref world.Get<ParticleEmitter>(entity);
+        manager.RegisterEmitter(entity, in stored);
+
+        var pool = manager.GetPool(entity)!;
+        var idx = pool.Allocate();
+        pool.Sizes[idx] = 16f;
+        pool.ColorsA[idx] = 1f;
+        pool.NormalizedAges[idx] = normalizedAge;
+
+        return manager;
+    }
+
+    #region Frame Progression Tests
+
+    [Theory]
+    [InlineData(0.0f, 0f)]    // Frame 0 -> column 0
+    [InlineData(0.25f, 0.25f)] // Frame 1 -> column 1
+    [InlineData(0.5f, 0.5f)]  // Frame 2 -> column 2
+    [InlineData(0.75f, 0.75f)] // Frame 3 -> column 3
+    [InlineData(0.99f, 0.75f)] // Still frame 3 (clamped by truncation)
+    [InlineData(1.0f, 0.75f)]  // Age at end clamps to the final frame
+    public void SpriteSheet_HorizontalStrip_FrameAdvancesWithAge(float normalizedAge, float expectedU)
+    {
+        var emitter = ParticleEmitter.Default with
+        {
+            Texture = new TextureHandle(1),
+            TextureSheetColumns = 4,
+            TextureSheetRows = 1
+        };
+
+        SetupSingleParticle(emitter, normalizedAge);
+        world!.Update(1f / 60f);
+
+        var cmd = Assert.Single(mockRenderer!.Commands.OfType<DrawTextureRotatedRegionCommand>());
+        Assert.True(cmd.SourceRect.X.ApproximatelyEquals(expectedU, 0.0001f),
+            $"Expected frame U {expectedU}, got {cmd.SourceRect.X}");
+        Assert.True(cmd.SourceRect.Y.IsApproximatelyZero(0.0001f));
+        Assert.True(cmd.SourceRect.Width.ApproximatelyEquals(0.25f, 0.0001f));
+        Assert.True(cmd.SourceRect.Height.ApproximatelyEquals(1f, 0.0001f));
+    }
+
+    [Theory]
+    [InlineData(0.0f, 0f, 0f)]    // Frame 0 -> col 0, row 0
+    [InlineData(0.25f, 0.5f, 0f)] // Frame 1 -> col 1, row 0
+    [InlineData(0.5f, 0f, 0.5f)]  // Frame 2 -> col 0, row 1
+    [InlineData(0.75f, 0.5f, 0.5f)] // Frame 3 -> col 1, row 1
+    public void SpriteSheet_Grid_FrameMapsToColumnAndRow(float normalizedAge, float expectedU, float expectedV)
+    {
+        var emitter = ParticleEmitter.Default with
+        {
+            Texture = new TextureHandle(1),
+            TextureSheetColumns = 2,
+            TextureSheetRows = 2
+        };
+
+        SetupSingleParticle(emitter, normalizedAge);
+        world!.Update(1f / 60f);
+
+        var cmd = Assert.Single(mockRenderer!.Commands.OfType<DrawTextureRotatedRegionCommand>());
+        Assert.True(cmd.SourceRect.X.ApproximatelyEquals(expectedU, 0.0001f),
+            $"Expected frame U {expectedU}, got {cmd.SourceRect.X}");
+        Assert.True(cmd.SourceRect.Y.ApproximatelyEquals(expectedV, 0.0001f),
+            $"Expected frame V {expectedV}, got {cmd.SourceRect.Y}");
+        Assert.True(cmd.SourceRect.Width.ApproximatelyEquals(0.5f, 0.0001f));
+        Assert.True(cmd.SourceRect.Height.ApproximatelyEquals(0.5f, 0.0001f));
+    }
+
+    #endregion
+
+    #region Single Frame Tests
+
+    [Fact]
+    public void SpriteSheet_SingleFrame_UsesPlainRotatedTexture()
+    {
+        var emitter = ParticleEmitter.Default with
+        {
+            Texture = new TextureHandle(1),
+            TextureSheetColumns = 1,
+            TextureSheetRows = 1
+        };
+
+        SetupSingleParticle(emitter, 0.5f);
+        world!.Update(1f / 60f);
+
+        // A 1x1 sheet is not animated: it must use the plain rotated-texture path (no source rect).
+        Assert.Single(mockRenderer!.Commands.OfType<DrawTextureRotatedCommand>());
+        Assert.Empty(mockRenderer.Commands.OfType<DrawTextureRotatedRegionCommand>());
+    }
+
+    [Fact]
+    public void SpriteSheet_UnsetGrid_BehavesAsSingleFrame()
+    {
+        // Zero columns/rows (struct default) must behave exactly like a plain textured particle.
+        var emitter = ParticleEmitter.Default with
+        {
+            Texture = new TextureHandle(1),
+            TextureSheetColumns = 0,
+            TextureSheetRows = 0
+        };
+
+        SetupSingleParticle(emitter, 0.5f);
+        world!.Update(1f / 60f);
+
+        Assert.Single(mockRenderer!.Commands.OfType<DrawTextureRotatedCommand>());
+        Assert.Empty(mockRenderer.Commands.OfType<DrawTextureRotatedRegionCommand>());
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Tier 1 (2D-compatible subset) of the #515 deferred features, per the tiering proposal on the issue:
- **Texture-sheet animation**: `TextureSheetColumns`/`Rows` on `ParticleEmitter`; frame driven by particle age via the existing `NormalizedAges` array (no pool-layout change, no speculative frame-rate field). Required one minimal renderer addition: `I2DRenderer.DrawTextureRotated(dest, sourceRect, rotation, origin, tint)` — the abstraction had UV-support and rotation separately but no combination; Silk + Mock implementations updated (Silk mirrors the existing rotation-stub behavior rather than diverging). Single-frame particles use the old path — bit-identical.
- **`ParticleSpace` World/Local**: default World = zero behavior change; Local stores emitter-relative offsets and translates at render time by the emitter's current transform (velocity integrates in the local frame — no update-system change needed).
- **New emission shapes**: `Hemisphere` (filled half-disc arc around `Direction`), `Circle` (ring perimeter, outward radial direction), `Edge` (centered segment via `Size`). 2D interpretations documented in XML docs + `docs/particles.md`.

## Test plan
- [x] 28 new tests (frame progression at controlled ages, 1×1 sheet identical to legacy, World-unchanged/Local-follows on emitter movement, per-shape position/direction bounds) — Particles 293/293
- [x] Consumer suites re-run for the I2DRenderer change: Graphics 557, Testing 1442, UI 1993 — all green
- [x] Release build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #515 (Tier 1). Tiers 2 (3D pool/billboards) and 3 (trails/collision/sub-emitters/GPU) remain per the proposal.