### PR TITLE
fix(network): Compute real correction magnitude and sync interpolation clock

### DIFF
--- a/src/KeenEyes.Network.Abstractions/Components/NetworkState.cs
+++ b/src/KeenEyes.Network.Abstractions/Components/NetworkState.cs
@@ -94,8 +94,25 @@ public record struct PredictionState : IComponent
     public bool MispredictionDetected { get; set; }
 
     /// <summary>
-    /// Gets or sets the magnitude of the last correction (for smoothing).
+    /// Gets or sets the magnitude of the last reconciliation correction, expressed as
+    /// the fraction of compared replicated components whose server-confirmed value
+    /// diverged from the client prediction beyond the misprediction threshold.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The value is normalized to [0, 1]: 0 means the last server confirmation matched
+    /// the prediction (no correction was applied), and 1 means every compared component
+    /// was corrected. A component that was confirmed by the server but had no saved
+    /// prediction counts as corrected.
+    /// </para>
+    /// <para>
+    /// Divergence per component is determined with the same comparison used for
+    /// misprediction detection: the serializer's epsilon-based dirty mask when the
+    /// component supports delta encoding, exact equality otherwise. The magnitude
+    /// therefore measures how broadly the prediction diverged across components, not
+    /// a spatial distance. Smoothing consumers can use it as a normalized weight.
+    /// </para>
+    /// </remarks>
     public float LastCorrectionMagnitude { get; set; }
 
     /// <summary>

--- a/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
+++ b/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
@@ -86,16 +86,17 @@ public sealed class ClientPredictionSystem(
         }
 
         // Compare predicted vs server state
-        var mispredicted = DetectMisprediction(predictedStates, serverStates);
+        var correctionMagnitude = ComputeCorrectionMagnitude(predictedStates, serverStates);
 
-        if (mispredicted)
+        if (correctionMagnitude > 0f)
         {
             predState.MispredictionDetected = true;
-            Reconcile(entity, serverTick, serverStates);
+            Reconcile(entity, serverTick, serverStates, correctionMagnitude);
         }
         else
         {
             predState.MispredictionDetected = false;
+            predState.LastCorrectionMagnitude = 0f;
         }
 
         // Update confirmed tick and clean up old predictions
@@ -136,27 +137,45 @@ public sealed class ClientPredictionSystem(
         predState.LastPredictedTick = tick;
     }
 
