### PR TITLE
feat(navigation): Add off-mesh links (component, build params, agent traversal)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="DotRecast.Core" Version="2026.1.3" />
     <PackageVersion Include="DotRecast.Detour" Version="2026.1.3" />
     <PackageVersion Include="DotRecast.Detour.Crowd" Version="2026.1.3" />
+    <PackageVersion Include="DotRecast.Detour.TileCache" Version="2026.1.3" />
     <PackageVersion Include="DotRecast.Recast" Version="2026.1.3" />
   </ItemGroup>
   <ItemGroup Label="Audio">

--- a/editor/KeenEyes.Editor/Navigation/NavMeshBakeCommand.cs
+++ b/editor/KeenEyes.Editor/Navigation/NavMeshBakeCommand.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using System.Numerics;
 using KeenEyes.Editor.Abstractions;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
 using KeenEyes.Navigation.DotRecast;
 
 namespace KeenEyes.Editor.Navigation;
@@ -114,10 +116,13 @@ public sealed class NavMeshBakeCommand : IEditorCommand
             var runtimeConfig = config.ToRuntimeConfig();
             var builder = new DotRecastMeshBuilder(runtimeConfig);
 
+            var offMeshLinks = CollectOffMeshLinks();
+
             bakedNavMesh = builder.Build(
                 geometryResult.Vertices,
                 geometryResult.Indices,
-                geometryResult.AreaIds);
+                geometryResult.AreaIds,
+                offMeshLinks: offMeshLinks);
 
             ReportProgress(
                 NavMeshBakePhase.Building,
@@ -183,6 +188,30 @@ public sealed class NavMeshBakeCommand : IEditorCommand
             Percentage = percentage,
             Message = message
         });
+    }
+
+    /// <summary>
+    /// Collects <see cref="OffMeshLink"/> components from the scene into
+    /// builder definitions. Link positions are world-space.
+    /// </summary>
+    private List<OffMeshLinkDefinition>? CollectOffMeshLinks()
+    {
+        List<OffMeshLinkDefinition>? links = null;
+
+        foreach (var entity in world.Query<OffMeshLink>())
+        {
+            ref readonly var link = ref world.Get<OffMeshLink>(entity);
+            links ??= [];
+            links.Add(new OffMeshLinkDefinition(
+                link.Start,
+                link.End,
+                link.Radius,
+                link.Bidirectional,
+                link.AreaType,
+                link.CostModifier));
+        }
+
+        return links;
     }
 
     private string GetDefaultOutputPath()

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -319,6 +319,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -450,6 +451,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/src/KeenEyes.Navigation.Abstractions/Components/NavMeshStreamingAnchor.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Components/NavMeshStreamingAnchor.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+namespace KeenEyes.Navigation.Abstractions.Components;
+
+/// <summary>
+/// Component that marks an entity as a navigation mesh streaming anchor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Navigation providers that support tile streaming keep navmesh tiles resident
+/// around the positions of anchor entities (typically players or cameras) and
+/// unload tiles that fall out of range. Attach this component alongside a
+/// transform to any entity whose surroundings must remain navigable.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// world.Spawn("Player")
+///     .With(new Transform3D(spawnPoint, Quaternion.Identity, Vector3.One))
+///     .With(new NavMeshStreamingAnchor())
+///     .Build();
+/// </code>
+/// </example>
+public struct NavMeshStreamingAnchor : IComponent
+{
+}

--- a/src/KeenEyes.Navigation.Abstractions/Components/OffMeshLink.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Components/OffMeshLink.cs
@@ -1,0 +1,88 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions.Components;
+
+/// <summary>
+/// Component describing an off-mesh connection between two points on the
+/// navigation mesh, such as a jump, ladder, or teleporter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Off-mesh links bridge parts of the navigation mesh that are not connected
+/// by walkable surface. Entities carrying this component are collected when
+/// the navigation mesh is built, and each link becomes an off-mesh connection
+/// in the baked mesh.
+/// </para>
+/// <para>
+/// <see cref="Start"/> and <see cref="End"/> are world-space positions. Both
+/// must lie within <see cref="Radius"/> of the walkable surface for the link
+/// to connect during the build.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// world.Spawn("LedgeJump")
+///     .With(OffMeshLink.Create(new Vector3(5, 0, 5), new Vector3(19, 0, 5)))
+///     .Build();
+/// </code>
+/// </example>
+public struct OffMeshLink : IComponent
+{
+    /// <summary>
+    /// The world-space start position of the link.
+    /// </summary>
+    public Vector3 Start;
+
+    /// <summary>
+    /// The world-space end position of the link.
+    /// </summary>
+    public Vector3 End;
+
+    /// <summary>
+    /// The radius within which each endpoint snaps to the navigation mesh.
+    /// </summary>
+    public float Radius;
+
+    /// <summary>
+    /// Whether the link can be traversed in both directions.
+    /// When false, agents can only travel from <see cref="Start"/> to <see cref="End"/>.
+    /// </summary>
+    public bool Bidirectional;
+
+    /// <summary>
+    /// The navigation area type assigned to the link.
+    /// </summary>
+    /// <remarks>
+    /// The area type determines the pathfinding cost multiplier (settable via
+    /// the provider's SetAreaCost) and which agents may use the link through
+    /// their <see cref="NavAreaMask"/>.
+    /// </remarks>
+    public NavAreaType AreaType;
+
+    /// <summary>
+    /// Modifier applied to the agent's movement speed while traversing the link.
+    /// </summary>
+    /// <remarks>
+    /// Traversal speed is the agent's speed divided by this value: a modifier of
+    /// 2 makes crossing take twice as long. Pathfinding cost is controlled by
+    /// the area cost of <see cref="AreaType"/>, not by this modifier.
+    /// </remarks>
+    public float CostModifier;
+
+    /// <summary>
+    /// Creates a bidirectional off-mesh link with default radius, area type, and cost.
+    /// </summary>
+    /// <param name="start">The world-space start position.</param>
+    /// <param name="end">The world-space end position.</param>
+    /// <returns>A new OffMeshLink component.</returns>
+    public static OffMeshLink Create(Vector3 start, Vector3 end)
+        => new()
+        {
+            Start = start,
+            End = end,
+            Radius = 0.5f,
+            Bidirectional = true,
+            AreaType = NavAreaType.OffMeshLink,
+            CostModifier = 1f
+        };
+}

--- a/src/KeenEyes.Navigation.Abstractions/Enums/NavPointProperties.cs
+++ b/src/KeenEyes.Navigation.Abstractions/Enums/NavPointProperties.cs
@@ -1,0 +1,24 @@
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Bit flags describing special properties of a <see cref="NavPoint"/> within a path.
+/// </summary>
+/// <remarks>
+/// Providers set these flags on path waypoints so that path-following logic can
+/// react to special traversal segments without provider-specific knowledge.
+/// </remarks>
+[Flags]
+public enum NavPointProperties
+{
+    /// <summary>
+    /// No special properties.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The point is the entry of an off-mesh connection. The segment from this
+    /// point to the next waypoint traverses the connection (jump, ladder,
+    /// teleporter, etc.) rather than walkable surface.
+    /// </summary>
+    OffMeshConnection = 1
+}

--- a/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
+++ b/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
@@ -18,10 +18,15 @@ namespace KeenEyes.Navigation.Abstractions;
 /// Optional identifier of the navmesh polygon containing this point.
 /// Zero if not applicable (e.g., for grid-based navigation).
 /// </param>
+/// <param name="Properties">
+/// Optional flags describing special properties of this point, such as
+/// marking the entry of an off-mesh connection.
+/// </param>
 public readonly record struct NavPoint(
     Vector3 Position,
     NavAreaType AreaType = NavAreaType.Walkable,
-    uint PolygonId = 0)
+    uint PolygonId = 0,
+    NavPointProperties Properties = NavPointProperties.None)
 {
     /// <summary>
     /// Creates a NavPoint at the specified position with default area type.

--- a/src/KeenEyes.Navigation.Abstractions/OffMeshLinkDefinition.cs
+++ b/src/KeenEyes.Navigation.Abstractions/OffMeshLinkDefinition.cs
@@ -1,0 +1,34 @@
+using System.Numerics;
+
+namespace KeenEyes.Navigation.Abstractions;
+
+/// <summary>
+/// Describes an off-mesh connection to bake into a navigation mesh.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the plain data shape consumed by mesh builders. It carries the same
+/// information as the <see cref="Components.OffMeshLink"/> component without
+/// coupling the builder to a world; callers collect link components (or any
+/// other source of links) into definitions before building.
+/// </para>
+/// </remarks>
+/// <param name="Start">The world-space start position of the connection.</param>
+/// <param name="End">The world-space end position of the connection.</param>
+/// <param name="Radius">The radius within which each endpoint snaps to the walkable surface.</param>
+/// <param name="Bidirectional">
+/// Whether the connection can be traversed in both directions. When false, it
+/// is only traversable from <paramref name="Start"/> to <paramref name="End"/>.
+/// </param>
+/// <param name="AreaType">The navigation area type assigned to the connection polygon.</param>
+/// <param name="CostModifier">
+/// Modifier applied to agent movement speed while traversing the link.
+/// Pathfinding cost is controlled by the area cost of <paramref name="AreaType"/>.
+/// </param>
+public sealed record OffMeshLinkDefinition(
+    Vector3 Start,
+    Vector3 End,
+    float Radius,
+    bool Bidirectional,
+    NavAreaType AreaType,
+    float CostModifier = 1f);

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
@@ -80,11 +80,21 @@ public sealed class DotRecastMeshBuilder
     /// <see cref="NavMeshConfig.TileSize"/> when greater than zero. Mirrors
     /// <c>NavMeshSurface.OverrideTileSize</c>. Ignored when tiling is disabled.
     /// </param>
+    /// <param name="offMeshLinks">
+    /// Optional off-mesh connections (jumps, ladders, teleporters) to bake into
+    /// the mesh. In tiled builds each connection is stored in the tile
+    /// containing its start point.
+    /// </param>
     /// <returns>The built navigation mesh data.</returns>
-    /// <exception cref="ArgumentException">Thrown when geometry is invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when geometry or off-mesh links are invalid.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when overrideTileSize is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mesh building fails.</exception>
-    public NavMeshData Build(ReadOnlySpan<float> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null, int overrideTileSize = 0)
+    public NavMeshData Build(
+        ReadOnlySpan<float> vertices,
+        ReadOnlySpan<int> indices,
+        int[]? areaIds = null,
+        int overrideTileSize = 0,
+        IReadOnlyList<OffMeshLinkDefinition>? offMeshLinks = null)
     {
         if (vertices.Length == 0 || vertices.Length % 3 != 0)
         {
@@ -112,7 +122,8 @@ public sealed class DotRecastMeshBuilder
         // Build the navmesh
         // areaIds reserved for future area marking support
         _ = areaIds;
-        return BuildFromGeometry(geom, bmin, bmax, overrideTileSize);
+        var connections = CreateOffMeshConnectionData(offMeshLinks);
+        return BuildFromGeometry(geom, bmin, bmax, overrideTileSize, connections);
     }
 
     /// <summary>
@@ -125,8 +136,17 @@ public sealed class DotRecastMeshBuilder
     /// Optional per-surface tile size (in cells) that overrides
     /// <see cref="NavMeshConfig.TileSize"/> when greater than zero.
     /// </param>
+    /// <param name="offMeshLinks">
+    /// Optional off-mesh connections (jumps, ladders, teleporters) to bake into
+    /// the mesh.
+    /// </param>
     /// <returns>The built navigation mesh data.</returns>
-    public NavMeshData Build(ReadOnlySpan<Vector3> vertices, ReadOnlySpan<int> indices, int[]? areaIds = null, int overrideTileSize = 0)
+    public NavMeshData Build(
+        ReadOnlySpan<Vector3> vertices,
+        ReadOnlySpan<int> indices,
+        int[]? areaIds = null,
+        int overrideTileSize = 0,
+        IReadOnlyList<OffMeshLinkDefinition>? offMeshLinks = null)
     {
         // Convert Vector3 to float triplets
         var floatVerts = new float[vertices.Length * 3];
@@ -137,7 +157,7 @@ public sealed class DotRecastMeshBuilder
             floatVerts[i * 3 + 2] = vertices[i].Z;
         }
 
-        return Build(floatVerts, indices, areaIds, overrideTileSize);
+        return Build(floatVerts, indices, areaIds, overrideTileSize, offMeshLinks);
     }
 
     /// <summary>
@@ -203,14 +223,19 @@ public sealed class DotRecastMeshBuilder
         return Build(vertices, indices, null);
     }
 
-    private NavMeshData BuildFromGeometry(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize)
+    private NavMeshData BuildFromGeometry(
+        IRcInputGeomProvider geom,
+        RcVec3f bmin,
+        RcVec3f bmax,
+        int overrideTileSize,
+        OffMeshConnectionData? connections)
     {
         return config.UseTiles
-            ? BuildTiled(geom, bmin, bmax, overrideTileSize)
-            : BuildSingleTile(geom, bmin, bmax);
+            ? BuildTiled(geom, bmin, bmax, overrideTileSize, connections)
+            : BuildSingleTile(geom, bmin, bmax, connections);
     }
 
-    private NavMeshData BuildSingleTile(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax)
+    private NavMeshData BuildSingleTile(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, OffMeshConnectionData? connections)
     {
         // Create Recast config (tile size is irrelevant when tiling is disabled)
         var rcConfig = CreateRcConfig(config.TileSize);
@@ -230,6 +255,7 @@ public sealed class DotRecastMeshBuilder
 
         // Create Detour navmesh data from result
         var dtParams = CreateNavMeshParams(result.Mesh, result.MeshDetail, bmin, bmax);
+        ApplyOffMeshConnections(dtParams, connections);
         var meshData = DtNavMeshBuilder.CreateNavMeshData(dtParams);
 
         if (meshData == null)
@@ -244,7 +270,7 @@ public sealed class DotRecastMeshBuilder
         return new NavMeshData(navMesh, config.ToAgentSettings());
     }
 
-    private NavMeshData BuildTiled(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize)
+    private NavMeshData BuildTiled(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize, OffMeshConnectionData? connections)
     {
         // Effective tile size honours a per-surface override (NavMeshSurface.OverrideTileSize)
         // when positive, otherwise falls back to the global config value.
@@ -301,6 +327,11 @@ public sealed class DotRecastMeshBuilder
                 result.TileX,
                 result.TileZ);
 
