### PR TITLE
fix: NavigationPlugin provider disposal bug + MCP TestBridge mock drift

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -109,6 +109,7 @@
     <Project Path="tests/KeenEyes.Input.Abstractions.Tests/KeenEyes.Input.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Localization.Tests/KeenEyes.Localization.Tests.csproj" />
     <Project Path="tests/KeenEyes.Logging.Tests/KeenEyes.Logging.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Mcp.TestBridge.Tests/KeenEyes.Mcp.TestBridge.Tests.csproj" />
     <Project Path="tests/KeenEyes.Navigation.Abstractions.Tests/KeenEyes.Navigation.Abstractions.Tests.csproj" />
     <Project Path="tests/KeenEyes.Navigation.DotRecast.Tests/KeenEyes.Navigation.DotRecast.Tests.csproj" />
     <Project Path="tests/KeenEyes.Navigation.Grid.Tests/KeenEyes.Navigation.Grid.Tests.csproj" />

--- a/src/KeenEyes.Navigation/NavigationPlugin.cs
+++ b/src/KeenEyes.Navigation/NavigationPlugin.cs
@@ -103,8 +103,15 @@ public sealed class NavigationPlugin : IWorldPlugin
         navigationContext.SetProvider(provider);
         context.SetExtension(navigationContext);
 