-    private bool DetectMisprediction(
+    /// <summary>
+    /// Computes the correction magnitude as the fraction of server-confirmed component
+    /// states that diverged from the prediction beyond the misprediction threshold.
+    /// </summary>
+    /// <param name="predicted">The predicted component states saved for the confirmed tick.</param>
+    /// <param name="server">The authoritative component states received from the server.</param>
+    /// <returns>
+    /// A value in [0, 1]: 0 when every compared component matched the prediction,
+    /// 1 when every compared component had to be corrected. A component with no
+    /// saved prediction counts as corrected.
+    /// </returns>
+    /// <remarks>
+    /// Component mismatch uses the same comparison as misprediction detection (the
+    /// serializer's epsilon-based dirty mask when delta encoding is supported, exact
+    /// equality otherwise). The abstractions cannot measure spatial distance without
+    /// reflection - the interpolator only blends values and the serializer only reports
+    /// which fields changed - so the normalized mismatch fraction is the most honest
+    /// measurable definition of correction size.
+    /// </remarks>
+    private float ComputeCorrectionMagnitude(
         IReadOnlyDictionary<Type, object> predicted,
         IReadOnlyDictionary<Type, object> server)
     {
         var threshold = plugin.Config.MispredictionThreshold;
+        var comparedCount = 0;
+        var correctedCount = 0;
 
         foreach (var (type, serverValue) in server)
         {
-            if (!predicted.TryGetValue(type, out var predictedValue))
-            {
-                // We don't have a prediction for this component, misprediction
-                return true;
-            }
+            comparedCount++;
 
-            if (!ValuesApproximatelyEqual(predictedValue, serverValue, threshold))
+            if (!predicted.TryGetValue(type, out var predictedValue) ||
+                !ValuesApproximatelyEqual(predictedValue, serverValue, threshold))
             {
-                return true;
+                correctedCount++;
             }
         }
 
-        return false;
+        return comparedCount == 0 ? 0f : (float)correctedCount / comparedCount;
     }
 
     private bool ValuesApproximatelyEqual(object predicted, object server, float threshold)
@@ -194,7 +213,8 @@ public sealed class ClientPredictionSystem(
     private void Reconcile(
         Entity entity,
         uint serverTick,
-        IReadOnlyDictionary<Type, object> serverStates)
+        IReadOnlyDictionary<Type, object> serverStates,
+        float correctionMagnitude)
     {
         // Step 1: Apply server state (rollback)
         ApplyServerState(entity, serverStates);
@@ -212,13 +232,10 @@ public sealed class ClientPredictionSystem(
             }
         }
 
-        // Calculate correction magnitude for smoothing
+        // Record the correction magnitude (fraction of compared components corrected,
+        // see ComputeCorrectionMagnitude) for smoothing consumers
         ref var predState = ref World.Get<PredictionState>(entity);
-
-        // If we have an interpolator, we could use it for smooth corrections
-        // For now, just set to a fixed value - a proper implementation would
-        // calculate the actual distance between old and new positions
-        predState.LastCorrectionMagnitude = 1.0f;
+        predState.LastCorrectionMagnitude = correctionMagnitude;
 
         // Store interpolator availability for potential future smoothing
         predState.SmoothingAvailable = smoothingInterpolator is not null;

--- a/src/KeenEyes.Network/Systems/InterpolationSystem.cs
+++ b/src/KeenEyes.Network/Systems/InterpolationSystem.cs
@@ -12,6 +12,15 @@ namespace KeenEyes.Network.Systems;
 /// between received snapshots. This hides network jitter and provides visually
 /// smooth movement.
 /// </para>
+/// <para>
+/// The system maintains a render clock that advances with local frame time but shares
+/// its origin with the tick-derived snapshot timestamps written by the network plugin
+/// (<see cref="InterpolationState.FromTime"/>/<see cref="InterpolationState.ToTime"/>).
+/// Whenever the clock drifts more than <see cref="MaxClockDriftSeconds"/> from the
+/// latest snapshot timestamp (first snapshot after joining a long-running server, a
+/// long stall, or a reconnect), it snaps to that timestamp so interpolation factors
+/// are correct immediately instead of after the clock catches up.
+/// </para>
 /// </remarks>
 /// <param name="interpolationDelayMs">The interpolation delay in milliseconds.</param>
 /// <param name="interpolator">The network interpolator for component interpolation.</param>
@@ -21,6 +30,17 @@ public sealed class InterpolationSystem(
     INetworkInterpolator? interpolator = null,
     Func<Entity, SnapshotBuffer?>? getSnapshotBuffer = null) : SystemBase
 {
+    /// <summary>
+    /// The maximum allowed drift, in seconds, between the render clock and the latest
+    /// snapshot timestamp before the clock snaps to the snapshot time basis.
+    /// </summary>
+    /// <remarks>
+    /// Large enough to tolerate normal jitter between frame-time accumulation and
+    /// tick-derived snapshot timestamps, small enough that joining a long-running
+    /// server or resuming after a stall resynchronizes on the next update.
+    /// </remarks>
+    public const double MaxClockDriftSeconds = 2.0;
+
     private readonly float interpolationDelay = interpolationDelayMs / 1000f;
     private double serverTime;
 
@@ -29,6 +49,9 @@ public sealed class InterpolationSystem(
     {
         // Advance server time estimate
         serverTime += deltaTime;
+
+        // Align the render clock with the tick-derived snapshot timestamps
+        SynchronizeClock();
 
         // Calculate render time (behind server time by interpolation delay)
         var renderTime = serverTime - interpolationDelay;
@@ -54,6 +77,34 @@ public sealed class InterpolationSystem(
                     ApplyInterpolation(entity, snapshotBuffer, interpState.Factor);
                 }
             }
+        }
+    }
+
+    private void SynchronizeClock()
+    {
+        // Find the newest snapshot timestamp written by the receive path. Entities with
+        // no snapshots yet carry the default ToTime of 0 and are ignored.
+        var latestToTime = 0.0;
+        foreach (var entity in World.Query<Interpolated, InterpolationState>())
+        {
+            ref readonly var interpState = ref World.Get<InterpolationState>(entity);
+            if (interpState.ToTime > latestToTime)
+            {
+                latestToTime = interpState.ToTime;
+            }
+        }
+
+        if (latestToTime <= 0.0)
+        {
+            return;
+        }
+
+        // Snap the render clock onto the snapshot time basis when it has drifted too
+        // far (first snapshots after joining, long pauses, reconnects). Within the
+        // window, keep accumulating frame time so rendering stays smooth.
+        if (Math.Abs(serverTime - latestToTime) > MaxClockDriftSeconds)
+        {
+            serverTime = latestToTime;
         }
     }
 

--- a/tests/KeenEyes.Network.Tests/PredictionReconciliationTests.cs
+++ b/tests/KeenEyes.Network.Tests/PredictionReconciliationTests.cs
@@ -2,6 +2,7 @@ using KeenEyes.Network.Components;
 using KeenEyes.Network.Prediction;
 using KeenEyes.Network.Protocol;
 using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Systems;
 using KeenEyes.Network.Transport;
 using KeenEyes.Testing.Network;
 
@@ -95,6 +96,43 @@ public struct NetInput : INetworkInput
 }
 
 /// <summary>