+            // All connections are offered to every tile; Detour keeps only the
+            // ones whose start point falls inside this tile's bounds, matching
+            // the reference Recast sample's tiled handling.
+            ApplyOffMeshConnections(dtParams, connections);
+
             var meshData = DtNavMeshBuilder.CreateNavMeshData(dtParams);
             if (meshData == null)
             {
@@ -341,11 +372,14 @@ public sealed class DotRecastMeshBuilder
         // The walkable area modification must resolve to a non-null area
         // (RC_WALKABLE_AREA); mapping it to RC_NULL_AREA (0) would make Recast treat
         // every span as unwalkable and produce an empty mesh.
+        // A border is only meaningful for tiled builds (it pads each tile so
+        // neighbouring tiles stitch correctly); applying one to a single-tile
+        // build shrinks and offsets the resulting mesh by the border width.
         return new RcConfig(
             useTiles: config.UseTiles,
             tileSizeX: tileSize,
             tileSizeZ: tileSize,
-            borderSize: config.MaxVertsPerPoly + 3,
+            borderSize: config.UseTiles ? config.MaxVertsPerPoly + 3 : 0,
             partition: RcPartition.WATERSHED,
             cellSize: config.CellSize,
             cellHeight: config.CellHeight,
@@ -400,5 +434,103 @@ public sealed class DotRecastMeshBuilder
         }
 
         return navMeshParams;
+    }
+
+    /// <summary>
+    /// Converts off-mesh link definitions into the parallel arrays expected by
+    /// <see cref="DtNavMeshCreateParams"/>. The arrays are shared across tiles
+    /// in tiled builds since Detour reads them without mutation.
+    /// </summary>
+    private static OffMeshConnectionData? CreateOffMeshConnectionData(IReadOnlyList<OffMeshLinkDefinition>? offMeshLinks)
+    {
+        if (offMeshLinks == null || offMeshLinks.Count == 0)
+        {
+            return null;
+        }
+
+        int count = offMeshLinks.Count;
+        var data = new OffMeshConnectionData
+        {
+            Verts = new float[count * 6],
+            Radii = new float[count],
+            Directions = new int[count],
+            Areas = new int[count],
+            Flags = new int[count],
+            UserIds = new int[count],
+            Count = count
+        };
+
+        for (int i = 0; i < count; i++)
+        {
+            var link = offMeshLinks[i];
+
+            if (link.Radius <= 0f)
+            {
+                throw new ArgumentException($"Off-mesh link {i} must have a positive radius", nameof(offMeshLinks));
+            }
+
+            // Polygon flags are serialized as 16-bit values, so the area type's
+            // mask bit must fit in that range (NavAreaType.NotWalkable does not).
+            if ((int)link.AreaType is < 0 or > 15)
+            {
+                throw new ArgumentException(
+                    $"Off-mesh link {i} area type {link.AreaType} cannot be represented as a polygon flag",
+                    nameof(offMeshLinks));
+            }
+
+            data.Verts[i * 6] = link.Start.X;
+            data.Verts[i * 6 + 1] = link.Start.Y;
+            data.Verts[i * 6 + 2] = link.Start.Z;
+            data.Verts[i * 6 + 3] = link.End.X;
+            data.Verts[i * 6 + 4] = link.End.Y;
+            data.Verts[i * 6 + 5] = link.End.Z;
+            data.Radii[i] = link.Radius;
+            data.Directions[i] = link.Bidirectional ? 1 : 0;
+            data.Areas[i] = (int)link.AreaType;
+
+            // The connection polygon's flag mirrors the NavAreaMask bit of its
+            // area type so query filters built from NavAreaMask include or
+            // exclude the link consistently with ground polygons.
+            data.Flags[i] = 1 << (int)link.AreaType;
+            data.UserIds[i] = i;
+        }
+
+        return data;
+    }
+
+    private static void ApplyOffMeshConnections(DtNavMeshCreateParams navMeshParams, OffMeshConnectionData? connections)
+    {
+        if (connections == null)
+        {
+            return;
+        }
+
+        navMeshParams.offMeshConVerts = connections.Verts;
+        navMeshParams.offMeshConRad = connections.Radii;
+        navMeshParams.offMeshConDir = connections.Directions;
+        navMeshParams.offMeshConAreas = connections.Areas;
+        navMeshParams.offMeshConFlags = connections.Flags;
+        navMeshParams.offMeshConUserID = connections.UserIds;
+        navMeshParams.offMeshConCount = connections.Count;
+    }
+
+    /// <summary>
+    /// Off-mesh connection arrays in the layout expected by Detour.
+    /// </summary>
+    private sealed class OffMeshConnectionData
+    {
+        public required float[] Verts { get; init; }
+
+        public required float[] Radii { get; init; }
+
+        public required int[] Directions { get; init; }
+
+        public required int[] Areas { get; init; }
+
+        public required int[] Flags { get; init; }
+
+        public required int[] UserIds { get; init; }
+
+        public required int Count { get; init; }
     }
 }

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
@@ -2,6 +2,8 @@ using System.Numerics;
 using DotRecast.Core;
 using DotRecast.Core.Numerics;
 using DotRecast.Detour;
+using DotRecast.Detour.TileCache;
+using DotRecast.Detour.TileCache.Io.Compress;
 using DotRecast.Recast;
 using DotRecast.Recast.Geom;
 using KeenEyes.Navigation.Abstractions;
@@ -33,6 +35,17 @@ namespace KeenEyes.Navigation.DotRecast;
 /// </remarks>
 public sealed class DotRecastMeshBuilder
 {
+    /// <summary>
+    /// Expected stacked heightfield layers per tile-cache grid cell, used to
+    /// size the navmesh tile budget. Matches the Recast demo's value.
+    /// </summary>
+    private const int ExpectedLayersPerTile = 4;
+
+    /// <summary>
+    /// Maximum simultaneous obstacles a tile cache can track.
+    /// </summary>
+    private const int MaxTileCacheObstacles = 128;
+
     private readonly NavMeshConfig config;
     private readonly RcBuilder builder;
 
@@ -96,16 +109,7 @@ public sealed class DotRecastMeshBuilder
         int overrideTileSize = 0,
         IReadOnlyList<OffMeshLinkDefinition>? offMeshLinks = null)
     {
-        if (vertices.Length == 0 || vertices.Length % 3 != 0)
-        {
-            throw new ArgumentException("Vertices must be XYZ triplets", nameof(vertices));
-        }
-
-        if (indices.Length == 0 || indices.Length % 3 != 0)
-        {
-            throw new ArgumentException("Indices must be triangle triplets", nameof(indices));
-        }
-
+        ValidateGeometry(vertices, indices);
         ArgumentOutOfRangeException.ThrowIfNegative(overrideTileSize);
 
         // Convert to arrays for DotRecast
@@ -272,6 +276,101 @@ public sealed class DotRecastMeshBuilder
 
     private NavMeshData BuildTiled(IRcInputGeomProvider geom, RcVec3f bmin, RcVec3f bmax, int overrideTileSize, OffMeshConnectionData? connections)
     {
+        var (navMeshParams, tiles) = BuildTileData(geom, bmin, bmax, overrideTileSize, connections);
+
+        if (tiles.Count == 0)
+        {
+            throw new InvalidOperationException("Failed to build navigation mesh");
+        }
+
+        var navMesh = new DtNavMesh();
+        navMesh.Init(navMeshParams, config.MaxVertsPerPoly);
+
+        foreach (var meshData in tiles)
+        {
+            navMesh.AddTile(meshData, 0, 0, out _);
+        }
+
+        return new NavMeshData(navMesh, config.ToAgentSettings());
+    }
+
+    /// <summary>
+    /// Builds all tiles of a tiled navigation mesh up front and returns them as
+    /// a streamable tile set instead of installing them into a navmesh.
+    /// </summary>
+    /// <param name="vertices">The mesh vertices (XYZ triplets).</param>
+    /// <param name="indices">The triangle indices.</param>
+    /// <param name="overrideTileSize">
+    /// Optional per-surface tile size (in cells) that overrides
+    /// <see cref="NavMeshConfig.TileSize"/> when greater than zero.
+    /// </param>
+    /// <param name="offMeshLinks">
+    /// Optional off-mesh connections to bake into the tiles.
+    /// </param>
+    /// <returns>
+    /// The tile set, ready to be streamed by <see cref="NavMeshStreamingManager"/>
+    /// or persisted per tile via <see cref="NavMeshTile.Serialize"/>.
+    /// </returns>
+    /// <remarks>
+    /// Tiles are built eagerly because Recast voxelization needs the full input
+    /// geometry; building at bake time keeps the runtime streaming cost down to
+    /// installing and removing pre-built tiles.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when geometry or off-mesh links are invalid.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when overrideTileSize is negative.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="NavMeshConfig.UseTiles"/> is disabled or no tile
+    /// contains walkable geometry.
+    /// </exception>
+    public NavMeshTileSet BuildTileSet(
+        ReadOnlySpan<float> vertices,
+        ReadOnlySpan<int> indices,
+        int overrideTileSize = 0,
+        IReadOnlyList<OffMeshLinkDefinition>? offMeshLinks = null)
+    {
+        if (!config.UseTiles)
+        {
+            throw new InvalidOperationException("BuildTileSet requires NavMeshConfig.UseTiles to be enabled");
+        }
+
+        ValidateGeometry(vertices, indices);
+        ArgumentOutOfRangeException.ThrowIfNegative(overrideTileSize);
+
+        var geom = new RcSampleInputGeomProvider(vertices.ToArray(), indices.ToArray());
+        var bmin = geom.GetMeshBoundsMin();
+        var bmax = geom.GetMeshBoundsMax();
+        var connections = CreateOffMeshConnectionData(offMeshLinks);
+
+        var (navMeshParams, tileData) = BuildTileData(geom, bmin, bmax, overrideTileSize, connections);
+
+        if (tileData.Count == 0)
+        {
+            throw new InvalidOperationException("Failed to build navigation mesh");
+        }
+
+        var tiles = new List<NavMeshTile>(tileData.Count);
+        foreach (var meshData in tileData)
+        {
+            tiles.Add(new NavMeshTile(meshData, config.MaxVertsPerPoly));
+        }
+
+        return new NavMeshTileSet(
+            new Vector3(navMeshParams.orig.X, navMeshParams.orig.Y, navMeshParams.orig.Z),
+            navMeshParams.tileWidth,
+            navMeshParams.maxTiles,
+            navMeshParams.maxPolys,
+            config.MaxVertsPerPoly,
+            config.ToAgentSettings(),
+            tiles);
+    }
+
+    private (DtNavMeshParams NavMeshParams, List<DtMeshData> Tiles) BuildTileData(
+        IRcInputGeomProvider geom,
+        RcVec3f bmin,
+        RcVec3f bmax,
+        int overrideTileSize,
+        OffMeshConnectionData? connections)
+    {
         // Effective tile size honours a per-surface override (NavMeshSurface.OverrideTileSize)
         // when positive, otherwise falls back to the global config value.
         int tileSize = overrideTileSize > 0 ? overrideTileSize : config.TileSize;
@@ -280,35 +379,12 @@ public sealed class DotRecastMeshBuilder
         // Partition the bounds into a grid of tiles: tw x th tiles of tileSize cells each.
         RcRecast.CalcTileCount(bmin, bmax, config.CellSize, rcConfig.TileSizeX, rcConfig.TileSizeZ, out int tw, out int th);
 
-        // Size the navmesh so tile + poly indices fit in the reference bit budget.
-        // DotRecast packs the polygon reference as salt|tile|poly; the tile and poly
-        // indices together use 22 bits. Allocate as many bits to the tile index as the
-        // grid needs (capped at 14 to leave room for salt), and give the rest to polys.
-        int tileColumns = Math.Max(1, tw * th);
-        int tileBits = Math.Min(BitOperations.Log2(BitOperations.RoundUpToPowerOf2((uint)tileColumns)), 14);
-        int polyBits = 22 - tileBits;
-        int maxTiles = 1 << tileBits;
-        int maxPolysPerTile = 1 << polyBits;
-
-        // Tile footprint in world units.
-        float tileWorldSize = rcConfig.TileSizeX * config.CellSize;
-
-        var navMeshParams = new DtNavMeshParams
-        {
-            orig = bmin,
-            tileWidth = tileWorldSize,
-            tileHeight = tileWorldSize,
-            maxTiles = maxTiles,
-            maxPolys = maxPolysPerTile
-        };
-
-        var navMesh = new DtNavMesh();
-        navMesh.Init(navMeshParams, config.MaxVertsPerPoly);
+        var navMeshParams = CreateTiledNavMeshParams(bmin, rcConfig.TileSizeX, tw * th, 1);
 
         // BuildTiles walks the whole tw x th grid and returns one result per tile.
         var results = builder.BuildTiles(geom, rcConfig, false, true);
 
-        int tilesAdded = 0;
+        var tiles = new List<DtMeshData>();
         foreach (var result in results)
         {
             // Skip empty tiles (no walkable geometry landed in this cell).
@@ -338,16 +414,146 @@ public sealed class DotRecastMeshBuilder
                 continue;
             }
 
-            navMesh.AddTile(meshData, 0, 0, out _);
-            tilesAdded++;
+            tiles.Add(meshData);
         }
 
-        if (tilesAdded == 0)
+        return (navMeshParams, tiles);
+    }
+
+    /// <summary>
+    /// Sizes navmesh parameters so tile + poly indices fit in the reference bit
+    /// budget. DotRecast packs the polygon reference as salt|tile|poly; the tile
+    /// and poly indices together use 22 bits. Allocate as many bits to the tile
+    /// index as the grid needs (capped at 14 to leave room for salt), and give
+    /// the rest to polys.
+    /// </summary>
+    private DtNavMeshParams CreateTiledNavMeshParams(RcVec3f orig, int tileSizeCells, int tileColumns, int layersPerTile)
+    {
+        int tileSlots = Math.Max(1, tileColumns * layersPerTile);
+        int tileBits = Math.Min(BitOperations.Log2(BitOperations.RoundUpToPowerOf2((uint)tileSlots)), 14);
+        int polyBits = 22 - tileBits;
+
+        // Tile footprint in world units.
+        float tileWorldSize = tileSizeCells * config.CellSize;
+
+        return new DtNavMeshParams
+        {
+            orig = orig,
+            tileWidth = tileWorldSize,
+            tileHeight = tileWorldSize,
+            maxTiles = 1 << tileBits,
+            maxPolys = 1 << polyBits
+        };
+    }
+
+    /// <summary>
+    /// Builds a navigation mesh backed by a Detour tile cache, enabling
+    /// obstacle-driven partial rebuilds at runtime.
+    /// </summary>
+    /// <param name="vertices">The mesh vertices (XYZ triplets).</param>
+    /// <param name="indices">The triangle indices.</param>
+    /// <returns>
+    /// The tile cache wrapper. Its <see cref="NavMeshTileCache.Mesh"/> is fully
+    /// built and immediately usable for pathfinding.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The tile cache pipeline is separate from the regular tiled build: it
+    /// voxelizes the geometry into compressed heightfield layers (rather than
+    /// polygon meshes) so affected tiles can be re-contoured quickly when
+    /// obstacles are added or removed. Because the intermediate data differs,
+    /// tile cache meshes do not interoperate with
+    /// <see cref="BuildTileSet"/>/<see cref="NavMeshStreamingManager"/> streaming
+    /// and do not support off-mesh links.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when geometry is invalid.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="NavMeshConfig.UseTiles"/> is disabled or mesh
+    /// building fails.
+    /// </exception>
+    public NavMeshTileCache BuildTileCache(ReadOnlySpan<float> vertices, ReadOnlySpan<int> indices)
+    {
+        if (!config.UseTiles)
+        {
+            throw new InvalidOperationException("BuildTileCache requires NavMeshConfig.UseTiles to be enabled");
+        }
+
+        ValidateGeometry(vertices, indices);
+
+        var geom = new RcSampleInputGeomProvider(vertices.ToArray(), indices.ToArray());
+        var bmin = geom.GetMeshBoundsMin();
+        var bmax = geom.GetMeshBoundsMax();
+
+        var rcConfig = CreateRcConfig(config.TileSize);
+        RcRecast.CalcTileCount(bmin, bmax, config.CellSize, rcConfig.TileSizeX, rcConfig.TileSizeZ, out int tw, out int th);
+
+        // Compressed heightfield layers, one build result per grid cell. Each
+        // cell can produce multiple stacked layers (overlapping walkable areas).
+        var storageParams = new DtTileCacheStorageParams(RcByteOrder.LITTLE_ENDIAN, false);
+        var layerResults = new DtTileCacheLayerBuilder(FastLzCompressorFactory.Instance)
+            .Build(geom, rcConfig, storageParams, 1, tw, th);
+
+        var navMeshParams = CreateTiledNavMeshParams(bmin, rcConfig.TileSizeX, tw * th, ExpectedLayersPerTile);
+        var navMesh = new DtNavMesh();
+        navMesh.Init(navMeshParams, config.MaxVertsPerPoly);
+
+        var tileCacheParams = new DtTileCacheParams
+        {
+            orig = bmin,
+            cs = config.CellSize,
+            ch = config.CellHeight,
+            width = rcConfig.TileSizeX,
+            height = rcConfig.TileSizeZ,
+            walkableHeight = config.AgentHeight,
+            walkableRadius = config.AgentRadius,
+            walkableClimb = config.MaxClimbHeight,
+            maxSimplificationError = config.MaxSimplificationError,
+            maxTiles = navMeshParams.maxTiles,
+            maxObstacles = MaxTileCacheObstacles
+        };
+
+        var tileCache = new DtTileCache(
+            in tileCacheParams,
+            storageParams,
+            navMesh,
+            DtTileCacheFastLzCompressor.Shared,
+            new WalkablePolyMeshProcess());
+
+        int tilesBuilt = 0;
+        foreach (var result in layerResults)
+        {
+            foreach (var layer in result.layers)
+            {
+                long tileRef = tileCache.AddTile(layer, 0);
+                if (tileRef != 0)
+                {
+                    // Contour the initial (obstacle-free) layer into navmesh polys.
+                    tileCache.BuildNavMeshTile(tileRef);
+                    tilesBuilt++;
+                }
+            }
+        }
+
+        if (tilesBuilt == 0)
         {
             throw new InvalidOperationException("Failed to build navigation mesh");
         }
 
-        return new NavMeshData(navMesh, config.ToAgentSettings());
+        return new NavMeshTileCache(tileCache, new NavMeshData(navMesh, config.ToAgentSettings()));
+    }
+
+    private static void ValidateGeometry(ReadOnlySpan<float> vertices, ReadOnlySpan<int> indices)
+    {
+        if (vertices.Length == 0 || vertices.Length % 3 != 0)
+        {
+            throw new ArgumentException("Vertices must be XYZ triplets", nameof(vertices));
+        }
+
+        if (indices.Length == 0 || indices.Length % 3 != 0)
+        {
+            throw new ArgumentException("Indices must be triangle triplets", nameof(indices));
+        }
     }
 
     /// <summary>