-        // Also register the INavigationProvider for direct access
-        context.SetExtension(provider);
+        // Ensure the INavigationProvider is accessible for direct queries.
+        // In the provider-plugin path (e.g. GridNavigationPlugin) the same instance is
+        // already registered; re-registering it would dispose it, because SetExtension
+        // disposes the extension it replaces. Only register when it is not already present.
+        if (!context.TryGetExtension<INavigationProvider>(out var registered)
+            || !ReferenceEquals(registered, provider))
+        {
+            context.SetExtension(provider);
+        }
 
         // Register systems
         RegisterSystems(context);

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/KeenEyes.Mcp.TestBridge.Tests.csproj
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/KeenEyes.Mcp.TestBridge.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\tools\KeenEyes.Mcp.TestBridge\KeenEyes.Mcp.TestBridge.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.TestBridge\KeenEyes.TestBridge.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Input.Abstractions\KeenEyes.Input.Abstractions.csproj" />
   </ItemGroup>
 

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockAIController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockAIController.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.AI;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IAIController for testing MCP tools.
+/// </summary>
+/// <remarks>
+/// Reports no AI components present, mirroring a world with no AIPlugin installed.
+/// </remarks>
+internal sealed class MockAIController : IAIController
+{
+    public Task<AIStatisticsSnapshot> GetStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new AIStatisticsSnapshot());
+
+    public Task<IReadOnlyList<int>> GetBehaviorTreeEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<BehaviorTreeSnapshot?>(null);
+
+    public Task<bool> ResetBehaviorTreeAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<IReadOnlyList<int>> GetStateMachineEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<StateMachineSnapshot?>(null);
+
+    public Task<bool> ForceStateTransitionAsync(int entityId, int stateIndex, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<IReadOnlyList<int>> GetUtilityAIEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<UtilityAISnapshot?>(null);
+
+    public Task<IReadOnlyList<UtilityScoreSnapshot>> ScoreAllActionsAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
+
+    public Task<bool> ForceUtilityEvaluationAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<IReadOnlyList<BlackboardEntrySnapshot>> GetBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
+
+    public Task<BlackboardEntrySnapshot?> GetBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+        => Task.FromResult<BlackboardEntrySnapshot?>(null);
+
+    public Task<bool> SetBlackboardValueAsync(int entityId, string key, JsonElement value, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> RemoveBlackboardValueAsync(int entityId, string key, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> ClearBlackboardAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockCaptureController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockCaptureController.cs
@@ -67,6 +67,53 @@ internal sealed class MockCaptureController : ICaptureController
         return Task.FromResult(FrameSize);
     }
 
+    public Task<FrameCapture> CaptureRegionAsync(int x, int y, int width, int height)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        var frame = new FrameCapture
+        {
+            Width = width,
+            Height = height,
+            Pixels = new byte[width * height * 4],
+            FrameNumber = 1,
+            Timestamp = TimeSpan.FromSeconds(1)
+        };
+
+        return Task.FromResult(frame);
+    }
+
+    public Task<byte[]> GetRegionScreenshotBytesAsync(int x, int y, int width, int height, ImageFormat format = ImageFormat.Png)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        if (ScreenshotData.Length > 0)
+        {
+            return Task.FromResult(ScreenshotData);
+        }
+
+        // Return a minimal PNG stub (PNG header)
+        byte[] pngHeader = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        return Task.FromResult(pngHeader);
+    }
+
+    public Task<string> SaveRegionScreenshotAsync(int x, int y, int width, int height, string filePath, ImageFormat format = ImageFormat.Png)
+    {
+        if (!IsAvailable)
+        {
+            throw new InvalidOperationException("Capture is not available");
+        }
+
+        // In a real implementation this would save to disk
+        return Task.FromResult(filePath);
+    }
+
     public Task StartRecordingAsync(int maxFrames = 300)
     {
         IsRecording = true;

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockMutationController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockMutationController.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using KeenEyes.TestBridge.Mutation;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IMutationController for testing MCP tools.
+/// </summary>
+internal sealed class MockMutationController : IMutationController
+{
+    private int nextEntityId = 1;
+
+    public Task<EntityResult> SpawnAsync(
+        string? name = null,
+        IReadOnlyList<ComponentData>? components = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(EntityResult.Ok(nextEntityId++, 1));
+
+    public Task<bool> DespawnAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<EntityResult> CloneAsync(
+        int entityId,
+        string? name = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(EntityResult.Ok(nextEntityId++, 1));
+
+    public Task<bool> SetNameAsync(int entityId, string name, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> ClearNameAsync(int entityId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> SetParentAsync(int entityId, int? parentId, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> AddComponentAsync(
+        int entityId,
+        string componentType,
+        JsonElement? data = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> RemoveComponentAsync(
+        int entityId,
+        string componentType,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> SetComponentAsync(
+        int entityId,
+        string componentType,
+        JsonElement data,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> SetFieldAsync(
+        int entityId,
+        string componentType,
+        string fieldName,
+        JsonElement value,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> AddTagAsync(int entityId, string tag, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<bool> RemoveTagAsync(int entityId, string tag, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
+
+    public Task<IReadOnlyList<int>> GetRootEntitiesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<int>>([]);
+
+    public Task<IReadOnlyList<string>> GetAllTagsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<string>>([]);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockProfileController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockProfileController.cs
@@ -1,0 +1,115 @@
+using KeenEyes.TestBridge.Profile;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IProfileController for testing MCP tools.
+/// </summary>
+/// <remarks>
+/// Reports profiling as unavailable and returns empty result sets, mirroring a
+/// world with no DebugPlugin installed.
+/// </remarks>
+internal sealed class MockProfileController : IProfileController
+{
+    public Task<bool> IsDebugModeEnabledAsync() => Task.FromResult(false);
+
+    public Task EnableDebugModeAsync() => Task.CompletedTask;
+
+    public Task DisableDebugModeAsync() => Task.CompletedTask;
+
+    public Task<bool> IsProfilingAvailableAsync() => Task.FromResult(false);
+
+    public Task ResetSystemProfilesAsync() => Task.CompletedTask;
+
+    public Task ResetQueryProfilesAsync() => Task.CompletedTask;
+
+    public Task ResetAllocationProfilesAsync() => Task.CompletedTask;
+
+    public Task EnableTimelineRecordingAsync() => Task.CompletedTask;
+
+    public Task DisableTimelineRecordingAsync() => Task.CompletedTask;
+
+    public Task ResetTimelineAsync() => Task.CompletedTask;
+
+    public Task<SystemProfileSnapshot?> GetSystemProfileAsync(string systemName)
+        => Task.FromResult<SystemProfileSnapshot?>(null);
+
+    public Task<IReadOnlyList<SystemProfileSnapshot>> GetAllSystemProfilesAsync()
+        => Task.FromResult<IReadOnlyList<SystemProfileSnapshot>>([]);
+
+    public Task<IReadOnlyList<SystemProfileSnapshot>> GetSlowestSystemsAsync(int count = 10)
+        => Task.FromResult<IReadOnlyList<SystemProfileSnapshot>>([]);
+
+    public Task<bool> IsQueryProfilingAvailableAsync() => Task.FromResult(false);
+
+    public Task<QueryProfileSnapshot?> GetQueryProfileAsync(string queryName)
+        => Task.FromResult<QueryProfileSnapshot?>(null);
+
+    public Task<IReadOnlyList<QueryProfileSnapshot>> GetAllQueryProfilesAsync()
+        => Task.FromResult<IReadOnlyList<QueryProfileSnapshot>>([]);
+
+    public Task<IReadOnlyList<QueryProfileSnapshot>> GetSlowestQueriesAsync(int count = 10)
+        => Task.FromResult<IReadOnlyList<QueryProfileSnapshot>>([]);
+
+    public Task<QueryCacheStatsSnapshot> GetQueryCacheStatsAsync()
+        => Task.FromResult(new QueryCacheStatsSnapshot
+        {
+            CacheHits = 0,
+            CacheMisses = 0,
+            CachedQueryCount = 0,
+            HitRate = 0.0
+        });
+
+    public Task<bool> IsGCTrackingAvailableAsync() => Task.FromResult(false);
+
+    public Task<AllocationProfileSnapshot?> GetAllocationProfileAsync(string systemName)
+        => Task.FromResult<AllocationProfileSnapshot?>(null);
+
+    public Task<IReadOnlyList<AllocationProfileSnapshot>> GetAllAllocationProfilesAsync()
+        => Task.FromResult<IReadOnlyList<AllocationProfileSnapshot>>([]);
+
+    public Task<IReadOnlyList<AllocationProfileSnapshot>> GetAllocationHotspotsAsync(int count = 10)
+        => Task.FromResult<IReadOnlyList<AllocationProfileSnapshot>>([]);
+
+    public Task<bool> IsMemoryTrackingAvailableAsync() => Task.FromResult(false);
+
+    public Task<MemoryStatsSnapshot> GetMemoryStatsAsync()
+        => Task.FromResult(new MemoryStatsSnapshot
+        {
+            EntitiesAllocated = 0,
+            EntitiesActive = 0,
+            EntitiesRecycled = 0,
+            EntityRecycleCount = 0,
+            ArchetypeCount = 0,
+            ComponentTypeCount = 0,
+            SystemCount = 0,
+            CachedQueryCount = 0,
+            QueryCacheHits = 0,
+            QueryCacheMisses = 0,
+            EstimatedComponentBytes = 0,
+            RecycleEfficiency = 0.0,
+            QueryCacheHitRate = 0.0
+        });
+
+    public Task<IReadOnlyList<ArchetypeStatsSnapshot>> GetArchetypeStatsAsync()
+        => Task.FromResult<IReadOnlyList<ArchetypeStatsSnapshot>>([]);
+
+    public Task<bool> IsTimelineAvailableAsync() => Task.FromResult(false);
+
+    public Task<TimelineStatsSnapshot> GetTimelineStatsAsync()
+        => Task.FromResult(new TimelineStatsSnapshot
+        {
+            IsRecording = false,
+            CurrentFrame = 0,
+            EntryCount = 0
+        });
+
+    public Task<IReadOnlyList<TimelineEntrySnapshot>> GetTimelineEntriesForFrameAsync(long frameNumber)
+        => Task.FromResult<IReadOnlyList<TimelineEntrySnapshot>>([]);
+
+    public Task<IReadOnlyList<TimelineEntrySnapshot>> GetRecentTimelineEntriesAsync(int count = 100)
+        => Task.FromResult<IReadOnlyList<TimelineEntrySnapshot>>([]);
+
+    public Task<IReadOnlyList<TimelineSystemStatsSnapshot>> GetTimelineSystemStatsAsync()
+        => Task.FromResult<IReadOnlyList<TimelineSystemStatsSnapshot>>([]);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockReplayController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockReplayController.cs
@@ -1,0 +1,93 @@
+using KeenEyes.TestBridge.Replay;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IReplayController for testing MCP tools.
+/// </summary>
+internal sealed class MockReplayController : IReplayController
+{
+    public Task<ReplayOperationResult> StartRecordingAsync(
+        string? name = null,
+        int maxFrames = 36000,
+        int snapshotIntervalMs = 5000)
+        => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> StopRecordingAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> CancelRecordingAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<bool> IsRecordingAsync() => Task.FromResult(false);
+
+    public Task<RecordingInfoSnapshot?> GetRecordingInfoAsync()
+        => Task.FromResult<RecordingInfoSnapshot?>(null);
+
+    public Task<ReplayOperationResult> ForceSnapshotAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> SaveAsync(string path) => Task.FromResult(ReplayOperationResult.Ok(path));
+
+    public Task<ReplayOperationResult> LoadAsync(string path) => Task.FromResult(ReplayOperationResult.Ok(path));
+
+    public Task<bool> DeleteAsync(string path) => Task.FromResult(true);
+
+    public Task<ReplayMetadataSnapshot?> GetMetadataAsync(string path)
+        => Task.FromResult<ReplayMetadataSnapshot?>(null);
+
+    public Task<ReplayOperationResult> PlayAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> PauseAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> StopPlaybackAsync() => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<PlaybackStateSnapshot> GetPlaybackStateAsync()
+        => Task.FromResult(new PlaybackStateSnapshot
+        {
+            IsLoaded = false,
+            IsPlaying = false,
+            IsPaused = false,
+            IsStopped = true,
+            CurrentFrame = 0,
+            TotalFrames = 0,
+            CurrentTimeSeconds = 0f,
+            TotalTimeSeconds = 0f,
+            PlaybackSpeed = 1f
+        });
+
+    public Task<ReplayOperationResult> SetSpeedAsync(float speed) => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> SeekFrameAsync(int frame) => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> SeekTimeAsync(float seconds) => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> StepForwardAsync(int frames = 1) => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayOperationResult> StepBackwardAsync(int frames = 1) => Task.FromResult(ReplayOperationResult.Ok());
+
+    public Task<ReplayFrameSnapshot?> GetFrameAsync(int frame) => Task.FromResult<ReplayFrameSnapshot?>(null);
+
+    public Task<ValidationResultSnapshot> ValidateAsync(string path)
+        => Task.FromResult(new ValidationResultSnapshot { IsValid = true, Path = path });
+
+    public Task<DeterminismResultSnapshot> CheckDeterminismAsync()
+        => Task.FromResult(new DeterminismResultSnapshot
+        {
+            IsDeterministic = true,
+            TotalFramesChecked = 0,
+            FramesWithChecksums = 0
+        });
+
+    public Task<IReadOnlyList<ReplayFileSnapshot>> ListAsync(string? directory = null)
+        => Task.FromResult<IReadOnlyList<ReplayFileSnapshot>>([]);
+
+    public Task<IReadOnlyList<ReplayFrameSnapshot>> GetFrameRangeAsync(int startFrame, int count)
+        => Task.FromResult<IReadOnlyList<ReplayFrameSnapshot>>([]);
+
+    public Task<IReadOnlyList<InputEventSnapshot>> GetInputsAsync(int startFrame, int endFrame)
+        => Task.FromResult<IReadOnlyList<InputEventSnapshot>>([]);
+
+    public Task<IReadOnlyList<ReplayEventSnapshot>> GetEventsAsync(int startFrame, int endFrame)
+        => Task.FromResult<IReadOnlyList<ReplayEventSnapshot>>([]);
+
+    public Task<IReadOnlyList<SnapshotMarkerSnapshot>> GetSnapshotsAsync()
+        => Task.FromResult<IReadOnlyList<SnapshotMarkerSnapshot>>([]);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockSnapshotController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockSnapshotController.cs
@@ -1,0 +1,51 @@
+using KeenEyes.TestBridge.Snapshot;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of ISnapshotController for testing MCP tools.
+/// </summary>
+internal sealed class MockSnapshotController : ISnapshotController
+{
+    public Task<SnapshotResult> CreateAsync(string name) => Task.FromResult(SnapshotResult.Ok(name));
+
+    public Task<SnapshotResult> RestoreAsync(string name) => Task.FromResult(SnapshotResult.Ok(name));
+
+    public Task<bool> DeleteAsync(string name) => Task.FromResult(true);
+
+    public Task<IReadOnlyList<SnapshotInfo>> ListAsync()
+        => Task.FromResult<IReadOnlyList<SnapshotInfo>>([]);
+
+    public Task<SnapshotInfo?> GetInfoAsync(string name) => Task.FromResult<SnapshotInfo?>(null);
+
+    public Task<SnapshotDiff> DiffAsync(string name1, string name2)
+        => Task.FromResult(EmptyDiff(name1, name2));
+
+    public Task<SnapshotDiff> DiffCurrentAsync(string name)
+        => Task.FromResult(EmptyDiff("current", name));
+
+    public Task<SnapshotResult> SaveToFileAsync(string name, string path)
+        => Task.FromResult(SnapshotResult.Ok(name));
+
+    public Task<SnapshotResult> LoadFromFileAsync(string path, string? name = null)
+        => Task.FromResult(SnapshotResult.Ok(name ?? "loaded"));
+
+    public Task<string> ExportJsonAsync(string name) => Task.FromResult("{}");
+
+    public Task<SnapshotResult> ImportJsonAsync(string json, string name)
+        => Task.FromResult(SnapshotResult.Ok(name));
+
+    public Task<SnapshotResult> QuickSaveAsync() => Task.FromResult(SnapshotResult.Ok("quicksave"));
+
+    public Task<SnapshotResult> QuickLoadAsync() => Task.FromResult(SnapshotResult.Ok("quicksave"));
+
+    private static SnapshotDiff EmptyDiff(string name1, string name2) => new()
+    {
+        Snapshot1 = name1,
+        Snapshot2 = name2,
+        AddedEntities = [],
+        RemovedEntities = [],
+        ModifiedEntities = [],
+        TotalChanges = 0
+    };
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockStateController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockStateController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using KeenEyes.TestBridge.State;
 
 namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
@@ -86,20 +87,19 @@ internal sealed class MockStateController : IStateController
         return Task.FromResult(entity);
     }
 
-    public Task<IReadOnlyDictionary<string, object?>?> GetComponentAsync(int entityId, string componentTypeName)
+    public Task<JsonElement?> GetComponentAsync(int entityId, string componentTypeName)
     {
         if (!Entities.TryGetValue(entityId, out var entity))
         {
-            return Task.FromResult<IReadOnlyDictionary<string, object?>?>(null);
+            return Task.FromResult<JsonElement?>(null);
         }
 
         if (!entity.Components.TryGetValue(componentTypeName, out var component))
         {
-            return Task.FromResult<IReadOnlyDictionary<string, object?>?>(null);
+            return Task.FromResult<JsonElement?>(null);
         }
 
-        return Task.FromResult<IReadOnlyDictionary<string, object?>?>(
-            component.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+        return Task.FromResult<JsonElement?>(component);
     }
 
     public Task<WorldStats> GetWorldStatsAsync() => Task.FromResult(Stats);
@@ -154,7 +154,7 @@ internal sealed class MockStateController : IStateController
             Id = id,
             Version = 1,
             Name = name,
-            Components = new Dictionary<string, IReadOnlyDictionary<string, object?>>(),
+            Components = new Dictionary<string, JsonElement>(),
             ComponentTypes = componentTypes ?? [],
             ParentId = parentId,
             ChildIds = [],
@@ -174,7 +174,7 @@ internal sealed class MockStateController : IStateController
             Name = name,
             Components = components.ToDictionary(
                 kvp => kvp.Key,
-                kvp => (IReadOnlyDictionary<string, object?>)kvp.Value),
+                kvp => JsonSerializer.SerializeToElement(kvp.Value)),
             ComponentTypes = [.. components.Keys],
             ParentId = null,
             ChildIds = [],

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockSystemController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockSystemController.cs
@@ -1,0 +1,43 @@
+using KeenEyes.TestBridge.Systems;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of ISystemController for testing MCP tools.
+/// </summary>
+internal sealed class MockSystemController : ISystemController
+{
+    public List<SystemSnapshot> Systems { get; } = [];
+
+    private static SystemSnapshot Make(string name, bool enabled) => new()
+    {
+        Name = name,
+        TypeName = name,
+        Enabled = enabled,
+        Phase = "Update",
+        Order = 0
+    };
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsAsync()
+        => Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems);
+
+    public Task<int> GetCountAsync() => Task.FromResult(Systems.Count);
+
+    public Task<SystemSnapshot?> GetSystemAsync(string name)
+        => Task.FromResult(Systems.Find(s => s.Name == name));
+
+    public Task<SystemSnapshot> EnableSystemAsync(string name) => Task.FromResult(Make(name, true));
+
+    public Task<SystemSnapshot> DisableSystemAsync(string name) => Task.FromResult(Make(name, false));
+
+    public Task<SystemSnapshot> ToggleSystemAsync(string name) => Task.FromResult(Make(name, true));
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetSystemsByPhaseAsync(string phase)
+        => Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.FindAll(s => s.Phase == phase));
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetEnabledSystemsAsync()
+        => Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.FindAll(s => s.Enabled));
+
+    public Task<IReadOnlyList<SystemSnapshot>> GetDisabledSystemsAsync()
+        => Task.FromResult<IReadOnlyList<SystemSnapshot>>(Systems.FindAll(s => !s.Enabled));
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTestBridge.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTestBridge.cs
@@ -1,10 +1,20 @@
+using KeenEyes.Input.Abstractions;
 using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.AI;
 using KeenEyes.TestBridge.Capture;
 using KeenEyes.TestBridge.Commands;
 using KeenEyes.TestBridge.Input;
 using KeenEyes.TestBridge.Logging;
+using KeenEyes.TestBridge.Mutation;
 using KeenEyes.TestBridge.Process;
+using KeenEyes.TestBridge.Profile;
+using KeenEyes.TestBridge.Replay;
+using KeenEyes.TestBridge.Snapshot;
 using KeenEyes.TestBridge.State;
+using KeenEyes.TestBridge.Systems;
+using KeenEyes.TestBridge.Time;
+using KeenEyes.TestBridge.Window;
+using KeenEyes.Testing.Input;
 
 namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
 
@@ -19,12 +29,30 @@ internal sealed class MockTestBridge : ITestBridge
     public MockCaptureController MockCapture { get; } = new();
     public MockProcessController MockProcess { get; } = new();
     public MockLogController MockLogs { get; } = new();
+    public MockWindowController MockWindow { get; } = new();
+    public MockTimeController MockTime { get; } = new();
+    public MockSystemController MockSystems { get; } = new();
+    public MockMutationController MockMutation { get; } = new();
+    public MockProfileController MockProfile { get; } = new();
+    public MockSnapshotController MockSnapshot { get; } = new();
+    public MockAIController MockAI { get; } = new();
+    public MockReplayController MockReplay { get; } = new();
+    public MockInputContext MockInputContext { get; } = new();
 
     IInputController ITestBridge.Input => MockInput;
     ICaptureController ITestBridge.Capture => MockCapture;
     IStateController ITestBridge.State => MockState;
     IProcessController ITestBridge.Process => MockProcess;
     ILogController ITestBridge.Logs => MockLogs;
+    IWindowController ITestBridge.Window => MockWindow;
+    ITimeController ITestBridge.Time => MockTime;
+    ISystemController ITestBridge.Systems => MockSystems;
+    IMutationController ITestBridge.Mutation => MockMutation;
+    IProfileController ITestBridge.Profile => MockProfile;
+    ISnapshotController ITestBridge.Snapshot => MockSnapshot;
+    IAIController ITestBridge.AI => MockAI;
+    IReplayController ITestBridge.Replay => MockReplay;
+    IInputContext ITestBridge.InputContext => MockInputContext;
 
     public Task<CommandResult> ExecuteAsync(ITestCommand command, CancellationToken cancellationToken = default)
     {

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTimeController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockTimeController.cs
@@ -1,0 +1,57 @@
+using KeenEyes.TestBridge.Time;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of ITimeController for testing MCP tools.
+/// </summary>
+internal sealed class MockTimeController : ITimeController
+{
+    public bool IsPaused { get; set; }
+    public float TimeScale { get; set; } = 1f;
+    public int PendingStepFrames { get; set; }
+    public long LastModifiedFrame { get; set; }
+
+    private TimeStateSnapshot Snapshot() => new()
+    {
+        IsPaused = IsPaused,
+        TimeScale = TimeScale,
+        TotalPausedTime = 0.0,
+        LastModifiedFrame = LastModifiedFrame,
+        PendingStepFrames = PendingStepFrames
+    };
+
+    public Task<TimeStateSnapshot> GetTimeStateAsync() => Task.FromResult(Snapshot());
+
+    public Task<TimeStateSnapshot> PauseAsync()
+    {
+        IsPaused = true;
+        return Task.FromResult(Snapshot());
+    }
+
+    public Task<TimeStateSnapshot> ResumeAsync()
+    {
+        IsPaused = false;
+        PendingStepFrames = 0;
+        return Task.FromResult(Snapshot());
+    }
+
+    public Task<TimeStateSnapshot> SetTimeScaleAsync(float scale)
+    {
+        TimeScale = scale;
+        return Task.FromResult(Snapshot());
+    }
+
+    public Task<TimeStateSnapshot> StepFrameAsync(int frames = 1)
+    {
+        IsPaused = true;
+        PendingStepFrames = frames;
+        return Task.FromResult(Snapshot());
+    }
+
+    public Task<TimeStateSnapshot> TogglePauseAsync()
+    {
+        IsPaused = !IsPaused;
+        return Task.FromResult(Snapshot());
+    }
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockWindowController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockWindowController.cs
@@ -1,0 +1,38 @@
+using KeenEyes.TestBridge.Window;
+
+namespace KeenEyes.Mcp.TestBridge.Tests.Mocks;
+
+/// <summary>
+/// Mock implementation of IWindowController for testing MCP tools.
+/// </summary>
+internal sealed class MockWindowController : IWindowController
+{
+    public bool IsAvailable { get; set; } = true;
+    public (int Width, int Height) Size { get; set; } = (1920, 1080);
+    public string Title { get; set; } = "MockWindow";
+    public bool IsClosing { get; set; }
+    public bool IsFocused { get; set; } = true;
+
+    public Task<WindowStateSnapshot> GetStateAsync()
+    {
+        return Task.FromResult(new WindowStateSnapshot
+        {
+            Width = Size.Width,
+            Height = Size.Height,
+            Title = Title,
+            IsClosing = IsClosing,
+            IsFocused = IsFocused,
+            AspectRatio = (float)Size.Width / Size.Height
+        });
+    }
+
+    public Task<(int Width, int Height)> GetSizeAsync() => Task.FromResult(Size);
+
+    public Task<string> GetTitleAsync() => Task.FromResult(Title);
+
+    public Task<bool> IsClosingAsync() => Task.FromResult(IsClosing);
+
+    public Task<bool> IsFocusedAsync() => Task.FromResult(IsFocused);
+
+    public Task<float> GetAspectRatioAsync() => Task.FromResult((float)Size.Width / Size.Height);
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Tools/InputParsingTests.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Tools/InputParsingTests.cs
@@ -10,16 +10,16 @@ namespace KeenEyes.Mcp.TestBridge.Tests.Tools;
 /// </summary>
 public sealed class InputParsingTests
 {
-    private static readonly MethodInfo ParseKeyMethod = typeof(InputTools)
+    private static readonly MethodInfo parseKeyMethod = typeof(InputTools)
         .GetMethod("ParseKey", BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    private static readonly MethodInfo ParseModifiersMethod = typeof(InputTools)
+    private static readonly MethodInfo parseModifiersMethod = typeof(InputTools)
         .GetMethod("ParseModifiers", BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    private static readonly MethodInfo ParseMouseButtonMethod = typeof(InputTools)
+    private static readonly MethodInfo parseMouseButtonMethod = typeof(InputTools)
         .GetMethod("ParseMouseButton", BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    private static readonly MethodInfo ParseGamepadButtonMethod = typeof(InputTools)
+    private static readonly MethodInfo parseGamepadButtonMethod = typeof(InputTools)
         .GetMethod("ParseGamepadButton", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     #region ParseKey Tests
@@ -42,7 +42,7 @@ public sealed class InputParsingTests
     [InlineData("F12", Key.F12)]
     public void ParseKey_ValidKeys_ReturnsCorrectEnum(string input, Key expected)
     {
-        var result = (Key)ParseKeyMethod.Invoke(null, [input])!;
+        var result = (Key)parseKeyMethod.Invoke(null, [input])!;
         result.ShouldBe(expected);
     }
 
@@ -52,7 +52,7 @@ public sealed class InputParsingTests
     [InlineData("NotAKey")]
     public void ParseKey_InvalidKeys_ThrowsArgumentException(string input)
     {
-        var exception = Should.Throw<TargetInvocationException>(() => ParseKeyMethod.Invoke(null, [input]));
+        var exception = Should.Throw<TargetInvocationException>(() => parseKeyMethod.Invoke(null, [input]));
         exception.InnerException.ShouldBeOfType<ArgumentException>();
     }
 
@@ -63,21 +63,21 @@ public sealed class InputParsingTests
     [Fact]
     public void ParseModifiers_Null_ReturnsNone()
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, [null])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, [null])!;
         result.ShouldBe(KeyModifiers.None);
     }
 
     [Fact]
     public void ParseModifiers_Empty_ReturnsNone()
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, [""])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, [""])!;
         result.ShouldBe(KeyModifiers.None);
     }
 
     [Fact]
     public void ParseModifiers_Shift_ReturnsShift()
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, ["Shift"])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, ["Shift"])!;
         result.ShouldBe(KeyModifiers.Shift);
     }
 
@@ -86,14 +86,14 @@ public sealed class InputParsingTests
     [InlineData("Control", KeyModifiers.Control)]
     public void ParseModifiers_Control_ReturnsControl(string input, KeyModifiers expected)
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, [input])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, [input])!;
         result.ShouldBe(expected);
     }
 
     [Fact]
     public void ParseModifiers_Alt_ReturnsAlt()
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, ["Alt"])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, ["Alt"])!;
         result.ShouldBe(KeyModifiers.Alt);
     }
 
@@ -104,14 +104,14 @@ public sealed class InputParsingTests
     [InlineData("Meta")]
     public void ParseModifiers_Super_ReturnsSuper(string input)
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, [input])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, [input])!;
         result.ShouldBe(KeyModifiers.Super);
     }
 
     [Fact]
     public void ParseModifiers_Multiple_ReturnsCombined()
     {
-        var result = (KeyModifiers)ParseModifiersMethod.Invoke(null, ["Shift,Ctrl"])!;
+        var result = (KeyModifiers)parseModifiersMethod.Invoke(null, ["Shift,Ctrl"])!;
         result.ShouldBe(KeyModifiers.Shift | KeyModifiers.Control);
     }
 
@@ -119,7 +119,7 @@ public sealed class InputParsingTests
     public void ParseModifiers_Invalid_ThrowsArgumentException()
     {
         var exception = Should.Throw<TargetInvocationException>(() =>
-            ParseModifiersMethod.Invoke(null, ["InvalidMod"]));
+            parseModifiersMethod.Invoke(null, ["InvalidMod"]));
         exception.InnerException.ShouldBeOfType<ArgumentException>();
     }
 
@@ -138,7 +138,7 @@ public sealed class InputParsingTests
     [InlineData("Button5", MouseButton.Button5)]
     public void ParseMouseButton_ValidButtons_ReturnsCorrectEnum(string? input, MouseButton expected)
     {
-        var result = (MouseButton)ParseMouseButtonMethod.Invoke(null, [input])!;
+        var result = (MouseButton)parseMouseButtonMethod.Invoke(null, [input])!;
         result.ShouldBe(expected);
     }
 
@@ -148,7 +148,7 @@ public sealed class InputParsingTests
     public void ParseMouseButton_InvalidButtons_ThrowsArgumentException(string input)
     {
         var exception = Should.Throw<TargetInvocationException>(() =>
-            ParseMouseButtonMethod.Invoke(null, [input]));
+            parseMouseButtonMethod.Invoke(null, [input]));
         exception.InnerException.ShouldBeOfType<ArgumentException>();
     }
 
@@ -175,7 +175,7 @@ public sealed class InputParsingTests
     [InlineData("DPadRight", GamepadButton.DPadRight)]
     public void ParseGamepadButton_ValidButtons_ReturnsCorrectEnum(string input, GamepadButton expected)
     {
-        var result = (GamepadButton)ParseGamepadButtonMethod.Invoke(null, [input])!;
+        var result = (GamepadButton)parseGamepadButtonMethod.Invoke(null, [input])!;
         result.ShouldBe(expected);
     }
 
@@ -189,7 +189,7 @@ public sealed class InputParsingTests
     public void ParseGamepadButton_InvalidButtons_ThrowsArgumentException(string input)
     {
         var exception = Should.Throw<TargetInvocationException>(() =>
-            ParseGamepadButtonMethod.Invoke(null, [input]));
+            parseGamepadButtonMethod.Invoke(null, [input]));
         exception.InnerException.ShouldBeOfType<ArgumentException>();
     }
 