+/// Replicated velocity component used to exercise multi-component correction magnitude.
+/// </summary>
+public struct NetVelocity : IComponent, INetworkSerializable, INetworkDeltaSerializable<NetVelocity>
+{
+    /// <summary>The X velocity.</summary>
+    public float VX;
+
+    /// <inheritdoc/>
+    public readonly void NetworkSerialize(ref BitWriter writer) => writer.WriteFloat(VX);
+
+    /// <inheritdoc/>
+    public void NetworkDeserialize(ref BitReader reader) => VX = reader.ReadFloat();
+
+    /// <inheritdoc/>
+    public readonly uint GetDirtyMask(in NetVelocity baseline) =>
+        MathF.Abs(VX - baseline.VX) > 0.0001f ? 1u : 0u;
+
+    /// <inheritdoc/>
+    public readonly void NetworkSerializeDelta(ref BitWriter writer, in NetVelocity baseline, uint dirtyMask)
+    {
+        if ((dirtyMask & 1) != 0)
+        {
+            writer.WriteFloat(VX);
+        }
+    }
+
+    /// <inheritdoc/>
+    public readonly void NetworkDeserializeDelta(ref BitReader reader, ref NetVelocity baseline, uint dirtyMask)
+    {
+        if ((dirtyMask & 1) != 0)
+        {
+            baseline.VX = reader.ReadFloat();
+        }
+    }
+}
+
+/// <summary>
 /// Test interpolator that linearly blends <see cref="NetPosition"/> values.
 /// </summary>
 public sealed class NetPositionInterpolator : INetworkInterpolator
@@ -156,6 +194,35 @@ public sealed class PredictionReconciliationTests
                 Frequency = 0,
                 Priority = 128,
                 SupportsInterpolation = true,
