### PR TITLE
fix(core): Validate WithBoxed value type; warn on Despawn during iteration

### DIFF
--- a/src/KeenEyes.Core/Entities/EntityBuilder.cs
+++ b/src/KeenEyes.Core/Entities/EntityBuilder.cs
@@ -199,10 +199,22 @@ public sealed class EntityBuilder : IEntityBuilder<EntityBuilder>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="info"/> or <paramref name="value"/> is null.
     /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value"/> is not an instance of the component type
+    /// described by <paramref name="info"/>.
+    /// </exception>
     public EntityBuilder WithBoxed(ComponentInfo info, object value)
     {
         ArgumentNullException.ThrowIfNull(info);
         ArgumentNullException.ThrowIfNull(value);
+
+        if (!info.Type.IsInstanceOfType(value))
+        {
+            throw new ArgumentException(
+                $"Value of type '{value.GetType()}' is not assignable to component type '{info.Type}'.",
+                nameof(value));
+        }
+
         components.Add((info, value));
         return this;
     }

--- a/src/KeenEyes.Core/World.Entities.cs
+++ b/src/KeenEyes.Core/World.Entities.cs
@@ -176,6 +176,13 @@ public sealed partial class World
     /// When an entity with a parent is despawned, it is automatically removed from its
     /// parent's children collection.
     /// </para>
+    /// <para>
+    /// <strong>Warning:</strong> Despawning entities during query iteration may cause
+    /// unexpected behavior — removal swaps the last entity into the freed slot, so one
+    /// entity can be skipped by the enumerator. Queue despawns with
+    /// <see cref="CommandBuffer.Despawn(Entity)"/> and apply them after iteration
+    /// completes instead.
+    /// </para>
     /// </remarks>
     /// <seealso cref="DespawnRecursive(Entity)"/>
     public bool Despawn(Entity entity)

--- a/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
@@ -548,4 +548,36 @@ public class WorldGetAllEntitiesTests
         Assert.Contains(entity2, entities);
         Assert.DoesNotContain(entity1, entities);
     }
+
+    #region WithBoxed Validation
+
+    [Fact]
+    public void WithBoxed_WithMatchingValueType_AddsComponent()
+    {
+        using var world = new World();
+        var info = world.Components.Register<BuilderTestPosition>();
+
+        var entity = world.Spawn()
+            .WithBoxed(info, new BuilderTestPosition { X = 3f, Y = 4f })
+            .Build();
+
+        var component = world.Get<BuilderTestPosition>(entity);
+        Assert.Equal(3f, component.X);
+        Assert.Equal(4f, component.Y);
+    }
+
+    [Fact]
+    public void WithBoxed_WithMismatchedValueType_ThrowsArgumentException()
+    {
+        using var world = new World();
+        var info = world.Components.Register<BuilderTestPosition>();
+
+        var builder = world.Spawn();
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => builder.WithBoxed(info, new BuilderTestVelocity { X = 1f, Y = 2f }));
+        Assert.Contains("not assignable", exception.Message);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
The two surviving actionable findings from the retired 2026-01 nightly review (#972, closed after full re-verification found its critical tier to be false positives):
- **`EntityBuilder.WithBoxed`** now throws `ArgumentException` when the boxed value isn't an instance of the `ComponentInfo`'s type — the XML docs already promised the invariant but nothing enforced it, so mismatches failed deep inside archetype storage. Instance check on an existing object (AOT-safe per CLAUDE.md).
- **`World.Despawn`** gains the during-iteration `<remarks>` warning `Remove<T>` already carries, with the accurate consequence (swap-back removal skips one entity — verified no crash is possible) and a pointer to `CommandBuffer.Despawn` for deferral.

## Test plan
- [x] 2 new tests (mismatch throws with clear message; happy path stores the component) — Core suite 2322/2322
- [x] Release build zero warnings (CS1591 + cref validation enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Fixes #1043, Fixes #1044