@@ -512,6 +718,39 @@ public sealed class DotRecastMeshBuilder
         navMeshParams.offMeshConFlags = connections.Flags;
         navMeshParams.offMeshConUserID = connections.UserIds;
         navMeshParams.offMeshConCount = connections.Count;
+    }
+
+    /// <summary>
+    /// Compressor factory that always yields the FastLZ compressor, regardless
+    /// of the storage compatibility mode. The stock
+    /// <c>DtTileCacheCompressorFactory.Shared</c> returns null for
+    /// non-compatibility storage unless a compressor is registered on its
+    /// global instance, which would be hidden static state.
+    /// </summary>
+    private sealed class FastLzCompressorFactory : IDtTileCacheCompressorFactory
+    {
+        public static readonly FastLzCompressorFactory Instance = new();
+
+        public IRcCompressor Create(int compatibility) => DtTileCacheFastLzCompressor.Shared;
+    }
+
+    /// <summary>
+    /// Flags every non-null-area polygon produced by a tile cache rebuild as
+    /// walkable, mirroring <see cref="MarkWalkablePolys"/> for the regular
+    /// build pipeline.
+    /// </summary>
+    private sealed class WalkablePolyMeshProcess : IDtTileCacheMeshProcess
+    {
+        public void Process(DtNavMeshCreateParams option)
+        {
+            for (int i = 0; i < option.polyCount; i++)
+            {
+                if (option.polyAreas[i] != RcRecast.RC_NULL_AREA)
+                {
+                    option.polyFlags[i] = 1;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
@@ -1,4 +1,5 @@
 using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
 
 namespace KeenEyes.Navigation.DotRecast;
 
@@ -56,6 +57,7 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
 {
     private readonly NavMeshConfig config;
     private readonly NavMeshData? prebuiltMesh;
+    private readonly NavMeshStreamingManager? streamingManager;
     private DotRecastProvider? provider;
     private NavMeshObstacleManager? obstacleManager;
 
@@ -123,6 +125,37 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         this.config = config;
     }
 
+    /// <summary>
+    /// Creates a new DotRecast navigation plugin that streams navmesh tiles
+    /// around anchor entities.
+    /// </summary>
+    /// <param name="streamingManager">
+    /// The streaming manager to drive. The plugin installs its
+    /// <see cref="NavMeshStreamingManager.Mesh"/> on the provider, exposes the
+    /// manager as a world extension, and registers a system that mirrors
+    /// entities carrying <c>NavMeshStreamingAnchor</c> into the manager each
+    /// update. The caller retains ownership and must dispose the manager after
+    /// the plugin is uninstalled.
+    /// </param>
+    /// <param name="config">The query configuration.</param>
+    /// <exception cref="ArgumentNullException">Thrown if streamingManager or config is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if configuration is invalid.</exception>
+    public DotRecastNavigationPlugin(NavMeshStreamingManager streamingManager, NavMeshConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(streamingManager);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException($"Invalid NavMeshConfig: {error}", nameof(config));
+        }
+
+        this.streamingManager = streamingManager;
+        this.config = config;
+        prebuiltMesh = streamingManager.Mesh;
+    }
+
     /// <inheritdoc/>
     public string Name => "DotRecastNavigation";
 
@@ -146,6 +179,15 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
 
         // Register the mesh builder for runtime navmesh generation
         context.SetExtension(new DotRecastMeshBuilder(config));
+
+        // Tile streaming: expose the manager and drive residency from anchor
+        // entities before path requests run (PathRequestSystem is order -100).
+        if (streamingManager != null)
+        {
+            context.RegisterComponent<NavMeshStreamingAnchor>();
+            context.SetExtension(streamingManager);
+            context.AddSystem<NavMeshStreamingSystem>(SystemPhase.Update, order: -200);
+        }
     }
 
     /// <inheritdoc/>
@@ -156,6 +198,11 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         context.RemoveExtension<INavigationProvider>();
         context.RemoveExtension<NavMeshObstacleManager>();
         context.RemoveExtension<DotRecastMeshBuilder>();
+
+        if (streamingManager != null)
+        {
+            context.RemoveExtension<NavMeshStreamingManager>();
+        }
 
         // Dispose the provider
         provider?.Dispose();

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
@@ -197,7 +197,14 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
             var pos = ToVector3(pt.pos);
 
             activeMesh.InternalNavMesh.GetPolyArea(pt.refs, out var area);
-            waypoints[i] = new NavPoint(pos, (NavAreaType)area, (uint)pt.refs);
+
+            // Surface Detour's off-mesh connection marker so path-following
+            // logic can detect link entry points in a provider-agnostic way.
+            var properties = (pt.flags & DtStraightPathFlags.DT_STRAIGHTPATH_OFFMESH_CONNECTION) != 0
+                ? NavPointProperties.OffMeshConnection
+                : NavPointProperties.None;
+
+            waypoints[i] = new NavPoint(pos, (NavAreaType)area, (uint)pt.refs, properties);
 
             if (i > 0)
             {

--- a/src/KeenEyes.Navigation.DotRecast/KeenEyes.Navigation.DotRecast.csproj
+++ b/src/KeenEyes.Navigation.DotRecast/KeenEyes.Navigation.DotRecast.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="DotRecast.Detour" />
     <PackageReference Include="DotRecast.Detour.Crowd" />
+    <PackageReference Include="DotRecast.Detour.TileCache" />
     <PackageReference Include="DotRecast.Recast" />
   </ItemGroup>
 

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshObstacleManager.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshObstacleManager.cs
@@ -15,8 +15,9 @@ namespace KeenEyes.Navigation.DotRecast;
 /// navmesh data, this approach uses query filters to exclude polygons.
 /// </para>
 /// <para>
-/// For true dynamic navmesh updates, consider using DotRecast.Detour.TileCache
-/// which supports streaming and runtime navmesh modification.
+/// For true dynamic navmesh updates that carve the walkable surface itself,
+/// build the mesh with <see cref="DotRecastMeshBuilder.BuildTileCache"/> and
+/// manage obstacles through the resulting <see cref="NavMeshTileCache"/>.
 /// </para>
 /// </remarks>
 public sealed class NavMeshObstacleManager

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingConfig.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingConfig.cs
@@ -1,0 +1,63 @@
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// Configuration for runtime navigation mesh tile streaming.
+/// </summary>
+/// <remarks>
+/// Tiles whose footprint lies within <see cref="LoadRadius"/> of any anchor are
+/// loaded; tiles farther than <see cref="LoadRadius"/> plus
+/// <see cref="UnloadHysteresis"/> from every anchor are unloaded. Tiles in the
+/// hysteresis band keep their current state, preventing load/unload thrash when
+/// an anchor hovers near a tile boundary.
+/// </remarks>
+public sealed class NavMeshStreamingConfig
+{
+    /// <summary>
+    /// Gets the default streaming configuration.
+    /// </summary>
+    public static NavMeshStreamingConfig Default => new();
+
+    /// <summary>
+    /// Gets or sets the radius (in world units) around each anchor within
+    /// which tiles are loaded.
+    /// </summary>
+    public float LoadRadius { get; set; } = 64f;
+
+    /// <summary>
+    /// Gets or sets the extra distance (in world units) beyond
+    /// <see cref="LoadRadius"/> a loaded tile must be from every anchor before
+    /// it is unloaded.
+    /// </summary>
+    public float UnloadHysteresis { get; set; } = 16f;
+
+    /// <summary>
+    /// Gets or sets the maximum number of tile install/remove operations
+    /// applied to the navigation mesh per <see cref="NavMeshStreamingManager.Update"/>
+    /// call. Bounds the per-frame cost of streaming.
+    /// </summary>
+    public int MaxTileOperationsPerUpdate { get; set; } = 4;
+
+    /// <summary>
+    /// Validates the configuration.
+    /// </summary>
+    /// <returns>An error message if invalid, or null if valid.</returns>
+    public string? Validate()
+    {
+        if (LoadRadius <= 0f)
+        {
+            return "LoadRadius must be greater than 0";
+        }
+
+        if (UnloadHysteresis < 0f)
+        {
+            return "UnloadHysteresis must be non-negative";
+        }
+
+        if (MaxTileOperationsPerUpdate < 1)
+        {
+            return "MaxTileOperationsPerUpdate must be at least 1";
+        }
+
+        return null;
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingManager.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingManager.cs
@@ -1,0 +1,329 @@
+using System.Collections.Concurrent;
+using System.Numerics;
+using DotRecast.Detour;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// Streams navigation mesh tiles in and out of a runtime navmesh based on the
+/// positions of registered anchors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The manager owns an initially empty navigation mesh (<see cref="Mesh"/>)
+/// sized for a pre-built <see cref="NavMeshTileSet"/>. Each <see cref="Update"/>
+/// evaluates tile residency: tiles within <see cref="NavMeshStreamingConfig.LoadRadius"/>
+/// of any anchor are installed, and loaded tiles beyond the radius plus
+/// <see cref="NavMeshStreamingConfig.UnloadHysteresis"/> are removed. At most
+/// <see cref="NavMeshStreamingConfig.MaxTileOperationsPerUpdate"/> install/remove
+/// operations are applied per call.
+/// </para>
+/// <para>
+/// Tiles that still hold their serialized form (a tile set restored with
+/// <see cref="NavMeshTileSet.Deserialize"/>) are decoded on background tasks;
+/// the navigation mesh itself is only ever mutated inside <see cref="Update"/>,
+/// so all pathfinding structures stay single-threaded. Install the mesh once
+/// via <see cref="DotRecastProvider.SetNavMesh"/> — tiles are added and removed
+/// in place, so the crowd simulation is not recreated by streaming operations.
+/// </para>
+/// <para>
+/// This class is not thread-safe; drive it from the world update thread.
+/// </para>
+/// </remarks>
+public sealed class NavMeshStreamingManager : IDisposable
+{
+    private readonly NavMeshStreamingConfig config;
+    private readonly NavMeshData mesh;
+    private readonly Vector3 origin;
+    private readonly float tileWorldSize;
+
+    private readonly Dictionary<(int X, int Z), NavMeshTile> tilesByCoord = [];
+    private readonly Dictionary<(int X, int Z), long> loadedTiles = [];
+    private readonly HashSet<(int X, int Z)> pendingLoads = [];
+    private readonly ConcurrentQueue<NavMeshTile> materializedQueue = new();
+    private readonly List<NavMeshTile> readyTiles = [];
+    private readonly List<(int X, int Z)> unloadScratch = [];
+    private readonly Dictionary<int, Vector3> anchors = [];
+    private bool disposed;
+
+    /// <summary>
+    /// Creates a streaming manager for a pre-built tile set.
+    /// </summary>
+    /// <param name="tileSet">The tile set to stream from.</param>
+    /// <param name="config">The streaming configuration.</param>
+    /// <exception cref="ArgumentNullException">Thrown when tileSet or config is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when config validation fails.</exception>
+    public NavMeshStreamingManager(NavMeshTileSet tileSet, NavMeshStreamingConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(tileSet);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException(error, nameof(config));
+        }
+
+        this.config = config;
+        origin = tileSet.Origin;
+        tileWorldSize = tileSet.TileWorldSize;
+        mesh = tileSet.CreateEmptyMesh();
+
+        foreach (var tile in tileSet.Tiles)
+        {
+            tilesByCoord[(tile.TileX, tile.TileZ)] = tile;
+        }
+    }
+
+    /// <summary>
+    /// Gets the streamed navigation mesh. Install it on a provider once via
+    /// <see cref="DotRecastProvider.SetNavMesh"/>; streaming mutates it in place.
+    /// </summary>
+    public NavMeshData Mesh => mesh;
+
+    /// <summary>
+    /// Gets the number of tiles currently installed in the navigation mesh.
+    /// </summary>
+    public int LoadedTileCount => loadedTiles.Count;
+
+    /// <summary>
+    /// Gets the number of registered anchors.
+    /// </summary>
+    public int AnchorCount => anchors.Count;
+
+    /// <summary>
+    /// Gets whether no tile loads are in flight or awaiting installation.
+    /// </summary>
+    /// <remarks>
+    /// When this is true and <see cref="Update"/> returns 0, tile residency has
+    /// reached a steady state for the current anchor positions.
+    /// </remarks>
+    public bool IsIdle => pendingLoads.Count == 0 && readyTiles.Count == 0 && materializedQueue.IsEmpty;
+
+    /// <summary>
+    /// Checks whether the tile at the given grid coordinate is currently
+    /// installed in the navigation mesh.
+    /// </summary>
+    /// <param name="tileX">The tile's X coordinate.</param>
+    /// <param name="tileZ">The tile's Z coordinate.</param>
+    /// <returns>True if the tile is loaded.</returns>
+    public bool IsTileLoaded(int tileX, int tileZ) => loadedTiles.ContainsKey((tileX, tileZ));
+
+    /// <summary>
+    /// Gets the grid coordinate of the tile containing the given world position.
+    /// </summary>
+    /// <param name="position">The world position.</param>
+    /// <returns>The tile coordinate; the tile may or may not exist in the set.</returns>
+    public (int TileX, int TileZ) GetTileCoordinate(Vector3 position)
+    {
+        int tileX = (int)MathF.Floor((position.X - origin.X) / tileWorldSize);
+        int tileZ = (int)MathF.Floor((position.Z - origin.Z) / tileWorldSize);
+        return (tileX, tileZ);
+    }
+
+    /// <summary>
+    /// Registers or moves a streaming anchor. Tiles are kept resident around
+    /// all registered anchors.
+    /// </summary>
+    /// <param name="anchorId">A caller-chosen identifier for the anchor.</param>
+    /// <param name="position">The anchor's world position.</param>
+    public void SetAnchor(int anchorId, Vector3 position)
+    {
+        ThrowIfDisposed();
+        anchors[anchorId] = position;
+    }
+
+    /// <summary>
+    /// Removes a streaming anchor. Tiles held resident only by this anchor
+    /// will unload on subsequent updates.
+    /// </summary>
+    /// <param name="anchorId">The anchor identifier passed to <see cref="SetAnchor"/>.</param>
+    /// <returns>True if the anchor was registered.</returns>
+    public bool RemoveAnchor(int anchorId)
+    {
+        ThrowIfDisposed();
+        return anchors.Remove(anchorId);
+    }
+
+    /// <summary>
+    /// Evaluates tile residency and applies up to
+    /// <see cref="NavMeshStreamingConfig.MaxTileOperationsPerUpdate"/> tile
+    /// install/remove operations. Call once per frame from the main thread.
+    /// </summary>
+    /// <returns>The number of tile operations applied this call.</returns>
+    public int Update()
+    {
+        ThrowIfDisposed();
+
+        // Collect tiles whose background decode finished since the last update.
+        while (materializedQueue.TryDequeue(out var materialized))
+        {
+            readyTiles.Add(materialized);
+        }
+
+        StartRequiredLoads();
+
+        int budget = config.MaxTileOperationsPerUpdate;
+        int operations = ApplyReadyLoads(budget);
+        operations += ApplyUnloads(budget - operations);
+        return operations;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        anchors.Clear();
+        pendingLoads.Clear();
+        readyTiles.Clear();
+        disposed = true;
+    }
+
+    /// <summary>
+    /// Begins loading every tile that should be resident but is neither loaded
+    /// nor already pending. Resident (already decoded) tiles are staged
+    /// directly; serialized tiles are decoded on a background task first.
+    /// </summary>
+    private void StartRequiredLoads()
+    {
+        foreach (var (coord, tile) in tilesByCoord)
+        {
+            if (loadedTiles.ContainsKey(coord) || pendingLoads.Contains(coord))
+            {
+                continue;
+            }
+
+            if (DistanceToNearestAnchor(coord) > config.LoadRadius)
+            {
+                continue;
+            }
+
+            pendingLoads.Add(coord);
+
+            if (tile.IsMaterialized)
+            {
+                readyTiles.Add(tile);
+            }
+            else
+            {
+                _ = Task.Run(() =>
+                {
+                    try
+                    {
+                        tile.GetMeshData();
+                    }
+                    catch (Exception)
+                    {
+                        // Never fault the background task: corrupt payloads
+                        // surface deterministically on the main thread when
+                        // the install re-attempts the decode.
+                    }
+
+                    materializedQueue.Enqueue(tile);
+                });
+            }
+        }
+    }
+
+    private int ApplyReadyLoads(int budget)
+    {
+        int operations = 0;
+        int index = 0;
+
+        while (index < readyTiles.Count && operations < budget)
+        {
+            var tile = readyTiles[index];
+            var coord = (tile.TileX, tile.TileZ);
+
+            // Anchors may have moved while the tile was decoding; drop loads
+            // that are no longer wanted without spending navmesh operations.
+            if (DistanceToNearestAnchor(coord) > config.LoadRadius)
+            {
+                readyTiles.RemoveAt(index);
+                pendingLoads.Remove(coord);
+                continue;
+            }
+
+            var status = mesh.InternalNavMesh.AddTile(tile.GetMeshData(), 0, 0, out long tileRef);
+            if (status.Succeeded())
+            {
+                loadedTiles[coord] = tileRef;
+            }
+
+            readyTiles.RemoveAt(index);
+            pendingLoads.Remove(coord);
+            operations++;
+        }
+
+        return operations;
+    }
+
+    private int ApplyUnloads(int budget)
+    {
+        if (budget <= 0)
+        {
+            return 0;
+        }
+
+        float unloadDistance = config.LoadRadius + config.UnloadHysteresis;
+
+        unloadScratch.Clear();
+        foreach (var coord in loadedTiles.Keys)
+        {
+            if (unloadScratch.Count >= budget)
+            {
+                break;
+            }
+
+            if (DistanceToNearestAnchor(coord) > unloadDistance)
+            {
+                unloadScratch.Add(coord);
+            }
+        }
+
+        foreach (var coord in unloadScratch)
+        {
+            mesh.InternalNavMesh.RemoveTile(loadedTiles[coord]);
+            loadedTiles.Remove(coord);
+        }
+
+        return unloadScratch.Count;
+    }
+
+    /// <summary>
+    /// Computes the XZ-plane distance from the tile's footprint (not its
+    /// center) to the nearest anchor, so a tile containing an anchor is always
+    /// at distance zero. Returns infinity when no anchors are registered.
+    /// </summary>
+    private float DistanceToNearestAnchor((int X, int Z) coord)
+    {
+        float minX = origin.X + coord.X * tileWorldSize;
+        float minZ = origin.Z + coord.Z * tileWorldSize;
+        float maxX = minX + tileWorldSize;
+        float maxZ = minZ + tileWorldSize;
+
+        float nearest = float.PositiveInfinity;
+        foreach (var position in anchors.Values)
+        {
+            float dx = MathF.Max(MathF.Max(minX - position.X, 0f), position.X - maxX);
+            float dz = MathF.Max(MathF.Max(minZ - position.Z, 0f), position.Z - maxZ);
+            float distance = MathF.Sqrt(dx * dx + dz * dz);
+
+            if (distance < nearest)
+            {
+                nearest = distance;
+            }
+        }
+
+        return nearest;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingSystem.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingSystem.cs
@@ -1,0 +1,69 @@
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// System that drives navigation mesh tile streaming from anchor entities.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each update, entities carrying <see cref="NavMeshStreamingAnchor"/> and
+/// <see cref="Transform3D"/> are mirrored into the world's
+/// <see cref="NavMeshStreamingManager"/> as streaming anchors, anchors for
+/// despawned entities are removed, and the manager applies its budgeted tile
+/// residency pass.
+/// </para>
+/// <para>
+/// Registered by <see cref="DotRecastNavigationPlugin"/> when constructed with
+/// a streaming manager. Runs early in the update phase so tiles are resident
+/// before path requests and agent steering execute.
+/// </para>
+/// </remarks>
+internal sealed class NavMeshStreamingSystem : SystemBase
+{
+    private NavMeshStreamingManager? manager;
+    private HashSet<int> currentAnchors = [];
+    private HashSet<int> previousAnchors = [];
+
+    /// <inheritdoc/>
+    protected override void OnInitialize()
+    {
+        if (!World.TryGetExtension(out NavMeshStreamingManager? streamingManager) || streamingManager is null)
+        {
+            throw new InvalidOperationException("NavMeshStreamingSystem requires the NavMeshStreamingManager extension.");
+        }
+
+        manager = streamingManager;
+    }
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        if (manager == null)
+        {
+            return;
+        }
+
+        currentAnchors.Clear();
+
+        foreach (var entity in World.Query<NavMeshStreamingAnchor, Transform3D>())
+        {
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+            manager.SetAnchor(entity.Id, transform.Position);
+            currentAnchors.Add(entity.Id);
+        }
+
+        foreach (int anchorId in previousAnchors)
+        {
+            if (!currentAnchors.Contains(anchorId))
+            {
+                manager.RemoveAnchor(anchorId);
+            }
+        }
+
+        (previousAnchors, currentAnchors) = (currentAnchors, previousAnchors);
+
+        manager.Update();
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshTile.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshTile.cs
@@ -1,0 +1,183 @@
+using DotRecast.Core;
+using DotRecast.Detour;
+using DotRecast.Detour.Io;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// A single navigation mesh tile that can be persisted and streamed independently.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tiles are the unit of persistence and runtime streaming for tiled navigation
+/// meshes. Each tile carries its grid coordinate and the Detour mesh data for
+/// that cell, serialized with DotRecast's tile format so cross-tile links are
+/// rebuilt when the tile is installed into a <see cref="global::DotRecast.Detour.DtNavMesh"/>.
+/// </para>
+/// <para>
+/// Tiles produced by <see cref="DotRecastMeshBuilder.BuildTileSet"/> hold their
+/// mesh data in memory. Tiles created via <see cref="Deserialize"/> keep the
+/// serialized payload and decode it lazily on first use, which lets the
+/// streaming pipeline perform the decode on a background thread.
+/// </para>
+/// </remarks>
+public sealed class NavMeshTile
+{
+    private const int Magic = 0x4B454E54; // "KENT" - KeenEyes NavMesh Tile
+    private const int FormatVersion = 1;
+
+    private readonly Lock materializeLock = new();
+    private readonly byte[]? payload;
+    private DtMeshData? meshData;
+
+    internal NavMeshTile(DtMeshData meshData, int maxVertsPerPoly)
+    {
+        this.meshData = meshData;
+        TileX = meshData.header.x;
+        TileZ = meshData.header.y;
+        Layer = meshData.header.layer;
+        MaxVertsPerPoly = maxVertsPerPoly;
+    }
+
+    private NavMeshTile(byte[] payload, int tileX, int tileZ, int layer, int maxVertsPerPoly)
+    {
+        this.payload = payload;
+        TileX = tileX;
+        TileZ = tileZ;
+        Layer = layer;
+        MaxVertsPerPoly = maxVertsPerPoly;
+    }
+
+    /// <summary>
+    /// Gets the tile's X coordinate in the tile grid.
+    /// </summary>
+    public int TileX { get; }
+
+    /// <summary>
+    /// Gets the tile's Z coordinate in the tile grid.
+    /// </summary>
+    public int TileZ { get; }
+
+    /// <summary>
+    /// Gets the tile's layer index. Always 0 for meshes built by
+    /// <see cref="DotRecastMeshBuilder"/>.
+    /// </summary>
+    public int Layer { get; }
+
+    /// <summary>
+    /// Gets the maximum vertices per polygon the tile was built with, which is
+    /// required to decode the serialized mesh data.
+    /// </summary>
+    internal int MaxVertsPerPoly { get; }
+
+    /// <summary>
+    /// Gets whether the tile's mesh data has been decoded into memory.
+    /// </summary>
+    internal bool IsMaterialized => meshData != null;
+
+    /// <summary>
+    /// Gets the tile's Detour mesh data, decoding the serialized payload on
+    /// first access. Safe to call from a background thread.
+    /// </summary>
+    internal DtMeshData GetMeshData()
+    {
+        if (meshData is { } data)
+        {
+            return data;
+        }
+
+        lock (materializeLock)
+        {
+            if (meshData == null)
+            {
+                using var stream = new MemoryStream(payload!);
+                using var reader = new BinaryReader(stream);
+                meshData = new DtMeshDataReader().Read(reader, MaxVertsPerPoly);
+            }
+
+            return meshData;
+        }
+    }
+
+    /// <summary>
+    /// Serializes this tile to a byte array for individual persistence.
+    /// </summary>
+    /// <returns>The serialized tile, readable by <see cref="Deserialize"/>.</returns>
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(Magic);
+        writer.Write(FormatVersion);
+        writer.Write(TileX);
+        writer.Write(TileZ);
+        writer.Write(Layer);
+        writer.Write(MaxVertsPerPoly);
+
+        byte[] body = GetPayload();
+        writer.Write(body.Length);
+        writer.Write(body);
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Deserializes a tile previously produced by <see cref="Serialize"/>.
+    /// </summary>
+    /// <param name="data">The serialized tile bytes.</param>
+    /// <returns>
+    /// The tile. The mesh data itself is decoded lazily on first use.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when data is null.</exception>
+    /// <exception cref="InvalidDataException">Thrown when data is invalid or an unsupported version.</exception>
+    public static NavMeshTile Deserialize(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        int magic = reader.ReadInt32();
+        if (magic != Magic)
+        {
+            throw new InvalidDataException("Invalid NavMeshTile data: wrong magic number");
+        }
+
+        int version = reader.ReadInt32();
+        if (version != FormatVersion)
+        {
+            throw new InvalidDataException($"Unsupported NavMeshTile version: {version}");
+        }
+
+        int tileX = reader.ReadInt32();
+        int tileZ = reader.ReadInt32();
+        int layer = reader.ReadInt32();
+        int maxVertsPerPoly = reader.ReadInt32();
+
+        int payloadLength = reader.ReadInt32();
+        byte[] payload = reader.ReadBytes(payloadLength);
+        if (payload.Length != payloadLength)
+        {
+            throw new InvalidDataException("Invalid NavMeshTile data: truncated payload");
+        }
+
+        return new NavMeshTile(payload, tileX, tileZ, layer, maxVertsPerPoly);
+    }
+
+    private byte[] GetPayload()
+    {
+        // A tile deserialized but never materialized can round-trip its
+        // original payload without decoding it.
+        if (meshData == null && payload != null)
+        {
+            return payload;
+        }
+
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        new DtMeshDataWriter().Write(writer, GetMeshData(), RcByteOrder.LITTLE_ENDIAN, false);
+        writer.Flush();
+        return stream.ToArray();
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshTileCache.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshTileCache.cs
@@ -1,0 +1,97 @@
+using System.Numerics;
+using DotRecast.Core.Numerics;
+using DotRecast.Detour.TileCache;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// A navigation mesh backed by a Detour tile cache, supporting obstacle-driven
+/// partial rebuilds of individual tiles at runtime.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built via <see cref="DotRecastMeshBuilder.BuildTileCache"/>. Unlike
+/// <see cref="NavMeshObstacleManager"/>, which only filters polygons during
+/// queries, obstacles added here carve the navmesh: affected tiles are
+/// re-contoured from their compressed heightfield layers so the walkable
+/// surface itself changes.
+/// </para>
+/// <para>
+/// Obstacle additions and removals are deferred requests. Call
+/// <see cref="Update"/> once per frame; each call rebuilds at most one affected
+/// tile, spreading the cost over frames to avoid hitches. All members must be
+/// called from the thread that owns the navigation mesh (typically the main
+/// update thread).
+/// </para>
+/// </remarks>
+public sealed class NavMeshTileCache
+{
+    private readonly DtTileCache tileCache;
+    private readonly NavMeshData mesh;
+
+    internal NavMeshTileCache(DtTileCache tileCache, NavMeshData mesh)
+    {
+        this.tileCache = tileCache;
+        this.mesh = mesh;
+    }
+
+    /// <summary>
+    /// Gets the navigation mesh maintained by the tile cache. Install it on a
+    /// provider via <see cref="DotRecastProvider.SetNavMesh"/>; tile rebuilds
+    /// mutate it in place, so it never needs to be re-set.
+    /// </summary>
+    public NavMeshData Mesh => mesh;
+
+    /// <summary>
+    /// Requests a cylindrical obstacle to be carved out of the navmesh.
+    /// </summary>
+    /// <param name="position">The center of the cylinder's base.</param>
+    /// <param name="radius">The cylinder radius.</param>
+    /// <param name="height">The cylinder height.</param>
+    /// <returns>An obstacle reference for later removal.</returns>
+    /// <remarks>The carve is applied by subsequent <see cref="Update"/> calls.</remarks>
+    public long AddCylinderObstacle(Vector3 position, float radius, float height)
+    {
+        return tileCache.AddObstacle(new RcVec3f(position.X, position.Y, position.Z), radius, height);
+    }
+
+    /// <summary>
+    /// Requests a box obstacle to be carved out of the navmesh.
+    /// </summary>
+    /// <param name="center">The center of the box.</param>
+    /// <param name="halfExtents">The half-extents of the box.</param>
+    /// <param name="yRotation">The rotation around the Y axis in radians.</param>
+    /// <returns>An obstacle reference for later removal.</returns>
+    /// <remarks>The carve is applied by subsequent <see cref="Update"/> calls.</remarks>
+    public long AddBoxObstacle(Vector3 center, Vector3 halfExtents, float yRotation = 0f)
+    {
+        return tileCache.AddBoxObstacle(
+            new RcVec3f(center.X, center.Y, center.Z),
+            new RcVec3f(halfExtents.X, halfExtents.Y, halfExtents.Z),
+            yRotation);
+    }
+
+    /// <summary>
+    /// Requests removal of a previously added obstacle, restoring the walkable
+    /// surface beneath it.
+    /// </summary>
+    /// <param name="obstacleRef">The obstacle reference returned by an add method.</param>
+    /// <remarks>The restore is applied by subsequent <see cref="Update"/> calls.</remarks>
+    public void RemoveObstacle(long obstacleRef)
+    {
+        tileCache.RemoveObstacle(obstacleRef);
+    }
+
+    /// <summary>
+    /// Processes pending obstacle requests, rebuilding at most one affected
+    /// tile per call.
+    /// </summary>
+    /// <returns>
+    /// True when the tile cache is up to date (no pending requests or dirty
+    /// tiles remain); false when more calls are needed.
+    /// </returns>
+    public bool Update()
+    {
+        return tileCache.Update();
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshTileSet.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshTileSet.cs
@@ -1,0 +1,198 @@
+using System.Numerics;
+using DotRecast.Core.Numerics;
+using DotRecast.Detour;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// A complete set of pre-built navigation mesh tiles plus the grid parameters
+/// needed to stream them into a runtime navigation mesh.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A tile set is produced by <see cref="DotRecastMeshBuilder.BuildTileSet"/> and
+/// consumed by <see cref="NavMeshStreamingManager"/>, which installs and removes
+/// individual tiles around registered anchors at runtime.
+/// </para>
+/// <para>
+/// The set can be serialized as a whole with <see cref="Serialize"/>, and each
+/// <see cref="NavMeshTile"/> can also be persisted individually via
+/// <see cref="NavMeshTile.Serialize"/> for worlds that store tiles as separate
+/// assets. Tile sets restored with <see cref="Deserialize"/> keep tiles in their
+/// serialized form and decode them lazily as they are streamed in.
+/// </para>
+/// </remarks>
+public sealed class NavMeshTileSet
+{
+    private const int Magic = 0x4B455453; // "KETS" - KeenEyes Tile Set
+    private const int FormatVersion = 1;
+
+    internal NavMeshTileSet(
+        Vector3 origin,
+        float tileWorldSize,
+        int maxTiles,
+        int maxPolysPerTile,
+        int maxVertsPerPoly,
+        AgentSettings builtForAgent,
+        IReadOnlyList<NavMeshTile> tiles)
+    {
+        Origin = origin;
+        TileWorldSize = tileWorldSize;
+        MaxTiles = maxTiles;
+        MaxPolysPerTile = maxPolysPerTile;
+        MaxVertsPerPoly = maxVertsPerPoly;
+        BuiltForAgent = builtForAgent;
+        Tiles = tiles;
+    }
+
+    /// <summary>
+    /// Gets the world-space origin of the tile grid (minimum corner).
+    /// </summary>
+    public Vector3 Origin { get; }
+
+    /// <summary>
+    /// Gets the side length of a tile in world units.
+    /// </summary>
+    public float TileWorldSize { get; }
+
+    /// <summary>
+    /// Gets the maximum number of tiles the runtime navigation mesh can hold.
+    /// </summary>
+    public int MaxTiles { get; }
+
+    /// <summary>
+    /// Gets the maximum number of polygons per tile.
+    /// </summary>
+    public int MaxPolysPerTile { get; }
+
+    /// <summary>
+    /// Gets the maximum vertices per polygon the tiles were built with.
+    /// </summary>
+    public int MaxVertsPerPoly { get; }
+
+    /// <summary>
+    /// Gets the agent settings the tiles were built for.
+    /// </summary>
+    public AgentSettings BuiltForAgent { get; }
+
+    /// <summary>
+    /// Gets the tiles in this set. Only tiles containing walkable geometry are
+    /// present; empty grid cells are omitted.
+    /// </summary>
+    public IReadOnlyList<NavMeshTile> Tiles { get; }
+
+    /// <summary>
+    /// Creates an empty runtime navigation mesh sized for this tile set, ready
+    /// for tiles to be streamed in.
+    /// </summary>
+    internal NavMeshData CreateEmptyMesh()
+    {
+        var navMeshParams = new DtNavMeshParams
+        {
+            orig = new RcVec3f(Origin.X, Origin.Y, Origin.Z),
+            tileWidth = TileWorldSize,
+            tileHeight = TileWorldSize,
+            maxTiles = MaxTiles,
+            maxPolys = MaxPolysPerTile
+        };
+
+        var navMesh = new DtNavMesh();
+        navMesh.Init(navMeshParams, MaxVertsPerPoly);
+        return new NavMeshData(navMesh, BuiltForAgent);
+    }
+
+    /// <summary>
+    /// Serializes the tile set (grid parameters and all tiles) to a byte array.
+    /// </summary>
+    /// <returns>The serialized tile set, readable by <see cref="Deserialize"/>.</returns>
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(Magic);
+        writer.Write(FormatVersion);
+
+        writer.Write(Origin.X);
+        writer.Write(Origin.Y);
+        writer.Write(Origin.Z);
+        writer.Write(TileWorldSize);
+        writer.Write(MaxTiles);
+        writer.Write(MaxPolysPerTile);
+        writer.Write(MaxVertsPerPoly);
+
+        writer.Write(BuiltForAgent.Radius);
+        writer.Write(BuiltForAgent.Height);
+        writer.Write(BuiltForAgent.MaxSlopeAngle);
+        writer.Write(BuiltForAgent.StepHeight);
+
+        writer.Write(Tiles.Count);
+        foreach (var tile in Tiles)
+        {
+            byte[] tileBytes = tile.Serialize();
+            writer.Write(tileBytes.Length);
+            writer.Write(tileBytes);
+        }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Deserializes a tile set previously produced by <see cref="Serialize"/>.
+    /// </summary>
+    /// <param name="data">The serialized tile set bytes.</param>
+    /// <returns>
+    /// The tile set. Individual tiles decode their mesh data lazily when first
+    /// streamed in.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when data is null.</exception>
+    /// <exception cref="InvalidDataException">Thrown when data is invalid or an unsupported version.</exception>
+    public static NavMeshTileSet Deserialize(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        int magic = reader.ReadInt32();
+        if (magic != Magic)
+        {
+            throw new InvalidDataException("Invalid NavMeshTileSet data: wrong magic number");
+        }
+
+        int version = reader.ReadInt32();
+        if (version != FormatVersion)
+        {
+            throw new InvalidDataException($"Unsupported NavMeshTileSet version: {version}");
+        }
+
+        var origin = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+        float tileWorldSize = reader.ReadSingle();
+        int maxTiles = reader.ReadInt32();
+        int maxPolysPerTile = reader.ReadInt32();
+        int maxVertsPerPoly = reader.ReadInt32();
+
+        var agent = new AgentSettings(
+            reader.ReadSingle(),
+            reader.ReadSingle(),
+            reader.ReadSingle(),
+            reader.ReadSingle());
+
+        int tileCount = reader.ReadInt32();
+        var tiles = new List<NavMeshTile>(tileCount);
+        for (int i = 0; i < tileCount; i++)
+        {
+            int tileLength = reader.ReadInt32();
+            byte[] tileBytes = reader.ReadBytes(tileLength);
+            if (tileBytes.Length != tileLength)
+            {
+                throw new InvalidDataException("Invalid NavMeshTileSet data: truncated tile");
+            }
+
+            tiles.Add(NavMeshTile.Deserialize(tileBytes));
+        }
+
+        return new NavMeshTileSet(origin, tileWorldSize, maxTiles, maxPolysPerTile, maxVertsPerPoly, agent, tiles);
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/packages.lock.json
+++ b/src/KeenEyes.Navigation.DotRecast/packages.lock.json
@@ -20,6 +20,16 @@
           "DotRecast.Detour": "2026.1.3"
         }
       },
+      "DotRecast.Detour.TileCache": {
+        "type": "Direct",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
+        }
+      },
       "DotRecast.Recast": {
         "type": "Direct",
         "requested": "[2026.1.3, )",

--- a/src/KeenEyes.Navigation/Events/OffMeshLinkEvents.cs
+++ b/src/KeenEyes.Navigation/Events/OffMeshLinkEvents.cs
@@ -1,0 +1,48 @@
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.Events;
+
+/// <summary>
+/// Event sent through the world messaging system when an agent begins
+/// traversing an off-mesh link.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subscribe to this event to trigger traversal animations (jump, climb,
+/// teleport) or gameplay logic when an agent leaves the walkable surface.
+/// The matching <see cref="OffMeshLinkTraversalCompleted"/> event is sent
+/// when the agent reaches the far endpoint.
+/// </para>
+/// <example>
+/// <code>
+/// var subscription = world.Subscribe&lt;OffMeshLinkTraversalStarted&gt;(evt =>
+/// {
+///     PlayJumpAnimation(evt.Entity);
+/// });
+/// </code>
+/// </example>
+/// </remarks>
+/// <param name="Entity">The agent entity traversing the link.</param>
+/// <param name="Start">The world-space position where the traversal begins.</param>
+/// <param name="End">The world-space position where the traversal ends.</param>
+/// <param name="AreaType">The navigation area type of the link.</param>
+public readonly record struct OffMeshLinkTraversalStarted(
+    Entity Entity,
+    Vector3 Start,
+    Vector3 End,
+    NavAreaType AreaType);
+
+/// <summary>
+/// Event sent through the world messaging system when an agent finishes
+/// traversing an off-mesh link and resumes normal path following.
+/// </summary>
+/// <param name="Entity">The agent entity that traversed the link.</param>
+/// <param name="Start">The world-space position where the traversal began.</param>
+/// <param name="End">The world-space position where the traversal ended.</param>
+/// <param name="AreaType">The navigation area type of the link.</param>
+public readonly record struct OffMeshLinkTraversalCompleted(
+    Entity Entity,
+    Vector3 Start,
+    Vector3 End,
+    NavAreaType AreaType);

--- a/src/KeenEyes.Navigation/NavigationContext.cs
+++ b/src/KeenEyes.Navigation/NavigationContext.cs
@@ -513,4 +513,40 @@ public struct AgentNavigationState
     /// The distance traveled along the path so far.
     /// </summary>
     public float DistanceTraveled;
+
+    /// <summary>
+    /// Whether the agent is currently traversing an off-mesh link.
+    /// </summary>
+    /// <remarks>
+    /// While true, the agent moves by linear interpolation from
+    /// <see cref="OffMeshLinkStart"/> to <see cref="OffMeshLinkEnd"/> instead
+    /// of normal waypoint steering.
+    /// </remarks>
+    public bool IsTraversingOffMeshLink;
+
+    /// <summary>
+    /// The world-space position where the current off-mesh traversal began.
+    /// </summary>
+    public Vector3 OffMeshLinkStart;
+
+    /// <summary>
+    /// The world-space position where the current off-mesh traversal ends.
+    /// </summary>
+    public Vector3 OffMeshLinkEnd;
+
+    /// <summary>
+    /// The area type of the off-mesh link being traversed.
+    /// </summary>
+    public NavAreaType OffMeshLinkAreaType;
+
+    /// <summary>
+    /// Normalized progress (0 to 1) along the current off-mesh traversal.
+    /// </summary>
+    public float OffMeshLinkProgress;
+
+    /// <summary>
+    /// The cost modifier of the link being traversed. Traversal speed is the
+    /// agent's speed divided by this value.
+    /// </summary>
+    public float OffMeshLinkCostModifier;
 }

--- a/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using KeenEyes.Common;
 using KeenEyes.Navigation.Abstractions;
 using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Events;
 
 namespace KeenEyes.Navigation.Systems;
 
@@ -95,6 +96,13 @@ internal sealed class NavMeshAgentSystem : SystemBase
     {
         var path = state.Path;
 
+        // Continue an in-progress off-mesh traversal before anything else
+        if (state.IsTraversingOffMeshLink)
+        {
+            TraverseOffMeshLink(entity, ref agent, ref transform, ref state, deltaTime);
+            return;
+        }
+
         // Check if we've reached the end of the path
         if (state.CurrentWaypointIndex >= path.Count)
         {
@@ -114,6 +122,14 @@ internal sealed class NavMeshAgentSystem : SystemBase
         float reachDistance = config!.WaypointReachDistance;
         if (distanceToWaypoint <= reachDistance)
         {
+            // Reaching an off-mesh connection entry switches the agent into
+            // link traversal instead of normal waypoint advancement.
+            if (IsOffMeshEntry(path, state.CurrentWaypointIndex))
+            {
+                BeginOffMeshTraversal(entity, ref agent, ref state);
+                return;
+            }
+
             state.CurrentWaypointIndex++;
 
             // Check if this was the last waypoint
@@ -181,6 +197,122 @@ internal sealed class NavMeshAgentSystem : SystemBase
         {
             CompleteNavigation(ref agent);
         }
+    }
+
+    private static bool IsOffMeshEntry(Abstractions.NavPath path, int waypointIndex)
+        => (path[waypointIndex].Properties & NavPointProperties.OffMeshConnection) != 0
+            && waypointIndex + 1 < path.Count;
+
+    private void BeginOffMeshTraversal(Entity entity, ref NavMeshAgent agent, ref AgentNavigationState state)
+    {
+        var entry = state.Path[state.CurrentWaypointIndex];
+        var exit = state.Path[state.CurrentWaypointIndex + 1];
+
+        state.IsTraversingOffMeshLink = true;
+        state.OffMeshLinkStart = entry.Position;
+        state.OffMeshLinkEnd = exit.Position;
+        state.OffMeshLinkAreaType = entry.AreaType;
+        state.OffMeshLinkProgress = 0f;
+        state.OffMeshLinkCostModifier = ResolveCostModifier(entry.Position, exit.Position);
+
+        agent.SteeringTarget = exit.Position;
+
+        World.Send(new OffMeshLinkTraversalStarted(entity, entry.Position, exit.Position, entry.AreaType));
+    }
+
+    private void TraverseOffMeshLink(
+        Entity entity,
+        ref NavMeshAgent agent,
+        ref Transform3D transform,
+        ref AgentNavigationState state,
+        float deltaTime)
+    {
+        var start = state.OffMeshLinkStart;
+        var end = state.OffMeshLinkEnd;
+        float length = Vector3.Distance(start, end);
+
+        // Traversal speed is the agent's speed scaled down by the link's cost
+        // modifier (a modifier of 2 makes the crossing take twice as long).
+        float costModifier = MathF.Max(state.OffMeshLinkCostModifier, 0.001f);
+        float traversalSpeed = agent.Speed / costModifier;
+
+        if (length.IsApproximatelyZero())
+        {
+            state.OffMeshLinkProgress = 1f;
+        }
+        else
+        {
+            state.OffMeshLinkProgress += traversalSpeed * deltaTime / length;
+            agent.DesiredVelocity = Vector3.Normalize(end - start) * traversalSpeed;
+        }
+
+        if (state.OffMeshLinkProgress >= 1f)
+        {
+            // Land exactly on the exit point and resume normal path following
+            // from the waypoint after the landing point.
+            var previousPosition = transform.Position;
+            transform.Position = end;
+            state.DistanceTraveled += Vector3.Distance(previousPosition, end);
+            state.IsTraversingOffMeshLink = false;
+            state.CurrentWaypointIndex += 2;
+
+            World.Send(new OffMeshLinkTraversalCompleted(entity, start, end, state.OffMeshLinkAreaType));
+
+            agent.RemainingDistance = CalculateRemainingDistance(
+                transform.Position,
+                state.Path,
+                state.CurrentWaypointIndex);
+
+            if (state.CurrentWaypointIndex >= state.Path.Count)
+            {
+                CompleteNavigation(ref agent);
+            }
+
+            return;
+        }
+
+        var newPosition = Vector3.Lerp(start, end, state.OffMeshLinkProgress);
+        state.DistanceTraveled += Vector3.Distance(transform.Position, newPosition);
+        transform.Position = newPosition;
+        agent.RemainingDistance = Vector3.Distance(newPosition, end) + CalculateRemainingDistance(
+            end,
+            state.Path,
+            state.CurrentWaypointIndex + 2);
+    }
+
+    /// <summary>
+    /// Resolves the cost modifier for a traversal by matching the traversal
+    /// endpoints against <see cref="OffMeshLink"/> components in the world.
+    /// </summary>
+    /// <remarks>
+    /// Link endpoints are snapped onto the navigation mesh during the build, so
+    /// matching uses a tolerance derived from each link's radius. Returns 1
+    /// when no matching link entity exists (e.g., the mesh was baked from
+    /// definitions that are not present in this world).
+    /// </remarks>
+    private float ResolveCostModifier(Vector3 start, Vector3 end)
+    {
+        foreach (var linkEntity in World.Query<OffMeshLink>())
+        {
+            ref readonly var link = ref World.Get<OffMeshLink>(linkEntity);
+
+            float tolerance = link.Radius + config!.WaypointReachDistance;
+            float toleranceSq = tolerance * tolerance;
+
+            bool forward =
+                Vector3.DistanceSquared(link.Start, start) <= toleranceSq &&
+                Vector3.DistanceSquared(link.End, end) <= toleranceSq;
+            bool reverse = link.Bidirectional &&
+                Vector3.DistanceSquared(link.End, start) <= toleranceSq &&
+                Vector3.DistanceSquared(link.Start, end) <= toleranceSq;
+
+            if (forward || reverse)
+            {
+                return MathF.Max(link.CostModifier, 0.001f);
+            }
+        }
+
+        return 1f;
     }
 
     private static void CompleteNavigation(ref NavMeshAgent agent)

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshStreamingSystemTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshStreamingSystemTests.cs
@@ -1,0 +1,105 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// World-level integration tests for <see cref="NavMeshStreamingSystem"/>:
+/// entities with <see cref="NavMeshStreamingAnchor"/> drive tile residency
+/// through the plugin-registered system.
+/// </summary>
+public class NavMeshStreamingSystemTests
+{
+    private const float SlabSize = 60f;
+    private const float TimeStep = 0.016f;
+
+    #region Helpers
+
+    private static NavMeshStreamingManager CreateStreamingManager()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        var tileSet = builder.BuildTileSet(vertices, indices);
+
+        return new NavMeshStreamingManager(tileSet, new NavMeshStreamingConfig
+        {
+            LoadRadius = 15f,
+            UnloadHysteresis = 5f,
+            MaxTileOperationsPerUpdate = 32
+        });
+    }
+
+    private static void PumpWorld(World world, int updates = 30)
+    {
+        for (int i = 0; i < updates; i++)
+        {
+            world.Update(TimeStep);
+        }
+    }
+
+    #endregion
+
+    [Fact]
+    public void Update_AnchorEntity_LoadsSurroundingTiles()
+    {
+        using var manager = CreateStreamingManager();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(manager, TestHelper.CreateTiledTestConfig()));
+
+        world.Spawn()
+            .With(new Transform3D(new Vector3(7f, 0f, 7f), Quaternion.Identity, Vector3.One))
+            .With(new NavMeshStreamingAnchor())
+            .Build();
+
+        PumpWorld(world);
+
+        Assert.True(manager.IsTileLoaded(0, 0), "The tile under the anchor entity should be loaded.");
+        Assert.True(manager.LoadedTileCount > 0);
+    }
+
+    [Fact]
+    public void Update_AnchorEntityMoved_ShiftsResidencyToNewPosition()
+    {
+        using var manager = CreateStreamingManager();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(manager, TestHelper.CreateTiledTestConfig()));
+
+        var anchor = world.Spawn()
+            .With(new Transform3D(new Vector3(7f, 0f, 7f), Quaternion.Identity, Vector3.One))
+            .With(new NavMeshStreamingAnchor())
+            .Build();
+
+        PumpWorld(world);
+        Assert.True(manager.IsTileLoaded(0, 0));
+
+        world.Get<Transform3D>(anchor).Position = new Vector3(55f, 0f, 55f);
+        PumpWorld(world);
+
+        Assert.False(manager.IsTileLoaded(0, 0), "Tiles left behind by the anchor entity should unload.");
+        var (tileX, tileZ) = manager.GetTileCoordinate(new Vector3(55f, 0f, 55f));
+        Assert.True(manager.IsTileLoaded(tileX, tileZ), "Tiles around the anchor's new position should load.");
+    }
+
+    [Fact]
+    public void Update_AnchorEntityDespawned_UnloadsAllTiles()
+    {
+        using var manager = CreateStreamingManager();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(manager, TestHelper.CreateTiledTestConfig()));
+
+        var anchor = world.Spawn()
+            .With(new Transform3D(new Vector3(7f, 0f, 7f), Quaternion.Identity, Vector3.One))
+            .With(new NavMeshStreamingAnchor())
+            .Build();
+
+        PumpWorld(world);
+        Assert.True(manager.LoadedTileCount > 0);
+
+        world.Despawn(anchor);
+        PumpWorld(world);
+
+        Assert.Equal(0, manager.LoadedTileCount);
+        Assert.Equal(0, manager.AnchorCount);
+    }
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshStreamingTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshStreamingTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for runtime navmesh tile streaming via <see cref="NavMeshStreamingManager"/>:
+/// anchor-driven residency, hysteresis, per-update operation budgets, path
+/// validity across streaming boundaries, and crowd survival across tile
+/// unloads.
+/// </summary>
+/// <remarks>
+/// The tiled test config uses 48-cell tiles at 0.3 cell size, so tiles are
+/// 14.4 world units on a side; a 60-unit slab spans a 5x5 tile grid whose
+/// tile (0, 0) covers x, z in [0, 14.4).
+/// </remarks>
+public class NavMeshStreamingTests
+{
+    private const float SlabSize = 60f;
+
+    #region Helpers
+
+    private static NavMeshTileSet BuildTestTileSet()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        return builder.BuildTileSet(vertices, indices);
+    }
+
+    private static NavMeshStreamingConfig CreateStreamingConfig(
+        float loadRadius = 15f,
+        float hysteresis = 10f,
+        int budget = 64)
+    {
+        return new NavMeshStreamingConfig
+        {
+            LoadRadius = loadRadius,
+            UnloadHysteresis = hysteresis,
+            MaxTileOperationsPerUpdate = budget
+        };
+    }
+
+    private static void PumpUntilIdle(NavMeshStreamingManager manager, int maxIterations = 2000)
+    {
+        for (int i = 0; i < maxIterations; i++)
+        {
+            int operations = manager.Update();
+            if (operations == 0 && manager.IsIdle)
+            {
+                return;
+            }
+
+            Thread.Sleep(1);
+        }
+
+        Assert.Fail("Streaming manager did not reach a steady state.");
+    }
+
+    #endregion
+
+    #region Tile Set Build Tests
+
+    [Fact]
+    public void BuildTileSet_WithTiledConfig_ProducesMultipleDistinctTiles()
+    {
+        var tileSet = BuildTestTileSet();
+
+        Assert.True(tileSet.Tiles.Count > 1, "A multi-tile slab should produce more than one tile.");
+
+        var coordinates = new HashSet<(int, int)>();
+        foreach (var tile in tileSet.Tiles)
+        {
+            Assert.True(coordinates.Add((tile.TileX, tile.TileZ)), "Tile coordinates should be unique.");
+        }
+    }
+
+    [Fact]
+    public void BuildTileSet_WithTilesDisabled_ThrowsInvalidOperationException()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTestConfig());
+
+        Assert.Throws<InvalidOperationException>(() => builder.BuildTileSet(vertices.AsSpan(), indices.AsSpan()));
+    }
+
+    #endregion
+
+    #region Residency Tests
+
+    [Fact]
+    public void Update_WithAnchor_LoadsTilesWithinRadiusOnly()
+    {
+        var tileSet = BuildTestTileSet();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig());
+
+        manager.SetAnchor(1, new Vector3(7f, 0f, 7f));
+        PumpUntilIdle(manager);
+
+        Assert.True(manager.IsTileLoaded(0, 0), "The tile containing the anchor should be loaded.");
+        Assert.False(manager.IsTileLoaded(3, 3), "A tile far beyond the load radius should not be loaded.");
+        Assert.True(manager.LoadedTileCount > 0);
+        Assert.True(manager.LoadedTileCount < tileSet.Tiles.Count, "Distant tiles should stay unloaded.");
+    }
+
+    [Fact]
+    public void Update_WithNoAnchors_LoadsNothing()
+    {
+        var tileSet = BuildTestTileSet();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig());
+
+        PumpUntilIdle(manager);
+
+        Assert.Equal(0, manager.LoadedTileCount);
+    }
+
+    [Fact]
+    public void Update_AnchorMovedFarAway_UnloadsOldTilesAndLoadsNewOnes()
+    {
+        var tileSet = BuildTestTileSet();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig(loadRadius: 10f, hysteresis: 5f));
+
+        manager.SetAnchor(1, new Vector3(7f, 0f, 7f));
+        PumpUntilIdle(manager);
+        Assert.True(manager.IsTileLoaded(0, 0));
+
+        manager.SetAnchor(1, new Vector3(55f, 0f, 55f));
+        PumpUntilIdle(manager);
+
+        Assert.False(manager.IsTileLoaded(0, 0), "Tiles far behind the anchor should unload.");
+        var (anchorTileX, anchorTileZ) = manager.GetTileCoordinate(new Vector3(55f, 0f, 55f));
+        Assert.True(manager.IsTileLoaded(anchorTileX, anchorTileZ), "Tiles around the new anchor position should load.");
+    }
+
+    [Fact]
+    public void Update_AnchorWithinHysteresisBand_KeepsTileLoaded()
+    {
+        var tileSet = BuildTestTileSet();
+
+        // Load radius 15, unload threshold 15 + 20 = 35. An anchor at x=32 is
+        // 17.6 units from tile (0, 0)'s edge (x <= 14.4): outside the load
+        // radius but inside the hysteresis band.
+        var config = CreateStreamingConfig(loadRadius: 15f, hysteresis: 20f);
+        var bandPosition = new Vector3(32f, 0f, 7f);
+
+        using var manager = new NavMeshStreamingManager(tileSet, config);
+        manager.SetAnchor(1, new Vector3(7f, 0f, 7f));
+        PumpUntilIdle(manager);
+        Assert.True(manager.IsTileLoaded(0, 0));
+
+        manager.SetAnchor(1, bandPosition);
+        PumpUntilIdle(manager);
+        Assert.True(manager.IsTileLoaded(0, 0), "A loaded tile inside the hysteresis band should stay loaded.");
+
+        // A fresh manager whose anchor starts in the band never loads the tile,
+        // proving the band preserves state rather than loading.
+        using var freshManager = new NavMeshStreamingManager(tileSet, config);
+        freshManager.SetAnchor(1, bandPosition);
+        PumpUntilIdle(freshManager);
+        Assert.False(freshManager.IsTileLoaded(0, 0), "A tile inside the hysteresis band should not be newly loaded.");
+    }
+
+    [Fact]
+    public void Update_WithBudgetOfOne_AppliesAtMostOneOperationPerUpdate()
+    {
+        var tileSet = BuildTestTileSet();
+        using var manager = new NavMeshStreamingManager(
+            tileSet,
+            CreateStreamingConfig(loadRadius: 1f, hysteresis: 1f, budget: 1));
+
+        // An anchor on the shared corner of four tiles requires four loads.
+        manager.SetAnchor(1, new Vector3(14.4f, 0f, 14.4f));
+
+        int firstUpdateOperations = manager.Update();
+        Assert.Equal(1, firstUpdateOperations);
+        Assert.Equal(1, manager.LoadedTileCount);
+
+        PumpUntilIdle(manager);
+        Assert.Equal(4, manager.LoadedTileCount);
+    }
+
+    [Fact]
+    public void SetAnchor_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var tileSet = BuildTestTileSet();
+        var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig());
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.SetAnchor(1, Vector3.Zero));
+    }
+
+    #endregion
+
+    #region Pathfinding Across Streaming Boundaries
+
+    [Fact]
+    public void FindPath_AcrossTileBoundary_WithBothTilesStreamedIn_IsValid()
+    {
+        var tileSet = BuildTestTileSet();
+        var navConfig = TestHelper.CreateTiledTestConfig();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig(loadRadius: 25f));
+        using var provider = new DotRecastProvider(navConfig);
+        provider.SetNavMesh(manager.Mesh);
+
+        var start = new Vector3(7f, 0f, 7f);    // tile (0, 0)
+        var end = new Vector3(25f, 0f, 25f);    // tile (1, 1)
+
+        manager.SetAnchor(1, start);
+        PumpUntilIdle(manager);
+
+        var path = provider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(path.IsValid, "Path across a streamed-in tile boundary should be valid.");
+        Assert.True(path.IsComplete, "Path across a streamed-in tile boundary should reach the destination.");
+    }
+
+    [Fact]
+    public void FindPath_IntoUnloadedRegion_FailsGracefullyThenSucceedsAfterLoad()
+    {
+        var tileSet = BuildTestTileSet();
+        var navConfig = TestHelper.CreateTiledTestConfig();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig(loadRadius: 10f));
+        using var provider = new DotRecastProvider(navConfig);
+        provider.SetNavMesh(manager.Mesh);
+
+        var start = new Vector3(7f, 0f, 7f);
+        var end = new Vector3(50f, 0f, 50f);    // tile (3, 3), far outside the anchor radius
+
+        manager.SetAnchor(1, start);
+        PumpUntilIdle(manager);
+
+        var blockedPath = provider.FindPath(start, end, AgentSettings.Default);
+        Assert.False(blockedPath.IsValid, "Pathing into an unloaded region should fail without throwing.");
+
+        // Stream in the destination region (and the corridor between).
+        manager.SetAnchor(2, end);
+        manager.SetAnchor(3, new Vector3(28f, 0f, 28f));
+        PumpUntilIdle(manager);
+
+        var openPath = provider.FindPath(start, end, AgentSettings.Default);
+        Assert.True(openPath.IsValid, "Path should succeed once the destination region is streamed in.");
+        Assert.True(openPath.IsComplete);
+    }
+
+    #endregion
+
+    #region Crowd Interaction Tests
+
+    [Fact]
+    public void UpdateCrowd_TileUnloadedUnderAgent_DoesNotThrowAndKeepsAgentRegistered()
+    {
+        var tileSet = BuildTestTileSet();
+        var navConfig = TestHelper.CreateTiledTestConfig();
+        using var manager = new NavMeshStreamingManager(tileSet, CreateStreamingConfig(loadRadius: 40f, hysteresis: 5f));
+        using var provider = new DotRecastProvider(navConfig);
+        provider.SetNavMesh(manager.Mesh);
+
+        var agentPosition = new Vector3(10f, 0f, 10f);
+        manager.SetAnchor(1, agentPosition);
+        PumpUntilIdle(manager);
+
+        var entity = new Entity(1, 1);
+        var agent = NavMeshAgent.Create();
+        var crowdAgent = CrowdAgent.Create();
+        Assert.True(provider.TryAddCrowdAgent(entity, agentPosition, in agent, in crowdAgent));
+        Assert.True(provider.RequestCrowdMoveTarget(entity, new Vector3(30f, 0f, 30f)));
+
+        for (int i = 0; i < 10; i++)
+        {
+            provider.UpdateCrowd(0.05f);
+        }
+
+        // Unload every tile, including the one under the agent. Because tiles
+        // are removed from the mesh in place (the mesh object is not swapped),
+        // the crowd must survive without being recreated.
+        manager.RemoveAnchor(1);
+        PumpUntilIdle(manager);
+        Assert.Equal(0, manager.LoadedTileCount);
+
+        for (int i = 0; i < 10; i++)
+        {
+            provider.UpdateCrowd(0.05f);
+        }
+
+        Assert.True(
+            provider.TryGetCrowdAgentState(entity, out _),
+            "The agent should remain registered after the ground under it unloads.");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshTileCacheTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshTileCacheTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Numerics;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for the tile-cache build mode: obstacle-driven partial rebuilds where
+/// adding an obstacle carves the walkable surface and removing it restores the
+/// surface, one tile rebuild per update.
+/// </summary>
+public class NavMeshTileCacheTests
+{
+    private const float SlabSize = 60f;
+
+    #region Helpers
+
+    private static NavMeshTileCache BuildTestTileCache()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        return builder.BuildTileCache(vertices, indices);
+    }
+
+    private static void PumpUntilUpToDate(NavMeshTileCache cache, int maxIterations = 500)
+    {
+        for (int i = 0; i < maxIterations; i++)
+        {
+            if (cache.Update())
+            {
+                return;
+            }
+        }
+
+        Assert.Fail("Tile cache did not finish processing obstacle requests.");
+    }
+
+    #endregion
+
+    #region Build Tests
+
+    [Fact]
+    public void BuildTileCache_WithTiledConfig_ProducesPathableMesh()
+    {
+        var cache = BuildTestTileCache();
+
+        using var provider = new DotRecastProvider(TestHelper.CreateTiledTestConfig());
+        provider.SetNavMesh(cache.Mesh);
+
+        var path = provider.FindPath(new Vector3(5f, 0f, 5f), new Vector3(55f, 0f, 55f), AgentSettings.Default);
+
+        Assert.True(path.IsValid, "A freshly built tile cache mesh should support pathfinding.");
+        Assert.True(path.IsComplete);
+    }
+
+    [Fact]
+    public void BuildTileCache_WithTilesDisabled_ThrowsInvalidOperationException()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTestConfig());
+
+        Assert.Throws<InvalidOperationException>(() => builder.BuildTileCache(vertices.AsSpan(), indices.AsSpan()));
+    }
+
+    #endregion
+
+    #region Obstacle Carving Tests
+
+    [Fact]
+    public void AddCylinderObstacle_AfterUpdate_CarvesWalkableSurface()
+    {
+        var cache = BuildTestTileCache();
+        var obstacleCenter = new Vector3(30f, 0f, 30f);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(obstacleCenter), "The surface should be walkable before carving.");
+
+        cache.AddCylinderObstacle(new Vector3(30f, -0.5f, 30f), radius: 3f, height: 2f);
+        PumpUntilUpToDate(cache);
+
+        Assert.False(cache.Mesh.IsOnNavMesh(obstacleCenter), "The carved region should no longer be walkable.");
+    }
+
+    [Fact]
+    public void RemoveObstacle_AfterUpdate_RestoresWalkableSurface()
+    {
+        var cache = BuildTestTileCache();
+        var obstacleCenter = new Vector3(30f, 0f, 30f);
+
+        long obstacleRef = cache.AddCylinderObstacle(new Vector3(30f, -0.5f, 30f), radius: 3f, height: 2f);
+        PumpUntilUpToDate(cache);
+        Assert.False(cache.Mesh.IsOnNavMesh(obstacleCenter));
+
+        cache.RemoveObstacle(obstacleRef);
+        PumpUntilUpToDate(cache);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(obstacleCenter), "Removing the obstacle should restore the surface.");
+    }
+
+    [Fact]
+    public void AddBoxObstacle_PathThroughObstacle_DetoursAndStaysValid()
+    {
+        var cache = BuildTestTileCache();
+        using var provider = new DotRecastProvider(TestHelper.CreateTiledTestConfig());
+        provider.SetNavMesh(cache.Mesh);
+
+        var start = new Vector3(20f, 0f, 30f);
+        var end = new Vector3(40f, 0f, 30f);
+
+        cache.AddBoxObstacle(new Vector3(30f, 0.5f, 30f), new Vector3(3f, 2f, 3f));
+        PumpUntilUpToDate(cache);
+
+        var path = provider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(path.IsValid, "The path should route around the carved obstacle.");
+        Assert.True(path.IsComplete);
+        Assert.False(cache.Mesh.IsOnNavMesh(new Vector3(30f, 0f, 30f)), "The box interior should be carved.");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshTileTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshTileTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Threading;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for per-tile and tile-set persistence: individual tile round-trips,
+/// whole-set round-trips, lazy materialization of deserialized tiles, and
+/// rejection of invalid data.
+/// </summary>
+public class NavMeshTileTests
+{
+    private const float SlabSize = 60f;
+
+    #region Helpers
+
+    private static NavMeshTileSet BuildTestTileSet()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        return builder.BuildTileSet(vertices, indices);
+    }
+
+    #endregion
+
+    #region NavMeshTile Round-Trip Tests
+
+    [Fact]
+    public void Serialize_RoundTrip_PreservesCoordinatesAndPolygons()
+    {
+        var tileSet = BuildTestTileSet();
+        var original = tileSet.Tiles[0];
+
+        byte[] bytes = original.Serialize();
+        var restored = NavMeshTile.Deserialize(bytes);
+
+        Assert.Equal(original.TileX, restored.TileX);
+        Assert.Equal(original.TileZ, restored.TileZ);
+        Assert.Equal(original.Layer, restored.Layer);
+        Assert.Equal(original.GetMeshData().header.polyCount, restored.GetMeshData().header.polyCount);
+        Assert.Equal(original.GetMeshData().header.vertCount, restored.GetMeshData().header.vertCount);
+    }
+
+    [Fact]
+    public void Serialize_OfUnmaterializedDeserializedTile_IsByteIdentical()
+    {
+        var tileSet = BuildTestTileSet();
+        byte[] bytes = tileSet.Tiles[0].Serialize();
+
+        var restored = NavMeshTile.Deserialize(bytes);
+        Assert.False(restored.IsMaterialized, "Deserialized tiles should decode lazily.");
+
+        byte[] reserialized = restored.Serialize();
+        Assert.True(bytes.SequenceEqual(reserialized), "Re-serializing an untouched tile should be lossless.");
+        Assert.False(restored.IsMaterialized, "Re-serializing should not force materialization.");
+    }
+
+    [Fact]
+    public void Deserialize_WithWrongMagic_ThrowsInvalidDataException()
+    {
+        byte[] bogus = new byte[64];
+        Assert.Throws<InvalidDataException>(() => NavMeshTile.Deserialize(bogus));
+    }
+
+    [Fact]
+    public void Deserialize_WithNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => NavMeshTile.Deserialize(null!));
+    }
+
+    #endregion
+
+    #region NavMeshTileSet Round-Trip Tests
+
+    [Fact]
+    public void TileSetSerialize_RoundTrip_PreservesGridParametersAndTiles()
+    {
+        var tileSet = BuildTestTileSet();
+
+        byte[] bytes = tileSet.Serialize();
+        var restored = NavMeshTileSet.Deserialize(bytes);
+
+        Assert.Equal(tileSet.Origin, restored.Origin);
+        Assert.Equal(tileSet.TileWorldSize, restored.TileWorldSize, 3);
+        Assert.Equal(tileSet.MaxTiles, restored.MaxTiles);
+        Assert.Equal(tileSet.MaxPolysPerTile, restored.MaxPolysPerTile);
+        Assert.Equal(tileSet.MaxVertsPerPoly, restored.MaxVertsPerPoly);
+        Assert.Equal(tileSet.BuiltForAgent.Radius, restored.BuiltForAgent.Radius, 3);
+        Assert.Equal(tileSet.Tiles.Count, restored.Tiles.Count);
+    }
+
+    [Fact]
+    public void TileSetDeserialize_StreamedWithLazyTiles_SupportsPathfinding()
+    {
+        var tileSet = BuildTestTileSet();
+        var restored = NavMeshTileSet.Deserialize(tileSet.Serialize());
+
+        Assert.All(restored.Tiles, tile => Assert.False(tile.IsMaterialized));
+
+        // Stream the restored set; tiles decode on background tasks as they load.
+        using var manager = new NavMeshStreamingManager(restored, new NavMeshStreamingConfig
+        {
+            LoadRadius = 30f,
+            UnloadHysteresis = 10f,
+            MaxTileOperationsPerUpdate = 8
+        });
+
+        manager.SetAnchor(1, new Vector3(15f, 0f, 15f));
+
+        for (int i = 0; i < 2000; i++)
+        {
+            int operations = manager.Update();
+            if (operations == 0 && manager.IsIdle)
+            {
+                break;
+            }
+
+            Thread.Sleep(1);
+        }
+
+        Assert.True(manager.LoadedTileCount > 1, "Lazily decoded tiles should stream in.");
+
+        using var provider = new DotRecastProvider(TestHelper.CreateTiledTestConfig());
+        provider.SetNavMesh(manager.Mesh);
+
+        var path = provider.FindPath(new Vector3(7f, 0f, 7f), new Vector3(25f, 0f, 25f), AgentSettings.Default);
+        Assert.True(path.IsValid, "Paths should work on a mesh streamed from a deserialized tile set.");
+    }
+
+    [Fact]
+    public void TileSetDeserialize_WithWrongMagic_ThrowsInvalidDataException()
+    {
+        byte[] bogus = new byte[64];
+        Assert.Throws<InvalidDataException>(() => NavMeshTileSet.Deserialize(bogus));
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/OffMeshLinkTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/OffMeshLinkTests.cs
@@ -1,0 +1,348 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Events;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// Tests for off-mesh link building, pathfinding, serialization, and agent
+/// traversal. The core fixture is two walkable slabs separated by a gap that
+/// only an off-mesh connection can bridge.
+/// </summary>
+public class OffMeshLinkTests
+{
+    private const float TimeStep = 0.05f;
+
+    // Two 10x10 slabs with a 4-unit gap between them along X.
+    private static readonly Vector3 linkStart = new(5f, 0f, 5f);
+    private static readonly Vector3 linkEnd = new(19f, 0f, 5f);
+    private static readonly Vector3 pathStart = new(2f, 0f, 5f);
+    private static readonly Vector3 pathEnd = new(22f, 0f, 5f);
+
+    #region Helpers
+
+    /// <summary>
+    /// Builds combined box geometry (8 vertices, 12 triangles per box) so that
+    /// multiple slabs can be voxelized in a single mesh build.
+    /// </summary>
+    private static (float[] Vertices, int[] Indices) BuildBoxesGeometry(params (Vector3 Min, Vector3 Max)[] boxes)
+    {
+        var vertices = new List<float>();
+        var indices = new List<int>();
+
+        foreach (var (min, max) in boxes)
+        {
+            int baseIndex = vertices.Count / 3;
+
+            vertices.AddRange(
+            [
+                // Bottom face
+                min.X, min.Y, min.Z,
+                max.X, min.Y, min.Z,
+                max.X, min.Y, max.Z,
+                min.X, min.Y, max.Z,
+
+                // Top face (walkable surface)
+                min.X, max.Y, min.Z,
+                max.X, max.Y, min.Z,
+                max.X, max.Y, max.Z,
+                min.X, max.Y, max.Z
+            ]);
+
+            int[] boxIndices =
+            [
+                // Bottom (normal down)
+                0, 2, 1,
+                0, 3, 2,
+
+                // Top (normal up - walkable)
+                4, 6, 5,
+                4, 7, 6,
+
+                // Sides
+                0, 1, 5,
+                0, 5, 4,
+                2, 3, 7,
+                2, 7, 6,
+                0, 4, 7,
+                0, 7, 3,
+                1, 2, 6,
+                1, 6, 5
+            ];
+
+            foreach (int index in boxIndices)
+            {
+                indices.Add(baseIndex + index);
+            }
+        }
+
+        return (vertices.ToArray(), indices.ToArray());
+    }
+
+    private static (float[] Vertices, int[] Indices) TwoSlabGeometry()
+        => BuildBoxesGeometry(
+            (new Vector3(0f, -1f, 0f), new Vector3(10f, 0f, 10f)),
+            (new Vector3(14f, -1f, 0f), new Vector3(24f, 0f, 10f)));
+
+    private static NavMeshData BuildTwoSlabMesh(IReadOnlyList<OffMeshLinkDefinition>? links, bool tiled = false)
+    {
+        var config = tiled ? TestHelper.CreateTiledTestConfig() : TestHelper.CreateTestConfig();
+        var builder = new DotRecastMeshBuilder(config);
+        var (vertices, indices) = TwoSlabGeometry();
+        return builder.Build(vertices, indices, offMeshLinks: links);
+    }
+
+    private static OffMeshLinkDefinition TwoSlabLink(bool bidirectional = true)
+        => new(linkStart, linkEnd, 1f, bidirectional, NavAreaType.OffMeshLink);
+
+    private static bool ContainsOffMeshPoint(NavPath path)
+        => path.Any(p => (p.Properties & NavPointProperties.OffMeshConnection) != 0);
+
+    #endregion
+
+    #region Component Tests
+
+    [Fact]
+    public void Create_WithEndpoints_ReturnsBidirectionalDefaults()
+    {
+        var link = OffMeshLink.Create(linkStart, linkEnd);
+
+        Assert.Equal(linkStart, link.Start);
+        Assert.Equal(linkEnd, link.End);
+        Assert.True(link.Bidirectional);
+        Assert.Equal(NavAreaType.OffMeshLink, link.AreaType);
+        Assert.True(link.Radius > 0f);
+        Assert.True(link.CostModifier.ApproximatelyEquals(1f));
+    }
+
+    #endregion
+
+    #region Build Tests
+
+    [Fact]
+    public void Build_WithOffMeshLink_PathCrossesDisconnectedSlabs()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink()]);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        var path = provider.FindPath(pathStart, pathEnd, mesh.BuiltForAgent);
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.True(ContainsOffMeshPoint(path));
+    }
+
+    [Fact]
+    public void Build_WithoutOffMeshLink_PathDoesNotReachAcrossGap()
+    {
+        var mesh = BuildTwoSlabMesh(null);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        var path = provider.FindPath(pathStart, pathEnd, mesh.BuiltForAgent);
+
+        // Without the link the best result is a partial path that stays on the
+        // first slab and never reaches the destination.
+        Assert.False(path.IsComplete);
+        if (path.IsValid)
+        {
+            Assert.True(path.End.Position.X < 12f);
+        }
+    }
+
+    [Fact]
+    public void Build_WithOneWayLink_ReversePathDoesNotCrossGap()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink(bidirectional: false)]);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        var forward = provider.FindPath(pathStart, pathEnd, mesh.BuiltForAgent);
+        var reverse = provider.FindPath(pathEnd, pathStart, mesh.BuiltForAgent);
+
+        Assert.True(forward.IsComplete);
+        Assert.True(ContainsOffMeshPoint(forward));
+
+        Assert.False(reverse.IsComplete);
+        if (reverse.IsValid)
+        {
+            Assert.True(reverse.End.Position.X > 12f);
+        }
+    }
+
+    [Fact]
+    public void Build_TiledWithOffMeshLink_PathCrossesDisconnectedSlabs()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink()], tiled: true);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTiledTestConfig());
+
+        var path = provider.FindPath(pathStart, pathEnd, mesh.BuiltForAgent);
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.True(ContainsOffMeshPoint(path));
+    }
+
+    #endregion
+
+    #region Serialization Tests
+
+    [Fact]
+    public void Serialize_WithOffMeshLink_RoundTripPreservesConnection()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink()]);
+
+        var data = mesh.Serialize();
+        var restored = NavMeshData.Deserialize(data);
+        using var provider = new DotRecastProvider(restored, TestHelper.CreateTestConfig());
+
+        var path = provider.FindPath(pathStart, pathEnd, restored.BuiltForAgent);
+
+        Assert.True(path.IsValid);
+        Assert.True(path.IsComplete);
+        Assert.True(ContainsOffMeshPoint(path));
+    }
+
+    #endregion
+
+    #region Area Cost Tests
+
+    /// <summary>
+    /// Builds a U-shaped walkable surface whose arms are also joined by an
+    /// off-mesh link, so a walkable alternative to the link always exists.
+    /// </summary>
+    private static NavMeshData BuildUShapeMesh(out OffMeshLinkDefinition link)
+    {
+        link = new OffMeshLinkDefinition(
+            new Vector3(5f, 0f, 35f),
+            new Vector3(25f, 0f, 35f),
+            1f,
+            Bidirectional: true,
+            NavAreaType.OffMeshLink);
+
+        var (vertices, indices) = BuildBoxesGeometry(
+            (new Vector3(0f, -1f, 0f), new Vector3(30f, 0f, 10f)),
+            (new Vector3(0f, -1f, 8f), new Vector3(10f, 0f, 40f)),
+            (new Vector3(20f, -1f, 8f), new Vector3(30f, 0f, 40f)));
+
+        var builder = TestHelper.CreateTestBuilder();
+        return builder.Build(vertices, indices, offMeshLinks: [link]);
+    }
+
+    // Query endpoints sit a little away from the link endpoints so the funnel
+    // emits the link entry as its own (flagged) corner vertex.
+    private static readonly Vector3 uShapeStart = new(5f, 0f, 38f);
+    private static readonly Vector3 uShapeEnd = new(25f, 0f, 38f);
+
+    [Fact]
+    public void FindPath_DefaultOffMeshLinkCost_UsesLinkShortcut()
+    {
+        var mesh = BuildUShapeMesh(out _);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        var path = provider.FindPath(uShapeStart, uShapeEnd, mesh.BuiltForAgent);
+
+        Assert.True(path.IsComplete);
+        Assert.True(ContainsOffMeshPoint(path));
+    }
+
+    [Fact]
+    public void FindPath_HighOffMeshLinkAreaCost_PrefersWalkableRoute()
+    {
+        var mesh = BuildUShapeMesh(out var link);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        provider.SetAreaCost(NavAreaType.OffMeshLink, 20f);
+        var path = provider.FindPath(uShapeStart, uShapeEnd, mesh.BuiltForAgent);
+
+        Assert.True(path.IsComplete);
+        Assert.False(ContainsOffMeshPoint(path));
+
+        // The walkable route goes around the U, so it is much longer than the
+        // direct link distance.
+        Assert.True(path.Length > Vector3.Distance(link.Start, link.End) * 2f);
+    }
+
+    #endregion
+
+    #region Agent Traversal Tests
+
+    [Fact]
+    public void Update_AgentPathIncludesOffMeshLink_TraversesLinkAndFiresEvents()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink()]);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        using var world = new World();
+        world.InstallPlugin(new NavigationPlugin(new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = provider
+        }));
+
+        var events = new List<string>();
+        var started = new List<OffMeshLinkTraversalStarted>();
+        var completed = new List<OffMeshLinkTraversalCompleted>();
+
+        using var startedSub = world.Subscribe<OffMeshLinkTraversalStarted>(evt =>
+        {
+            started.Add(evt);
+            events.Add("started");
+        });
+        using var completedSub = world.Subscribe<OffMeshLinkTraversalCompleted>(evt =>
+        {
+            completed.Add(evt);
+            events.Add("completed");
+        });
+
+        // A matching link entity lets the traversal resolve its cost modifier.
+        var linkComponent = OffMeshLink.Create(linkStart, linkEnd);
+        linkComponent.Radius = 1f;
+        world.Spawn().With(linkComponent).Build();
+
+        var agentComponent = NavMeshAgent.Create();
+        agentComponent.StoppingDistance = 0.5f;
+        var agent = world.Spawn()
+            .With(new Transform3D(new Vector3(3f, 0f, 5f), Quaternion.Identity, Vector3.One))
+            .With(agentComponent)
+            .Build();
+
+        var context = world.GetExtension<NavigationContext>();
+        context.SetDestination(agent, new Vector3(21f, 0f, 5f));
+
+        bool sawTraversalState = false;
+        for (int i = 0; i < 1000; i++)
+        {
+            world.Update(TimeStep);
+
+            if (context.TryGetAgentState(agent, out var state) && state.IsTraversingOffMeshLink)
+            {
+                sawTraversalState = true;
+            }
+
+            if (world.Get<NavMeshAgent>(agent).IsStopped && !world.Get<NavMeshAgent>(agent).PathPending)
+            {
+                break;
+            }
+        }
+
+        Assert.True(sawTraversalState, "Agent never entered the off-mesh traversal state");
+        Assert.Single(started);
+        Assert.Single(completed);
+        Assert.Equal(["started", "completed"], events);
+
+        Assert.Equal(agent, started[0].Entity);
+        Assert.Equal(agent, completed[0].Entity);
+        Assert.Equal(NavAreaType.OffMeshLink, started[0].AreaType);
+        Assert.True(Vector3.Distance(started[0].Start, linkStart) < 1.5f);
+        Assert.True(Vector3.Distance(started[0].End, linkEnd) < 1.5f);
+
+        // The agent must have crossed the gap onto the far slab.
+        var position = world.Get<Transform3D>(agent).Position;
+        Assert.True(position.X > 14f, $"Agent did not reach the far slab (X = {position.X})");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/packages.lock.json
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/packages.lock.json
@@ -243,6 +243,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -303,6 +304,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {


### PR DESCRIPTION
## Summary
- **`OffMeshLink` component** (world-space Start/End, Radius, Bidirectional, AreaType, CostModifier) + `OffMeshLinkDefinition` for the World-decoupled builder API; the editor's `NavMeshBakeCommand` collects components into definitions at bake time.
- **Build integration** in both single-tile and tiled paths via `DtNavMeshCreateParams.offMeshCon*` — tiled handling verified against decompiled 2026.1.3 (`ClassifyOffMeshPoint` keeps in-tile starts; `ConnectExtOffMeshLinks` bridges far endpoints). Serialization needed no changes (`DtMeshSetWriter/Reader` already round-trips connections — test-verified).
- **Agent traversal:** `DT_STRAIGHTPATH_OFFMESH_CONNECTION` surfaces as `NavPointProperties.OffMeshConnection`; `NavMeshAgentSystem` lerps start→end at `Speed / CostModifier` with state in `AgentNavigationState`, publishing `OffMeshLinkTraversalStarted/Completed` via world messaging (Navigation's first events — Physics' pattern). Planning cost = the link's `AreaType` area cost via `SetAreaCost` (steering verified: cost 20 routes around, default routes through).
- **Pre-existing builder bug fixed:** single-tile builds applied a bogus `borderSize`, shrinking/offsetting every solo navmesh by ~2.7 world units (10×10 slab → 6.6×4.5 usable). Border now applies only to tiled builds, matching upstream Recast solo behavior. All existing suites still pass.
- Crowd agents (`DtCrowd` has its own connection state machine) noted as future work — out of #1002's scope.

## Test plan
- [x] 9 new tests: disconnected slabs joined only by the link (and **no path without it**), one-way directionality, traversal events + arrival on the far slab, cost-based steering both ways, multi-tile links, serialization round-trip — 79 passed / 52 pre-existing skips
- [x] Grid (167) + Abstractions (127) suites green; Navigation.Tests unchanged (13 pre-existing, fixed separately in #1036)
- [x] Release builds zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #1002, part of #643. Remaining in the epic: #1003 streaming.