### PR TITLE
feat(navigation): Route NavMeshObstacle components through the TileCache rebuild path

### DIFF
--- a/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
@@ -58,6 +58,8 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
     private readonly NavMeshConfig config;
     private readonly NavMeshData? prebuiltMesh;
     private readonly NavMeshStreamingManager? streamingManager;
+    private readonly NavMeshTileCache? tileCache;
+    private readonly NavMeshObstacleCarveConfig? carveConfig;
     private DotRecastProvider? provider;
     private NavMeshObstacleManager? obstacleManager;
 
@@ -156,6 +158,49 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         prebuiltMesh = streamingManager.Mesh;
     }
 
+    /// <summary>
+    /// Creates a new DotRecast navigation plugin whose navmesh is backed by a
+    /// tile cache, routing carving <c>NavMeshObstacle</c> components through
+    /// runtime tile rebuilds.
+    /// </summary>
+    /// <param name="tileCache">
+    /// The tile cache built via <see cref="DotRecastMeshBuilder.BuildTileCache"/>.
+    /// The plugin installs its <see cref="NavMeshTileCache.Mesh"/> on the
+    /// provider, exposes the tile cache as a world extension, and registers a
+    /// system that mirrors entities carrying a carving <c>NavMeshObstacle</c>
+    /// into the cache each update. The caller retains ownership of the cache.
+    /// </param>
+    /// <param name="config">The query configuration.</param>
+    /// <param name="carveConfig">
+    /// The per-tick rebuild budget for obstacle carving. Defaults to
+    /// <see cref="NavMeshObstacleCarveConfig.Default"/> when null.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown if tileCache or config is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if configuration is invalid.</exception>
+    public DotRecastNavigationPlugin(NavMeshTileCache tileCache, NavMeshConfig config, NavMeshObstacleCarveConfig? carveConfig = null)
+    {
+        ArgumentNullException.ThrowIfNull(tileCache);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var error = config.Validate();
+        if (error != null)
+        {
+            throw new ArgumentException($"Invalid NavMeshConfig: {error}", nameof(config));
+        }
+
+        var resolvedCarveConfig = carveConfig ?? NavMeshObstacleCarveConfig.Default;
+        var carveError = resolvedCarveConfig.Validate();
+        if (carveError != null)
+        {
+            throw new ArgumentException($"Invalid NavMeshObstacleCarveConfig: {carveError}", nameof(carveConfig));
+        }
+
+        this.tileCache = tileCache;
+        this.carveConfig = resolvedCarveConfig;
+        this.config = config;
+        prebuiltMesh = tileCache.Mesh;
+    }
+
     /// <inheritdoc/>
     public string Name => "DotRecastNavigation";
 
@@ -188,6 +233,15 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
             context.SetExtension(streamingManager);
             context.AddSystem<NavMeshStreamingSystem>(SystemPhase.Update, order: -200);
         }
+
+        // Tile-cache obstacle carving: expose the cache and drive obstacle
+        // requests plus budgeted rebuilds before path requests run.
+        if (tileCache != null && carveConfig != null)
+        {
+            context.RegisterComponent<NavMeshObstacle>();
+            context.SetExtension(tileCache);
+            context.AddSystem(new ObstacleCarveSystem(tileCache, carveConfig), SystemPhase.Update, order: -200);
+        }
     }
 
     /// <inheritdoc/>