### PR DESCRIPTION
## Summary
Two tracked test-health issues; the first turned out to be a **production bug, not a test bug**:
- **#1030 root cause correction:** the 13 `Navigation.Tests` failures were not test isolation. `GridNavigationPlugin` registers its provider as the `INavigationProvider` extension; `NavigationPlugin.Install` then re-registered the **same instance** via `SetExtension` — and `ExtensionManager.SetExtension` disposes the extension it replaces, so the provider was disposed during its own installation. Fix: `NavigationPlugin` only registers the extension when it isn't already the registered instance (custom-provider path unchanged). 46/46 green. *Reviewer note: a complementary hardening would be a `ReferenceEquals` guard inside `ExtensionManager.SetExtension` itself so no future caller can trip this — left out here to keep the change scoped; say the word and it can follow with its own tests.*
- **#1025:** MCP TestBridge mocks brought up to the full current `ITestBridge`/`ICaptureController` surface (8 new mock controllers in the established recording/canned style, region-capture methods, plus undisclosed `JsonElement` drift in `MockStateController`). **The test project was missing from `KeenEyes.slnx` — that's how the break evaded CI.** Now added, which is also the drift guard: any future interface change fails the solution build immediately. 80/80 green.

## Test plan
- [x] Navigation.Tests 46/46 (was 33/46) — independently verified
- [x] Mcp.TestBridge.Tests 80/80 (was: did not compile) — independently verified; project confirmed in slnx
- [x] Full slnx Release build zero errors; `dotnet format` clean on touched projects
- [ ] CI green

## Related Issues
Fixes #1030 (with corrected root cause noted there), Fixes #1025.