### PR TITLE
feat(samples): Add racing sample with ghost mode

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -21,6 +21,7 @@
     <Project Path="samples/KeenEyes.Sample.Multiplayer/KeenEyes.Sample.Multiplayer.csproj" />
     <Project Path="samples/KeenEyes.Sample.Physics/KeenEyes.Sample.Physics.csproj" />
     <Project Path="samples/KeenEyes.Sample.Prefabs/KeenEyes.Sample.Prefabs.csproj" />
+    <Project Path="samples/KeenEyes.Sample.Racing/KeenEyes.Sample.Racing.csproj" />
     <Project Path="samples/KeenEyes.Sample.Relationships/KeenEyes.Sample.Relationships.csproj" />
     <Project Path="samples/KeenEyes.Sample.RenderingCulling/KeenEyes.Sample.RenderingCulling.csproj" />
     <Project Path="samples/KeenEyes.Sample.Replay/KeenEyes.Sample.Replay.csproj" />

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -249,6 +249,57 @@ ghostPlayer.SyncMode = GhostSyncMode.TimeSynced;
 ghostPlayer.Play();
 ```
 
+### Ghost trails
+
+A ghost can optionally leave a fading trail showing the path it has recently traveled — useful for visualizing racing lines and comparing trajectories. Like the rest of `GhostVisualConfig`, the trail is **data-only**: the ghost system computes trail points but never draws them, so games (or the editor) supply the rendering.
+
+Enable and shape the trail through `GhostVisualConfig`:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `ShowTrail` | `false` | Master switch. When `false`, the trail provider is never consulted, so there is zero behavior change. |
+| `TrailLength` | `60` | Maximum number of recent frames in the trail (bounds the buffer a renderer needs). |
+| `TrailFadeStart` | `0.5f` | Opacity at the oldest (tail) point; the head is fully opaque. |
+| `TrailWidth` | `0.1f` | Line/ribbon thickness in world units. |
+| `TrailStyle` | `TrailStyle.Line` | `Line`, `Ribbon`, `Dots`, or `Gradient`. |
+
+The trail points come from `GhostPlayer` (also surfaced on `GhostInstance`):
+
+```csharp
+// Zero-allocation: fills a caller-owned buffer, returns the number of points written.
+public int GetTrailPoints(Span<Vector3> destination);
+
+// Convenience: allocates a new array of up to maxPoints entries.
+public Vector3[] GetTrailPoints(int maxPoints);
+```
+
+Points are the recorded frame positions at or before the current playhead, ordered **oldest first, newest last**, so they feed a line strip directly. The provider tracks the playhead across `Update`, `UpdateByDistance`, `SeekToTime`, and `SeekToFrame`. It returns **no points while the playhead sits on the first frame** — before playback has advanced, and after `Stop` resets it — because there is no traversed path to show. The `Span<Vector3>` overload does not allocate; reuse one buffer sized to `TrailLength` across frames. The `int maxPoints` overload allocates a fresh array per call and is a convenience for non-hot paths.
+
+Drawing a trail with a 2D renderer is a short loop over the points, fading opacity from `TrailFadeStart` at the tail to full opacity at the head, using the existing `I2DRenderer.DrawLineStrip` seam:
+
+```csharp
+Span<Vector2> screen = stackalloc Vector2[config.TrailLength];
+Span<Vector3> world = stackalloc Vector3[config.TrailLength];
+
+int count = ghost.GetTrailPoints(world);
+for (int i = 0; i < count; i++)
+{
+    screen[i] = WorldToScreen(world[i]); // your camera projection
+}
+
+if (count >= 2 && config.TrailStyle != TrailStyle.Dots)
+{
+    // Fade the whole strip toward the head; per-vertex gradients would draw
+    // segment-by-segment with an interpolated alpha across [TrailFadeStart, 1].
+    var color = config.TintColor with { W = config.TrailFadeStart };
+    renderer.DrawLineStrip(screen[..count], color, config.TrailWidth);
+}
+```
+
+**`Ribbon` limitation:** a true ribbon is an oriented 3D strip that needs a 3D line renderer, which KeenEyes does not currently provide. The 2D reference renderers therefore treat `TrailStyle.Ribbon` as `TrailStyle.Line` (documented, not silent). `Dots` draws discrete markers per point; `Gradient` grades color/opacity along the path.
+
+The `samples/KeenEyes.Sample.Racing` sample enables trails on its ghosts (`GhostSetup`) and renders age-faded glyphs in the console track view (`TrackRenderer`), reading the points through the zero-allocation `GetTrailPoints(Span<Vector3>)` overload with a reusable buffer.
+
 ## Performance
 
 - Recording has effectively zero overhead when `IsRecording` is `false` — the plugin's system hooks and event subscriptions short-circuit immediately.

--- a/samples/KeenEyes.Sample.Racing/Components/LapTimer.cs
+++ b/samples/KeenEyes.Sample.Racing/Components/LapTimer.cs
@@ -1,0 +1,27 @@
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Accumulates elapsed time for the current lap and records the final lap time.
+/// </summary>
+/// <remarks>
+/// Pure data only. <see cref="LapTrackingSystem"/> advances the timer and marks
+/// the lap finished once the car crosses the start/finish line.
+/// </remarks>
+[Component(Serializable = true)]
+public partial struct LapTimer
+{
+    /// <summary>
+    /// Time elapsed since the lap started, in seconds.
+    /// </summary>
+    public float ElapsedSeconds;
+
+    /// <summary>
+    /// Whether the lap has been completed.
+    /// </summary>
+    public bool Finished;
+
+    /// <summary>
+    /// The final lap time in seconds, valid once <see cref="Finished"/> is true.
+    /// </summary>
+    public float FinishedSeconds;
+}

--- a/samples/KeenEyes.Sample.Racing/Components/TrackPosition.cs
+++ b/samples/KeenEyes.Sample.Racing/Components/TrackPosition.cs
@@ -1,0 +1,22 @@
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Tracks how far a car has travelled along the track during the current lap.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distance is measured in world units from the start/finish line. It is the
+/// key that drives <see cref="KeenEyes.Replay.Ghost.GhostSyncMode.DistanceSynced"/>
+/// ghost playback: the ghost is positioned at wherever it was when it had
+/// travelled the same distance, so the live car and its ghosts can be compared
+/// at identical points on the track regardless of who is faster.
+/// </para>
+/// </remarks>
+[Component(Serializable = true)]
+public partial struct TrackPosition
+{
+    /// <summary>
+    /// Cumulative distance travelled along the track this lap, in world units.
+    /// </summary>
+    public float Distance;
+}

--- a/samples/KeenEyes.Sample.Racing/Components/Vehicle.cs
+++ b/samples/KeenEyes.Sample.Racing/Components/Vehicle.cs
@@ -1,0 +1,51 @@
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Dynamic state of a race car as it drives around the track.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a pure-data component: it holds the car's speed and steering state
+/// but contains no logic. All driving behavior lives in
+/// <see cref="VehicleMovementSystem"/>.
+/// </para>
+/// <para>
+/// The component is marked <c>Serializable</c> so it is captured in replay
+/// snapshots alongside the car's <see cref="KeenEyes.Common.Transform3D"/>.
+/// </para>
+/// </remarks>
+[Component(Serializable = true)]
+public partial struct Vehicle
+{
+    /// <summary>
+    /// Throttle input for this frame, from 0 (coasting) to 1 (full power).
+    /// </summary>
+    /// <remarks>
+    /// In this sample the throttle is supplied by a deterministic, scripted
+    /// "driver" so the demo runs unattended and reproducibly. In a real game
+    /// this would come from player input.
+    /// </remarks>
+    public float Throttle;
+
+    /// <summary>
+    /// Current forward speed in world units per second.
+    /// </summary>
+    public float CurrentSpeed;
+
+    /// <summary>
+    /// Maximum forward speed in world units per second.
+    /// </summary>
+    public float MaxSpeed;
+
+    /// <summary>
+    /// Acceleration in world units per second squared, applied while the
+    /// current speed is below the throttle target.
+    /// </summary>
+    public float Acceleration;
+
+    /// <summary>
+    /// Current steering / heading angle in radians (the direction the car
+    /// faces), derived each frame from the tangent of the racing line.
+    /// </summary>
+    public float Steering;
+}

--- a/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
@@ -21,19 +21,33 @@ public static class GhostSetup
     public const string CarEntityName = "RaceCar";
 
     /// <summary>Gold, mostly transparent styling for the fastest recorded lap.</summary>
+    /// <remarks>
+    /// Enables a gradient racing-line trail so the fastest lap's path is easy to trace.
+    /// </remarks>
     public static GhostVisualConfig BestLap { get; } = new()
     {
         TintColor = new Vector4(1f, 0.84f, 0f, 1f),
         Opacity = 0.4f,
         Label = "Best Lap",
+        ShowTrail = true,
+        TrailLength = 40,
+        TrailFadeStart = 0.25f,
+        TrailStyle = TrailStyle.Gradient,
     };
 
     /// <summary>Cyan, semi-transparent styling for the immediately preceding lap.</summary>
+    /// <remarks>
+    /// Enables a shorter dotted trail to distinguish it from the best lap's line.
+    /// </remarks>
     public static GhostVisualConfig PreviousLap { get; } = new()
     {
         TintColor = new Vector4(0f, 0.7f, 1f, 1f),
         Opacity = 0.55f,
         Label = "Previous Lap",
+        ShowTrail = true,
+        TrailLength = 24,
+        TrailFadeStart = 0.4f,
+        TrailStyle = TrailStyle.Dots,
     };
 
     /// <summary>

--- a/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Numerics;
+using KeenEyes.Replay;
+using KeenEyes.Replay.Ghost;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Helpers for turning a recorded lap into a ghost and for the visual styling of
+/// the ghosts shown during a race.
+/// </summary>
+/// <remarks>
+/// The visual configs are the payload a real renderer would consume: a tint, an
+/// opacity and a label per ghost. The ghost system itself never renders anything -
+/// it only carries these hints so the game (here, the console view) can present
+/// each ghost distinctly.
+/// </remarks>
+public static class GhostSetup
+{
+    /// <summary>The entity name recorded for the player's car, used for extraction.</summary>
+    public const string CarEntityName = "RaceCar";
+
+    /// <summary>Gold, mostly transparent styling for the fastest recorded lap.</summary>
+    public static GhostVisualConfig BestLap { get; } = new()
+    {
+        TintColor = new Vector4(1f, 0.84f, 0f, 1f),
+        Opacity = 0.4f,
+        Label = "Best Lap",
+    };
+
+    /// <summary>Cyan, semi-transparent styling for the immediately preceding lap.</summary>
+    public static GhostVisualConfig PreviousLap { get; } = new()
+    {
+        TintColor = new Vector4(0f, 0.7f, 1f, 1f),
+        Opacity = 0.55f,
+        Label = "Previous Lap",
+    };
+
+    /// <summary>
+    /// Extracts the car's ghost from a recorded lap and writes it to a
+    /// <c>.keghost</c> file.
+    /// </summary>
+    /// <param name="replay">The recorded lap.</param>
+    /// <param name="path">Destination path for the <c>.keghost</c> file.</param>
+    /// <returns>The extracted ghost data.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the car could not be extracted (for example, if no snapshots
+    /// captured its <see cref="KeenEyes.Common.Transform3D"/>).
+    /// </exception>
+    public static GhostData ExtractAndSave(ReplayData replay, string path)
+    {
+        ArgumentNullException.ThrowIfNull(replay);
+        ArgumentNullException.ThrowIfNull(path);
+
+        var extractor = new GhostExtractor();
+        var ghost = extractor.ExtractGhost(replay, CarEntityName)
+            ?? throw new InvalidOperationException(
+                $"Could not extract a ghost for '{CarEntityName}'. Ensure the replay " +
+                "captured keyframe snapshots containing the car's Transform3D.");
+
+        GhostFileFormat.WriteToFile(path, ghost);
+        return ghost;
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Replay;
+using KeenEyes.Replay.Ghost;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// The outcome of running one lap.
+/// </summary>
+/// <param name="Replay">The full replay recording of the lap.</param>
+/// <param name="LapSeconds">The final lap time, in seconds.</param>
+public readonly record struct LapResult(ReplayData Replay, float LapSeconds);
+
+/// <summary>
+/// Runs a single lap in an isolated world: sets up recording, drives the car with
+/// scripted throttle, optionally races it against a set of ghosts, and prints
+/// progress and live time gaps.
+/// </summary>
+public sealed class RaceManager
+{
+    // 20 Hz snapshots (every 0.05s) with delta compression disabled so that every
+    // snapshot is a full keyframe. The ghost extractor only reads keyframes, so this
+    // pairing is what yields a smooth ghost - see the README for the full rationale.
+    private static readonly ReplayOptions recordingOptions = new()
+    {
+        SnapshotInterval = TimeSpan.FromSeconds(0.05),
+        KeyframeInterval = 1,
+        RecordSystemEvents = false,
+        RecordComponentEvents = false,
+        RecordEntityEvents = false,
+    };
+
+    private const float DeltaTime = 1f / 60f;
+    private const int SafetyFrameCap = 60 * 60; // 60 seconds of simulation.
+
+    private readonly Track track;
+    private readonly TrackRenderer renderer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RaceManager"/> class.
+    /// </summary>
+    /// <param name="track">The track to race on.</param>
+    /// <param name="renderer">The console renderer for the top-down view.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is null.</exception>
+    public RaceManager(Track track, TrackRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+        ArgumentNullException.ThrowIfNull(renderer);
+        this.track = track;
+        this.renderer = renderer;
+    }
+
+    /// <summary>
+    /// Runs one lap and returns its recording and final time.
+    /// </summary>
+    /// <param name="serializer">The serializer used to capture snapshots (must handle Transform3D).</param>
+    /// <param name="recordingName">A name for the replay recording.</param>
+    /// <param name="targetThrottle">The scripted throttle held for the whole lap (0..1).</param>
+    /// <param name="ghosts">Ghosts to race against, or null for a solo recording lap.</param>
+    /// <returns>The lap result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is null.</exception>
+    public LapResult RunLap(
+        RacingComponentSerializer serializer,
+        string recordingName,
+        float targetThrottle,
+        GhostManager? ghosts)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(recordingName);
+
+        using var world = new World();
+        world.InstallPlugin(new ReplayPlugin(serializer, recordingOptions));
+        world.AddSystem(new VehicleMovementSystem(track), SystemPhase.Update);
+        world.AddSystem(new LapTrackingSystem(track.Length), SystemPhase.Update);
+
+        var car = world.Spawn(GhostSetup.CarEntityName)
+            .With(new Vehicle { MaxSpeed = 60f, Acceleration = 45f })
+            .With(new TrackPosition())
+            .With(new LapTimer())
+            .With(new Transform3D(
+                track.PositionAt(0f),
+                Quaternion.CreateFromYawPitchRoll(track.HeadingAt(0f), 0f, 0f),
+                Vector3.One))
+            .Build();
+
+        var recorder = world.GetExtension<ReplayRecorder>();
+        recorder.StartRecording(recordingName);
+        ghosts?.PlayAll();
+
+        var nextCheckpoint = 0.25f;
+        var frame = 0;
+
+        while (true)
+        {
+            // The scripted "driver" writes this frame's input, then systems run.
+            world.Get<Vehicle>(car).Throttle = targetThrottle;
+            world.Update(DeltaTime);
+
+            var distance = world.Get<TrackPosition>(car).Distance;
+            var elapsed = world.Get<LapTimer>(car).ElapsedSeconds;
+            var finished = world.Get<LapTimer>(car).Finished;
+
+            // Distance-synced ghosts advance to wherever they were at the same distance.
+            ghosts?.UpdateByDistance(distance);
+
+            var fraction = Math.Clamp(distance / track.Length, 0f, 1f);
+            if (fraction >= nextCheckpoint && nextCheckpoint < 1f)
+            {
+                ReportCheckpoint(world, car, ghosts, fraction, elapsed);
+                nextCheckpoint += 0.25f;
+            }
+
+            if (finished || ++frame >= SafetyFrameCap)
+            {
+                break;
+            }
+        }
+
+        var replay = recorder.StopRecording()
+            ?? throw new InvalidOperationException("Recording produced no data.");
+        ghosts?.StopAll();
+
+        var lapSeconds = world.Get<LapTimer>(car).FinishedSeconds;
+        return new LapResult(replay, lapSeconds);
+    }
+
+    private void ReportCheckpoint(
+        World world,
+        Entity car,
+        GhostManager? ghosts,
+        float fraction,
+        float elapsed)
+    {
+        Console.WriteLine($"  [{fraction * 100,3:F0}%]  t = {elapsed,6:F2}s");
+
+        if (ghosts is null)
+        {
+            return;
+        }
+
+        var markers = new List<TrackMarker>
+        {
+            new('C', "Your Car", world.Get<Transform3D>(car).Position),
+        };
+
+        foreach (var ghost in ghosts.ActiveGhosts)
+        {
+            // Positive gap: the live car reached this distance later than the ghost
+            // did, so the car is behind. Negative gap means the car is ahead.
+            var gap = elapsed - (float)ghost.Player.CurrentTime.TotalSeconds;
+            var status = gap <= 0f ? "ahead" : "behind";
+            var label = ghost.Label ?? ghost.Id;
+            var symbol = char.ToUpperInvariant(label[0]);
+
+            Console.WriteLine($"          vs {label,-13} {gap:+0.00;-0.00}s ({status})");
+            markers.Add(new TrackMarker(symbol, label, ghost.Position));
+        }
+
+        Console.WriteLine(renderer.Render(markers));
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
@@ -39,6 +39,10 @@ public sealed class RaceManager
     private readonly Track track;
     private readonly TrackRenderer renderer;
 
+    // Reused across checkpoints so reading a ghost's trail allocates nothing per call.
+    // Sized to comfortably hold the sample's configured trail lengths.
+    private readonly Vector3[] trailBuffer = new Vector3[128];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RaceManager"/> class.
     /// </summary>
@@ -145,6 +149,7 @@ public sealed class RaceManager
         {
             new('C', "Your Car", world.Get<Transform3D>(car).Position),
         };
+        var trails = new List<TrackTrail>();
 
         foreach (var ghost in ghosts.ActiveGhosts)
         {
@@ -157,8 +162,24 @@ public sealed class RaceManager
 
             Console.WriteLine($"          vs {label,-13} {gap:+0.00;-0.00}s ({status})");
             markers.Add(new TrackMarker(symbol, label, ghost.Position));
+
+            // When the ghost opts into a trail, read its recent path from the
+            // data-only provider. GetTrailPoints writes into our reusable buffer with
+            // no per-call allocation; we then snapshot just the points it wrote.
+            if (ghost.ShowTrail)
+            {
+                var length = Math.Min(ghost.Config.TrailLength, trailBuffer.Length);
+                var count = ghost.GetTrailPoints(trailBuffer.AsSpan(0, length));
+                if (count > 0)
+                {
+                    trails.Add(new TrackTrail(
+                        trailBuffer.AsSpan(0, count).ToArray(),
+                        ghost.Config.TrailFadeStart,
+                        ghost.Config.TrailStyle));
+                }
+            }
         }
 
-        Console.WriteLine(renderer.Render(markers));
+        Console.WriteLine(renderer.Render(markers, trails));
     }
 }

--- a/samples/KeenEyes.Sample.Racing/Game/RacingComponentSerializer.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/RacingComponentSerializer.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.Numerics;
+using System.Text.Json;
+using KeenEyes.Capabilities;
+using KeenEyes.Common;
+using KeenEyes.Generated;
+using KeenEyes.Serialization;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// A component serializer that adds <see cref="Transform3D"/> support on top of the
+/// generated <see cref="ComponentSerializer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the key integration piece for the ghost pipeline. The source-generated
+/// <see cref="ComponentSerializer"/> only knows about components declared with
+/// <c>[Component(Serializable = true)]</c> <em>inside this project</em>. The ghost
+/// extractor, however, reads <see cref="Transform3D"/> - an engine type from
+/// <c>KeenEyes.Common</c> that the generator never sees. Without a serializer that
+/// can turn <see cref="Transform3D"/> into JSON, it would never appear in replay
+/// snapshots and no ghost could be extracted.
+/// </para>
+/// <para>
+/// The wrapper delegates every call to the generated serializer, intercepting only
+/// <see cref="Transform3D"/>. The JSON layout it emits (<c>Position</c>,
+/// <c>Rotation</c>, <c>Scale</c> objects with <c>X/Y/Z/W</c> members) is exactly what
+/// <see cref="KeenEyes.Replay.Ghost.GhostExtractor"/> looks for. Serialization is done
+/// with an explicit <see cref="Utf8JsonWriter"/> rather than reflection so the sample
+/// stays consistent with the engine's Native-AOT-friendly conventions.
+/// </para>
+/// </remarks>
+public sealed class RacingComponentSerializer : IComponentSerializer
+{
+    private const string Transform3DName = "KeenEyes.Common.Transform3D";
+
+    private readonly IComponentSerializer inner = ComponentSerializer.Instance;
+
+    private static bool IsTransform(Type type) => type == typeof(Transform3D);
+
+    private static bool IsTransform(string typeName) =>
+        typeName.StartsWith(Transform3DName, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public bool IsSerializable(Type type) => IsTransform(type) || inner.IsSerializable(type);
+
+    /// <inheritdoc />
+    public bool IsSerializable(string typeName) => IsTransform(typeName) || inner.IsSerializable(typeName);
+
+    /// <inheritdoc />
+    public JsonElement? Serialize(Type type, object value)
+    {
+        if (!IsTransform(type))
+        {
+            return inner.Serialize(type, value);
+        }
+
+        var transform = (Transform3D)value;
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            WriteVector3(writer, "Position", transform.Position);
+            WriteQuaternion(writer, "Rotation", transform.Rotation);
+            WriteVector3(writer, "Scale", transform.Scale);
+            writer.WriteEndObject();
+        }
+
+        using var document = JsonDocument.Parse(stream.ToArray());
+        return document.RootElement.Clone();
+    }
+
+    /// <inheritdoc />
+    public object? Deserialize(string typeName, JsonElement json)
+    {
+        if (!IsTransform(typeName))
+        {
+            return inner.Deserialize(typeName, json);
+        }
+
+        var position = ReadVector3(json, "Position");
+        var rotation = ReadQuaternion(json, "Rotation");
+        var scale = ReadVector3(json, "Scale");
+        return new Transform3D(position, rotation, scale);
+    }
+
+    /// <inheritdoc />
+    public Type? GetType(string typeName) =>
+        IsTransform(typeName) ? typeof(Transform3D) : inner.GetType(typeName);
+
+    /// <inheritdoc />
+    public ComponentInfo? RegisterComponent(ISerializationCapability serialization, string typeName, bool isTag)
+    {
+        ArgumentNullException.ThrowIfNull(serialization);
+        return IsTransform(typeName)
+            ? (ComponentInfo)serialization.Components.Register<Transform3D>(isTag)
+            : inner.RegisterComponent(serialization, typeName, isTag);
+    }
+
+    /// <inheritdoc />
+    public bool SetSingleton(ISerializationCapability serialization, string typeName, object value) =>
+        inner.SetSingleton(serialization, typeName, value);
+
+    /// <inheritdoc />
+    public object? CreateDefault(string typeName) =>
+        IsTransform(typeName) ? Transform3D.Identity : inner.CreateDefault(typeName);
+
+    /// <inheritdoc />
+    public int GetVersion(string typeName) => IsTransform(typeName) ? 1 : inner.GetVersion(typeName);
+
+    /// <inheritdoc />
+    public int GetVersion(Type type) => IsTransform(type) ? 1 : inner.GetVersion(type);
+
+    private static void WriteVector3(Utf8JsonWriter writer, string name, Vector3 value)
+    {
+        writer.WriteStartObject(name);
+        writer.WriteNumber("X", value.X);
+        writer.WriteNumber("Y", value.Y);
+        writer.WriteNumber("Z", value.Z);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteQuaternion(Utf8JsonWriter writer, string name, Quaternion value)
+    {
+        writer.WriteStartObject(name);
+        writer.WriteNumber("X", value.X);
+        writer.WriteNumber("Y", value.Y);
+        writer.WriteNumber("Z", value.Z);
+        writer.WriteNumber("W", value.W);
+        writer.WriteEndObject();
+    }
+
+    private static Vector3 ReadVector3(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value))
+        {
+            return Vector3.Zero;
+        }
+
+        return new Vector3(
+            value.GetProperty("X").GetSingle(),
+            value.GetProperty("Y").GetSingle(),
+            value.GetProperty("Z").GetSingle());
+    }
+
+    private static Quaternion ReadQuaternion(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value))
+        {
+            return Quaternion.Identity;
+        }
+
+        return new Quaternion(
+            value.GetProperty("X").GetSingle(),
+            value.GetProperty("Y").GetSingle(),
+            value.GetProperty("Z").GetSingle(),
+            value.GetProperty("W").GetSingle());
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Game/Track.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/Track.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Numerics;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// A simple circular racing line in the XZ plane.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The track is fully parametric: given a distance travelled from the
+/// start/finish line, it returns the world-space position on the racing line and
+/// the heading (yaw) tangent to the line at that point. This keeps the sample
+/// deterministic and headless-friendly - there is no physics or collision, just
+/// a car sliding along a known curve.
+/// </para>
+/// <para>
+/// Because arc length along a circle is simply <c>radius * angle</c>, distance
+/// maps linearly to angle, which makes distance-synced ghost comparison exact.
+/// </para>
+/// </remarks>
+public sealed class Track
+{
+    /// <summary>
+    /// Initializes a new circular track with the given radius, centered at the origin.
+    /// </summary>
+    /// <param name="radius">Radius of the circular racing line, in world units.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when radius is not positive.</exception>
+    public Track(float radius)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(radius);
+        Radius = radius;
+        Length = 2f * MathF.PI * radius;
+    }
+
+    /// <summary>
+    /// Gets the radius of the circular racing line, in world units.
+    /// </summary>
+    public float Radius { get; }
+
+    /// <summary>
+    /// Gets the total length of one lap, in world units.
+    /// </summary>
+    public float Length { get; }
+
+    /// <summary>
+    /// Gets the world-space position on the racing line at the given distance.
+    /// </summary>
+    /// <param name="distance">Distance travelled from the start/finish line, in world units.</param>
+    /// <returns>The position on the racing line.</returns>
+    public Vector3 PositionAt(float distance)
+    {
+        var angle = distance / Radius;
+        return new Vector3(Radius * MathF.Cos(angle), 0f, Radius * MathF.Sin(angle));
+    }
+
+    /// <summary>
+    /// Gets the heading (yaw, in radians) tangent to the racing line at the given distance.
+    /// </summary>
+    /// <param name="distance">Distance travelled from the start/finish line, in world units.</param>
+    /// <returns>The heading angle in radians.</returns>
+    public float HeadingAt(float distance)
+    {
+        // The tangent of a circle leads the radial angle by 90 degrees.
+        var angle = distance / Radius;
+        return angle + MathF.PI / 2f;
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// A marker to draw on the ASCII track view: the live car or a ghost.
+/// </summary>
+/// <param name="Symbol">The single character used to plot this marker.</param>
+/// <param name="Label">A human-readable name shown in the legend.</param>
+/// <param name="Position">The marker's world-space position.</param>
+public readonly record struct TrackMarker(char Symbol, string Label, Vector3 Position);
+
+/// <summary>
+/// Renders a top-down ASCII view of the circular track with the car and its ghosts.
+/// </summary>
+/// <remarks>
+/// This is the sample's "presentation tier": a console visualization that runs
+/// anywhere, with no window or GPU. It maps the track's XZ plane onto a character
+/// grid so the relative positions of the car and its ghosts are visible at a glance.
+/// </remarks>
+public sealed class TrackRenderer
+{
+    private readonly Track track;
+    private readonly int width;
+    private readonly int height;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrackRenderer"/> class.
+    /// </summary>
+    /// <param name="track">The track to draw.</param>
+    /// <param name="width">Grid width in characters.</param>
+    /// <param name="height">Grid height in characters.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="track"/> is null.</exception>
+    public TrackRenderer(Track track, int width = 51, int height = 25)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+        this.track = track;
+        this.width = width;
+        this.height = height;
+    }
+
+    /// <summary>
+    /// Builds the ASCII view for the given markers.
+    /// </summary>
+    /// <param name="markers">The markers to plot on the track.</param>
+    /// <returns>A multi-line string containing the rendered view and legend.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="markers"/> is null.</exception>
+    public string Render(IReadOnlyList<TrackMarker> markers)
+    {
+        ArgumentNullException.ThrowIfNull(markers);
+
+        var grid = new char[height, width];
+        for (var row = 0; row < height; row++)
+        {
+            for (var col = 0; col < width; col++)
+            {
+                grid[row, col] = ' ';
+            }
+        }
+
+        // Draw the racing line by sampling the track at many points.
+        var samples = width * height;
+        for (var i = 0; i < samples; i++)
+        {
+            var distance = track.Length * i / samples;
+            Plot(grid, track.PositionAt(distance), '.');
+        }
+
+        // Overlay the markers on top of the racing line, in the order given (the
+        // live car first). When distance-synced ghosts share the car's exact track
+        // position, later markers would land on an occupied cell; those are left
+        // off the map (and the legend) so the car stays visible - the temporal gap
+        // to each ghost is reported separately by the caller.
+        var occupied = new HashSet<(int Row, int Col)>();
+        var plotted = new List<TrackMarker>();
+        foreach (var marker in markers)
+        {
+            if (TryPlot(grid, occupied, marker.Position, marker.Symbol))
+            {
+                plotted.Add(marker);
+            }
+        }
+
+        var builder = new StringBuilder();
+        for (var row = 0; row < height; row++)
+        {
+            for (var col = 0; col < width; col++)
+            {
+                builder.Append(grid[row, col]);
+            }
+            builder.Append('\n');
+        }
+
+        builder.Append("  Legend: ");
+        for (var i = 0; i < plotted.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append("   ");
+            }
+            builder.Append(plotted[i].Symbol).Append('=').Append(plotted[i].Label);
+        }
+
+        return builder.ToString();
+    }
+
+    private bool TryPlot(char[,] grid, HashSet<(int Row, int Col)> occupied, Vector3 position, char symbol)
+    {
+        // Map world XZ (range roughly [-R, R]) onto the character grid.
+        var normalizedX = (position.X + track.Radius) / (2f * track.Radius);
+        var normalizedZ = (position.Z + track.Radius) / (2f * track.Radius);
+
+        var col = (int)MathF.Round(normalizedX * (width - 1));
+        var row = (int)MathF.Round(normalizedZ * (height - 1));
+
+        col = Math.Clamp(col, 0, width - 1);
+        row = Math.Clamp(row, 0, height - 1);
+
+        if (!occupied.Add((row, col)))
+        {
+            return false;
+        }
+
+        grid[row, col] = symbol;
+        return true;
+    }
+
+    private void Plot(char[,] grid, Vector3 position, char symbol)
+    {
+        // Map world XZ (range roughly [-R, R]) onto the character grid.
+        var normalizedX = (position.X + track.Radius) / (2f * track.Radius);
+        var normalizedZ = (position.Z + track.Radius) / (2f * track.Radius);
+
+        var col = (int)MathF.Round(normalizedX * (width - 1));
+        var row = (int)MathF.Round(normalizedZ * (height - 1));
+
+        col = Math.Clamp(col, 0, width - 1);
+        row = Math.Clamp(row, 0, height - 1);
+
+        grid[row, col] = symbol;
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
+using KeenEyes.Replay.Ghost;
 
 namespace KeenEyes.Sample.Racing;
 
@@ -12,6 +13,14 @@ namespace KeenEyes.Sample.Racing;
 /// <param name="Label">A human-readable name shown in the legend.</param>
 /// <param name="Position">The marker's world-space position.</param>
 public readonly record struct TrackMarker(char Symbol, string Label, Vector3 Position);
+
+/// <summary>
+/// A fading motion trail to draw behind a ghost on the ASCII track view.
+/// </summary>
+/// <param name="Points">The trail points, ordered oldest first, newest last.</param>
+/// <param name="FadeStart">The opacity at the oldest (tail) point; the head is fully opaque.</param>
+/// <param name="Style">The requested trail style (see the per-style notes on the renderer's Render method).</param>
+public readonly record struct TrackTrail(IReadOnlyList<Vector3> Points, float FadeStart, TrailStyle Style);
 
 /// <summary>
 /// Renders a top-down ASCII view of the circular track with the car and its ghosts.
@@ -42,15 +51,34 @@ public sealed class TrackRenderer
         this.height = height;
     }
 
+    // Glyph ramp for trail age, faintest (oldest) to boldest (newest). Renderers on a
+    // real GPU would fade an alpha value instead; on a character grid we quantize the
+    // computed opacity onto these glyphs so the direction of travel reads at a glance.
+    private static readonly char[] trailGlyphs = [':', '+', '*'];
+
     /// <summary>
-    /// Builds the ASCII view for the given markers.
+    /// Builds the ASCII view for the given markers and ghost trails.
     /// </summary>
     /// <param name="markers">The markers to plot on the track.</param>
+    /// <param name="trails">
+    /// The ghost trails to draw beneath the markers. Pass an empty list for no trails.
+    /// </param>
     /// <returns>A multi-line string containing the rendered view and legend.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="markers"/> is null.</exception>
-    public string Render(IReadOnlyList<TrackMarker> markers)
+    /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
+    /// <remarks>
+    /// Trails are drawn on top of the racing line but beneath the car/ghost markers, so
+    /// a head marker always wins its cell. Each trail point is quantized to a glyph by
+    /// its age-based opacity (fading from <see cref="TrackTrail.FadeStart"/> at the tail
+    /// to fully opaque at the head). <see cref="TrailStyle.Dots"/> draws every other
+    /// point for a dashed look; <see cref="TrailStyle.Line"/>, <see cref="TrailStyle.Gradient"/>,
+    /// and <see cref="TrailStyle.Ribbon"/> draw a continuous run of glyphs. This 2D view
+    /// has no oriented 3D primitive, so <see cref="TrailStyle.Ribbon"/> falls back to the
+    /// line rendering.
+    /// </remarks>
+    public string Render(IReadOnlyList<TrackMarker> markers, IReadOnlyList<TrackTrail> trails)
     {
         ArgumentNullException.ThrowIfNull(markers);
+        ArgumentNullException.ThrowIfNull(trails);
 
         var grid = new char[height, width];
         for (var row = 0; row < height; row++)
@@ -67,6 +95,12 @@ public sealed class TrackRenderer
         {
             var distance = track.Length * i / samples;
             Plot(grid, track.PositionAt(distance), '.');
+        }
+
+        // Draw ghost trails on top of the racing line but under the markers below.
+        foreach (var trail in trails)
+        {
+            PlotTrail(grid, trail);
         }
 
         // Overlay the markers on top of the racing line, in the order given (the
@@ -126,6 +160,33 @@ public sealed class TrackRenderer
 
         grid[row, col] = symbol;
         return true;
+    }
+
+    private void PlotTrail(char[,] grid, TrackTrail trail)
+    {
+        var points = trail.Points;
+        if (points.Count == 0)
+        {
+            return;
+        }
+
+        // Dots draw a dashed trail; every other line style draws a continuous run.
+        var step = trail.Style == TrailStyle.Dots ? 2 : 1;
+
+        for (var i = 0; i < points.Count; i += step)
+        {
+            // Opacity ramps from FadeStart at the tail to 1.0 at the head. With a
+            // single point, treat it as the head (fully opaque).
+            var age = points.Count > 1 ? (float)i / (points.Count - 1) : 1f;
+            var opacity = trail.FadeStart + (1f - trail.FadeStart) * age;
+
+            var glyph = trailGlyphs[Math.Clamp(
+                (int)(opacity * trailGlyphs.Length),
+                0,
+                trailGlyphs.Length - 1)];
+
+            Plot(grid, points[i], glyph);
+        }
     }
 
     private void Plot(char[,] grid, Vector3 position, char symbol)

--- a/samples/KeenEyes.Sample.Racing/KeenEyes.Sample.Racing.csproj
+++ b/samples/KeenEyes.Sample.Racing/KeenEyes.Sample.Racing.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Common\KeenEyes.Common.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Replay\KeenEyes.Replay.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/KeenEyes.Sample.Racing/Program.cs
+++ b/samples/KeenEyes.Sample.Racing/Program.cs
@@ -1,0 +1,136 @@
+using KeenEyes.Replay.Ghost;
+using KeenEyes.Sample.Racing;
+
+// =============================================================================
+// KEEN EYES ECS - Racing Ghost Mode Demo
+// =============================================================================
+// This sample drives a car around a circular time-trial track three times,
+// building up ghosts from earlier laps and racing against them:
+//
+//   1. Record via ReplayPlugin + ReplayRecorder.
+//   2. Extract a lightweight ghost from the replay with GhostExtractor.
+//   3. Save/load it as a .keghost file with GhostFileFormat.
+//   4. Race against it through GhostManager in DistanceSynced mode, printing the
+//      live time gap (ahead/behind) at the same point on the track.
+//   5. On the final lap, race two ghosts at once (best lap + previous lap).
+//
+// Everything runs unattended and headless - the "player" is a deterministic
+// scripted throttle - so the demo is reproducible and CI-friendly.
+// =============================================================================
+
+Console.WriteLine("KeenEyes ECS - Racing Ghost Mode Demo");
+Console.WriteLine(new string('=', 60));
+
+var track = new Track(radius: 50f);
+var renderer = new TrackRenderer(track);
+var raceManager = new RaceManager(track, renderer);
+var serializer = new RacingComponentSerializer();
+
+Console.WriteLine($"Track: circular, radius {track.Radius:F0}, lap length {track.Length:F1} units.\n");
+
+var ghostDirectory = Path.Combine(Path.GetTempPath(), "keeneyes-racing-ghosts");
+Directory.CreateDirectory(ghostDirectory);
+var lap1Path = Path.Combine(ghostDirectory, "lap1.keghost");
+var lap2Path = Path.Combine(ghostDirectory, "lap2.keghost");
+
+try
+{
+    // -------------------------------------------------------------------------
+    // LAP 1 - solo recording lap. No ghosts to chase yet.
+    // -------------------------------------------------------------------------
+    Console.WriteLine("[Lap 1] Solo hot lap - recording (throttle 0.80)\n");
+    var lap1 = raceManager.RunLap(serializer, "Lap 1", targetThrottle: 0.80f, ghosts: null);
+
+    var lap1Ghost = GhostSetup.ExtractAndSave(lap1.Replay, lap1Path);
+    Console.WriteLine($"\n  Lap 1 time: {lap1.LapSeconds:F2}s");
+    Console.WriteLine(
+        $"  Recorded {lap1.Replay.Snapshots.Count} snapshots -> extracted {lap1Ghost.FrameCount} ghost frames " +
+        $"({new FileInfo(lap1Path).Length:N0} bytes on disk).\n");
+
+    // -------------------------------------------------------------------------
+    // LAP 2 - race against lap 1 (the previous lap), loaded from memory.
+    // -------------------------------------------------------------------------
+    Console.WriteLine(new string('-', 60));
+    Console.WriteLine("[Lap 2] Racing the previous lap's ghost (throttle 0.60)\n");
+
+    LapResult lap2;
+    using (var lap2Ghosts = new GhostManager { DefaultSyncMode = GhostSyncMode.DistanceSynced })
+    {
+        lap2Ghosts.AddGhost("previous", lap1Ghost, GhostSetup.PreviousLap);
+        lap2 = raceManager.RunLap(serializer, "Lap 2", targetThrottle: 0.60f, ghosts: lap2Ghosts);
+    }
+
+    GhostSetup.ExtractAndSave(lap2.Replay, lap2Path);
+    Console.WriteLine($"\n  Lap 2 time: {lap2.LapSeconds:F2}s");
+    Console.WriteLine($"  {Compare("Lap 2", lap2.LapSeconds, "Lap 1", lap1.LapSeconds)}\n");
+
+    // -------------------------------------------------------------------------
+    // LAP 3 - race two ghosts at once: best lap + previous lap, both loaded
+    // from their .keghost files.
+    // -------------------------------------------------------------------------
+    Console.WriteLine(new string('-', 60));
+    Console.WriteLine("[Lap 3] Racing two ghosts: best lap + previous lap (throttle 0.95)\n");
+
+    // The previous lap is always lap 2; the best lap is whichever prior lap was fastest.
+    var bestIsLap1 = lap1.LapSeconds <= lap2.LapSeconds;
+    var bestPath = bestIsLap1 ? lap1Path : lap2Path;
+    var bestLabel = bestIsLap1 ? "Lap 1" : "Lap 2";
+    var bestTime = bestIsLap1 ? lap1.LapSeconds : lap2.LapSeconds;
+
+    LapResult lap3;
+    using (var lap3Ghosts = new GhostManager { DefaultSyncMode = GhostSyncMode.DistanceSynced })
+    {
+        lap3Ghosts.AddGhostFromFile("best", bestPath, GhostSetup.BestLap);
+        lap3Ghosts.AddGhostFromFile("previous", lap2Path, GhostSetup.PreviousLap);
+        lap3 = raceManager.RunLap(serializer, "Lap 3", targetThrottle: 0.95f, ghosts: lap3Ghosts);
+    }
+
+    Console.WriteLine($"\n  Lap 3 time: {lap3.LapSeconds:F2}s");
+    Console.WriteLine($"  {Compare("Lap 3", lap3.LapSeconds, $"best ({bestLabel})", bestTime)}");
+    Console.WriteLine($"  {Compare("Lap 3", lap3.LapSeconds, "previous (Lap 2)", lap2.LapSeconds)}\n");
+
+    // -------------------------------------------------------------------------
+    // Final standings.
+    // -------------------------------------------------------------------------
+    Console.WriteLine(new string('=', 60));
+    Console.WriteLine("Final standings\n");
+
+    var times = new (string Label, float Seconds)[]
+    {
+        ("Lap 1", lap1.LapSeconds),
+        ("Lap 2", lap2.LapSeconds),
+        ("Lap 3", lap3.LapSeconds),
+    };
+
+    var fastest = times[0];
+    foreach (var entry in times)
+    {
+        if (entry.Seconds < fastest.Seconds)
+        {
+            fastest = entry;
+        }
+    }
+
+    foreach (var entry in times)
+    {
+        var marker = entry.Label == fastest.Label ? "  <- fastest" : string.Empty;
+        Console.WriteLine($"  {entry.Label}: {entry.Seconds,6:F2}s{marker}");
+    }
+
+    Console.WriteLine("\nDemo complete.");
+}
+finally
+{
+    if (Directory.Exists(ghostDirectory))
+    {
+        Directory.Delete(ghostDirectory, recursive: true);
+    }
+}
+
+// Formats a comparison between a lap time and a reference time.
+static string Compare(string lapLabel, float lapSeconds, string referenceLabel, float referenceSeconds)
+{
+    var delta = lapSeconds - referenceSeconds;
+    var verdict = delta < 0f ? "faster" : "slower";
+    return $"{lapLabel} is {Math.Abs(delta):F2}s {verdict} than {referenceLabel} ({delta:+0.00;-0.00}s).";
+}

--- a/samples/KeenEyes.Sample.Racing/README.md
+++ b/samples/KeenEyes.Sample.Racing/README.md
@@ -1,0 +1,169 @@
+# KeenEyes.Sample.Racing
+
+This sample demonstrates the **Ghost Mode** pipeline in `KeenEyes.Replay` in a
+time-trial racing context: record a lap, distil it into a lightweight *ghost*, save
+it to disk, then race against it - and against multiple ghosts at once - while
+showing the live time gap.
+
+It is the first end-to-end consumer of the ghost pipeline, so it also shows the one
+piece of integration glue a real game needs: making the engine's `Transform3D`
+component serializable into replay snapshots.
+
+## What it demonstrates
+
+1. **Recording** a lap with `ReplayPlugin` + `ReplayRecorder`.
+2. **Extracting** a ghost from the replay with `GhostExtractor.ExtractGhost`.
+3. **Saving / loading** ghosts as `.keghost` files via `GhostFileFormat`.
+4. **Racing** against ghosts through `GhostManager` in `GhostSyncMode.DistanceSynced`,
+   printing the live **time gap** (ahead / behind) at the same point on the track.
+5. **Multiple simultaneous ghosts** - the final lap races the *best* lap and the
+   *previous* lap at the same time, each with its own `GhostVisualConfig`
+   (tint, opacity, label).
+
+Everything runs **headless and unattended**. The "player" is a deterministic
+scripted throttle, so the demo is reproducible and CI-friendly - no window, GPU, or
+input required.
+
+## Running the sample
+
+```bash
+dotnet run --project samples/KeenEyes.Sample.Racing -c Release
+```
+
+The demo drives three laps of a circular track:
+
+| Lap | Throttle | Role |
+|-----|----------|------|
+| 1 | 0.80 | Solo hot lap - recorded, becomes the *best* lap |
+| 2 | 0.60 | Slower lap, raced against lap 1 (the *previous* lap) |
+| 3 | 0.95 | Fastest lap, raced against **two** ghosts: best (lap 1) + previous (lap 2) |
+
+It prints per-quarter progress, a top-down ASCII view of the track, the live time
+gap to each ghost, and a final standings table.
+
+## Project layout
+
+```
+KeenEyes.Sample.Racing/
+├── Program.cs                         # Orchestrates the three-lap demo
+├── Components/
+│   ├── Vehicle.cs                     # Speed / steering state (pure data)
+│   ├── TrackPosition.cs               # Distance travelled along the track
+│   └── LapTimer.cs                    # Elapsed / final lap time
+├── Systems/
+│   ├── VehicleMovementSystem.cs       # Drives the car along the racing line
+│   └── LapTrackingSystem.cs           # Lap timing and completion
+└── Game/
+    ├── Track.cs                       # Parametric circular racing line
+    ├── RaceManager.cs                 # Runs one lap: record + race + report
+    ├── GhostSetup.cs                  # Ghost extraction + visual configs
+    ├── TrackRenderer.cs               # Top-down ASCII track view
+    └── RacingComponentSerializer.cs   # Makes Transform3D serializable
+```
+
+## Key concepts
+
+### Making `Transform3D` recordable
+
+The ghost extractor reads each entity's `KeenEyes.Common.Transform3D` out of replay
+snapshots. But the source-generated `ComponentSerializer` only knows about components
+declared with `[Component(Serializable = true)]` **in this project** - it never sees
+engine types from `KeenEyes.Common`.
+
+`RacingComponentSerializer` closes that gap. It wraps the generated serializer and
+intercepts only `Transform3D`, emitting the exact JSON shape the extractor expects
+(`Position` / `Rotation` / `Scale` with `X/Y/Z/W` members). Everything else is
+delegated straight through. This is the pattern any game will use to record engine
+components for ghosts.
+
+```csharp
+var serializer = new RacingComponentSerializer();
+world.InstallPlugin(new ReplayPlugin(serializer, recordingOptions));
+```
+
+### Recording settings chosen for smooth ghosts
+
+```csharp
+new ReplayOptions
+{
+    SnapshotInterval = TimeSpan.FromSeconds(0.05), // ~20 Hz snapshots
+    KeyframeInterval = 1,                          // every snapshot is a full keyframe
+    RecordSystemEvents = false,
+    RecordComponentEvents = false,
+    RecordEntityEvents = false,
+}
+```
+
+Two settings matter for ghost fidelity, and they interact:
+
+- **`SnapshotInterval`** controls how often the world state is captured. Ghost frames
+  come from snapshots, so a short interval means a smoother ghost.
+- **`KeyframeInterval`** controls how many snapshots are stored as full *keyframes*
+  versus space-saving *deltas*. **The ghost extractor only reads keyframes** - delta
+  markers carry no snapshot. With the default `KeyframeInterval = 10`, only every
+  tenth snapshot would be usable and the ghost would be jerky. Setting it to `1`
+  makes every snapshot a keyframe, so all ~100+ frames per lap feed the ghost.
+
+The trade-off: `KeyframeInterval = 1` disables delta compression, so the replay is
+larger. That is the right call here - a single-car time-trial recording is tiny
+(a few kilobytes) and fidelity is what matters for a good ghost.
+
+### Distance-synced comparison
+
+Ghosts play back in `DistanceSynced` mode: each frame the manager is told how far the
+car has travelled, and it positions each ghost at wherever *it* was after the same
+distance.
+
+```csharp
+using var ghosts = new GhostManager { DefaultSyncMode = GhostSyncMode.DistanceSynced };
+ghosts.AddGhostFromFile("best", bestPath, GhostSetup.BestLap);
+ghosts.AddGhostFromFile("previous", lap2Path, GhostSetup.PreviousLap);
+ghosts.PlayAll();
+
+// each frame:
+ghosts.UpdateByDistance(car.TrackPosition.Distance);
+foreach (var ghost in ghosts.ActiveGhosts)
+{
+    var gap = carElapsedSeconds - ghost.Player.CurrentTime.TotalSeconds;
+    // gap < 0 => the car reached this distance sooner => it is ahead
+}
+```
+
+Because the comparison is at *equal distance*, the ghost sits at the same point on the
+track as the car - the difference between them is **time**, not position. That is why
+the ASCII map shows the car lapping while the head-to-head result is reported as a
+live time gap rather than as separated dots on the track.
+
+### Ghost visual configuration
+
+`GhostVisualConfig` is metadata a renderer consumes; the ghost system never draws
+anything itself. This sample uses it to label and color each ghost distinctly:
+
+```csharp
+public static GhostVisualConfig BestLap { get; } = new()
+{
+    TintColor = new Vector4(1f, 0.84f, 0f, 1f), // gold
+    Opacity = 0.4f,
+    Label = "Best Lap",
+};
+```
+
+## Sample output (excerpt)
+
+```
+[Lap 3] Racing two ghosts: best lap + previous lap (throttle 0.95)
+
+  [ 50%]  t =   3.38s
+          vs Best Lap      -0.42s (ahead)
+          vs Previous Lap  -1.38s (ahead)
+
+  Lap 3 time: 6.15s
+  Lap 3 is 0.93s faster than best (Lap 1) (-0.93s).
+  Lap 3 is 2.98s faster than previous (Lap 2) (-2.98s).
+
+Final standings
+
+  Lap 1:   7.08s
+  Lap 2:   9.13s
+  Lap 3:   6.15s  <- fastest
+```

--- a/samples/KeenEyes.Sample.Racing/Systems/LapTrackingSystem.cs
+++ b/samples/KeenEyes.Sample.Racing/Systems/LapTrackingSystem.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Advances each car's lap timer and detects lap completion.
+/// </summary>
+/// <remarks>
+/// A lap is complete once the car's <see cref="TrackPosition.Distance"/> reaches
+/// the track length. The final lap time is latched into
+/// <see cref="LapTimer.FinishedSeconds"/> so the driver loop can stop the lap and
+/// compare it against ghosts.
+/// </remarks>
+public sealed class LapTrackingSystem : SystemBase
+{
+    private readonly float lapLength;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LapTrackingSystem"/> class.
+    /// </summary>
+    /// <param name="lapLength">The length of one lap, in world units.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when lap length is not positive.</exception>
+    public LapTrackingSystem(float lapLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(lapLength);
+        this.lapLength = lapLength;
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<TrackPosition, LapTimer>())
+        {
+            ref var trackPosition = ref World.Get<TrackPosition>(entity);
+            ref var lapTimer = ref World.Get<LapTimer>(entity);
+
+            if (lapTimer.Finished)
+            {
+                continue;
+            }
+
+            lapTimer.ElapsedSeconds += deltaTime;
+
+            if (trackPosition.Distance >= lapLength)
+            {
+                lapTimer.Finished = true;
+                lapTimer.FinishedSeconds = lapTimer.ElapsedSeconds;
+            }
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/Systems/VehicleMovementSystem.cs
+++ b/samples/KeenEyes.Sample.Racing/Systems/VehicleMovementSystem.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Numerics;
+using KeenEyes.Common;
+
+namespace KeenEyes.Sample.Racing;
+
+/// <summary>
+/// Drives each car along the parametric racing line based on its throttle input.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each frame the system eases the car's current speed toward its throttle
+/// target, advances its distance along the track, and writes the resulting
+/// world position and heading into the car's <see cref="Transform3D"/>. The
+/// <see cref="Transform3D"/> is what the replay recorder captures and what the
+/// ghost pipeline later reads back, so keeping it accurate every frame is what
+/// makes smooth ghosts possible.
+/// </para>
+/// </remarks>
+public sealed class VehicleMovementSystem : SystemBase
+{
+    private readonly Track track;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VehicleMovementSystem"/> class.
+    /// </summary>
+    /// <param name="track">The track whose racing line the cars follow.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="track"/> is null.</exception>
+    public VehicleMovementSystem(Track track)
+    {
+        ArgumentNullException.ThrowIfNull(track);
+        this.track = track;
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Vehicle, TrackPosition, Transform3D>())
+        {
+            ref var vehicle = ref World.Get<Vehicle>(entity);
+            ref var trackPosition = ref World.Get<TrackPosition>(entity);
+            ref var transform = ref World.Get<Transform3D>(entity);
+
+            // Ease the current speed toward the throttle target. Using a tolerance
+            // comparison (never == on floats) avoids jitter once the target is reached.
+            var targetSpeed = Math.Clamp(vehicle.Throttle, 0f, 1f) * vehicle.MaxSpeed;
+            if (!vehicle.CurrentSpeed.ApproximatelyEquals(targetSpeed))
+            {
+                var step = vehicle.Acceleration * deltaTime;
+                if (vehicle.CurrentSpeed < targetSpeed)
+                {
+                    vehicle.CurrentSpeed = MathF.Min(vehicle.CurrentSpeed + step, targetSpeed);
+                }
+                else
+                {
+                    vehicle.CurrentSpeed = MathF.Max(vehicle.CurrentSpeed - step, targetSpeed);
+                }
+            }
+
+            // Advance along the track and sample the racing line for the new pose.
+            trackPosition.Distance += vehicle.CurrentSpeed * deltaTime;
+
+            vehicle.Steering = track.HeadingAt(trackPosition.Distance);
+            transform.Position = track.PositionAt(trackPosition.Distance);
+            transform.Rotation = Quaternion.CreateFromYawPitchRoll(vehicle.Steering, 0f, 0f);
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.Racing/packages.lock.json
+++ b/samples/KeenEyes.Sample.Racing/packages.lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/src/KeenEyes.Replay/Ghost/GhostManager.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostManager.cs
@@ -508,4 +508,20 @@ public readonly record struct GhostInstance(
     /// Gets the optional label for this ghost.
     /// </summary>
     public string? Label => Config.Label;
+
+    /// <summary>
+    /// Gets a value indicating whether this ghost should render a motion trail.
+    /// </summary>
+    public bool ShowTrail => Config.ShowTrail;
+
+    /// <summary>
+    /// Copies this ghost's recent trail points into the supplied buffer.
+    /// </summary>
+    /// <param name="destination">The buffer to fill, oldest point first.</param>
+    /// <returns>The number of points written.</returns>
+    /// <remarks>
+    /// This is a convenience pass-through to
+    /// <see cref="GhostPlayer.GetTrailPoints(Span{Vector3})"/> and does not allocate.
+    /// </remarks>
+    public int GetTrailPoints(Span<Vector3> destination) => Player.GetTrailPoints(destination);
 }

--- a/src/KeenEyes.Replay/Ghost/GhostPlayer.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostPlayer.cs
@@ -753,6 +753,86 @@ public sealed class GhostPlayer : IDisposable
     }
 
     /// <summary>
+    /// Copies the ghost's recent trail points into the supplied buffer.
+    /// </summary>
+    /// <param name="destination">
+    /// The buffer to fill. Points are written oldest-first, so the last written
+    /// element is the most recent position (nearest the ghost's current position).
+    /// If the buffer is smaller than the available history, only the most recent
+    /// points that fit are written.
+    /// </param>
+    /// <returns>The number of points written to <paramref name="destination"/>.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// The trail is the sequence of recorded frame positions at or before the current
+    /// playback position, ordered from oldest to newest. It tracks the playhead across
+    /// <see cref="Update"/>, <see cref="UpdateByDistance"/>, <see cref="SeekToTime"/>,
+    /// and <see cref="SeekToFrame"/>.
+    /// </para>
+    /// <para>
+    /// The trail is empty while the playhead sits on the first frame - that is, before
+    /// playback has advanced past the start and after <see cref="Stop"/> resets it -
+    /// since there is no traversed path to show.
+    /// </para>
+    /// <para>
+    /// This overload does not allocate: it writes directly into the caller's span.
+    /// Renderers should reuse a single buffer sized to
+    /// <see cref="GhostVisualConfig.TrailLength"/> across frames.
+    /// </para>
+    /// </remarks>
+    public int GetTrailPoints(Span<Vector3> destination)
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            return FillTrailPoints(destination);
+        }
+    }
+
+    /// <summary>
+    /// Gets the ghost's recent trail points as a newly allocated array.
+    /// </summary>
+    /// <param name="maxPoints">The maximum number of points to return.</param>
+    /// <returns>
+    /// An array of trail points ordered from oldest to newest, containing at most
+    /// <paramref name="maxPoints"/> entries. Returns an empty array when there is no
+    /// trail (for example, before playback starts).
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxPoints"/> is negative.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// This convenience overload allocates a new array on each call. For per-frame
+    /// rendering, prefer <see cref="GetTrailPoints(Span{Vector3})"/> with a reusable
+    /// buffer to avoid garbage.
+    /// </remarks>
+    public Vector3[] GetTrailPoints(int maxPoints)
+    {
+        if (maxPoints < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxPoints), maxPoints,
+                "Maximum points cannot be negative.");
+        }
+
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            int available = AvailableTrailPointCount();
+            int count = Math.Min(maxPoints, available);
+            if (count == 0)
+            {
+                return [];
+            }
+
+            var result = new Vector3[count];
+            FillTrailPoints(result);
+            return result;
+        }
+    }
+
+    /// <summary>
     /// Releases all resources used by the <see cref="GhostPlayer"/>.
     /// </summary>
     public void Dispose()
@@ -772,6 +852,55 @@ public sealed class GhostPlayer : IDisposable
             Unload();
             disposed = true;
         }
+    }
+
+    // Number of recorded frames at or before the current playhead. Must be called
+    // with syncRoot held.
+    private int AvailableTrailPointCount()
+    {
+        if (ghostData is null)
+        {
+            return 0;
+        }
+
+        var frames = ghostData.Frames;
+        if (frames.Count == 0)
+        {
+            return 0;
+        }
+
+        // The trail is the path behind the playhead. When the playhead sits on the
+        // first frame there is no traversed path yet, so the trail is empty - this
+        // covers "before playback starts" (Load leaves the playhead at frame 0) and
+        // "after Stop" (Stop resets the playhead to frame 0).
+        if (currentFrameIndex <= 0)
+        {
+            return 0;
+        }
+
+        return currentFrameIndex + 1;
+    }
+
+    // Writes the most recent trail points (oldest-first) into destination and returns
+    // the count written. Must be called with syncRoot held.
+    private int FillTrailPoints(Span<Vector3> destination)
+    {
+        int available = AvailableTrailPointCount();
+        if (available == 0 || destination.Length == 0)
+        {
+            return 0;
+        }
+
+        var frames = ghostData!.Frames;
+        int count = Math.Min(destination.Length, available);
+        int start = currentFrameIndex - count + 1;
+
+        for (int i = 0; i < count; i++)
+        {
+            destination[i] = frames[start + i].Position;
+        }
+
+        return count;
     }
 
     private bool UpdateTimeSynced(float deltaTime)

--- a/src/KeenEyes.Replay/Ghost/GhostVisualConfig.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostVisualConfig.cs
@@ -139,6 +139,71 @@ public sealed record GhostVisualConfig
     public Vector4? OutlineColor { get; init; }
 
     /// <summary>
+    /// Gets or sets whether the ghost should render a motion trail.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When true, games should read the ghost's recent path from
+    /// <see cref="GhostPlayer.GetTrailPoints(System.Span{Vector3})"/> and draw a
+    /// fading trail behind the ghost. When false (the default), no trail is drawn
+    /// and the trail provider is never consulted, so there is zero behavior change.
+    /// </para>
+    /// <para>
+    /// The ghost system does not render the trail itself; these settings are hints
+    /// for the game's rendering code.
+    /// </para>
+    /// </remarks>
+    public bool ShowTrail { get; init; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of recent frames included in the trail.
+    /// </summary>
+    /// <value>
+    /// A positive frame count. Default is 60 (roughly one second at 60 fps).
+    /// </value>
+    /// <remarks>
+    /// This bounds both the visual length of the trail and the buffer a renderer
+    /// needs to request from
+    /// <see cref="GhostPlayer.GetTrailPoints(System.Span{Vector3})"/>. Longer trails
+    /// use more memory in the caller's buffer but do not affect stored ghost data.
+    /// </remarks>
+    public int TrailLength { get; init; } = 60;
+
+    /// <summary>
+    /// Gets or sets the opacity at the oldest (tail) end of the trail.
+    /// </summary>
+    /// <value>
+    /// A value between 0.0 (fully transparent tail) and 1.0 (no fade). Default is 0.5.
+    /// </value>
+    /// <remarks>
+    /// The trail fades from this opacity at the tail toward full opacity at the head
+    /// (the ghost's current position). Renderers should interpolate opacity across the
+    /// trail points using this as the starting value.
+    /// </remarks>
+    public float TrailFadeStart { get; init; } = 0.5f;
+
+    /// <summary>
+    /// Gets or sets the width of the trail, in world units.
+    /// </summary>
+    /// <value>
+    /// A positive width. Default is 0.1.
+    /// </value>
+    /// <remarks>
+    /// Renderers that draw the trail as a line or ribbon should use this as the line
+    /// thickness. Renderers that draw discrete markers may ignore it.
+    /// </remarks>
+    public float TrailWidth { get; init; } = 0.1f;
+
+    /// <summary>
+    /// Gets or sets the style used to draw the trail.
+    /// </summary>
+    /// <remarks>
+    /// Default is <see cref="TrailStyle.Line"/>. See <see cref="TrailStyle"/> for the
+    /// available styles and the <see cref="TrailStyle.Ribbon"/> fallback note.
+    /// </remarks>
+    public TrailStyle TrailStyle { get; init; } = TrailStyle.Line;
+
+    /// <summary>
     /// Creates a new <see cref="GhostVisualConfig"/> with the specified opacity.
     /// </summary>
     /// <param name="opacity">The opacity value (0.0 to 1.0).</param>

--- a/src/KeenEyes.Replay/Ghost/TrailStyle.cs
+++ b/src/KeenEyes.Replay/Ghost/TrailStyle.cs
@@ -1,0 +1,40 @@
+namespace KeenEyes.Replay.Ghost;
+
+/// <summary>
+/// Describes how a ghost's motion trail should be drawn by a renderer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ghost system is data-only: it never renders trails itself. This enum is a
+/// hint carried on <see cref="GhostVisualConfig"/> that a renderer reads to decide
+/// how to visualize the points returned by
+/// <see cref="GhostPlayer.GetTrailPoints(System.Span{System.Numerics.Vector3})"/>.
+/// </para>
+/// </remarks>
+public enum TrailStyle
+{
+    /// <summary>
+    /// A single connected line through the trail points (e.g. a polyline / line strip).
+    /// </summary>
+    Line,
+
+    /// <summary>
+    /// A 3D ribbon oriented along the ghost's facing direction.
+    /// </summary>
+    /// <remarks>
+    /// Ribbons require an oriented 3D line renderer. The 2D reference renderers that
+    /// ship with KeenEyes have no such primitive, so they fall back to
+    /// <see cref="Line"/> when this style is requested.
+    /// </remarks>
+    Ribbon,
+
+    /// <summary>
+    /// Discrete position markers at each trail point rather than a connected line.
+    /// </summary>
+    Dots,
+
+    /// <summary>
+    /// A connected line whose color/opacity is graded along the path from tail to head.
+    /// </summary>
+    Gradient
+}

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
@@ -1,0 +1,298 @@
+using System.Numerics;
+using KeenEyes.Replay.Ghost;
+
+namespace KeenEyes.Replay.Tests.Ghost;
+
+/// <summary>
+/// Unit tests for ghost trail support: <see cref="GhostVisualConfig"/> trail fields
+/// and the trail-point provider on <see cref="GhostPlayer"/> / <see cref="GhostInstance"/>.
+/// </summary>
+public class GhostTrailTests
+{
+    // Five frames one unit apart along +X, one second apart.
+    private static GhostData CreateTestGhostData()
+    {
+        return new GhostData
+        {
+            Name = "Trail Ghost",
+            EntityName = "Player",
+            RecordingStarted = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(4),
+            FrameCount = 5,
+            Frames =
+            [
+                new GhostFrame(new Vector3(0, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(0)) { Distance = 0f },
+                new GhostFrame(new Vector3(1, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(1)) { Distance = 1f },
+                new GhostFrame(new Vector3(2, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(2)) { Distance = 2f },
+                new GhostFrame(new Vector3(3, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(3)) { Distance = 3f },
+                new GhostFrame(new Vector3(4, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(4)) { Distance = 4f }
+            ]
+        };
+    }
+
+    #region GhostVisualConfig Defaults
+
+    [Fact]
+    public void GhostVisualConfig_Default_HasTrailDisabled()
+    {
+        var config = new GhostVisualConfig();
+
+        Assert.False(config.ShowTrail);
+        Assert.Equal(60, config.TrailLength);
+        Assert.Equal(0.5f, config.TrailFadeStart);
+        Assert.Equal(0.1f, config.TrailWidth);
+        Assert.Equal(TrailStyle.Line, config.TrailStyle);
+    }
+
+    [Fact]
+    public void GhostVisualConfig_WithTrailSettings_RetainsValues()
+    {
+        var config = new GhostVisualConfig
+        {
+            ShowTrail = true,
+            TrailLength = 30,
+            TrailFadeStart = 0.2f,
+            TrailWidth = 0.5f,
+            TrailStyle = TrailStyle.Dots
+        };
+
+        Assert.True(config.ShowTrail);
+        Assert.Equal(30, config.TrailLength);
+        Assert.Equal(0.2f, config.TrailFadeStart);
+        Assert.Equal(0.5f, config.TrailWidth);
+        Assert.Equal(TrailStyle.Dots, config.TrailStyle);
+    }
+
+    #endregion
+
+    #region Empty Before Playback
+
+    [Fact]
+    public void GetTrailPoints_BeforePlayback_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetTrailPoints_NoGhostLoaded_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetTrailPoints_AfterStop_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(3);
+
+        // Sanity: seeking gives a trail.
+        Assert.Equal(4, player.GetTrailPoints(64).Length);
+
+        player.Play();
+        player.Stop();
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        Assert.Equal(0, player.GetTrailPoints(buffer));
+    }
+
+    #endregion
+
+    #region Points, Order, and Count
+
+    [Fact]
+    public void GetTrailPoints_AtFrame_ReturnsPathOldestToNewest()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToFrame(3);
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(4, count);
+        Assert.Equal(new Vector3(0, 0, 0), buffer[0]);
+        Assert.Equal(new Vector3(1, 0, 0), buffer[1]);
+        Assert.Equal(new Vector3(2, 0, 0), buffer[2]);
+        Assert.Equal(new Vector3(3, 0, 0), buffer[3]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_AsPlaybackAdvances_GrowsWithPlayhead()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToFrame(1);
+        Assert.Equal(2, player.GetTrailPoints(64).Length);
+
+        player.SeekToFrame(2);
+        Assert.Equal(3, player.GetTrailPoints(64).Length);
+
+        player.SeekToFrame(4);
+        var trail = player.GetTrailPoints(64);
+        Assert.Equal(5, trail.Length);
+        Assert.Equal(new Vector3(4, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_WithFrameSyncedPlayback_TracksAdvancingFrames()
+    {
+        using var player = new GhostPlayer
+        {
+            SyncMode = GhostSyncMode.FrameSynced
+        };
+        player.Load(CreateTestGhostData());
+        player.Play();
+
+        player.Update(0f); // -> frame 1
+        player.Update(0f); // -> frame 2
+
+        var trail = player.GetTrailPoints(64);
+
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(0, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(2, 0, 0), trail[^1]);
+    }
+
+    #endregion
+
+    #region TrailLength / Buffer Bounds
+
+    [Fact]
+    public void GetTrailPoints_BufferSmallerThanHistory_ReturnsMostRecentPoints()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        Span<Vector3> buffer = stackalloc Vector3[2];
+        int count = player.GetTrailPoints(buffer);
+
+        // Only the two most recent points fit.
+        Assert.Equal(2, count);
+        Assert.Equal(new Vector3(3, 0, 0), buffer[0]);
+        Assert.Equal(new Vector3(4, 0, 0), buffer[1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_RespectsMaxPoints()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        var trail = player.GetTrailPoints(maxPoints: 3);
+
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(2, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(4, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_MaxPointsZero_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        Assert.Empty(player.GetTrailPoints(maxPoints: 0));
+    }
+
+    [Fact]
+    public void GetTrailPoints_NegativeMaxPoints_ThrowsArgumentOutOfRange()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.GetTrailPoints(maxPoints: -1));
+    }
+
+    #endregion
+
+    #region Seek Consistency
+
+    [Fact]
+    public void GetTrailPoints_AfterSeekToTime_ReturnsPathUpToThatTime()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToTime(TimeSpan.FromSeconds(2));
+
+        var trail = player.GetTrailPoints(64);
+
+        // Frames 0..2 are at or before t=2s.
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(0, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(2, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_SeekBackward_ShrinksTrail()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToTime(TimeSpan.FromSeconds(4));
+        Assert.Equal(5, player.GetTrailPoints(64).Length);
+
+        player.SeekToTime(TimeSpan.FromSeconds(1));
+        Assert.Equal(2, player.GetTrailPoints(64).Length);
+    }
+
+    #endregion
+
+    #region Disposal
+
+    [Fact]
+    public void GetTrailPoints_AfterDispose_ThrowsObjectDisposed()
+    {
+        var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            Span<Vector3> buffer = stackalloc Vector3[4];
+            player.GetTrailPoints(buffer);
+        });
+    }
+
+    #endregion
+
+    #region GhostInstance Surface
+
+    [Fact]
+    public void GhostInstance_GetTrailPoints_MatchesPlayer()
+    {
+        using var manager = new GhostManager();
+        var config = new GhostVisualConfig { ShowTrail = true, TrailLength = 32 };
+        manager.AddGhost("ghost", CreateTestGhostData(), config);
+
+        var instance = Assert.Single(manager.ActiveGhosts);
+        instance.Player.SeekToFrame(2);
+
+        Assert.True(instance.ShowTrail);
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = instance.GetTrailPoints(buffer);
+
+        Assert.Equal(3, count);
+        Assert.Equal(new Vector3(2, 0, 0), buffer[2]);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`samples/KeenEyes.Sample.Racing`** — the first end-to-end consumer of the Ghost pipeline: lap 1 records via `ReplayPlugin` → ghost extracted + saved as `.keghost` → lap 2 races the previous-lap ghost (`DistanceSynced`) with a live time-gap readout → lap 3 races **two** simultaneous ghosts (best + previous, each with its own `GhostVisualConfig`). Headless/deterministic (scripted throttle, ASCII track view) — runs unattended with `dotnet run`; added to the slnx.
- **Two real integration lessons, documented in the README:**
  1. `GhostExtractor` reads transforms **only from full keyframes**, so with delta compression's default `KeyframeInterval=10` ghosts would be jerky — the sample uses `SnapshotInterval=0.05s` + `KeyframeInterval=1` and explains the size/fidelity trade-off (single-car recording ≈ 4 KB, so fidelity wins).
  2. The source-generated `ComponentSerializer` only covers the consuming project's components — engine components like `Transform3D` (exactly what ghosts need) require a thin delegating `IComponentSerializer` wrapper (`RacingComponentSerializer`, reflection-free via `Utf8JsonWriter`). This is the reusable pattern for any game recording engine components.
- `DistanceSynced` semantics called out: a distance-synced ghost occupies the same track point by definition, so comparison is temporal (time gaps), not spatial.

## Test plan
- [x] `dotnet run` completes unattended with sensible output (verified independently — lap 3 beats both ghosts, standings printed)
- [x] Sample + full slnx build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #789 (part of #98). Creates the consumer seam #788 (ghost trails) extends. Follow-up filed for the keyframe-only extraction limitation.