@@ -202,6 +256,11 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         if (streamingManager != null)
         {
             context.RemoveExtension<NavMeshStreamingManager>();
+        }
+
+        if (tileCache != null)
+        {
+            context.RemoveExtension<NavMeshTileCache>();
         }
 
         // Dispose the provider

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshObstacleCarveConfig.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshObstacleCarveConfig.cs
@@ -1,0 +1,41 @@
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// Configuration for the per-tick budget applied when routing
+/// <c>NavMeshObstacle</c> components through a <see cref="NavMeshTileCache"/>.
+/// </summary>
+/// <remarks>
+/// A <see cref="NavMeshTileCache"/> rebuilds at most one affected tile per
+/// <see cref="NavMeshTileCache.Update"/> call, so the obstacle carve system pumps
+/// <see cref="NavMeshTileCache.Update"/> up to
+/// <see cref="MaxTileRebuildsPerUpdate"/> times each frame. This bounds the
+/// per-frame carving cost, spreading a large re-contour across multiple frames.
+/// </remarks>
+public sealed class NavMeshObstacleCarveConfig
+{
+    /// <summary>
+    /// Gets the default obstacle carve configuration.
+    /// </summary>
+    public static NavMeshObstacleCarveConfig Default => new();
+
+    /// <summary>
+    /// Gets or sets the maximum number of <see cref="NavMeshTileCache.Update"/>
+    /// calls (each rebuilding at most one tile) applied per world update. Bounds
+    /// the per-frame cost of obstacle-driven tile rebuilds.
+    /// </summary>
+    public int MaxTileRebuildsPerUpdate { get; set; } = 4;
+
+    /// <summary>
+    /// Validates the configuration.
+    /// </summary>
+    /// <returns>An error message if invalid, or null if valid.</returns>
+    public string? Validate()
+    {
+        if (MaxTileRebuildsPerUpdate < 1)
+        {
+            return "MaxTileRebuildsPerUpdate must be at least 1";
+        }
+
+        return null;
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/ObstacleCarveSystem.cs
+++ b/src/KeenEyes.Navigation.DotRecast/ObstacleCarveSystem.cs
@@ -1,0 +1,136 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast;
+
+/// <summary>
+/// System that routes carving <see cref="NavMeshObstacle"/> components through a
+/// <see cref="NavMeshTileCache"/>, carving the walkable surface itself instead of
+/// only modifying query costs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered by <see cref="DotRecastNavigationPlugin"/> when the plugin is
+/// constructed with a <see cref="NavMeshTileCache"/>. Each update, entities
+/// carrying a carving <see cref="NavMeshObstacle"/> and a <see cref="Transform3D"/>
+/// are mirrored into the tile cache as cylinder or box obstacles: newly seen
+/// obstacles are added, obstacles that moved past their
+/// <see cref="NavMeshObstacle.CarvingMoveThreshold"/> are re-carved (removed and
+/// re-added, since the tile cache has no in-place move), and obstacles whose
+/// entity despawned or dropped the component are removed.
+/// </para>
+/// <para>
+/// After reconciling requests the system pumps <see cref="NavMeshTileCache.Update"/>
+/// up to <see cref="NavMeshObstacleCarveConfig.MaxTileRebuildsPerUpdate"/> times,
+/// spreading tile re-contouring across frames. Runs early in the update phase so
+/// carves land before path requests execute. Non-carving obstacles are ignored
+/// here and remain the responsibility of the provider-agnostic soft-cost path.
+/// </para>
+/// </remarks>
+/// <param name="tileCache">The tile cache whose navmesh is carved.</param>
+/// <param name="config">The per-tick rebuild budget.</param>
+internal sealed class ObstacleCarveSystem(NavMeshTileCache tileCache, NavMeshObstacleCarveConfig config) : SystemBase
+{
+    private readonly Dictionary<int, CarvedObstacle> carved = [];
+    private readonly HashSet<int> seen = [];
+    private readonly List<int> removalScratch = [];
+
+    /// <inheritdoc/>
+    public override void Update(float deltaTime)
+    {
+        seen.Clear();
+
+        foreach (var entity in World.Query<NavMeshObstacle, Transform3D>())
+        {
+            ref readonly var obstacle = ref World.Get<NavMeshObstacle>(entity);
+
+            // Non-carving obstacles are local-avoidance only; leave them to the
+            // provider-agnostic soft-cost path.
+            if (!obstacle.Carving)
+            {
+                continue;
+            }
+
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+            var worldPosition = transform.Position + obstacle.Center;
+            seen.Add(entity.Id);
+
+            if (!carved.TryGetValue(entity.Id, out var state))
+            {
+                long addedRef = AddObstacle(in obstacle, worldPosition, transform.Rotation);
+                carved[entity.Id] = new CarvedObstacle { ObstacleRef = addedRef, LastPosition = worldPosition };
+                continue;
+            }
+
+            // The tile cache exposes no in-place move, so a significant move is a
+            // remove followed by a re-add at the new position.
+            float movedDistance = Vector3.Distance(worldPosition, state.LastPosition);
+            if (movedDistance >= obstacle.CarvingMoveThreshold)
+            {
+                tileCache.RemoveObstacle(state.ObstacleRef);
+                long movedRef = AddObstacle(in obstacle, worldPosition, transform.Rotation);
+                carved[entity.Id] = new CarvedObstacle { ObstacleRef = movedRef, LastPosition = worldPosition };
+            }
+        }
+
+        // Remove carves whose entity despawned or dropped the carving obstacle.
+        removalScratch.Clear();
+        foreach (var (entityId, _) in carved)
+        {
+            if (!seen.Contains(entityId))
+            {
+                removalScratch.Add(entityId);
+            }
+        }
+
+        foreach (int entityId in removalScratch)
+        {
+            tileCache.RemoveObstacle(carved[entityId].ObstacleRef);
+            carved.Remove(entityId);
+        }
+
+        // Pump the incremental rebuild under the per-tick budget; stop early once
+        // the tile cache reports it is up to date.
+        int budget = config.MaxTileRebuildsPerUpdate;
+        for (int i = 0; i < budget; i++)
+        {
+            if (tileCache.Update())
+            {
+                break;
+            }
+        }
+    }
+
+    private long AddObstacle(in NavMeshObstacle obstacle, Vector3 worldPosition, Quaternion rotation)
+    {
+        if (obstacle.Shape == ObstacleShape.Box)
+        {
+            // The component's world position is the box center, matching the tile
+            // cache box convention directly.
+            return tileCache.AddBoxObstacle(worldPosition, obstacle.Size * 0.5f, ExtractYaw(rotation));
+        }
+
+        // Cylinder: the tile cache wants the center of the base, but the component
+        // treats its world position as the volumetric center, so lower the base by
+        // half the height to keep the carve straddling the walkable surface.
+        var basePosition = worldPosition - new Vector3(0f, obstacle.Height * 0.5f, 0f);
+        return tileCache.AddCylinderObstacle(basePosition, obstacle.Radius, obstacle.Height);
+    }
+
+    /// <summary>
+    /// Extracts the heading (rotation about the Y axis) from a quaternion so a box
+    /// obstacle is carved with the entity's yaw.
+    /// </summary>
+    private static float ExtractYaw(Quaternion q)
+    {
+        return MathF.Atan2(2f * (q.X * q.Z + q.W * q.Y), 1f - 2f * (q.X * q.X + q.Y * q.Y));
+    }
+
+    private struct CarvedObstacle
+    {
+        public long ObstacleRef;
+        public Vector3 LastPosition;
+    }
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/ObstacleCarveSystemTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/ObstacleCarveSystemTests.cs
@@ -1,0 +1,234 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Navigation.Abstractions;
+using KeenEyes.Navigation.Abstractions.Components;
+
+namespace KeenEyes.Navigation.DotRecast.Tests;
+
+/// <summary>
+/// World-level integration tests for <see cref="ObstacleCarveSystem"/>: entities
+/// carrying a carving <see cref="NavMeshObstacle"/> drive tile-cache rebuilds
+/// through the plugin-registered system, carving and restoring the walkable
+/// surface as obstacles are added, moved, and removed.
+/// </summary>
+public class ObstacleCarveSystemTests
+{
+    private const float SlabSize = 60f;
+    private const float TimeStep = 0.016f;
+
+    #region Helpers
+
+    private static NavMeshTileCache BuildTileCache()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        return builder.BuildTileCache(vertices, indices);
+    }
+
+    private static void PumpWorld(World world, int updates = 60)
+    {
+        for (int i = 0; i < updates; i++)
+        {
+            world.Update(TimeStep);
+        }
+    }
+
+    /// <summary>
+    /// Spawns an entity with a carving cylinder obstacle centered on the given
+    /// world position (Center offset zero, so the transform position is the carve
+    /// center).
+    /// </summary>
+    private static Entity SpawnCylinderObstacle(World world, Vector3 position, float radius = 3f, float height = 2f)
+    {
+        return world.Spawn()
+            .With(new Transform3D(position, Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Cylinder(radius, height, carving: true))
+            .Build();
+    }
+
+    #endregion
+
+    [Fact]
+    public void Update_CarvingObstacleEntity_BlocksPreviouslyValidPath()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(cache, TestHelper.CreateTiledTestConfig()));
+        var provider = world.GetExtension<DotRecastProvider>();
+
+        var start = new Vector3(30f, 0f, 8f);
+        var end = new Vector3(30f, 0f, 52f);
+
+        var before = provider.FindPath(start, end, AgentSettings.Default);
+        Assert.True(before.IsValid);
+        Assert.True(before.IsComplete, "A path across the open slab should exist before carving.");
+
+        // A box wall spanning the full width of the slab (overhanging both X edges)
+        // splits the slab into a near and far half, disconnecting the two points.
+        world.Spawn()
+            .With(new Transform3D(new Vector3(30f, 0f, 30f), Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Box(new Vector3(80f, 4f, 8f), carving: true))
+            .Build();
+
+        PumpWorld(world);
+
+        Assert.False(cache.Mesh.IsOnNavMesh(new Vector3(30f, 0f, 30f)), "The wall interior should be carved.");
+
+        var after = provider.FindPath(start, end, AgentSettings.Default);
+        Assert.False(after.IsComplete, "The carved wall should block the previously valid path.");
+    }
+
+    [Fact]
+    public void Update_RemovingObstacleComponent_RestoresCarvedSurface()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(cache, TestHelper.CreateTiledTestConfig()));
+
+        var carveCenter = new Vector3(30f, 0f, 30f);
+        var obstacle = SpawnCylinderObstacle(world, carveCenter);
+
+        PumpWorld(world);
+        Assert.False(cache.Mesh.IsOnNavMesh(carveCenter), "The obstacle should carve the surface.");
+
+        Assert.True(world.Remove<NavMeshObstacle>(obstacle));
+        PumpWorld(world);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(carveCenter), "Removing the obstacle component should restore the surface.");
+    }
+
+    [Fact]
+    public void Update_DespawningObstacleEntity_RestoresCarvedSurface()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(cache, TestHelper.CreateTiledTestConfig()));
+
+        var carveCenter = new Vector3(30f, 0f, 30f);
+        var obstacle = SpawnCylinderObstacle(world, carveCenter);
+
+        PumpWorld(world);
+        Assert.False(cache.Mesh.IsOnNavMesh(carveCenter));
+
+        world.Despawn(obstacle);
+        PumpWorld(world);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(carveCenter), "Despawning the obstacle entity should clean up its carve.");
+    }
+
+    [Fact]
+    public void Update_ObstacleEntityMoved_RelocatesCarve()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(cache, TestHelper.CreateTiledTestConfig()));
+
+        var firstPosition = new Vector3(20f, 0f, 30f);
+        var secondPosition = new Vector3(40f, 0f, 30f);
+        var obstacle = SpawnCylinderObstacle(world, firstPosition);
+
+        PumpWorld(world);
+        Assert.False(cache.Mesh.IsOnNavMesh(firstPosition), "The initial position should be carved.");
+        Assert.True(cache.Mesh.IsOnNavMesh(secondPosition), "The destination should still be walkable.");
+
+        world.Get<Transform3D>(obstacle).Position = secondPosition;
+        PumpWorld(world);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(firstPosition), "Moving the obstacle should restore the original position.");
+        Assert.False(cache.Mesh.IsOnNavMesh(secondPosition), "The carve should relocate to the new position.");
+    }
+
+    [Fact]
+    public void Update_BudgetOfOne_LimitsTileRebuildsPerFrame()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(
+            cache,
+            TestHelper.CreateTiledTestConfig(),
+            new NavMeshObstacleCarveConfig { MaxTileRebuildsPerUpdate = 1 }));
+
+        // A large box straddles many tiles, so a single-tile-per-frame budget
+        // cannot drain the rebuild queue in one update.
+        world.Spawn()
+            .With(new Transform3D(new Vector3(30f, 0f, 30f), Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Box(new Vector3(40f, 4f, 40f), carving: true))
+            .Build();
+
+        // One world update: the obstacle is added and exactly one tile is rebuilt.
+        world.Update(TimeStep);
+
+        int extraPumps = 0;
+        while (!cache.Update())
+        {
+            extraPumps++;
+        }
+
+        Assert.True(extraPumps >= 1, "With a budget of one, a multi-tile carve should leave work for later frames.");
+    }
+
+    [Fact]
+    public void Update_LargeBudget_DrainsRebuildQueueInOneFrame()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(
+            cache,
+            TestHelper.CreateTiledTestConfig(),
+            new NavMeshObstacleCarveConfig { MaxTileRebuildsPerUpdate = 256 }));
+
+        world.Spawn()
+            .With(new Transform3D(new Vector3(30f, 0f, 30f), Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Box(new Vector3(40f, 4f, 40f), carving: true))
+            .Build();
+
+        world.Update(TimeStep);
+
+        // A generous budget drains every dirty tile in the same frame, so the tile
+        // cache reports up to date on the first follow-up pump.
+        Assert.True(cache.Update(), "A large budget should fully settle the carve within one frame.");
+    }
+
+    [Fact]
+    public void Update_NonCarvingObstacle_LeavesSurfaceWalkable()
+    {
+        var cache = BuildTileCache();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(cache, TestHelper.CreateTiledTestConfig()));
+
+        var center = new Vector3(30f, 0f, 30f);
+        world.Spawn()
+            .With(new Transform3D(center, Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Cylinder(3f, 2f, carving: false))
+            .Build();
+
+        PumpWorld(world);
+
+        Assert.True(cache.Mesh.IsOnNavMesh(center), "Non-carving obstacles must not carve the tile cache.");
+    }
+
+    [Fact]
+    public void Update_NonTileCachePlugin_DoesNotCarveMesh()
+    {
+        var (vertices, indices) = TestHelper.BuildSlabGeometry(SlabSize);
+        var builder = new DotRecastMeshBuilder(TestHelper.CreateTiledTestConfig());
+        var mesh = builder.Build(vertices, indices);
+
+        using var world = new World();
+        // A plain prebuilt-mesh plugin has no tile cache, so the carve system is
+        // never registered and carving obstacles have no effect on the mesh.
+        world.InstallPlugin(new DotRecastNavigationPlugin(mesh, TestHelper.CreateTiledTestConfig()));
+
+        var center = new Vector3(30f, 0f, 30f);
+        Assert.True(mesh.IsOnNavMesh(center));
+
+        world.Spawn()
+            .With(new Transform3D(center, Quaternion.Identity, Vector3.One))
+            .With(NavMeshObstacle.Box(new Vector3(8f, 4f, 8f), carving: true))
+            .Build();
+
+        PumpWorld(world);
+
+        Assert.True(mesh.IsOnNavMesh(center), "A non-tile-cache provider must ignore the carve path and leave the mesh untouched.");
+    }
+}