+                SupportsPrediction = true,
+                SupportsDelta = true,
+            });
+
+        return serializer;
+    }
+
+    private static MockNetworkSerializer CreateSerializerWithVelocity()
+    {
+        var serializer = CreateSerializer();
+        serializer.RegisterComponentWithDelta<NetVelocity>(
+            serialize: (ref BitWriter w, NetVelocity v) => w.WriteFloat(v.VX),
+            deserialize: (ref BitReader r) => new NetVelocity { VX = r.ReadFloat() },
+            getDirtyMask: (NetVelocity current, NetVelocity baseline) => current.GetDirtyMask(baseline),
+            serializeDelta: (ref BitWriter w, NetVelocity current, NetVelocity baseline, uint mask) =>
+                current.NetworkSerializeDelta(ref w, baseline, mask),
+            deserializeDelta: (ref BitReader r, NetVelocity baseline, uint mask) =>
+            {
+                new NetVelocity().NetworkDeserializeDelta(ref r, ref baseline, mask);
+                return baseline;
+            },
+            new NetworkComponentInfo
+            {
+                Type = typeof(NetVelocity),
+                NetworkTypeId = 2,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
                 SupportsPrediction = true,
                 SupportsDelta = true,
             });
@@ -314,6 +381,156 @@ public sealed class PredictionReconciliationTests
 
     #endregion
 
+    #region Correction Magnitude Tests
+
+    [Fact]
+    public async Task OnServerStateReceived_PredictionMatches_ResetsCorrectionMagnitudeToZero()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        await server.ListenAsync(7777);
+
+        var serializer = CreateSerializer();
+        var config = new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            EnablePrediction = true,
+            Serializer = serializer,
+        };
+        var clientPlugin = new NetworkClientPlugin(client, config);
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await clientPlugin.ConnectAsync();
+        clientPlugin.UpdateTick(5);
+
+        var predictedEntity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(predictedEntity, new NetPosition { X = 10f, Y = 0f });
+
+        clientWorld.Update(0.016f);
+
+        // Simulate a stale magnitude left over from an earlier correction;
+        // a matching confirmation must clear it.
+        {
+            ref var predState = ref clientWorld.Get<PredictionState>(predictedEntity);
+            predState.LastCorrectionMagnitude = 0.75f;
+        }
+
+        // Server confirms exactly what the client predicted.
+        SendComponentUpdate(server, serverTick: 5, networkId: 1, serializer, new NetPosition { X = 10f, Y = 0f });
+        client.Update();
+
+        ref readonly var result = ref clientWorld.Get<PredictionState>(predictedEntity);
+        Assert.False(result.MispredictionDetected);
+        Assert.Equal(0f, result.LastCorrectionMagnitude, 0.0001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task Reconcile_SingleComponentDiverged_SetsCorrectionMagnitudeToOne()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        await server.ListenAsync(7777);
+
+        var serializer = CreateSerializer();
+        var config = new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            EnablePrediction = true,
+            Serializer = serializer,
+        };
+        var clientPlugin = new NetworkClientPlugin(client, config);
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await clientPlugin.ConnectAsync();
+        clientPlugin.UpdateTick(5);
+
+        var predictedEntity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(predictedEntity, new NetPosition { X = 10f, Y = 0f });
+
+        clientWorld.Update(0.016f);
+
+        // The only compared component diverges: 1 of 1 corrected -> magnitude 1.
+        SendComponentUpdate(server, serverTick: 5, networkId: 1, serializer, new NetPosition { X = 3f, Y = 0f });
+        client.Update();
+
+        ref readonly var result = ref clientWorld.Get<PredictionState>(predictedEntity);
+        Assert.True(result.MispredictionDetected);
+        Assert.Equal(1f, result.LastCorrectionMagnitude, 0.0001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task Reconcile_MoreComponentsDiverged_IncreasesCorrectionMagnitude()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        await server.ListenAsync(7777);
+
+        var serializer = CreateSerializerWithVelocity();
+        var config = new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            EnablePrediction = true,
+            Serializer = serializer,
+        };
+        var clientPlugin = new NetworkClientPlugin(client, config);
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await clientPlugin.ConnectAsync();
+        clientPlugin.UpdateTick(5);
+
+        var predictedEntity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(predictedEntity, new NetPosition { X = 10f, Y = 0f });
+        clientWorld.Add(predictedEntity, new NetVelocity { VX = 1f });
+
+        // Save the tick-5 prediction for both components.
+        clientWorld.Update(0.016f);
+
+        // Tick 5: only the position diverges -> 1 of 2 compared components corrected.
+        SendComponentUpdates(server, serverTick: 5, networkId: 1, serializer,
+            (typeof(NetPosition), new NetPosition { X = 3f, Y = 0f }),
+            (typeof(NetVelocity), new NetVelocity { VX = 1f }));
+        client.Update();
+
+        var partialMagnitude = clientWorld.Get<PredictionState>(predictedEntity).LastCorrectionMagnitude;
+        Assert.Equal(0.5f, partialMagnitude, 0.0001f);
+
+        // Save the tick-6 prediction (post-reconciliation values).
+        clientPlugin.UpdateTick(6);
+        clientWorld.Update(0.016f);
+
+        // Tick 6: both components diverge -> 2 of 2 compared components corrected.
+        SendComponentUpdates(server, serverTick: 6, networkId: 1, serializer,
+            (typeof(NetPosition), new NetPosition { X = 50f, Y = 20f }),
+            (typeof(NetVelocity), new NetVelocity { VX = 9f }));
+        client.Update();
+
+        var fullMagnitude = clientWorld.Get<PredictionState>(predictedEntity).LastCorrectionMagnitude;
+        Assert.Equal(1f, fullMagnitude, 0.0001f);
+
+        // The magnitude grows monotonically with the breadth of the divergence.
+        Assert.True(fullMagnitude > partialMagnitude);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
     #region Interpolation Tests
 
     [Fact]
