### PR TITLE
perf(editor): Add editor entity-scale benchmarks

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -8,6 +8,7 @@
     <Project Path="benchmarks/KeenEyes.AotVsJit.Benchmarks/KeenEyes.AotVsJit.Benchmarks.csproj" />
     <Project Path="benchmarks/KeenEyes.AotVsJit.Benchmarks/StartupTimeBenchmark/StartupTimeBenchmark.csproj" />
     <Project Path="benchmarks/KeenEyes.Benchmarks/KeenEyes.Benchmarks.csproj" />
+    <Project Path="benchmarks/KeenEyes.Editor.Benchmarks/KeenEyes.Editor.Benchmarks.csproj" />
     <Project Path="benchmarks/KeenEyes.Spatial.Benchmarks/KeenEyes.Spatial.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/samples/">

--- a/benchmarks/KeenEyes.Editor.Benchmarks/HierarchyRefreshBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/HierarchyRefreshBenchmarks.cs
@@ -1,0 +1,69 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+using KeenEyes.Editor.Application;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures the data work behind a hierarchy-panel refresh: the root-entity scan plus the
+/// recursive parent/child/name walk that <c>HierarchyPanel.RefreshHierarchy</c> performs to
+/// build its tree. Widget creation and GPU drawing are deliberately excluded - only the
+/// traversal that produces the node list is timed.
+/// </summary>
+[MemoryDiagnoser]
+public class HierarchyRefreshBenchmarks
+{
+    private EditorWorldManager worldManager = null!;
+    private List<HierarchyNode> nodes = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        worldManager = new EditorWorldManager();
+        SceneGenerator.Generate(
+            worldManager.World,
+            EntityCount,
+            sceneRoot: worldManager.CurrentSceneRoot);
+
+        nodes = new List<HierarchyNode>(EntityCount);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => worldManager.Dispose();
+
+    /// <summary>
+    /// Rebuilds the flattened hierarchy node list from the current scene.
+    /// </summary>
+    [Benchmark]
+    public int RefreshTreeData()
+    {
+        nodes.Clear();
+
+        foreach (var root in worldManager.GetRootEntities())
+        {
+            AddNode(root, -1, 0);
+        }
+
+        return nodes.Count;
+    }
+
+    private void AddNode(Entity entity, int parentIndex, int depth)
+    {
+        var index = nodes.Count;
+        nodes.Add(new HierarchyNode(entity, worldManager.GetEntityName(entity), parentIndex, depth));
+
+        foreach (var child in worldManager.GetChildren(entity))
+        {
+            AddNode(child, index, depth + 1);
+        }
+    }
+
+    /// <summary>
+    /// A flattened hierarchy tree node, mirroring the per-entity data the panel materializes.
+    /// </summary>
+    private readonly record struct HierarchyNode(Entity Entity, string Name, int ParentIndex, int Depth);
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/IntrospectionBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/IntrospectionBenchmarks.cs
@@ -1,0 +1,106 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+using KeenEyes.Editor.Common.Inspector;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures <see cref="ComponentIntrospector"/> doing a full inspector pass: enumerating every
+/// component on an entity and, for each, resolving editable fields/properties, their metadata,
+/// and their current values. This is the inspector-responsiveness proxy - the work done when an
+/// entity is selected (one entity) versus a bulk/multi-select refresh (100 entities).
+/// </summary>
+/// <remarks>
+/// The introspector caches reflection metadata per type after first use, matching how the editor
+/// reuses it across frames; the global setup warms that cache so the benchmark reflects steady
+/// state rather than cold reflection.
+/// </remarks>
+[MemoryDiagnoser]
+public class IntrospectionBenchmarks
+{
+    private World world = null!;
+    private Entity singleEntity;
+    private Entity[] hundredEntities = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new World();
+        var entities = SceneGenerator.Generate(world, EntityCount);
+
+        // Pick a deep actor (rich archetype: transform, velocity, health, tags, render meta).
+        singleEntity = entities[^1];
+
+        // A representative bulk-select slice from the deeper (actor) portion of the scene.
+        hundredEntities = entities.Skip(entities.Count - 100).Take(100).ToArray();
+
+        // Warm the introspector's per-type reflection caches.
+        _ = Inspect(singleEntity);
+        foreach (var entity in hundredEntities)
+        {
+            _ = Inspect(entity);
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => world.Dispose();
+
+    /// <summary>
+    /// Full inspection of a single selected entity.
+    /// </summary>
+    [Benchmark]
+    public int InspectSingleEntity() => Inspect(singleEntity);
+
+    /// <summary>
+    /// Full inspection of 100 entities (bulk / multi-select refresh).
+    /// </summary>
+    [Benchmark]
+    public int InspectHundredEntities()
+    {
+        var acc = 0;
+        foreach (var entity in hundredEntities)
+        {
+            acc += Inspect(entity);
+        }
+
+        return acc;
+    }
+
+    private int Inspect(Entity entity)
+    {
+        var acc = 0;
+
+        foreach (var (type, value) in world.GetComponents(entity))
+        {
+            foreach (var field in ComponentIntrospector.GetEditableFields(type))
+            {
+                var metadata = ComponentIntrospector.GetFieldMetadata(field);
+                acc += metadata.DisplayName.Length;
+
+                var fieldValue = ComponentIntrospector.GetFieldValue(value, field);
+                if (fieldValue is not null)
+                {
+                    acc += fieldValue.GetHashCode();
+                }
+            }
+
+            foreach (var property in ComponentIntrospector.GetEditableProperties(type))
+            {
+                var metadata = ComponentIntrospector.GetPropertyMetadata(property);
+                acc += metadata.DisplayName.Length;
+
+                var propertyValue = ComponentIntrospector.GetPropertyValue(value, property);
+                if (propertyValue is not null)
+                {
+                    acc += propertyValue.GetHashCode();
+                }
+            }
+        }
+
+        return acc;
+    }
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/KeenEyes.Editor.Benchmarks.csproj
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/KeenEyes.Editor.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Benchmarks need Release builds for accurate measurements -->
+    <Configuration>Release</Configuration>
+    <!-- Suppress missing XML doc warnings for benchmarks -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Editor.Abstractions\KeenEyes.Editor.Abstractions.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Editor.Common\KeenEyes.Editor.Common.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Editor\KeenEyes.Editor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/KeenEyes.Editor.Benchmarks/PlayModeBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/PlayModeBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+using KeenEyes.Editor.PlayMode;
+using KeenEyes.Editor.Serialization;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures play-mode enter and exit at scale using the exact production wiring from
+/// <c>EditorApplication</c>: a real <see cref="PlayModeManager"/> backed by a real
+/// <see cref="EditorComponentSerializer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the deepest headless-constructible layer. <c>PlayModeManager</c> itself needs
+/// only a <c>World</c> and an <c>IComponentSerializer</c> - no window, renderer, or running
+/// application - so the benchmark exercises the genuine snapshot/restore path rather than a
+/// stand-in. Enter captures a <c>WorldSnapshot</c> of the whole scene; exit clears the world
+/// and rebuilds it from that snapshot.
+/// </para>
+/// <para>
+/// These operations mutate world state, so the class uses per-target iteration setup to
+/// guarantee the manager is in the correct state before each timed call. Each snapshot
+/// operation costs hundreds of milliseconds, so BenchmarkDotNet naturally pilots to a single
+/// invocation per iteration (with unroll factor 1), keeping every timed call a real state
+/// transition.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class PlayModeBenchmarks
+{
+    private World world = null!;
+    private PlayModeManager manager = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new World();
+        SceneGenerator.Generate(world, EntityCount);
+        manager = new PlayModeManager(world, new EditorComponentSerializer());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => world.Dispose();
+
+    [IterationSetup(Target = nameof(PlayEnter))]
+    public void EnsureEditing()
+    {
+        if (manager.IsInPlayMode)
+        {
+            manager.Stop();
+        }
+    }
+
+    [IterationSetup(Target = nameof(PlayExit))]
+    public void EnsurePlaying()
+    {
+        if (manager.IsEditing)
+        {
+            manager.Play();
+        }
+    }
+
+    /// <summary>
+    /// Enters play mode: captures a full world snapshot.
+    /// </summary>
+    [Benchmark]
+    public bool PlayEnter() => manager.Play();
+
+    /// <summary>
+    /// Exits play mode: clears the world and restores it from the snapshot.
+    /// </summary>
+    [Benchmark]
+    public bool PlayExit() => manager.Stop();
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/Program.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/Program.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+using KeenEyes.Editor.Benchmarks;
+
+// Editor entity-scale benchmarks (issue #1005).
+// Measures the perf-relevant, headless-testable editor operations against
+// deterministically generated scenes of 1,000 and 5,000 entities.
+//
+// Usage:
+//   dotnet run -c Release                              # Run all editor benchmarks
+//   dotnet run -c Release -- --filter *PlayMode*       # Run only play-mode benchmarks
+//   dotnet run -c Release -- --list flat               # List all benchmarks
+
+// The benchmark project transitively references the whole editor + engine graph. Under the
+// default toolchain, BenchmarkDotNet spins up a fresh isolated build of that entire graph per
+// run, which blows past its 2-minute build timeout. Running in-process (emit toolchain) skips
+// the isolated build entirely - appropriate for a baseline macro-benchmark where absolute
+// isolation matters less than getting stable millisecond-scale numbers. Paired with a ShortRun
+// job (3 warmup + 3 target iterations). MemoryDiagnoser is applied per class.
+var job = Job.ShortRun
+    .WithToolchain(InProcessEmitToolchain.Instance);
+
+var config = DefaultConfig.Instance
+    .AddJob(job)
+    .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(SceneGenerator).Assembly)
+    .Run(args, config);

--- a/benchmarks/KeenEyes.Editor.Benchmarks/SceneComponents.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/SceneComponents.cs
@@ -1,0 +1,71 @@
+using System.Numerics;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Full 3D transform: the dominant per-entity component in editor scenes.
+/// </summary>
+public struct EditorTransform : IComponent
+{
+    public Vector3 Position;
+    public Quaternion Rotation;
+    public Vector3 Scale;
+}
+
+/// <summary>
+/// Linear velocity, consumed by the representative scene-simulation systems.
+/// </summary>
+public struct Velocity : IComponent
+{
+    public Vector3 Linear;
+}
+
+/// <summary>
+/// Health, a small custom gameplay component with two integer fields.
+/// </summary>
+public struct Health : IComponent
+{
+    public int Current;
+    public int Max;
+}
+
+/// <summary>
+/// Render metadata: a custom component exercising string and enum inspection.
+/// </summary>
+public struct RenderMeta : IComponent
+{
+    public string MaterialName;
+    public int LayerId;
+    public bool Visible;
+    public RenderQueue Queue;
+}
+
+/// <summary>
+/// Spawn descriptor: a custom component with float and int payload.
+/// </summary>
+public struct SpawnInfo : IComponent
+{
+    public int Seed;
+    public float Weight;
+}
+
+/// <summary>
+/// Render ordering bucket, used to exercise enum field inspection/serialization.
+/// </summary>
+public enum RenderQueue
+{
+    Background,
+    Geometry,
+    Transparent,
+    Overlay
+}
+
+/// <summary>
+/// Tag marking entities that are static (non-moving) in the scene.
+/// </summary>
+public struct StaticTag : ITagComponent;
+
+/// <summary>
+/// Tag marking entities that can be selected in the editor.
+/// </summary>
+public struct SelectableTag : ITagComponent;

--- a/benchmarks/KeenEyes.Editor.Benchmarks/SceneGenerator.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/SceneGenerator.cs
@@ -1,0 +1,146 @@
+using System.Numerics;
+
+using KeenEyes;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Deterministic generator for editor benchmark scenes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Produces a reproducible forest of entities with a fixed branching factor so that
+/// every entity count maps to a stable 4-level hierarchy (depths 0-3). Component
+/// assignment is driven purely by entity index; all numeric field values come from a
+/// seeded <see cref="Random"/>, so a given (count, seed) pair always yields byte-for-byte
+/// identical scenes across runs.
+/// </para>
+/// <para>
+/// The mix intentionally spans several archetypes: transforms on every entity, tags,
+/// gameplay data, and custom string/enum-bearing components. This mirrors a realistic
+/// authored scene rather than a single hot archetype.
+/// </para>
+/// </remarks>
+public static class SceneGenerator
+{
+    /// <summary>
+    /// Branching factor. With 17 children per node, counts up to 5,220 stay within four
+    /// levels (1 + 17 + 289 + 4,913), covering both the 1,000 and 5,000 entity scales.
+    /// </summary>
+    private const int Branching = 17;
+
+    private static readonly string[] materials =
+    [
+        "Standard", "Metal", "Glass", "Foliage", "Terrain", "Skin", "Emissive", "Water"
+    ];
+
+    /// <summary>
+    /// Generates <paramref name="count"/> entities into <paramref name="world"/>.
+    /// </summary>
+    /// <param name="world">The world to populate.</param>
+    /// <param name="count">The number of entities to create.</param>
+    /// <param name="seed">Seed for deterministic field values.</param>
+    /// <param name="sceneRoot">
+    /// Optional scene root. When valid, every generated entity is registered with the
+    /// scene via <see cref="SceneManager.AddToScene"/> so hierarchy-panel style traversal
+    /// sees them as scene members.
+    /// </param>
+    /// <returns>The generated entities, in creation order.</returns>
+    public static IReadOnlyList<Entity> Generate(
+        World world,
+        int count,
+        int seed = 1337,
+        Entity sceneRoot = default)
+    {
+        var random = new Random(seed);
+        var entities = new Entity[count];
+        var depths = new int[count];
+
+        for (int i = 0; i < count; i++)
+        {
+            var depth = i == 0 ? 0 : depths[(i - 1) / Branching] + 1;
+            depths[i] = depth;
+
+            var builder = world.Spawn($"Entity_{i}")
+                .With(new EditorTransform
+                {
+                    Position = new Vector3(
+                        (float)(random.NextDouble() * 200.0 - 100.0),
+                        (float)(random.NextDouble() * 200.0 - 100.0),
+                        (float)(random.NextDouble() * 200.0 - 100.0)),
+                    Rotation = Quaternion.CreateFromYawPitchRoll(
+                        (float)(random.NextDouble() * Math.PI * 2.0),
+                        (float)(random.NextDouble() * Math.PI * 2.0),
+                        (float)(random.NextDouble() * Math.PI * 2.0)),
+                    Scale = Vector3.One
+                });
+
+            // Grouping entities (upper levels) are static containers; deeper entities are
+            // dynamic actors. This produces a realistic spread of distinct archetypes.
+            if (depth <= 1)
+            {
+                builder.With(new StaticTag());
+                builder.With(new RenderMeta
+                {
+                    MaterialName = materials[i % materials.Length],
+                    LayerId = depth,
+                    Visible = true,
+                    Queue = RenderQueue.Geometry
+                });
+            }
+            else
+            {
+                builder.With(new Velocity
+                {
+                    Linear = new Vector3(
+                        (float)(random.NextDouble() * 2.0 - 1.0),
+                        (float)(random.NextDouble() * 2.0 - 1.0),
+                        (float)(random.NextDouble() * 2.0 - 1.0))
+                });
+                builder.With(new SelectableTag());
+                builder.With(new Health
+                {
+                    Current = 50 + random.Next(0, 50),
+                    Max = 100
+                });
+            }
+
+            // Every third entity gets an extra custom component, widening archetype variety.
+            if (i % 3 == 0)
+            {
+                builder.With(new SpawnInfo
+                {
+                    Seed = random.Next(),
+                    Weight = (float)random.NextDouble()
+                });
+            }
+
+            // Roughly half the actors carry render metadata as well.
+            if (depth >= 2 && i % 2 == 0)
+            {
+                builder.With(new RenderMeta
+                {
+                    MaterialName = materials[i % materials.Length],
+                    LayerId = depth,
+                    Visible = i % 5 != 0,
+                    Queue = (RenderQueue)(i % 4)
+                });
+            }
+
+            var entity = builder.Build();
+            entities[i] = entity;
+
+            if (i > 0)
+            {
+                world.SetParent(entity, entities[(i - 1) / Branching]);
+            }
+
+            if (sceneRoot.IsValid && world.IsAlive(sceneRoot))
+            {
+                world.Scenes.AddToScene(entity, sceneRoot);
+            }
+        }
+
+        return entities;
+    }
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/SceneSerializationBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/SceneSerializationBenchmarks.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+using KeenEyes.Editor.Assets;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures <see cref="SceneSerializer"/> save and load of a generated scene: the cost of
+/// persisting an authored scene to a <c>.kescene</c> file and reopening it. Save writes the
+/// captured world to disk; Load parses the file and reconstructs every entity, component,
+/// and parent/child relationship into a fresh world.
+/// </summary>
+[MemoryDiagnoser]
+public class SceneSerializationBenchmarks
+{
+    private World sourceWorld = null!;
+    private SceneSerializer serializer = null!;
+    private string scenePath = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        serializer = new SceneSerializer();
+
+        sourceWorld = new World();
+        SceneGenerator.Generate(sourceWorld, EntityCount);
+
+        scenePath = Path.Combine(
+            Path.GetTempPath(),
+            $"keeneyes-bench-scene-{EntityCount}-{Guid.NewGuid():N}.kescene");
+
+        // Materialize the file so Load has real content to read from the first iteration.
+        serializer.Save(sourceWorld, "Benchmark", scenePath);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        sourceWorld.Dispose();
+        if (File.Exists(scenePath))
+        {
+            File.Delete(scenePath);
+        }
+    }
+
+    /// <summary>
+    /// Captures the world and writes the scene file to disk.
+    /// </summary>
+    [Benchmark]
+    public void Save() => serializer.Save(sourceWorld, "Benchmark", scenePath);
+
+    /// <summary>
+    /// Parses the scene file and rebuilds the full entity graph into a fresh world.
+    /// </summary>
+    [Benchmark]
+    public void Load()
+    {
+        using var world = new World();
+        _ = SceneSerializer.Load(world, scenePath);
+    }
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/SelectionUndoBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/SelectionUndoBenchmarks.cs
@@ -1,0 +1,93 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+using KeenEyes.Editor.Commands;
+using KeenEyes.Editor.Selection;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures selection-change latency and a representative undo/redo command cycle at scene
+/// scale. The command benchmarks run a full execute -> undo -> redo -> undo cycle (net-neutral,
+/// so the world state is identical every iteration) to time both the forward and inverse paths
+/// of a command as it manipulates a large world.
+/// </summary>
+[MemoryDiagnoser]
+public class SelectionUndoBenchmarks
+{
+    private World world = null!;
+    private SelectionManager selection = null!;
+    private UndoRedoManager undoRedo = null!;
+
+    private Entity entityA;
+    private Entity entityB;
+    private bool toggle;
+
+    private SetComponentCommand<Health> setComponentCommand = null!;
+    private ReparentEntityCommand reparentCommand = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new World();
+        var entities = SceneGenerator.Generate(world, EntityCount);
+
+        selection = new SelectionManager();
+        undoRedo = new UndoRedoManager();
+
+        // Two distinct actors for the selection-change benchmark.
+        entityA = entities[^1];
+        entityB = entities[^2];
+
+        // Set-component command targets a health-bearing actor with a changed value.
+        var target = entities[^1];
+        var newHealth = world.Has<Health>(target)
+            ? world.Get<Health>(target) with { Current = 1 }
+            : new Health { Current = 1, Max = 100 };
+        setComponentCommand = new SetComponentCommand<Health>(world, target, newHealth);
+
+        // Reparent command moves a deep leaf under the scene's top-level root (no cycle).
+        reparentCommand = new ReparentEntityCommand(world, entities[^1], entities[0]);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => world.Dispose();
+
+    /// <summary>
+    /// A single-entity selection change (the common inspector-driving event).
+    /// </summary>
+    [Benchmark]
+    public Entity SelectionChange()
+    {
+        toggle = !toggle;
+        selection.Select(toggle ? entityA : entityB);
+        return selection.PrimarySelection;
+    }
+
+    /// <summary>
+    /// Execute/undo/redo cycle of a set-component command through the undo stack.
+    /// </summary>
+    [Benchmark]
+    public void SetComponentUndoRedo()
+    {
+        undoRedo.Execute(setComponentCommand);
+        undoRedo.Undo();
+        undoRedo.Redo();
+        undoRedo.Undo();
+    }
+
+    /// <summary>
+    /// Execute/undo/redo cycle of a reparent command through the undo stack.
+    /// </summary>
+    [Benchmark]
+    public void ReparentUndoRedo()
+    {
+        undoRedo.Execute(reparentCommand);
+        undoRedo.Undo();
+        undoRedo.Redo();
+        undoRedo.Undo();
+    }
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/UpdateTickBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/UpdateTickBenchmarks.cs
@@ -1,0 +1,75 @@
+using BenchmarkDotNet.Attributes;
+
+using KeenEyes;
+
+namespace KeenEyes.Editor.Benchmarks;
+
+/// <summary>
+/// Measures a single scene-world <see cref="World.Update"/> tick with representative
+/// editor-side systems registered (no rendering). This is the "editor FPS" proxy: the
+/// per-frame CPU cost the editor pays to simulate an open scene.
+/// </summary>
+[MemoryDiagnoser]
+public class UpdateTickBenchmarks
+{
+    private World world = null!;
+
+    [Params(1000, 5000)]
+    public int EntityCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new World();
+        world.AddSystem(new MovementSystem());
+        world.AddSystem(new HealthRegenSystem());
+
+        SceneGenerator.Generate(world, EntityCount);
+
+        // Prime archetype/query caches and the change tracker with one warm tick.
+        world.Update(0.016f);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => world.Dispose();
+
+    /// <summary>
+    /// One 60fps frame tick over the whole scene.
+    /// </summary>
+    [Benchmark]
+    public void UpdateTick() => world.Update(0.016f);
+}
+
+/// <summary>
+/// Representative motion system: integrates transforms of dynamic actors.
+/// </summary>
+internal sealed class MovementSystem : SystemBase
+{
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<EditorTransform, Velocity>())
+        {
+            ref var transform = ref World.Get<EditorTransform>(entity);
+            ref readonly var velocity = ref World.Get<Velocity>(entity);
+            transform.Position += velocity.Linear * deltaTime;
+        }
+    }
+}
+
+/// <summary>
+/// Representative gameplay system: regenerates health toward its maximum.
+/// </summary>
+internal sealed class HealthRegenSystem : SystemBase
+{
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Health>())
+        {
+            ref var health = ref World.Get<Health>(entity);
+            if (health.Current < health.Max)
+            {
+                health.Current++;
+            }
+        }
+    }
+}

--- a/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
@@ -1,0 +1,760 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "BenchmarkDotNet": {
+        "type": "Direct",
+        "requested": "[0.15.8, )",
+        "resolved": "0.15.8",
+        "contentHash": "paCfrWxSeHqn3rUZc0spYXVFnHCF0nzRhG0nOLnyTjZYs8spsimBaaNmb3vwqvALKIplbYq/TF393vYiYSnh/Q==",
+        "dependencies": {
+          "BenchmarkDotNet.Annotations": "0.15.8",
+          "CommandLineParser": "2.9.1",
+          "Gee.External.Capstone": "2.3.0",
+          "Iced": "1.21.0",
+          "Microsoft.CodeAnalysis.CSharp": "4.14.0",
+          "Microsoft.Diagnostics.Runtime": "3.1.512801",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.1.21",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Perfolizer": "[0.6.1]",
+          "System.Management": "9.0.5"
+        }
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+      },
+      "BenchmarkDotNet.Annotations": {
+        "type": "Transitive",
+        "resolved": "0.15.8",
+        "contentHash": "hfucY0ycAsB0SsoaZcaAp9oq5wlWBJcylvEJb9pmvdYUx6PD6S4mDiYnZWjdjAlLhIpe/xtGCwzORfzAzPqvzA=="
+      },
+      "CommandLineParser": {
+        "type": "Transitive",
+        "resolved": "2.9.1",
+        "contentHash": "OE0sl1/sQ37bjVsPKKtwQlWDgqaxWgtme3xZz7JssWUzg5JpMIyHgCTY9MVMxOg48fJ1AgGT3tgdH5m/kQ5xhA=="
+      },
+      "Cyotek.Drawing.BitmapFont": {
+        "type": "Transitive",
+        "resolved": "2.0.4",
+        "contentHash": "iA6WehGVdMUuNbfsQQDq/Bt+mMd/OqHjiMUtKFLIQd/0pyYh4ehT7FEjTxN9/4OXNKQZsp9bAJgltP2nnswUJg=="
+      },
+      "FontStashSharp.Base": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "kw8ovakGHz8jCah+H5M7qI8aOvtESF0jQRpcpubXUMsSid86dRO6DoDPlh+Tk/XAW5a3XgzGDgsHfeZTfZTr+Q=="
+      },
+      "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "xjzgWeiaODbW7DR/kI05V7C3CVtDvtB+4TrgX4EKNpRGzxb42vsvXKWrXORQWU2LCLnPPqdBNNSgtRujnpK2ww==",
+        "dependencies": {
+          "FontStashSharp.Base": "1.2.3",
+          "StbTrueTypeSharp": "1.26.12"
+        }
+      },
+      "Gee.External.Capstone": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2ap/rYmjtzCOT8hxrnEW/QeiOt+paD8iRrIcdKX0cxVwWLFa1e+JDBNeECakmccXrSFeBQuu5AV8SNkipFMMMw=="
+      },
+      "Iced": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.Diagnostics.NETCore.Client": {
+        "type": "Transitive",
+        "resolved": "0.2.510501",
+        "contentHash": "juoqJYMDs+lRrrZyOkXXMImJHneCF23cuvO4waFRd2Ds7j+ZuGIPbJm0Y/zz34BdeaGiiwGWraMUlln05W1PCQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "6.0.0"
+        }
+      },
+      "Microsoft.Diagnostics.Runtime": {
+        "type": "Transitive",
+        "resolved": "3.1.512801",
+        "contentHash": "0lMUDr2oxNZa28D6NH5BuSQEe5T9tZziIkvkD44YkkCGQXPJqvFjLq5ZQq1hYLl3RjQJrY+hR0jFgap+EWPDTw==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.410101"
+        }
+      },
+      "Microsoft.Diagnostics.Tracing.TraceEvent": {
+        "type": "Transitive",
+        "resolved": "3.1.21",
+        "contentHash": "/OrJFKaojSR6TkUKtwh8/qA9XWNtxLrXMqvEb89dBSKCWjaGVTbKMYodIUgF5deCEtmd6GXuRerciXGl5bhZ7Q==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.510501",
+          "System.Reflection.TypeExtensions": "4.7.0"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "Perfolizer": {
+        "type": "Transitive",
+        "resolved": "0.6.1",
+        "contentHash": "CR1QmWg4XYBd1Pb7WseP+sDmV8nGPwvmowKynExTqr3OuckIGVMhvmN4LC5PGzfXqDlR295+hz/T7syA1CxEqA==",
+        "dependencies": {
+          "Pragmastat": "3.2.4"
+        }
+      },
+      "Pragmastat": {
+        "type": "Transitive",
+        "resolved": "3.2.4",
+        "contentHash": "I5qFifWw/gaTQT52MhzjZpkm/JPlfjSeO/DTZJjO7+hTKI+0aGRgOgZ3NN6D96dDuuqbIAZSeA5RimtHjqrA2A=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.26.12",
+        "contentHash": "hCc6/OsfcPa5VsLECcEU2m78WOshBrKwK42nAodSm9Z5wH68f7n66SoiRLCdGCkDaqbWz2TlX4zYHIjogj1HJA=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "cuzLM2MWutf9ZBEMPYYfd0DXwYdvntp7VCT6a/wvbKCa2ZuvGmW74xi+YBa2mrfEieAXqM4TNKlMmSnfAfpUoQ=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "n6o9PZm9p25+zAzC3/48K0oHnaPKTInRrxqFq1fi/5TPbMLjuoCm/h//mS3cUmSy+9AO1Z+qsC/Ilt/ZFatv5Q==",
+        "dependencies": {
+          "System.CodeDom": "9.0.5"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "VybpaOQQhqE6siHppMktjfGBw1GCwvCqiufqmP8F1nj7fTUNtW35LOEt3UZTEsECfo+ELAl/9o9nJx3U91i7vA=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.animation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.assets": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Animation": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "NLayer": "[2.0.1, )",
+          "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
+          "SharpGLTF.Core": "[1.0.6, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
+      "keeneyes.editor": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Editor.Abstractions": "[1.0.0, )",
+          "KeenEyes.Editor.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Silk": "[1.0.0, )",
+          "KeenEyes.Input.Silk": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )",
+          "KeenEyes.Navigation.DotRecast": "[1.0.0, )",
+          "KeenEyes.Platform.Silk": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
+          "KeenEyes.Runtime": "[1.0.0, )",
+          "KeenEyes.TestBridge": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge.Ipc": "[1.0.0, )",
+          "KeenEyes.UI": "[1.0.0, )",
+          "NuGet.Configuration": "[7.6.0, )",
+          "NuGet.Protocol": "[7.6.0, )",
+          "NuGet.Versioning": "[7.6.0, )"
+        }
+      },
+      "keeneyes.editor.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
+      "keeneyes.editor.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Editor.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.silk": {
+        "type": "Project",
+        "dependencies": {
+          "FontStashSharp.PlatformAgnostic": "[1.5.6, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Maths": "[2.23.0, )",
+          "Silk.NET.OpenGL": "[2.23.0, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.input": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )"
+        }
+      },
+      "keeneyes.localization": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Assets": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )",
+          "MessageFormat": "[8.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.dotrecast": {
+        "type": "Project",
+        "dependencies": {
+          "DotRecast.Detour": "[2026.1.3, )",
+          "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
+          "DotRecast.Recast": "[2026.1.3, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
+        }
+      },
+      "keeneyes.runtime": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
+          "KeenEyes.Testing": "[1.0.0, )",
+          "StbImageWriteSharp": "[1.16.7, )"
+        }
+      },
+      "keeneyes.testbridge.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge.ipc": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.TestBridge": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Localization": "[1.0.0, )",
+          "KeenEyes.UI.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.ui.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "DotRecast.Core": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "d+3AfgrG1KfbzrWrcQEASLd4rcI5w0Hp9xI6/T4pFnZhxcO3pKU1mZ9H149axeg0rx36Tf3x3mSGuk0ivLP2Lw=="
+      },
+      "DotRecast.Detour": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "t7Mh/tbueiKJ8MuH33gVSWYGNAas4K9BBMsASEnn9yI6Op+N5fylAaaVpGPaRmobKweyL9oBmH1Y/7Miwobuiw==",
+        "dependencies": {
+          "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.Crowd": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
+        }
+      },
+      "DotRecast.Recast": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "7neVO7d9WZ/pIRyE+MPBcFILrD9x9JebikwImtCA01cIcPbOyEskA1KUotngxPbm/T7HTJqit7qmBwhV9GlLeA==",
+        "dependencies": {
+          "DotRecast.Core": "2026.1.3"
+        }
+      },
+      "FontStashSharp.PlatformAgnostic": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.6, )",
+        "resolved": "1.5.6",
+        "contentHash": "aIuRgPeucC3zkCZvY8Y8E8JyrvukUX8MfKCUO31HWOg3yuYniHUA/3kjpNJE2apRGQzmreYhWFMatKv8cgGRxw==",
+        "dependencies": {
+          "Cyotek.Drawing.BitmapFont": "2.0.4",
+          "FontStashSharp.Base": "1.2.3",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.3",
+          "StbImageSharp": "2.30.15"
+        }
+      },
+      "MessageFormat": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "+nmYgGQVhGXmvQd+AMYILZGTxOP4J9tOR3KbjoxMDDICRrSzHYB9v1aRRVnXkD1ZeBapscFWIf5B/ck3p9R1mg=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "30ffAcvc+M4xXFN06dg2bKyH5eXgJQmyuB5H5cpC47559rQV5x7vZRyyC/YakNLQtBG3IdW/ZAyLCMeDBGDxXg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "NLayer": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "0nhnDRx98u7zXXbPIF11QYYupOOOQ9W22eqoyQyXn/gitRXbf9zAK8YfxyqS1Ix+TSqJv8EPNSk3VkDb7fChKw=="
+      },
+      "NuGet.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
+      },
+      "NVorbis": {
+        "type": "CentralTransitive",
+        "requested": "[0.10.5, )",
+        "resolved": "0.10.5",
+        "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
+      },
+      "SharpGLTF.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.6, )",
+        "resolved": "1.0.6",
+        "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.OpenGL": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "CIakUoUqiAyRPykMk54tr1M1XpbJrT/iw12T85HDQcuRCFlBa1cxbX7v3FmtznKO5eM89esfmGNCgqDaKBiWfg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      },
+      "StbImageWriteSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.7, )",
+        "resolved": "1.16.7",
+        "contentHash": "NF9kOxi0iS9VunklnRKgOpAWC2knCGKRjdy7RT6XAqYNyb7LQfyPHPdl4l1fJw7TFYKrGQzQOmK1XpBONC2MoA=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **`benchmarks/KeenEyes.Editor.Benchmarks`** (in the slnx): deterministic seeded scene generator (17-ary, 4-level hierarchy, mixed archetypes) at 1,000 and 5,000 entities, benchmarking the editor's six hot paths: scene update tick, `SceneSerializer` save/load, play-mode enter/exit (**real `PlayModeManager` + `EditorComponentSerializer`** — the production wiring, headless), hierarchy tree-data refresh, `ComponentIntrospector`, selection + undo/redo commands. MemoryDiagnoser on.
- Runs **in-process** (`InProcessEmitToolchain`, ShortRun): the project's full editor+engine dependency graph blows BenchmarkDotNet's isolated-rebuild timeout, and BDN 0.15.8 has no `WithBuildTimeout` — documented in the config.
- **Baseline result: every threshold passes at 5k** — interactive paths ≤1.8 ms (≈11% of a 60 fps frame at worst), one-shot ops ≤121 ms. Full table + thresholds posted on #1005.
- Allocation outliers flagged (not failures): save/load/play-exit at 5k allocate 42–58 MB via the editor-tier reflection+JSON path — optional GC-pressure follow-up candidate.

## Test plan
- [x] Full 22-benchmark run completed (134 s); results captured on #1005
- [x] Benchmark project + full slnx build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Refs #1005; provides the evidence for #600's final criterion.