### PR DESCRIPTION
## Summary
- **`ObstacleCarveSystem`** (order -200, mirroring the streaming attachment seam — the provider stays cache-unaware): entities with carving `NavMeshObstacle` components flow to `NavMeshTileCache.AddCylinderObstacle`/`AddBoxObstacle`/`RemoveObstacle`; moves ≥ `CarvingMoveThreshold` re-carve (verified: `DtTileCache` has no in-place move); despawn/component-removal cleans up; `Update()` pumped under a `NavMeshObstacleCarveConfig.MaxTileRebuildsPerUpdate` budget.
- **New plugin constructor** `DotRecastNavigationPlugin(NavMeshTileCache, NavMeshConfig, carveConfig?)` installs the cache's mesh, exposes the cache as a world extension, and registers the carve system. Existing constructors untouched — the provider-agnostic soft-cost `ObstacleUpdateSystem` path stays bit-identical for non-TileCache meshes.
- Both `ObstacleShape` values mapped (cylinder base lowered by Height/2 to straddle the surface; box with Y-axis yaw from the transform). Non-carving obstacles skipped.

## Test plan
- [x] 8 new tests: carve blocks a valid path / removal & despawn restore it / move relocates / budget-of-one defers work / large budget drains / non-carving ignored / non-TileCache plugin unaffected — 113 passed / 52 pre-existing skips
- [x] Navigation.Tests 46/46 (no new failures); three nav projects build Release zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Fixes #1041, completes the last #643 spin-off. Noted: `CarvingMoveThreshold`'s XML summary says "time in seconds" but established code treats it as distance — doc nit inherited from `ObstacleUpdateSystem`, worth a one-line doc fix in passing review.