### PR TITLE
feat(replay): Add ghost trail support (config, trail points, sample rendering)

### DIFF
--- a/docs/replay.md
+++ b/docs/replay.md
@@ -249,6 +249,57 @@ ghostPlayer.SyncMode = GhostSyncMode.TimeSynced;
 ghostPlayer.Play();
 ```
 
+### Ghost trails
+
+A ghost can optionally leave a fading trail showing the path it has recently traveled — useful for visualizing racing lines and comparing trajectories. Like the rest of `GhostVisualConfig`, the trail is **data-only**: the ghost system computes trail points but never draws them, so games (or the editor) supply the rendering.
+
+Enable and shape the trail through `GhostVisualConfig`:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `ShowTrail` | `false` | Master switch. When `false`, the trail provider is never consulted, so there is zero behavior change. |
+| `TrailLength` | `60` | Maximum number of recent frames in the trail (bounds the buffer a renderer needs). |
+| `TrailFadeStart` | `0.5f` | Opacity at the oldest (tail) point; the head is fully opaque. |
+| `TrailWidth` | `0.1f` | Line/ribbon thickness in world units. |
+| `TrailStyle` | `TrailStyle.Line` | `Line`, `Ribbon`, `Dots`, or `Gradient`. |
+
+The trail points come from `GhostPlayer` (also surfaced on `GhostInstance`):
+
+```csharp
+// Zero-allocation: fills a caller-owned buffer, returns the number of points written.
+public int GetTrailPoints(Span<Vector3> destination);
+
+// Convenience: allocates a new array of up to maxPoints entries.
+public Vector3[] GetTrailPoints(int maxPoints);
+```
+
+Points are the recorded frame positions at or before the current playhead, ordered **oldest first, newest last**, so they feed a line strip directly. The provider tracks the playhead across `Update`, `UpdateByDistance`, `SeekToTime`, and `SeekToFrame`. It returns **no points while the playhead sits on the first frame** — before playback has advanced, and after `Stop` resets it — because there is no traversed path to show. The `Span<Vector3>` overload does not allocate; reuse one buffer sized to `TrailLength` across frames. The `int maxPoints` overload allocates a fresh array per call and is a convenience for non-hot paths.
+
+Drawing a trail with a 2D renderer is a short loop over the points, fading opacity from `TrailFadeStart` at the tail to full opacity at the head, using the existing `I2DRenderer.DrawLineStrip` seam:
+
+```csharp
+Span<Vector2> screen = stackalloc Vector2[config.TrailLength];
+Span<Vector3> world = stackalloc Vector3[config.TrailLength];
+
+int count = ghost.GetTrailPoints(world);
+for (int i = 0; i < count; i++)
+{
+    screen[i] = WorldToScreen(world[i]); // your camera projection
+}
+
+if (count >= 2 && config.TrailStyle != TrailStyle.Dots)
+{
+    // Fade the whole strip toward the head; per-vertex gradients would draw
+    // segment-by-segment with an interpolated alpha across [TrailFadeStart, 1].
+    var color = config.TintColor with { W = config.TrailFadeStart };
+    renderer.DrawLineStrip(screen[..count], color, config.TrailWidth);
+}
+```
+
+**`Ribbon` limitation:** a true ribbon is an oriented 3D strip that needs a 3D line renderer, which KeenEyes does not currently provide. The 2D reference renderers therefore treat `TrailStyle.Ribbon` as `TrailStyle.Line` (documented, not silent). `Dots` draws discrete markers per point; `Gradient` grades color/opacity along the path.
+
+The `samples/KeenEyes.Sample.Racing` sample enables trails on its ghosts (`GhostSetup`) and renders age-faded glyphs in the console track view (`TrackRenderer`), reading the points through the zero-allocation `GetTrailPoints(Span<Vector3>)` overload with a reusable buffer.
+
 ## Performance
 
 - Recording has effectively zero overhead when `IsRecording` is `false` — the plugin's system hooks and event subscriptions short-circuit immediately.

--- a/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/GhostSetup.cs
@@ -21,19 +21,33 @@ public static class GhostSetup
     public const string CarEntityName = "RaceCar";
 
     /// <summary>Gold, mostly transparent styling for the fastest recorded lap.</summary>
+    /// <remarks>
+    /// Enables a gradient racing-line trail so the fastest lap's path is easy to trace.
+    /// </remarks>
     public static GhostVisualConfig BestLap { get; } = new()
     {
         TintColor = new Vector4(1f, 0.84f, 0f, 1f),
         Opacity = 0.4f,
         Label = "Best Lap",
+        ShowTrail = true,
+        TrailLength = 40,
+        TrailFadeStart = 0.25f,
+        TrailStyle = TrailStyle.Gradient,
     };
 
     /// <summary>Cyan, semi-transparent styling for the immediately preceding lap.</summary>
+    /// <remarks>
+    /// Enables a shorter dotted trail to distinguish it from the best lap's line.
+    /// </remarks>
     public static GhostVisualConfig PreviousLap { get; } = new()
     {
         TintColor = new Vector4(0f, 0.7f, 1f, 1f),
         Opacity = 0.55f,
         Label = "Previous Lap",
+        ShowTrail = true,
+        TrailLength = 24,
+        TrailFadeStart = 0.4f,
+        TrailStyle = TrailStyle.Dots,
     };
 
     /// <summary>

--- a/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
@@ -39,6 +39,10 @@ public sealed class RaceManager
     private readonly Track track;
     private readonly TrackRenderer renderer;
 
+    // Reused across checkpoints so reading a ghost's trail allocates nothing per call.
+    // Sized to comfortably hold the sample's configured trail lengths.
+    private readonly Vector3[] trailBuffer = new Vector3[128];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RaceManager"/> class.
     /// </summary>
@@ -145,6 +149,7 @@ public sealed class RaceManager
         {
             new('C', "Your Car", world.Get<Transform3D>(car).Position),
         };
+        var trails = new List<TrackTrail>();
 
         foreach (var ghost in ghosts.ActiveGhosts)
         {
@@ -157,8 +162,24 @@ public sealed class RaceManager
 
             Console.WriteLine($"          vs {label,-13} {gap:+0.00;-0.00}s ({status})");
             markers.Add(new TrackMarker(symbol, label, ghost.Position));
+
+            // When the ghost opts into a trail, read its recent path from the
+            // data-only provider. GetTrailPoints writes into our reusable buffer with
+            // no per-call allocation; we then snapshot just the points it wrote.
+            if (ghost.ShowTrail)
+            {
+                var length = Math.Min(ghost.Config.TrailLength, trailBuffer.Length);
+                var count = ghost.GetTrailPoints(trailBuffer.AsSpan(0, length));
+                if (count > 0)
+                {
+                    trails.Add(new TrackTrail(
+                        trailBuffer.AsSpan(0, count).ToArray(),
+                        ghost.Config.TrailFadeStart,
+                        ghost.Config.TrailStyle));
+                }
+            }
         }
 
-        Console.WriteLine(renderer.Render(markers));
+        Console.WriteLine(renderer.Render(markers, trails));
     }
 }

--- a/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/TrackRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
+using KeenEyes.Replay.Ghost;
 
 namespace KeenEyes.Sample.Racing;
 
@@ -12,6 +13,14 @@ namespace KeenEyes.Sample.Racing;
 /// <param name="Label">A human-readable name shown in the legend.</param>
 /// <param name="Position">The marker's world-space position.</param>
 public readonly record struct TrackMarker(char Symbol, string Label, Vector3 Position);
+
+/// <summary>
+/// A fading motion trail to draw behind a ghost on the ASCII track view.
+/// </summary>
+/// <param name="Points">The trail points, ordered oldest first, newest last.</param>
+/// <param name="FadeStart">The opacity at the oldest (tail) point; the head is fully opaque.</param>
+/// <param name="Style">The requested trail style (see the per-style notes on the renderer's Render method).</param>
+public readonly record struct TrackTrail(IReadOnlyList<Vector3> Points, float FadeStart, TrailStyle Style);
 
 /// <summary>
 /// Renders a top-down ASCII view of the circular track with the car and its ghosts.
@@ -42,15 +51,34 @@ public sealed class TrackRenderer
         this.height = height;
     }
 
+    // Glyph ramp for trail age, faintest (oldest) to boldest (newest). Renderers on a
+    // real GPU would fade an alpha value instead; on a character grid we quantize the
+    // computed opacity onto these glyphs so the direction of travel reads at a glance.
+    private static readonly char[] trailGlyphs = [':', '+', '*'];
+
     /// <summary>
-    /// Builds the ASCII view for the given markers.
+    /// Builds the ASCII view for the given markers and ghost trails.
     /// </summary>
     /// <param name="markers">The markers to plot on the track.</param>
+    /// <param name="trails">
+    /// The ghost trails to draw beneath the markers. Pass an empty list for no trails.
+    /// </param>
     /// <returns>A multi-line string containing the rendered view and legend.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="markers"/> is null.</exception>
-    public string Render(IReadOnlyList<TrackMarker> markers)
+    /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
+    /// <remarks>
+    /// Trails are drawn on top of the racing line but beneath the car/ghost markers, so
+    /// a head marker always wins its cell. Each trail point is quantized to a glyph by
+    /// its age-based opacity (fading from <see cref="TrackTrail.FadeStart"/> at the tail
+    /// to fully opaque at the head). <see cref="TrailStyle.Dots"/> draws every other
+    /// point for a dashed look; <see cref="TrailStyle.Line"/>, <see cref="TrailStyle.Gradient"/>,
+    /// and <see cref="TrailStyle.Ribbon"/> draw a continuous run of glyphs. This 2D view
+    /// has no oriented 3D primitive, so <see cref="TrailStyle.Ribbon"/> falls back to the
+    /// line rendering.
+    /// </remarks>
+    public string Render(IReadOnlyList<TrackMarker> markers, IReadOnlyList<TrackTrail> trails)
     {
         ArgumentNullException.ThrowIfNull(markers);
+        ArgumentNullException.ThrowIfNull(trails);
 
         var grid = new char[height, width];
         for (var row = 0; row < height; row++)
@@ -67,6 +95,12 @@ public sealed class TrackRenderer
         {
             var distance = track.Length * i / samples;
             Plot(grid, track.PositionAt(distance), '.');
+        }
+
+        // Draw ghost trails on top of the racing line but under the markers below.
+        foreach (var trail in trails)
+        {
+            PlotTrail(grid, trail);
         }
 
         // Overlay the markers on top of the racing line, in the order given (the
@@ -126,6 +160,33 @@ public sealed class TrackRenderer
 
         grid[row, col] = symbol;
         return true;
+    }
+
+    private void PlotTrail(char[,] grid, TrackTrail trail)
+    {
+        var points = trail.Points;
+        if (points.Count == 0)
+        {
+            return;
+        }
+
+        // Dots draw a dashed trail; every other line style draws a continuous run.
+        var step = trail.Style == TrailStyle.Dots ? 2 : 1;
+
+        for (var i = 0; i < points.Count; i += step)
+        {
+            // Opacity ramps from FadeStart at the tail to 1.0 at the head. With a
+            // single point, treat it as the head (fully opaque).
+            var age = points.Count > 1 ? (float)i / (points.Count - 1) : 1f;
+            var opacity = trail.FadeStart + (1f - trail.FadeStart) * age;
+
+            var glyph = trailGlyphs[Math.Clamp(
+                (int)(opacity * trailGlyphs.Length),
+                0,
+                trailGlyphs.Length - 1)];
+
+            Plot(grid, points[i], glyph);
+        }
     }
 
     private void Plot(char[,] grid, Vector3 position, char symbol)

--- a/src/KeenEyes.Replay/Ghost/GhostManager.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostManager.cs
@@ -508,4 +508,20 @@ public readonly record struct GhostInstance(
     /// Gets the optional label for this ghost.
     /// </summary>
     public string? Label => Config.Label;
+
+    /// <summary>
+    /// Gets a value indicating whether this ghost should render a motion trail.
+    /// </summary>
+    public bool ShowTrail => Config.ShowTrail;
+
+    /// <summary>
+    /// Copies this ghost's recent trail points into the supplied buffer.
+    /// </summary>
+    /// <param name="destination">The buffer to fill, oldest point first.</param>
+    /// <returns>The number of points written.</returns>
+    /// <remarks>
+    /// This is a convenience pass-through to
+    /// <see cref="GhostPlayer.GetTrailPoints(Span{Vector3})"/> and does not allocate.
+    /// </remarks>
+    public int GetTrailPoints(Span<Vector3> destination) => Player.GetTrailPoints(destination);
 }

--- a/src/KeenEyes.Replay/Ghost/GhostPlayer.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostPlayer.cs
@@ -753,6 +753,86 @@ public sealed class GhostPlayer : IDisposable
     }
 
     /// <summary>
+    /// Copies the ghost's recent trail points into the supplied buffer.
+    /// </summary>
+    /// <param name="destination">
+    /// The buffer to fill. Points are written oldest-first, so the last written
+    /// element is the most recent position (nearest the ghost's current position).
+    /// If the buffer is smaller than the available history, only the most recent
+    /// points that fit are written.
+    /// </param>
+    /// <returns>The number of points written to <paramref name="destination"/>.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// The trail is the sequence of recorded frame positions at or before the current
+    /// playback position, ordered from oldest to newest. It tracks the playhead across
+    /// <see cref="Update"/>, <see cref="UpdateByDistance"/>, <see cref="SeekToTime"/>,
+    /// and <see cref="SeekToFrame"/>.
+    /// </para>
+    /// <para>
+    /// The trail is empty while the playhead sits on the first frame - that is, before
+    /// playback has advanced past the start and after <see cref="Stop"/> resets it -
+    /// since there is no traversed path to show.
+    /// </para>
+    /// <para>
+    /// This overload does not allocate: it writes directly into the caller's span.
+    /// Renderers should reuse a single buffer sized to
+    /// <see cref="GhostVisualConfig.TrailLength"/> across frames.
+    /// </para>
+    /// </remarks>
+    public int GetTrailPoints(Span<Vector3> destination)
+    {
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            return FillTrailPoints(destination);
+        }
+    }
+
+    /// <summary>
+    /// Gets the ghost's recent trail points as a newly allocated array.
+    /// </summary>
+    /// <param name="maxPoints">The maximum number of points to return.</param>
+    /// <returns>
+    /// An array of trail points ordered from oldest to newest, containing at most
+    /// <paramref name="maxPoints"/> entries. Returns an empty array when there is no
+    /// trail (for example, before playback starts).
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxPoints"/> is negative.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <remarks>
+    /// This convenience overload allocates a new array on each call. For per-frame
+    /// rendering, prefer <see cref="GetTrailPoints(Span{Vector3})"/> with a reusable
+    /// buffer to avoid garbage.
+    /// </remarks>
+    public Vector3[] GetTrailPoints(int maxPoints)
+    {
+        if (maxPoints < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxPoints), maxPoints,
+                "Maximum points cannot be negative.");
+        }
+
+        ThrowIfDisposed();
+
+        lock (syncRoot)
+        {
+            int available = AvailableTrailPointCount();
+            int count = Math.Min(maxPoints, available);
+            if (count == 0)
+            {
+                return [];
+            }
+
+            var result = new Vector3[count];
+            FillTrailPoints(result);
+            return result;
+        }
+    }
+
+    /// <summary>
     /// Releases all resources used by the <see cref="GhostPlayer"/>.
     /// </summary>
     public void Dispose()
@@ -772,6 +852,55 @@ public sealed class GhostPlayer : IDisposable
             Unload();
             disposed = true;
         }
+    }
+
+    // Number of recorded frames at or before the current playhead. Must be called
+    // with syncRoot held.
+    private int AvailableTrailPointCount()
+    {
+        if (ghostData is null)
+        {
+            return 0;
+        }
+
+        var frames = ghostData.Frames;
+        if (frames.Count == 0)
+        {
+            return 0;
+        }
+
+        // The trail is the path behind the playhead. When the playhead sits on the
+        // first frame there is no traversed path yet, so the trail is empty - this
+        // covers "before playback starts" (Load leaves the playhead at frame 0) and
+        // "after Stop" (Stop resets the playhead to frame 0).
+        if (currentFrameIndex <= 0)
+        {
+            return 0;
+        }
+
+        return currentFrameIndex + 1;
+    }
+
+    // Writes the most recent trail points (oldest-first) into destination and returns
+    // the count written. Must be called with syncRoot held.
+    private int FillTrailPoints(Span<Vector3> destination)
+    {
+        int available = AvailableTrailPointCount();
+        if (available == 0 || destination.Length == 0)
+        {
+            return 0;
+        }
+
+        var frames = ghostData!.Frames;
+        int count = Math.Min(destination.Length, available);
+        int start = currentFrameIndex - count + 1;
+
+        for (int i = 0; i < count; i++)
+        {
+            destination[i] = frames[start + i].Position;
+        }
+
+        return count;
     }
 
     private bool UpdateTimeSynced(float deltaTime)

--- a/src/KeenEyes.Replay/Ghost/GhostVisualConfig.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostVisualConfig.cs
@@ -139,6 +139,71 @@ public sealed record GhostVisualConfig
     public Vector4? OutlineColor { get; init; }
 
     /// <summary>
+    /// Gets or sets whether the ghost should render a motion trail.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When true, games should read the ghost's recent path from
+    /// <see cref="GhostPlayer.GetTrailPoints(System.Span{Vector3})"/> and draw a
+    /// fading trail behind the ghost. When false (the default), no trail is drawn
+    /// and the trail provider is never consulted, so there is zero behavior change.
+    /// </para>
+    /// <para>
+    /// The ghost system does not render the trail itself; these settings are hints
+    /// for the game's rendering code.
+    /// </para>
+    /// </remarks>
+    public bool ShowTrail { get; init; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of recent frames included in the trail.
+    /// </summary>
+    /// <value>
+    /// A positive frame count. Default is 60 (roughly one second at 60 fps).
+    /// </value>
+    /// <remarks>
+    /// This bounds both the visual length of the trail and the buffer a renderer
+    /// needs to request from
+    /// <see cref="GhostPlayer.GetTrailPoints(System.Span{Vector3})"/>. Longer trails
+    /// use more memory in the caller's buffer but do not affect stored ghost data.
+    /// </remarks>
+    public int TrailLength { get; init; } = 60;
+
+    /// <summary>
+    /// Gets or sets the opacity at the oldest (tail) end of the trail.
+    /// </summary>
+    /// <value>
+    /// A value between 0.0 (fully transparent tail) and 1.0 (no fade). Default is 0.5.
+    /// </value>
+    /// <remarks>
+    /// The trail fades from this opacity at the tail toward full opacity at the head
+    /// (the ghost's current position). Renderers should interpolate opacity across the
+    /// trail points using this as the starting value.
+    /// </remarks>
+    public float TrailFadeStart { get; init; } = 0.5f;
+
+    /// <summary>
+    /// Gets or sets the width of the trail, in world units.
+    /// </summary>
+    /// <value>
+    /// A positive width. Default is 0.1.
+    /// </value>
+    /// <remarks>
+    /// Renderers that draw the trail as a line or ribbon should use this as the line
+    /// thickness. Renderers that draw discrete markers may ignore it.
+    /// </remarks>
+    public float TrailWidth { get; init; } = 0.1f;
+
+    /// <summary>
+    /// Gets or sets the style used to draw the trail.
+    /// </summary>
+    /// <remarks>
+    /// Default is <see cref="TrailStyle.Line"/>. See <see cref="TrailStyle"/> for the
+    /// available styles and the <see cref="TrailStyle.Ribbon"/> fallback note.
+    /// </remarks>
+    public TrailStyle TrailStyle { get; init; } = TrailStyle.Line;
+
+    /// <summary>
     /// Creates a new <see cref="GhostVisualConfig"/> with the specified opacity.
     /// </summary>
     /// <param name="opacity">The opacity value (0.0 to 1.0).</param>

--- a/src/KeenEyes.Replay/Ghost/TrailStyle.cs
+++ b/src/KeenEyes.Replay/Ghost/TrailStyle.cs
@@ -1,0 +1,40 @@
+namespace KeenEyes.Replay.Ghost;
+
+/// <summary>
+/// Describes how a ghost's motion trail should be drawn by a renderer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ghost system is data-only: it never renders trails itself. This enum is a
+/// hint carried on <see cref="GhostVisualConfig"/> that a renderer reads to decide
+/// how to visualize the points returned by
+/// <see cref="GhostPlayer.GetTrailPoints(System.Span{System.Numerics.Vector3})"/>.
+/// </para>
+/// </remarks>
+public enum TrailStyle
+{
+    /// <summary>
+    /// A single connected line through the trail points (e.g. a polyline / line strip).
+    /// </summary>
+    Line,
+
+    /// <summary>
+    /// A 3D ribbon oriented along the ghost's facing direction.
+    /// </summary>
+    /// <remarks>
+    /// Ribbons require an oriented 3D line renderer. The 2D reference renderers that
+    /// ship with KeenEyes have no such primitive, so they fall back to
+    /// <see cref="Line"/> when this style is requested.
+    /// </remarks>
+    Ribbon,
+
+    /// <summary>
+    /// Discrete position markers at each trail point rather than a connected line.
+    /// </summary>
+    Dots,
+
+    /// <summary>
+    /// A connected line whose color/opacity is graded along the path from tail to head.
+    /// </summary>
+    Gradient
+}

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
@@ -1,0 +1,298 @@
+using System.Numerics;
+using KeenEyes.Replay.Ghost;
+
+namespace KeenEyes.Replay.Tests.Ghost;
+
+/// <summary>
+/// Unit tests for ghost trail support: <see cref="GhostVisualConfig"/> trail fields
+/// and the trail-point provider on <see cref="GhostPlayer"/> / <see cref="GhostInstance"/>.
+/// </summary>
+public class GhostTrailTests
+{
+    // Five frames one unit apart along +X, one second apart.
+    private static GhostData CreateTestGhostData()
+    {
+        return new GhostData
+        {
+            Name = "Trail Ghost",
+            EntityName = "Player",
+            RecordingStarted = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(4),
+            FrameCount = 5,
+            Frames =
+            [
+                new GhostFrame(new Vector3(0, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(0)) { Distance = 0f },
+                new GhostFrame(new Vector3(1, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(1)) { Distance = 1f },
+                new GhostFrame(new Vector3(2, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(2)) { Distance = 2f },
+                new GhostFrame(new Vector3(3, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(3)) { Distance = 3f },
+                new GhostFrame(new Vector3(4, 0, 0), Quaternion.Identity, TimeSpan.FromSeconds(4)) { Distance = 4f }
+            ]
+        };
+    }
+
+    #region GhostVisualConfig Defaults
+
+    [Fact]
+    public void GhostVisualConfig_Default_HasTrailDisabled()
+    {
+        var config = new GhostVisualConfig();
+
+        Assert.False(config.ShowTrail);
+        Assert.Equal(60, config.TrailLength);
+        Assert.Equal(0.5f, config.TrailFadeStart);
+        Assert.Equal(0.1f, config.TrailWidth);
+        Assert.Equal(TrailStyle.Line, config.TrailStyle);
+    }
+
+    [Fact]
+    public void GhostVisualConfig_WithTrailSettings_RetainsValues()
+    {
+        var config = new GhostVisualConfig
+        {
+            ShowTrail = true,
+            TrailLength = 30,
+            TrailFadeStart = 0.2f,
+            TrailWidth = 0.5f,
+            TrailStyle = TrailStyle.Dots
+        };
+
+        Assert.True(config.ShowTrail);
+        Assert.Equal(30, config.TrailLength);
+        Assert.Equal(0.2f, config.TrailFadeStart);
+        Assert.Equal(0.5f, config.TrailWidth);
+        Assert.Equal(TrailStyle.Dots, config.TrailStyle);
+    }
+
+    #endregion
+
+    #region Empty Before Playback
+
+    [Fact]
+    public void GetTrailPoints_BeforePlayback_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetTrailPoints_NoGhostLoaded_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetTrailPoints_AfterStop_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(3);
+
+        // Sanity: seeking gives a trail.
+        Assert.Equal(4, player.GetTrailPoints(64).Length);
+
+        player.Play();
+        player.Stop();
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        Assert.Equal(0, player.GetTrailPoints(buffer));
+    }
+
+    #endregion
+
+    #region Points, Order, and Count
+
+    [Fact]
+    public void GetTrailPoints_AtFrame_ReturnsPathOldestToNewest()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToFrame(3);
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = player.GetTrailPoints(buffer);
+
+        Assert.Equal(4, count);
+        Assert.Equal(new Vector3(0, 0, 0), buffer[0]);
+        Assert.Equal(new Vector3(1, 0, 0), buffer[1]);
+        Assert.Equal(new Vector3(2, 0, 0), buffer[2]);
+        Assert.Equal(new Vector3(3, 0, 0), buffer[3]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_AsPlaybackAdvances_GrowsWithPlayhead()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToFrame(1);
+        Assert.Equal(2, player.GetTrailPoints(64).Length);
+
+        player.SeekToFrame(2);
+        Assert.Equal(3, player.GetTrailPoints(64).Length);
+
+        player.SeekToFrame(4);
+        var trail = player.GetTrailPoints(64);
+        Assert.Equal(5, trail.Length);
+        Assert.Equal(new Vector3(4, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_WithFrameSyncedPlayback_TracksAdvancingFrames()
+    {
+        using var player = new GhostPlayer
+        {
+            SyncMode = GhostSyncMode.FrameSynced
+        };
+        player.Load(CreateTestGhostData());
+        player.Play();
+
+        player.Update(0f); // -> frame 1
+        player.Update(0f); // -> frame 2
+
+        var trail = player.GetTrailPoints(64);
+
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(0, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(2, 0, 0), trail[^1]);
+    }
+
+    #endregion
+
+    #region TrailLength / Buffer Bounds
+
+    [Fact]
+    public void GetTrailPoints_BufferSmallerThanHistory_ReturnsMostRecentPoints()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        Span<Vector3> buffer = stackalloc Vector3[2];
+        int count = player.GetTrailPoints(buffer);
+
+        // Only the two most recent points fit.
+        Assert.Equal(2, count);
+        Assert.Equal(new Vector3(3, 0, 0), buffer[0]);
+        Assert.Equal(new Vector3(4, 0, 0), buffer[1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_RespectsMaxPoints()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        var trail = player.GetTrailPoints(maxPoints: 3);
+
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(2, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(4, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_MaxPointsZero_ReturnsEmpty()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.SeekToFrame(4);
+
+        Assert.Empty(player.GetTrailPoints(maxPoints: 0));
+    }
+
+    [Fact]
+    public void GetTrailPoints_NegativeMaxPoints_ThrowsArgumentOutOfRange()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => player.GetTrailPoints(maxPoints: -1));
+    }
+
+    #endregion
+
+    #region Seek Consistency
+
+    [Fact]
+    public void GetTrailPoints_AfterSeekToTime_ReturnsPathUpToThatTime()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToTime(TimeSpan.FromSeconds(2));
+
+        var trail = player.GetTrailPoints(64);
+
+        // Frames 0..2 are at or before t=2s.
+        Assert.Equal(3, trail.Length);
+        Assert.Equal(new Vector3(0, 0, 0), trail[0]);
+        Assert.Equal(new Vector3(2, 0, 0), trail[^1]);
+    }
+
+    [Fact]
+    public void GetTrailPoints_SeekBackward_ShrinksTrail()
+    {
+        using var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+
+        player.SeekToTime(TimeSpan.FromSeconds(4));
+        Assert.Equal(5, player.GetTrailPoints(64).Length);
+
+        player.SeekToTime(TimeSpan.FromSeconds(1));
+        Assert.Equal(2, player.GetTrailPoints(64).Length);
+    }
+
+    #endregion
+
+    #region Disposal
+
+    [Fact]
+    public void GetTrailPoints_AfterDispose_ThrowsObjectDisposed()
+    {
+        var player = new GhostPlayer();
+        player.Load(CreateTestGhostData());
+        player.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() =>
+        {
+            Span<Vector3> buffer = stackalloc Vector3[4];
+            player.GetTrailPoints(buffer);
+        });
+    }
+
+    #endregion
+
+    #region GhostInstance Surface
+
+    [Fact]
+    public void GhostInstance_GetTrailPoints_MatchesPlayer()
+    {
+        using var manager = new GhostManager();
+        var config = new GhostVisualConfig { ShowTrail = true, TrailLength = 32 };
+        manager.AddGhost("ghost", CreateTestGhostData(), config);
+
+        var instance = Assert.Single(manager.ActiveGhosts);
+        instance.Player.SeekToFrame(2);
+
+        Assert.True(instance.ShowTrail);
+
+        Span<Vector3> buffer = stackalloc Vector3[8];
+        int count = instance.GetTrailPoints(buffer);
+
+        Assert.Equal(3, count);
+        Assert.Equal(new Vector3(2, 0, 0), buffer[2]);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`GhostVisualConfig` trail fields** per the issue (`ShowTrail` default off — zero behavior change, `TrailLength`, `TrailFadeStart`, `TrailWidth`, `TrailStyle` Line/Ribbon/Dots/Gradient).
- **Trail-point provider** on `GhostPlayer` (surfaced via `GhostInstance`): `int GetTrailPoints(Span<Vector3>)` — zero-alloc, oldest→newest (feeds `DrawLineStrip` directly) — plus a convenience array overload. Correct across `Update`/`UpdateByDistance`/seeks; empty at playhead 0 (covers pre-play AND post-Stop — gated on playhead index, not playback state, so seeks behave).
- **Reference rendering in the racing sample** (age-faded ASCII glyphs; best-lap ghost = Gradient, previous = Dots) — keeps `KeenEyes.Replay` free of Graphics dependencies. `docs/replay.md` gained a trails section with the `DrawLineStrip` sketch for windowed games.
- **Ribbon documented as a Line fallback in 2D** (no oriented 3D line primitive exists) — honest limitation in XML docs + docs page.

## Test plan
- [x] 16 new tests (ordering, growth, length/maxPoints bounds, FrameSynced, seek consistency both directions, buffer-smaller-than-history, disposed/negative-arg, defaults-off) — 593/593
- [x] Racing sample still runs unattended with trails visible (re-verified)
- [x] Release build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #788 (part of #98). **Stacked on #1034** — merge that first.