@@ -360,6 +577,83 @@ public sealed class PredictionReconciliationTests
         server.Dispose();
     }
 
+    [Fact]
+    public void InterpolationSystem_FirstSnapshotPairAheadOfLocalClock_ProducesCorrectFactor()
+    {
+        using var world = new World();
+
+        var buffers = new Dictionary<Entity, SnapshotBuffer>();
+        var system = new InterpolationSystem(
+            interpolationDelayMs: 50f,
+            interpolator: new NetPositionInterpolator(),
+            getSnapshotBuffer: entity => buffers.GetValueOrDefault(entity));
+        world.AddSystem(system, SystemPhase.Update);
+
+        // Joining a long-running server: the plugin's tick-derived snapshot timestamps
+        // start around 100s while the system's render clock starts at zero.
+        var entity = world.Spawn()
+            .With(default(Interpolated))
+            .With(new InterpolationState { FromTime = 100.0, ToTime = 100.1 })
+            .With(new NetPosition { X = 0f, Y = 0f })
+            .Build();
+
+        var buffer = new SnapshotBuffer();
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 0f, Y = 0f });
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 10f, Y = 0f });
+        buffers[entity] = buffer;
+
+        // On the very first update the clock must adopt the snapshot time basis:
+        // render time = 100.1 - 0.05 = 100.05 -> factor (100.05 - 100.0) / 0.1 = 0.5.
+        // Without origin sync the factor would clamp to 0 until ~100s of frame time
+        // had accumulated.
+        world.Update(0.016f);
+
+        Assert.Equal(0.5f, world.Get<InterpolationState>(entity).Factor, 0.001f);
+        Assert.Equal(5f, world.Get<NetPosition>(entity).X, 0.001f);
+    }
+
+    [Fact]
+    public void InterpolationSystem_AfterLongStall_ResynchronizesToSnapshotTimestamps()
+    {
+        using var world = new World();
+
+        var buffers = new Dictionary<Entity, SnapshotBuffer>();
+        var system = new InterpolationSystem(
+            interpolationDelayMs: 50f,
+            interpolator: new NetPositionInterpolator(),
+            getSnapshotBuffer: entity => buffers.GetValueOrDefault(entity));
+        world.AddSystem(system, SystemPhase.Update);
+
+        var entity = world.Spawn()
+            .With(default(Interpolated))
+            .With(new InterpolationState { FromTime = 0.0, ToTime = 0.1 })
+            .With(new NetPosition { X = 0f, Y = 0f })
+            .Build();
+
+        var buffer = new SnapshotBuffer();
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 0f, Y = 0f });
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 10f, Y = 0f });
+        buffers[entity] = buffer;
+
+        // Normal operation: the render clock and snapshot timestamps share the origin.
+        world.Update(0.1f);
+        Assert.Equal(0.5f, world.Get<InterpolationState>(entity).Factor, 0.001f);
+
+        // Simulated stall/reconnect: the next snapshots arrive with timestamps ~50s
+        // ahead of the local render clock.
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 20f, Y = 0f });
+        buffer.PushSnapshot(typeof(NetPosition), new NetPosition { X = 30f, Y = 0f });
+        world.Set(entity, new InterpolationState { FromTime = 50.0, ToTime = 50.1 });
+
+        // One frame later the clock snaps to the new basis instead of clamping the
+        // factor to 0 for the next ~50 seconds of frame time.
+        // Render time = 50.1 - 0.05 = 50.05 -> factor 0.5 -> X = 25 (blend of 20 and 30).
+        world.Update(0.016f);
+
+        Assert.Equal(0.5f, world.Get<InterpolationState>(entity).Factor, 0.001f);
+        Assert.Equal(25f, world.Get<NetPosition>(entity).X, 0.001f);
+    }
+
     #endregion
 
     private static void SendComponentUpdate(
@@ -375,6 +669,27 @@ public sealed class PredictionReconciliationTests
         writer.WriteNetworkId(networkId);
         writer.WriteComponentCount(1);
         writer.WriteComponent(serializer, typeof(NetPosition), state);
+        server.SendToAll(writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+        server.Update();
+    }
+
+    private static void SendComponentUpdates(
+        LocalTransport server,
+        uint serverTick,
+        uint networkId,
+        MockNetworkSerializer serializer,
+        params (Type Type, object Value)[] components)
+    {
+        Span<byte> buffer = stackalloc byte[256];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.ComponentUpdate, serverTick);
+        writer.WriteNetworkId(networkId);
+        writer.WriteComponentCount((byte)components.Length);
+        foreach (var (type, value) in components)
+        {
+            writer.WriteComponent(serializer, type, value);
+        }
+
         server.SendToAll(writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
         server.Update();
     }


### PR DESCRIPTION
## Summary
The two remnants documented when #1008 activated reconciliation:
- **Real `LastCorrectionMagnitude`** replacing the 1.0f placeholder: normalized mismatch fraction (corrected components / compared components, in [0,1]; reset to 0 on matching confirmations — previously stale). Chosen because it's the most honest *measurable* definition given the abstractions: `INetworkInterpolator` exposes no distance metric and the dirty-mask has no per-type field count, so a spatial/field metric would require banned reflection. Uses the exact comparison misprediction detection already uses; semantics documented on the field.
- **Interpolation render-clock origin sync**: `InterpolationSystem` snaps its accumulated clock to the latest tick-derived snapshot timestamp when drift exceeds a documented `MaxClockDriftSeconds` (2 s) window — fixing late-join (factor no longer clamps to 0 for seconds) and stalls/reconnects, while preserving the sub-second smoothing behavior existing tests pin.

## Test plan
- [x] 5 new tests: magnitude resets on match, 1.0 on full divergence, monotonic 0.5→1.0 across 1-of-2 vs 2-of-2 corrections, correct factor from the very first snapshot pair, resync after a 50 s stall — 313 passed / 2 pre-existing skips, existing tests unmodified
- [x] Release builds zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Fixes #586 — the final item of the networking plan; #353 can close once this merges.