### PR TITLE
feat(replay): Add local playtest session bundles with pluggable upload

### DIFF
--- a/src/KeenEyes.Replay/KeenEyes.Replay.csproj
+++ b/src/KeenEyes.Replay/KeenEyes.Replay.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Common\KeenEyes.Common.csproj" />
     <ProjectReference Include="..\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\KeenEyes.Logging\KeenEyes.Logging.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.Replay/Playtest/DirectoryUploadTarget.cs
+++ b/src/KeenEyes.Replay/Playtest/DirectoryUploadTarget.cs
@@ -1,0 +1,47 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// An <see cref="IPlaytestUploadTarget"/> that copies playtest bundles into a target
+/// directory, such as a shared network drive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The target directory is not created automatically: the copy fails if the directory does
+/// not exist, so a misconfigured drop location surfaces as an error rather than silently
+/// creating a stray folder. The bundle file name is preserved in the destination.
+/// </para>
+/// </remarks>
+public sealed class DirectoryUploadTarget : IPlaytestUploadTarget
+{
+    private readonly string targetDirectory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DirectoryUploadTarget"/> class.
+    /// </summary>
+    /// <param name="targetDirectory">The directory that bundles are copied into.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="targetDirectory"/> is null or whitespace.
+    /// </exception>
+    public DirectoryUploadTarget(string targetDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetDirectory);
+        this.targetDirectory = targetDirectory;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="DirectoryNotFoundException">
+    /// Thrown when the configured target directory does not exist.
+    /// </exception>
+    public Task UploadAsync(string bundlePath, PlaytestManifest manifest, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bundlePath);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var destination = Path.Combine(targetDirectory, Path.GetFileName(bundlePath));
+        File.Copy(bundlePath, destination, overwrite: true);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/KeenEyes.Replay/Playtest/IPlaytestUploadTarget.cs
+++ b/src/KeenEyes.Replay/Playtest/IPlaytestUploadTarget.cs
@@ -1,0 +1,24 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Defines a pluggable destination that a completed playtest bundle can be uploaded to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// KeenEyes ships one implementation, <see cref="DirectoryUploadTarget"/>, which copies the
+/// bundle to a target directory (for example a shared network drive). Studios can implement
+/// this interface to deliver bundles to their own backend (an HTTP endpoint, object storage,
+/// an issue tracker, and so on) without KeenEyes shipping or hosting any such service.
+/// </para>
+/// </remarks>
+public interface IPlaytestUploadTarget
+{
+    /// <summary>
+    /// Uploads the bundle at the specified path to this target.
+    /// </summary>
+    /// <param name="bundlePath">The path to the local bundle archive to upload.</param>
+    /// <param name="manifest">The manifest describing the bundle contents.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the upload has finished.</returns>
+    Task UploadAsync(string bundlePath, PlaytestManifest manifest, CancellationToken cancellationToken);
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestBundleResult.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestBundleResult.cs
@@ -1,0 +1,41 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// The outcome of ending a playtest session and producing its bundle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bundle is always written to disk before any upload is attempted, so
+/// <see cref="BundlePath"/> is valid regardless of whether an upload target was configured
+/// or the upload succeeded. When an upload fails, the local bundle is preserved and the
+/// failure is surfaced via <see cref="UploadError"/> rather than thrown.
+/// </para>
+/// </remarks>
+public sealed record PlaytestBundleResult
+{
+    /// <summary>
+    /// Gets the path to the local bundle archive on disk.
+    /// </summary>
+    public required string BundlePath { get; init; }
+
+    /// <summary>
+    /// Gets the manifest that describes the bundle contents.
+    /// </summary>
+    public required PlaytestManifest Manifest { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the bundle was successfully uploaded.
+    /// </summary>
+    /// <remarks>
+    /// Always <see langword="false"/> when no upload target was configured.
+    /// </remarks>
+    public bool Uploaded { get; init; }
+
+    /// <summary>
+    /// Gets the exception that caused an upload to fail, if any.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null"/> when no upload was attempted or the upload succeeded.
+    /// </remarks>
+    public Exception? UploadError { get; init; }
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestCrashInfo.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestCrashInfo.cs
@@ -1,0 +1,32 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Captures the details of an exception that terminated a playtest session.
+/// </summary>
+/// <remarks>
+/// Crash information is stored as <c>crash.json</c> in a playtest bundle archive and is
+/// only present in bundles produced by
+/// <see cref="PlaytestSession.CaptureCrashBundle(Exception)"/>.
+/// </remarks>
+public sealed record PlaytestCrashInfo
+{
+    /// <summary>
+    /// Gets the fully qualified type name of the captured exception.
+    /// </summary>
+    public required string ExceptionType { get; init; }
+
+    /// <summary>
+    /// Gets the exception message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Gets the exception stack trace, if one was available.
+    /// </summary>
+    public string? StackTrace { get; init; }
+
+    /// <summary>
+    /// Gets the details of the inner exception, if one was present.
+    /// </summary>
+    public PlaytestCrashInfo? InnerException { get; init; }
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestFeedback.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestFeedback.cs
@@ -1,0 +1,26 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Represents a single timestamped feedback entry recorded during a playtest session.
+/// </summary>
+/// <remarks>
+/// Feedback entries are stored, in the order they were recorded, as <c>feedback.json</c>
+/// in a playtest bundle archive.
+/// </remarks>
+public sealed record PlaytestFeedback
+{
+    /// <summary>
+    /// Gets the UTC timestamp when the feedback was recorded.
+    /// </summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets the caller-defined category of the feedback (for example "bug" or "suggestion").
+    /// </summary>
+    public required string Category { get; init; }
+
+    /// <summary>
+    /// Gets the free-form feedback message.
+    /// </summary>
+    public required string Message { get; init; }
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestJsonContext.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestJsonContext.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Source-generated JSON serialization context for playtest bundle types.
+/// </summary>
+/// <remarks>
+/// This context enables Native AOT-compatible JSON serialization without reflection for the
+/// documents written into a playtest bundle archive. It mirrors the pattern established by
+/// <see cref="ReplayJsonContext"/>.
+/// </remarks>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PlaytestManifest))]
+[JsonSerializable(typeof(PlaytestCrashInfo))]
+[JsonSerializable(typeof(IReadOnlyList<PlaytestFeedback>), TypeInfoPropertyName = "FeedbackList")]
+[JsonSerializable(typeof(IReadOnlyList<PlaytestLogEntry>), TypeInfoPropertyName = "LogEntryList")]
+internal partial class PlaytestJsonContext : JsonSerializerContext
+{
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestLogEntry.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestLogEntry.cs
@@ -1,0 +1,35 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// A serializable projection of a captured log entry included in a playtest bundle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Log entries are captured from an optional <see cref="Logging.ILogQueryable"/> source at
+/// the moment the bundle is written and stored as <c>logs.json</c> in the archive. This
+/// projection is used instead of <see cref="Logging.LogEntry"/> so the bundle format stays
+/// stable and source-generation friendly, independent of the logging provider internals.
+/// </para>
+/// </remarks>
+public sealed record PlaytestLogEntry
+{
+    /// <summary>
+    /// Gets the time the message was logged.
+    /// </summary>
+    public required DateTime Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets the severity level of the message.
+    /// </summary>
+    public required string Level { get; init; }
+
+    /// <summary>
+    /// Gets the category or source of the message.
+    /// </summary>
+    public required string Category { get; init; }
+
+    /// <summary>
+    /// Gets the log message text.
+    /// </summary>
+    public required string Message { get; init; }
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestManifest.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestManifest.cs
@@ -1,0 +1,61 @@
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Describes the contents and provenance of a playtest bundle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The manifest is serialized as <c>manifest.json</c> at the root of a playtest bundle
+/// archive. It records who produced the session, when it ran, the engine and game
+/// versions in effect, and an inventory of the other entries in the archive so tools can
+/// discover the bundle contents without unpacking every file.
+/// </para>
+/// </remarks>
+public sealed record PlaytestManifest
+{
+    /// <summary>
+    /// Gets the unique identifier assigned to this playtest session.
+    /// </summary>
+    public required Guid SessionId { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the playtester who produced this session.
+    /// </summary>
+    public required string PlaytesterId { get; init; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the session started.
+    /// </summary>
+    public required DateTimeOffset StartedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the session ended or was captured.
+    /// </summary>
+    public required DateTimeOffset EndedUtc { get; init; }
+
+    /// <summary>
+    /// Gets the KeenEyes engine version that produced this bundle, if available.
+    /// </summary>
+    public string? EngineVersion { get; init; }
+
+    /// <summary>
+    /// Gets the host game/application version that produced this bundle, if available.
+    /// </summary>
+    public string? GameVersion { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this bundle was produced by a crash capture.
+    /// </summary>
+    public bool HasCrash { get; init; }
+
+    /// <summary>
+    /// Gets the caller-supplied metadata associated with the session, if any.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// Gets the inventory of entry names contained in the bundle archive, including
+    /// <c>manifest.json</c> itself.
+    /// </summary>
+    public required IReadOnlyList<string> Entries { get; init; }
+}

--- a/src/KeenEyes.Replay/Playtest/PlaytestSession.cs
+++ b/src/KeenEyes.Replay/Playtest/PlaytestSession.cs
@@ -1,0 +1,377 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using KeenEyes.Logging;
+
+namespace KeenEyes.Replay.Playtest;
+
+/// <summary>
+/// Orchestrates a local playtest session, bundling a crash replay, structured feedback, and
+/// optionally captured logs into a single manifest'd archive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A session composes with a world's existing <see cref="ReplayRecorder"/> rather than
+/// creating its own. The recorder is already wired into the world's frame loop by
+/// <see cref="ReplayPlugin"/>, so reusing it is the only way the bundled replay reflects
+/// actual gameplay. For crash replays, configure that recorder's
+/// <see cref="ReplayOptions.UseRingBuffer"/> and <see cref="ReplayOptions.MaxFrames"/> so the
+/// last N frames before a crash are retained; the session flushes that ring buffer when a
+/// bundle is produced.
+/// </para>
+/// <para>
+/// Crash capture is explicit: the game calls <see cref="CaptureCrashBundle(Exception)"/> from
+/// its own exception handler. KeenEyes deliberately does not install a global
+/// <see cref="AppDomain.UnhandledException"/> handler, keeping crash handling traceable and
+/// under the application's control.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // During startup: install the replay plugin configured as a crash ring buffer.
+/// var options = new ReplayOptions { UseRingBuffer = true, MaxFrames = 600 };
+/// world.InstallPlugin(new ReplayPlugin(serializer, options));
+/// var recorder = world.GetExtension&lt;ReplayRecorder&gt;();
+///
+/// var session = new PlaytestSession(recorder, "playtests", new DirectoryUploadTarget("//share/playtests"));
+/// session.StartSession("tester-42");
+///
+/// try
+/// {
+///     // ... run the game loop; frames flow into the recorder automatically ...
+///     session.RecordFeedback("bug", "The door on level 2 will not open.");
+///     var result = await session.EndSessionAsync();
+/// }
+/// catch (Exception ex)
+/// {
+///     var bundlePath = session.CaptureCrashBundle(ex);
+///     throw;
+/// }
+/// </code>
+/// </example>
+public sealed class PlaytestSession
+{
+    private const string ManifestEntryName = "manifest.json";
+    private const string ReplayEntryName = "replay.kreplay";
+    private const string FeedbackEntryName = "feedback.json";
+    private const string LogsEntryName = "logs.json";
+    private const string CrashEntryName = "crash.json";
+
+    private readonly ReplayRecorder recorder;
+    private readonly string outputDirectory;
+    private readonly IPlaytestUploadTarget? uploadTarget;
+    private readonly ILogQueryable? logSource;
+    private readonly ReplayFileOptions? replayFileOptions;
+    private readonly List<PlaytestFeedback> feedback = [];
+
+    private Guid sessionId;
+    private string? playtesterId;
+    private IReadOnlyDictionary<string, string>? metadata;
+    private DateTimeOffset startedUtc;
+    private SessionState state = SessionState.NotStarted;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaytestSession"/> class.
+    /// </summary>
+    /// <param name="recorder">
+    /// The world's replay recorder, typically obtained via
+    /// <c>world.GetExtension&lt;ReplayRecorder&gt;()</c> after installing <see cref="ReplayPlugin"/>.
+    /// </param>
+    /// <param name="outputDirectory">
+    /// The directory where bundle archives are written. Created if it does not exist.
+    /// </param>
+    /// <param name="uploadTarget">
+    /// An optional destination that <see cref="EndSessionAsync"/> uploads the bundle to.
+    /// </param>
+    /// <param name="logSource">
+    /// An optional log source whose entries are captured into the bundle at write time.
+    /// </param>
+    /// <param name="replayFileOptions">
+    /// Optional options controlling how the replay is encoded into the bundle.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="recorder"/> is null.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="outputDirectory"/> is null or whitespace.
+    /// </exception>
+    public PlaytestSession(
+        ReplayRecorder recorder,
+        string outputDirectory,
+        IPlaytestUploadTarget? uploadTarget = null,
+        ILogQueryable? logSource = null,
+        ReplayFileOptions? replayFileOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+
+        this.recorder = recorder;
+        this.outputDirectory = outputDirectory;
+        this.uploadTarget = uploadTarget;
+        this.logSource = logSource;
+        this.replayFileOptions = replayFileOptions;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier of the current session.
+    /// </summary>
+    /// <remarks>Meaningful only after <see cref="StartSession"/> has been called.</remarks>
+    public Guid SessionId => sessionId;
+
+    /// <summary>
+    /// Gets a value indicating whether a session is currently active.
+    /// </summary>
+    public bool IsActive => state == SessionState.Active;
+
+    /// <summary>
+    /// Starts a new playtest session and begins replay recording.
+    /// </summary>
+    /// <param name="playtesterId">The identifier of the playtester producing the session.</param>
+    /// <param name="metadata">Optional metadata recorded in the bundle manifest.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="playtesterId"/> is null or whitespace.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a session is already active.
+    /// </exception>
+    public void StartSession(string playtesterId, IReadOnlyDictionary<string, string>? metadata = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(playtesterId);
+
+        if (state == SessionState.Active)
+        {
+            throw new InvalidOperationException("A playtest session is already active. Call EndSessionAsync first.");
+        }
+
+        sessionId = Guid.NewGuid();
+        this.playtesterId = playtesterId;
+        this.metadata = metadata;
+        startedUtc = DateTimeOffset.UtcNow;
+        feedback.Clear();
+        state = SessionState.Active;
+
+        recorder.StartRecording($"Playtest {sessionId}");
+    }
+
+    /// <summary>
+    /// Records a timestamped feedback entry for the active session.
+    /// </summary>
+    /// <param name="category">The caller-defined category (for example "bug" or "suggestion").</param>
+    /// <param name="message">The free-form feedback message.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="category"/> or <paramref name="message"/> is null or whitespace.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no session is active.
+    /// </exception>
+    public void RecordFeedback(string category, string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(category);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        EnsureActive();
+
+        feedback.Add(new PlaytestFeedback
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Category = category,
+            Message = message
+        });
+    }
+
+    /// <summary>
+    /// Ends the active session, writes its bundle, and uploads it if an upload target was
+    /// configured.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>
+    /// A result describing the local bundle path and the upload outcome. The local bundle is
+    /// always written before any upload is attempted; an upload failure is surfaced via
+    /// <see cref="PlaytestBundleResult.UploadError"/> without discarding the local bundle.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown when no session is active.</exception>
+    public async Task<PlaytestBundleResult> EndSessionAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureActive();
+
+        var replay = recorder.StopRecording();
+        var manifest = WriteBundle(replay, crash: null, out var bundlePath);
+        state = SessionState.Ended;
+
+        if (uploadTarget is null)
+        {
+            return new PlaytestBundleResult { BundlePath = bundlePath, Manifest = manifest };
+        }
+
+        try
+        {
+            await uploadTarget.UploadAsync(bundlePath, manifest, cancellationToken).ConfigureAwait(false);
+            return new PlaytestBundleResult { BundlePath = bundlePath, Manifest = manifest, Uploaded = true };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new PlaytestBundleResult { BundlePath = bundlePath, Manifest = manifest, UploadError = ex };
+        }
+    }
+
+    /// <summary>
+    /// Flushes the crash replay ring buffer and writes a bundle capturing the specified
+    /// exception, then ends the session.
+    /// </summary>
+    /// <param name="exception">The exception that terminated the session.</param>
+    /// <returns>The path to the local crash bundle archive.</returns>
+    /// <remarks>
+    /// <para>
+    /// Call this from the application's exception handler. Crash bundles are written locally
+    /// and, unlike <see cref="EndSessionAsync"/>, are not uploaded: uploading is best deferred
+    /// to a subsequent process launch rather than attempted while the process is unwinding
+    /// from an unhandled exception. The returned path can be handed to an
+    /// <see cref="IPlaytestUploadTarget"/> later.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="exception"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no session is active.</exception>
+    public string CaptureCrashBundle(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        EnsureActive();
+
+        var replay = recorder.StopRecording();
+        WriteBundle(replay, crash: ToCrashInfo(exception), out var bundlePath);
+        state = SessionState.Ended;
+
+        return bundlePath;
+    }
+
+    private void EnsureActive()
+    {
+        if (state != SessionState.Active)
+        {
+            throw new InvalidOperationException("No playtest session is active. Call StartSession first.");
+        }
+    }
+
+    private PlaytestManifest WriteBundle(ReplayData? replay, PlaytestCrashInfo? crash, out string bundlePath)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        bundlePath = Path.Combine(outputDirectory, $"playtest-{sessionId}.zip");
+
+        var logs = CaptureLogs();
+
+        // Build the entry inventory up front so the manifest can describe the whole archive.
+        var entries = new List<string> { ManifestEntryName };
+        if (replay is not null)
+        {
+            entries.Add(ReplayEntryName);
+        }
+
+        entries.Add(FeedbackEntryName);
+        if (logs is not null)
+        {
+            entries.Add(LogsEntryName);
+        }
+
+        if (crash is not null)
+        {
+            entries.Add(CrashEntryName);
+        }
+
+        var manifest = new PlaytestManifest
+        {
+            SessionId = sessionId,
+            PlaytesterId = playtesterId!,
+            StartedUtc = startedUtc,
+            EndedUtc = DateTimeOffset.UtcNow,
+            EngineVersion = EngineVersion,
+            GameVersion = GameVersion,
+            HasCrash = crash is not null,
+            Metadata = metadata,
+            Entries = entries
+        };
+
+        using var stream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
+
+        WriteJsonEntry(archive, ManifestEntryName, manifest, PlaytestJsonContext.Default.PlaytestManifest);
+
+        if (replay is not null)
+        {
+            var replayBytes = ReplayFileFormat.Write(replay, replayFileOptions);
+            WriteBytesEntry(archive, ReplayEntryName, replayBytes);
+        }
+
+        WriteJsonEntry<IReadOnlyList<PlaytestFeedback>>(archive, FeedbackEntryName, feedback, PlaytestJsonContext.Default.FeedbackList);
+
+        if (logs is not null)
+        {
+            WriteJsonEntry(archive, LogsEntryName, logs, PlaytestJsonContext.Default.LogEntryList);
+        }
+
+        if (crash is not null)
+        {
+            WriteJsonEntry(archive, CrashEntryName, crash, PlaytestJsonContext.Default.PlaytestCrashInfo);
+        }
+
+        return manifest;
+    }
+
+    private IReadOnlyList<PlaytestLogEntry>? CaptureLogs()
+    {
+        if (logSource is null)
+        {
+            return null;
+        }
+
+        var entries = logSource.GetEntries();
+        var projected = new List<PlaytestLogEntry>(entries.Count);
+        foreach (var entry in entries)
+        {
+            projected.Add(new PlaytestLogEntry
+            {
+                Timestamp = entry.Timestamp,
+                Level = entry.Level.ToString(),
+                Category = entry.Category,
+                Message = entry.Message
+            });
+        }
+
+        return projected;
+    }
+
+    private static PlaytestCrashInfo ToCrashInfo(Exception exception)
+    {
+        return new PlaytestCrashInfo
+        {
+            ExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+            Message = exception.Message,
+            StackTrace = exception.StackTrace,
+            InnerException = exception.InnerException is { } inner ? ToCrashInfo(inner) : null
+        };
+    }
+
+    private static void WriteJsonEntry<T>(ZipArchive archive, string entryName, T value, JsonTypeInfo<T> typeInfo)
+    {
+        var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+        using var entryStream = entry.Open();
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(value, typeInfo);
+        entryStream.Write(bytes);
+    }
+
+    private static void WriteBytesEntry(ZipArchive archive, string entryName, byte[] bytes)
+    {
+        var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+        using var entryStream = entry.Open();
+        entryStream.Write(bytes);
+    }
+
+    private static string? EngineVersion => typeof(PlaytestSession).Assembly.GetName().Version?.ToString();
+
+    private static string? GameVersion => Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+
+    private enum SessionState
+    {
+        NotStarted,
+        Active,
+        Ended
+    }
+}

--- a/src/KeenEyes.Replay/packages.lock.json
+++ b/src/KeenEyes.Replay/packages.lock.json
@@ -22,6 +22,12 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
+      },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
       }
     }
   }

--- a/tests/KeenEyes.Replay.Tests/PlaytestSessionTests.cs
+++ b/tests/KeenEyes.Replay.Tests/PlaytestSessionTests.cs
@@ -1,0 +1,397 @@
+using System.IO.Compression;
+using System.Text.Json;
+using KeenEyes.Logging;
+using KeenEyes.Logging.Providers;
+using KeenEyes.Replay.Playtest;
+
+namespace KeenEyes.Replay.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PlaytestSession"/> and its bundle format.
+/// </summary>
+public sealed class PlaytestSessionTests
+{
+    private static readonly JsonSerializerOptions readOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    #region Test Infrastructure
+
+    /// <summary>
+    /// Creates and manages a unique temporary directory, deleting it on disposal.
+    /// </summary>
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "keeneyes-playtest-tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; leaked temp files are acceptable in tests.
+            }
+        }
+    }
+
+    private static ReplayRecorder CreateRecorder(World world, ReplayOptions? options = null)
+        => new(world, new MockComponentSerializer(), options);
+
+    private static void DriveFrames(ReplayRecorder recorder, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            recorder.BeginFrame(0.016f);
+            recorder.EndFrame(0.016f);
+        }
+    }
+
+    private static byte[] ReadEntryBytes(string bundlePath, string entryName)
+    {
+        using var archive = ZipFile.OpenRead(bundlePath);
+        var entry = archive.GetEntry(entryName);
+        Assert.NotNull(entry);
+
+        using var entryStream = entry!.Open();
+        using var buffer = new MemoryStream();
+        entryStream.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+
+    private static bool EntryExists(string bundlePath, string entryName)
+    {
+        using var archive = ZipFile.OpenRead(bundlePath);
+        return archive.GetEntry(entryName) is not null;
+    }
+
+    private static T ReadEntryJson<T>(string bundlePath, string entryName)
+    {
+        var bytes = ReadEntryBytes(bundlePath, entryName);
+        var value = JsonSerializer.Deserialize<T>(bytes, readOptions);
+        Assert.NotNull(value);
+        return value!;
+    }
+
+    #endregion
+
+    #region Constructor and Guard Tests
+
+    [Fact]
+    public void Constructor_WithNullRecorder_ThrowsArgumentNullException()
+    {
+        using var temp = new TempDirectory();
+
+        Assert.Throws<ArgumentNullException>(() => new PlaytestSession(null!, temp.Path));
+    }
+
+    [Fact]
+    public void Constructor_WithBlankOutputDirectory_ThrowsArgumentException()
+    {
+        using var world = new World();
+        var recorder = CreateRecorder(world);
+
+        Assert.Throws<ArgumentException>(() => new PlaytestSession(recorder, "   "));
+    }
+
+    [Fact]
+    public void StartSession_WhenAlreadyActive_ThrowsInvalidOperationException()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+
+        session.StartSession("tester-1");
+
+        Assert.Throws<InvalidOperationException>(() => session.StartSession("tester-2"));
+    }
+
+    [Fact]
+    public void RecordFeedback_WhenNotStarted_ThrowsInvalidOperationException()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+
+        Assert.Throws<InvalidOperationException>(() => session.RecordFeedback("bug", "message"));
+    }
+
+    [Fact]
+    public void CaptureCrashBundle_WithNullException_ThrowsArgumentNullException()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+        session.StartSession("tester-1");
+
+        Assert.Throws<ArgumentNullException>(() => session.CaptureCrashBundle(null!));
+    }
+
+    #endregion
+
+    #region Bundle Content Tests
+
+    [Fact]
+    public async Task EndSessionAsync_WithRecordedSession_ProducesWellFormedBundle()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var recorder = CreateRecorder(world);
+        var session = new PlaytestSession(recorder, temp.Path);
+
+        var metadata = new Dictionary<string, string> { ["build"] = "0.1.0-alpha" };
+        session.StartSession("tester-42", metadata);
+        DriveFrames(recorder, 10);
+        session.RecordFeedback("bug", "The door on level 2 will not open.");
+
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(File.Exists(result.BundlePath));
+
+        // Manifest is well-formed and describes the session.
+        var manifest = ReadEntryJson<PlaytestManifest>(result.BundlePath, "manifest.json");
+        Assert.Equal(session.SessionId, manifest.SessionId);
+        Assert.Equal("tester-42", manifest.PlaytesterId);
+        Assert.False(manifest.HasCrash);
+        Assert.True(manifest.EndedUtc >= manifest.StartedUtc);
+        Assert.Equal("0.1.0-alpha", manifest.Metadata!["build"]);
+        Assert.Contains("manifest.json", manifest.Entries);
+        Assert.Contains("replay.kreplay", manifest.Entries);
+        Assert.Contains("feedback.json", manifest.Entries);
+
+        // Replay entry is a readable .kreplay file with the driven frames.
+        var replayBytes = ReadEntryBytes(result.BundlePath, "replay.kreplay");
+        Assert.True(ReplayFileFormat.IsValidFormat(replayBytes));
+        var (_, replayData) = ReplayFileFormat.Read(replayBytes);
+        Assert.Equal(10, replayData.FrameCount);
+
+        // Feedback entry round-trips.
+        var feedback = ReadEntryJson<List<PlaytestFeedback>>(result.BundlePath, "feedback.json");
+        var entry = Assert.Single(feedback);
+        Assert.Equal("bug", entry.Category);
+        Assert.Equal("The door on level 2 will not open.", entry.Message);
+    }
+
+    [Fact]
+    public async Task EndSessionAsync_WithNoData_ProducesValidMinimalBundle()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+
+        session.StartSession("tester-1");
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(File.Exists(result.BundlePath));
+
+        var manifest = ReadEntryJson<PlaytestManifest>(result.BundlePath, "manifest.json");
+        Assert.Equal("tester-1", manifest.PlaytesterId);
+        Assert.False(manifest.HasCrash);
+
+        // Feedback entry is present but empty.
+        var feedback = ReadEntryJson<List<PlaytestFeedback>>(result.BundlePath, "feedback.json");
+        Assert.Empty(feedback);
+
+        // No crash or logs entries in a no-op session.
+        Assert.False(EntryExists(result.BundlePath, "crash.json"));
+        Assert.False(EntryExists(result.BundlePath, "logs.json"));
+    }
+
+    [Fact]
+    public async Task RecordFeedback_MultipleEntries_PreservesOrderAndTimestamps()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+
+        session.StartSession("tester-1");
+        session.RecordFeedback("bug", "first");
+        session.RecordFeedback("suggestion", "second");
+        session.RecordFeedback("praise", "third");
+
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        var feedback = ReadEntryJson<List<PlaytestFeedback>>(result.BundlePath, "feedback.json");
+        Assert.Equal(3, feedback.Count);
+        Assert.Equal(["first", "second", "third"], feedback.Select(f => f.Message));
+        Assert.Equal(["bug", "suggestion", "praise"], feedback.Select(f => f.Category));
+
+        // Timestamps are recorded in non-decreasing order.
+        Assert.True(feedback[0].Timestamp <= feedback[1].Timestamp);
+        Assert.True(feedback[1].Timestamp <= feedback[2].Timestamp);
+    }
+
+    [Fact]
+    public async Task EndSessionAsync_WithLogSource_IncludesCapturedLogs()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var logProvider = new RingBufferLogProvider();
+        logProvider.Log(LogLevel.Warning, "Gameplay", "low health", null);
+        logProvider.Log(LogLevel.Error, "Physics", "penetration detected", null);
+
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path, logSource: logProvider);
+        session.StartSession("tester-1");
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(EntryExists(result.BundlePath, "logs.json"));
+        var logs = ReadEntryJson<List<PlaytestLogEntry>>(result.BundlePath, "logs.json");
+        Assert.Equal(2, logs.Count);
+        Assert.Equal("Warning", logs[0].Level);
+        Assert.Equal("low health", logs[0].Message);
+        Assert.Equal("Physics", logs[1].Category);
+    }
+
+    #endregion
+
+    #region Crash Capture Tests
+
+    [Fact]
+    public void CaptureCrashBundle_WithRingBuffer_FlushesBufferAndIncludesCrashDetails()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var options = new ReplayOptions { UseRingBuffer = true, MaxFrames = 5 };
+        var recorder = CreateRecorder(world, options);
+        var session = new PlaytestSession(recorder, temp.Path);
+
+        session.StartSession("tester-1");
+
+        // Drive more frames than the ring buffer holds so flushing keeps only the last 5.
+        DriveFrames(recorder, 20);
+
+        InvalidOperationException captured;
+        try
+        {
+            throw new InvalidOperationException("boom during playtest");
+        }
+        catch (InvalidOperationException ex)
+        {
+            captured = ex;
+        }
+
+        var bundlePath = session.CaptureCrashBundle(captured);
+
+        Assert.True(File.Exists(bundlePath));
+
+        var manifest = ReadEntryJson<PlaytestManifest>(bundlePath, "manifest.json");
+        Assert.True(manifest.HasCrash);
+        Assert.Contains("crash.json", manifest.Entries);
+
+        // Crash details carry the exception type, message, and stack trace.
+        var crash = ReadEntryJson<PlaytestCrashInfo>(bundlePath, "crash.json");
+        Assert.Equal(typeof(InvalidOperationException).FullName, crash.ExceptionType);
+        Assert.Equal("boom during playtest", crash.Message);
+        Assert.False(string.IsNullOrEmpty(crash.StackTrace));
+
+        // The flushed ring buffer contains only the retained window of frames.
+        var replayBytes = ReadEntryBytes(bundlePath, "replay.kreplay");
+        var (_, replayData) = ReplayFileFormat.Read(replayBytes);
+        Assert.Equal(5, replayData.FrameCount);
+    }
+
+    [Fact]
+    public void CaptureCrashBundle_WithInnerException_CapturesInnerDetails()
+    {
+        using var world = new World();
+        using var temp = new TempDirectory();
+        var session = new PlaytestSession(CreateRecorder(world), temp.Path);
+        session.StartSession("tester-1");
+
+        var exception = new InvalidOperationException("outer", new ArgumentException("inner"));
+        var bundlePath = session.CaptureCrashBundle(exception);
+
+        var crash = ReadEntryJson<PlaytestCrashInfo>(bundlePath, "crash.json");
+        Assert.NotNull(crash.InnerException);
+        Assert.Equal(typeof(ArgumentException).FullName, crash.InnerException!.ExceptionType);
+        Assert.Equal("inner", crash.InnerException.Message);
+    }
+
+    #endregion
+
+    #region Upload Tests
+
+    [Fact]
+    public async Task EndSessionAsync_WithDirectoryUploadTarget_DeliversBundle()
+    {
+        using var world = new World();
+        using var sourceDir = new TempDirectory();
+        using var targetDir = new TempDirectory();
+
+        var target = new DirectoryUploadTarget(targetDir.Path);
+        var session = new PlaytestSession(CreateRecorder(world), sourceDir.Path, target);
+
+        session.StartSession("tester-1");
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.Uploaded);
+        Assert.Null(result.UploadError);
+
+        var delivered = Path.Combine(targetDir.Path, Path.GetFileName(result.BundlePath));
+        Assert.True(File.Exists(delivered));
+    }
+
+    [Fact]
+    public async Task EndSessionAsync_WithNonexistentUploadDirectory_KeepsBundleAndSurfacesError()
+    {
+        using var world = new World();
+        using var sourceDir = new TempDirectory();
+
+        var missingDir = Path.Combine(Path.GetTempPath(), "keeneyes-playtest-tests", Guid.NewGuid().ToString("N"));
+        var target = new DirectoryUploadTarget(missingDir);
+        var session = new PlaytestSession(CreateRecorder(world), sourceDir.Path, target);
+
+        session.StartSession("tester-1");
+        var result = await session.EndSessionAsync(TestContext.Current.CancellationToken);
+
+        // Upload failed, but the local bundle survives and the error is surfaced.
+        Assert.False(result.Uploaded);
+        Assert.NotNull(result.UploadError);
+        Assert.IsType<DirectoryNotFoundException>(result.UploadError);
+        Assert.True(File.Exists(result.BundlePath));
+        Assert.False(Directory.Exists(missingDir));
+    }
+
+    [Fact]
+    public async Task DirectoryUploadTarget_UploadAsync_CopiesBundlePreservingFileName()
+    {
+        using var sourceDir = new TempDirectory();
+        using var targetDir = new TempDirectory();
+
+        var bundlePath = Path.Combine(sourceDir.Path, "playtest-sample.zip");
+        await File.WriteAllTextAsync(bundlePath, "bundle-contents", TestContext.Current.CancellationToken);
+
+        var manifest = new PlaytestManifest
+        {
+            SessionId = Guid.NewGuid(),
+            PlaytesterId = "tester-1",
+            StartedUtc = DateTimeOffset.UtcNow,
+            EndedUtc = DateTimeOffset.UtcNow,
+            Entries = ["manifest.json"]
+        };
+
+        var target = new DirectoryUploadTarget(targetDir.Path);
+        await target.UploadAsync(bundlePath, manifest, TestContext.Current.CancellationToken);
+
+        var delivered = Path.Combine(targetDir.Path, "playtest-sample.zip");
+        Assert.True(File.Exists(delivered));
+        Assert.Equal("bundle-contents", await File.ReadAllTextAsync(delivered, TestContext.Current.CancellationToken));
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Replay.Tests/packages.lock.json
+++ b/tests/KeenEyes.Replay.Tests/packages.lock.json
@@ -242,7 +242,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge.abstractions": {


### PR DESCRIPTION
## Summary
The re-scoped v1 of the playtesting infrastructure (per the re-scope comment on the issue — entirely local + pluggable, no hosted service):
- **`PlaytestSession`** (`src/KeenEyes.Replay/Playtest/`): wraps the world's *existing* `ReplayRecorder` (a session-owned recorder would be attached to no frame hooks — documented), timestamped `RecordFeedback`, and **explicit** `CaptureCrashBundle(Exception)` called from the game's own handler (no global AppDomain hooks, per explicit-over-implicit) that flushes the ring buffer + recursive exception details locally without attempting upload mid-unwind.
- **Bundle**: single zip (BCL `ZipArchive`, no new deps) — `manifest.json` (session GUID, playtester id, timestamps, engine/game versions via AOT-safe assembly-name metadata, entry inventory), `replay.kreplay` via the existing format, `feedback.json` (always present, so no-op sessions still yield valid bundles), optional `logs.json` (optional `ILogQueryable` parameter; one-way ProjectReference to `KeenEyes.Logging`, entries projected to a stable DTO), `crash.json` when captured. Source-generated JSON context throughout.
- **`IPlaytestUploadTarget`** + `DirectoryUploadTarget` (shared-drive case). `EndSessionAsync` writes the local bundle first, then uploads; failures surface via `PlaytestBundleResult.UploadError` with the bundle preserved. (Named `EndSessionAsync` rather than the issue's `EndSession` — upload is inherently async.)
- Lockfiles updated only with the new `KeenEyes.Logging` project entry (required, not churn).

## Test plan
- [x] 14 new tests: bundle unzipped + manifest/replay/feedback validated, crash flush with inner exceptions, feedback ordering, DirectoryUploadTarget delivery, failed upload preserves bundle + surfaces error, minimal no-op bundle, log inclusion against `RingBufferLogProvider` — 591/591
- [x] Release build zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #85 (final item of the #98 replay plan).