### PR TITLE
feat(replay): Reconstruct ghost frames at delta markers

### DIFF
--- a/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
+++ b/samples/KeenEyes.Sample.Racing/Game/RaceManager.cs
@@ -21,13 +21,12 @@ public readonly record struct LapResult(ReplayData Replay, float LapSeconds);
 /// </summary>
 public sealed class RaceManager
 {
-    // 20 Hz snapshots (every 0.05s) with delta compression disabled so that every
-    // snapshot is a full keyframe. The ghost extractor only reads keyframes, so this
-    // pairing is what yields a smooth ghost - see the README for the full rationale.
+    // 20 Hz snapshots (every 0.05s) with the default delta compression left on. The ghost
+    // extractor reconstructs state at delta markers, so every snapshot feeds the ghost and
+    // the recording stays compact - see the README for the full rationale.
     private static readonly ReplayOptions recordingOptions = new()
     {
         SnapshotInterval = TimeSpan.FromSeconds(0.05),
-        KeyframeInterval = 1,
         RecordSystemEvents = false,
         RecordComponentEvents = false,
         RecordEntityEvents = false,

--- a/samples/KeenEyes.Sample.Racing/README.md
+++ b/samples/KeenEyes.Sample.Racing/README.md
@@ -87,7 +87,7 @@ world.InstallPlugin(new ReplayPlugin(serializer, recordingOptions));
 new ReplayOptions
 {
     SnapshotInterval = TimeSpan.FromSeconds(0.05), // ~20 Hz snapshots
-    KeyframeInterval = 1,                          // every snapshot is a full keyframe
+    // KeyframeInterval left at its default (10) - delta compression stays on.
     RecordSystemEvents = false,
     RecordComponentEvents = false,
     RecordEntityEvents = false,
@@ -99,14 +99,16 @@ Two settings matter for ghost fidelity, and they interact:
 - **`SnapshotInterval`** controls how often the world state is captured. Ghost frames
   come from snapshots, so a short interval means a smoother ghost.
 - **`KeyframeInterval`** controls how many snapshots are stored as full *keyframes*
-  versus space-saving *deltas*. **The ghost extractor only reads keyframes** - delta
-  markers carry no snapshot. With the default `KeyframeInterval = 10`, only every
-  tenth snapshot would be usable and the ghost would be jerky. Setting it to `1`
-  makes every snapshot a keyframe, so all ~100+ frames per lap feed the ghost.
+  versus space-saving *deltas*. **The ghost extractor reconstructs state at delta
+  markers** by replaying the delta chain from the governing keyframe, so *every*
+  snapshot feeds the ghost regardless of this setting. With the default
+  `KeyframeInterval = 10`, roughly one snapshot in ten is a full keyframe and the rest
+  are compact deltas - yet all ~100+ frames per lap still produce ghost frames.
 
-The trade-off: `KeyframeInterval = 1` disables delta compression, so the replay is
-larger. That is the right call here - a single-car time-trial recording is tiny
-(a few kilobytes) and fidelity is what matters for a good ghost.
+That is why this sample leaves `KeyframeInterval` at its default: the ghost is smooth
+*and* the recording stays small. (Earlier versions had to force `KeyframeInterval = 1`
+because the extractor read only keyframes; that workaround is no longer needed - see
+issue #1035.)
 
 ### Distance-synced comparison
 

--- a/src/KeenEyes.Core/Serialization/DeltaSnapshotApplier.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaSnapshotApplier.cs
@@ -1,0 +1,213 @@
+namespace KeenEyes.Serialization;
+
+/// <summary>
+/// Reconstructs a full <see cref="WorldSnapshot"/> by applying a <see cref="DeltaSnapshot"/>
+/// to a baseline snapshot, without requiring a live <see cref="World"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DeltaRestorer"/> mutates a live world in place; this applier is its
+/// world-free counterpart. It operates purely on the serialized representation
+/// (<see cref="WorldSnapshot"/>, <see cref="SerializedEntity"/>, <see cref="SerializedComponent"/>)
+/// and never deserializes component payloads, so it needs no component serializer and
+/// performs no reflection.
+/// </para>
+/// <para>
+/// This makes it suitable for tools that must reconstruct historical state offline -
+/// for example extracting ghost trails from a delta-compressed replay - where spinning
+/// up a world purely to read back state would be wasteful and would require a serializer.
+/// </para>
+/// <para>
+/// To reconstruct the state at a delta marker, restore the governing keyframe's
+/// <see cref="WorldSnapshot"/> and apply each intervening delta in order:
+/// <code>
+/// var state = keyframe.Snapshot!;
+/// foreach (var marker in deltaMarkersInOrder)
+/// {
+///     state = DeltaSnapshotApplier.Apply(state, marker.Delta!);
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+public static class DeltaSnapshotApplier
+{
+    /// <summary>
+    /// Applies a delta snapshot to a baseline snapshot and returns the reconstructed state.
+    /// </summary>
+    /// <param name="baseline">
+    /// The snapshot the delta is relative to - either a keyframe or a previously
+    /// reconstructed state.
+    /// </param>
+    /// <param name="delta">The incremental changes to apply.</param>
+    /// <returns>
+    /// A new <see cref="WorldSnapshot"/> representing the world state after the delta
+    /// is applied. The input snapshots are never mutated.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="baseline"/> or <paramref name="delta"/> is null.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The delta is applied in the same conceptual order as <see cref="DeltaRestorer.ApplyDelta"/>:
+    /// destroyed entities are removed, created entities are appended, then per-entity
+    /// modifications (name, parent, and added/removed/modified components) are applied,
+    /// followed by singleton additions, replacements, and removals.
+    /// </para>
+    /// <para>
+    /// Baseline entity order is preserved and newly created entities are appended, keeping
+    /// parents ahead of children as required by <see cref="WorldSnapshot.Entities"/>.
+    /// References that cannot be resolved (a modification targeting an entity absent from
+    /// the baseline, a removal of a component that is not present) are skipped, mirroring
+    /// the lenient behavior of <see cref="DeltaRestorer"/>.
+    /// </para>
+    /// </remarks>
+    public static WorldSnapshot Apply(WorldSnapshot baseline, DeltaSnapshot delta)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(delta);
+
+        // Rebuild the entity list: baseline entities (minus destroyed ones) keep their
+        // order, then created entities are appended. indexById tracks each surviving
+        // entity's slot so modifications can be applied in place.
+        var destroyed = new HashSet<int>(delta.DestroyedEntityIds);
+        var entities = new List<SerializedEntity>(baseline.Entities.Count);
+        var indexById = new Dictionary<int, int>(baseline.Entities.Count);
+
+        foreach (var entity in baseline.Entities)
+        {
+            if (destroyed.Contains(entity.Id))
+            {
+                continue;
+            }
+
+            indexById[entity.Id] = entities.Count;
+            entities.Add(entity);
+        }
+
+        foreach (var created in delta.CreatedEntities)
+        {
+            if (indexById.TryGetValue(created.Id, out var existingIndex))
+            {
+                // An id collision with a surviving entity is unexpected; treat the created
+                // record as authoritative to match a live re-spawn's last-writer-wins result.
+                entities[existingIndex] = created;
+            }
+            else
+            {
+                indexById[created.Id] = entities.Count;
+                entities.Add(created);
+            }
+        }
+
+        foreach (var modification in delta.ModifiedEntities)
+        {
+            if (!indexById.TryGetValue(modification.EntityId, out var index))
+            {
+                continue; // Entity not present in the baseline - skip.
+            }
+
+            entities[index] = ApplyEntityDelta(entities[index], modification);
+        }
+
+        var singletons = ApplySingletonChanges(baseline.Singletons, delta);
+
+        return new WorldSnapshot
+        {
+            Version = baseline.Version,
+            Timestamp = delta.Timestamp,
+            Entities = entities,
+            Singletons = singletons,
+            Metadata = baseline.Metadata,
+        };
+    }
+
+    /// <summary>
+    /// Produces a new <see cref="SerializedEntity"/> with the entity delta applied.
+    /// </summary>
+    private static SerializedEntity ApplyEntityDelta(SerializedEntity entity, EntityDelta delta)
+    {
+        var name = delta.NewName ?? entity.Name;
+
+        int? parentId = entity.ParentId;
+        if (delta.ParentRemoved)
+        {
+            parentId = null;
+        }
+        else if (delta.NewParentId.HasValue)
+        {
+            parentId = delta.NewParentId;
+        }
+
+        var components = new List<SerializedComponent>(entity.Components);
+
+        if (delta.RemovedComponentTypes.Count > 0)
+        {
+            var removed = new HashSet<string>(delta.RemovedComponentTypes, StringComparer.Ordinal);
+            components.RemoveAll(c => removed.Contains(c.TypeName));
+        }
+
+        foreach (var added in delta.AddedComponents)
+        {
+            ReplaceOrAppendComponent(components, added);
+        }
+
+        foreach (var modified in delta.ModifiedComponents)
+        {
+            ReplaceOrAppendComponent(components, modified);
+        }
+
+        return entity with
+        {
+            Name = name,
+            ParentId = parentId,
+            Components = components,
+        };
+    }
+
+    /// <summary>
+    /// Replaces the component with a matching type name, or appends it when absent.
+    /// </summary>
+    private static void ReplaceOrAppendComponent(List<SerializedComponent> components, SerializedComponent component)
+    {
+        var index = components.FindIndex(c => string.Equals(c.TypeName, component.TypeName, StringComparison.Ordinal));
+        if (index >= 0)
+        {
+            components[index] = component;
+        }
+        else
+        {
+            components.Add(component);
+        }
+    }
+
+    /// <summary>
+    /// Applies singleton additions, replacements, and removals from the delta.
+    /// </summary>
+    private static List<SerializedSingleton> ApplySingletonChanges(
+        IReadOnlyList<SerializedSingleton> baseline,
+        DeltaSnapshot delta)
+    {
+        var singletons = new List<SerializedSingleton>(baseline);
+
+        if (delta.RemovedSingletonTypes.Count > 0)
+        {
+            var removed = new HashSet<string>(delta.RemovedSingletonTypes, StringComparer.Ordinal);
+            singletons.RemoveAll(s => removed.Contains(s.TypeName));
+        }
+
+        foreach (var modified in delta.ModifiedSingletons)
+        {
+            var index = singletons.FindIndex(s => string.Equals(s.TypeName, modified.TypeName, StringComparison.Ordinal));
+            if (index >= 0)
+            {
+                singletons[index] = modified;
+            }
+            else
+            {
+                singletons.Add(modified);
+            }
+        }
+
+        return singletons;
+    }
+}

--- a/src/KeenEyes.Replay/Ghost/GhostExtractor.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostExtractor.cs
@@ -100,86 +100,7 @@ public sealed class GhostExtractor
             return null;
         }
 
-        var frames = new List<GhostFrame>();
-        TimeSpan lastFrameTime = TimeSpan.MinValue;
-        float cumulativeDistance = 0f;
-        Vector3? lastPosition = null;
-
-        foreach (var snapshotMarker in replay.Snapshots)
-        {
-            // Ghost extraction reads full entity state; delta markers carry no snapshot.
-            if (snapshotMarker.Snapshot is null)
-            {
-                continue;
-            }
-
-            // Skip if we haven't passed the minimum interval
-            if (MinFrameInterval > TimeSpan.Zero &&
-                snapshotMarker.ElapsedTime - lastFrameTime < MinFrameInterval)
-            {
-                continue;
-            }
-
-            // Find the entity in this snapshot
-            var entity = snapshotMarker.Snapshot.Entities
-                .FirstOrDefault(e => e.Name == entityName);
-
-            if (entity is null)
-            {
-                continue;
-            }
-
-            // Find the Transform3D component
-            var transformComponent = entity.Components
-                .FirstOrDefault(c => c.TypeName.StartsWith(Transform3DTypeName, StringComparison.Ordinal));
-
-            if (transformComponent is null || transformComponent.Data is null)
-            {
-                continue;
-            }
-
-            // Parse the transform data
-            var transform = ParseTransform3D(transformComponent.Data.Value);
-            if (transform is null)
-            {
-                continue;
-            }
-
-            var (position, rotation, scale) = transform.Value;
-
-            // Calculate distance if enabled
-            if (CalculateDistance && lastPosition.HasValue)
-            {
-                cumulativeDistance += Vector3.Distance(lastPosition.Value, position);
-            }
-            lastPosition = position;
-
-            // Create the ghost frame
-            var ghostFrame = new GhostFrame(position, rotation, snapshotMarker.ElapsedTime)
-            {
-                Scale = scale,
-                Distance = cumulativeDistance
-            };
-
-            frames.Add(ghostFrame);
-            lastFrameTime = snapshotMarker.ElapsedTime;
-        }
-
-        if (frames.Count == 0)
-        {
-            return null;
-        }
-
-        return new GhostData
-        {
-            Name = replay.Name,
-            EntityName = entityName,
-            RecordingStarted = replay.RecordingStarted,
-            Duration = frames[^1].ElapsedTime - frames[0].ElapsedTime,
-            FrameCount = frames.Count,
-            Frames = frames,
-            Metadata = replay.Metadata
-        };
+        return BuildGhost(replay, entity => entity.Name == entityName, entityName);
     }
 
     /// <summary>
@@ -209,38 +130,48 @@ public sealed class GhostExtractor
             return null;
         }
 
+        return BuildGhost(replay, entity => entity.Id == entityId, entityName: null);
+    }
+
+    /// <summary>
+    /// Builds ghost data for the entity matched by <paramref name="matchEntity"/> across the
+    /// replay's reconstructed states.
+    /// </summary>
+    /// <param name="replay">The source replay data.</param>
+    /// <param name="matchEntity">Predicate that selects the target entity in each state.</param>
+    /// <param name="entityName">
+    /// The known entity name, or <c>null</c> to capture it from the first matching entity
+    /// (used by the by-id overload where the name is not known up front).
+    /// </param>
+    /// <returns>The extracted ghost data, or null when no frames were produced.</returns>
+    private GhostData? BuildGhost(ReplayData replay, Func<SerializedEntity, bool> matchEntity, string? entityName)
+    {
         var frames = new List<GhostFrame>();
         TimeSpan lastFrameTime = TimeSpan.MinValue;
         float cumulativeDistance = 0f;
         Vector3? lastPosition = null;
-        string? entityName = null;
+        var resolvedName = entityName;
 
-        foreach (var snapshotMarker in replay.Snapshots)
+        // Each marker contributes a frame: keyframes are read directly, delta markers are
+        // reconstructed by applying the delta chain from the governing keyframe.
+        foreach (var (marker, state) in ReconstructStates(replay))
         {
-            // Ghost extraction reads full entity state; delta markers carry no snapshot.
-            if (snapshotMarker.Snapshot is null)
-            {
-                continue;
-            }
-
             // Skip if we haven't passed the minimum interval
             if (MinFrameInterval > TimeSpan.Zero &&
-                snapshotMarker.ElapsedTime - lastFrameTime < MinFrameInterval)
+                marker.ElapsedTime - lastFrameTime < MinFrameInterval)
             {
                 continue;
             }
 
-            // Find the entity in this snapshot
-            var entity = snapshotMarker.Snapshot.Entities
-                .FirstOrDefault(e => e.Id == entityId);
-
+            // Find the entity in the reconstructed state
+            var entity = state.Entities.FirstOrDefault(matchEntity);
             if (entity is null)
             {
                 continue;
             }
 
-            // Capture entity name from first occurrence
-            entityName ??= entity.Name;
+            // Capture the entity name from the first occurrence when it was not supplied.
+            resolvedName ??= entity.Name;
 
             // Find the Transform3D component
             var transformComponent = entity.Components
@@ -251,7 +182,8 @@ public sealed class GhostExtractor
                 continue;
             }
 
-            // Parse the transform data
+            // Parse the transform data. Malformed component data yields null and the frame
+            // is skipped, so a single corrupt marker does not abort the whole extraction.
             var transform = ParseTransform3D(transformComponent.Data.Value);
             if (transform is null)
             {
@@ -268,14 +200,14 @@ public sealed class GhostExtractor
             lastPosition = position;
 
             // Create the ghost frame
-            var ghostFrame = new GhostFrame(position, rotation, snapshotMarker.ElapsedTime)
+            var ghostFrame = new GhostFrame(position, rotation, marker.ElapsedTime)
             {
                 Scale = scale,
                 Distance = cumulativeDistance
             };
 
             frames.Add(ghostFrame);
-            lastFrameTime = snapshotMarker.ElapsedTime;
+            lastFrameTime = marker.ElapsedTime;
         }
 
         if (frames.Count == 0)
@@ -286,13 +218,70 @@ public sealed class GhostExtractor
         return new GhostData
         {
             Name = replay.Name,
-            EntityName = entityName,
+            EntityName = resolvedName,
             RecordingStarted = replay.RecordingStarted,
             Duration = frames[^1].ElapsedTime - frames[0].ElapsedTime,
             FrameCount = frames.Count,
             Frames = frames,
             Metadata = replay.Metadata
         };
+    }
+
+    /// <summary>
+    /// Reconstructs the full world state at each snapshot marker in recording order.
+    /// </summary>
+    /// <param name="replay">The source replay data.</param>
+    /// <returns>
+    /// A sequence of markers paired with the world state at that marker. Keyframes yield
+    /// their stored snapshot directly; delta markers yield the state produced by applying
+    /// their delta to the running reconstructed state.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// A delta marker that precedes the first keyframe cannot be reconstructed and is
+    /// skipped. If applying a delta throws (a corrupt or inconsistent marker), that marker
+    /// is skipped and the running baseline is discarded: because each delta is relative to
+    /// the immediately preceding marker, a broken link makes every subsequent delta
+    /// unreconstructable until the next keyframe re-establishes a self-contained baseline.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<(SnapshotMarker Marker, WorldSnapshot State)> ReconstructStates(ReplayData replay)
+    {
+        WorldSnapshot? currentState = null;
+
+        foreach (var marker in replay.Snapshots)
+        {
+            if (marker.Snapshot is not null)
+            {
+                // Keyframe: a self-contained restore point resets the running state.
+                currentState = marker.Snapshot;
+            }
+            else if (marker.Delta is not null && currentState is not null)
+            {
+                WorldSnapshot next;
+                try
+                {
+                    next = DeltaSnapshotApplier.Apply(currentState, marker.Delta);
+                }
+                catch (Exception)
+                {
+                    // Broad catch: a malformed delta must not abort extraction. Skip this
+                    // marker and invalidate the chain until the next keyframe.
+                    currentState = null;
+                    continue;
+                }
+
+                currentState = next;
+            }
+            else
+            {
+                // Delta marker with no governing keyframe, or a marker carrying neither a
+                // snapshot nor a delta: nothing to reconstruct from.
+                continue;
+            }
+
+            yield return (marker, currentState);
+        }
     }
 
     /// <summary>
@@ -323,8 +312,9 @@ public sealed class GhostExtractor
             return result;
         }
 
-        // Find all unique entity names with transforms. Delta markers carry no full
-        // snapshot, so only keyframe markers contribute entity names here.
+        // Discover candidate entity names from keyframes, which carry full state. Each named
+        // entity is then extracted via ExtractGhost, whose reconstruction fills in the
+        // frames contributed by the intervening delta markers.
         var entityNames = replay.Snapshots
             .Where(s => s.Snapshot is not null)
             .SelectMany(s => s.Snapshot!.Entities)
@@ -381,8 +371,10 @@ public sealed class GhostExtractor
 
             return (position, rotation, scale);
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException or FormatException)
         {
+            // Malformed transform data (wrong JSON shape, or a value that is not a number).
+            // Treat as unreadable so the caller skips the frame rather than throwing.
             return null;
         }
     }

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostExtractorTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostExtractorTests.cs
@@ -1,0 +1,175 @@
+using System.Numerics;
+using System.Text.Json;
+using KeenEyes.Common;
+using KeenEyes.Replay.Ghost;
+
+namespace KeenEyes.Replay.Tests.Ghost;
+
+/// <summary>
+/// Tests for <see cref="GhostExtractor"/> reconstructing ghost frames at delta markers
+/// of delta-compressed replays, so ghost fidelity no longer depends on
+/// <see cref="ReplayOptions.KeyframeInterval"/> being 1 (see issue #1035).
+/// </summary>
+public class GhostExtractorTests
+{
+    private const float FrameDelta = 0.05f;
+    private const string TransformTypeName = "KeenEyes.Common.Transform3D";
+
+    [Fact]
+    public void ExtractGhost_DeltaCompressedRecording_MatchesAllKeyframeRecording()
+    {
+        // Identical scripted gameplay recorded twice: once with delta compression on
+        // (mixed keyframes + deltas) and once with every snapshot a full keyframe.
+        var serializer = new RestorationTestSerializer().WithComponent<Transform3D>();
+        var deltaReplay = RecordRace(serializer, keyframeInterval: 10, snapshotFrames: 30);
+        var keyframeReplay = RecordRace(serializer, keyframeInterval: 1, snapshotFrames: 30);
+
+        // Preconditions: the delta recording actually used deltas, the keyframe one did not.
+        Assert.Contains(deltaReplay.Snapshots, m => !m.IsKeyframe);
+        Assert.All(keyframeReplay.Snapshots, m => Assert.True(m.IsKeyframe));
+
+        var extractor = new GhostExtractor();
+        var deltaGhost = extractor.ExtractGhost(deltaReplay, "Racer");
+        var keyframeGhost = extractor.ExtractGhost(keyframeReplay, "Racer");
+
+        Assert.NotNull(deltaGhost);
+        Assert.NotNull(keyframeGhost);
+
+        // Every marker contributes a frame in both recordings, so the counts match.
+        Assert.Equal(keyframeGhost!.FrameCount, deltaGhost!.FrameCount);
+        Assert.Equal(keyframeGhost.Frames.Count, deltaGhost.Frames.Count);
+
+        // Reconstructed positions/rotations must match the all-keyframe ghost exactly
+        // (within floating-point tolerance) frame for frame.
+        for (int i = 0; i < keyframeGhost.Frames.Count; i++)
+        {
+            var expected = keyframeGhost.Frames[i];
+            var actual = deltaGhost.Frames[i];
+
+            Assert.Equal(expected.ElapsedTime, actual.ElapsedTime);
+            Assert.True(expected.Position.X.ApproximatelyEquals(actual.Position.X));
+            Assert.True(expected.Position.Y.ApproximatelyEquals(actual.Position.Y));
+            Assert.True(expected.Position.Z.ApproximatelyEquals(actual.Position.Z));
+            Assert.True(expected.Rotation.X.ApproximatelyEquals(actual.Rotation.X));
+            Assert.True(expected.Rotation.Y.ApproximatelyEquals(actual.Rotation.Y));
+            Assert.True(expected.Rotation.Z.ApproximatelyEquals(actual.Rotation.Z));
+            Assert.True(expected.Rotation.W.ApproximatelyEquals(actual.Rotation.W));
+            Assert.True(expected.Distance.ApproximatelyEquals(actual.Distance));
+        }
+    }
+
+    [Fact]
+    public void ExtractGhost_CorruptedDeltaMarker_SkipsMarkerAndContinues()
+    {
+        var serializer = new RestorationTestSerializer().WithComponent<Transform3D>();
+        var replay = RecordRace(serializer, keyframeInterval: 10, snapshotFrames: 30);
+
+        var extractor = new GhostExtractor();
+        var baseline = extractor.ExtractGhost(replay, "Racer");
+        Assert.NotNull(baseline);
+
+        // Corrupt a single mid-chain delta marker's transform data. The next delta rewrites
+        // the transform, so only this one marker should drop out of the ghost.
+        var corruptIndex = replay.Snapshots
+            .Select((marker, index) => (marker, index))
+            .First(x => !x.marker.IsKeyframe && x.index < replay.Snapshots.Count - 1)
+            .index;
+        var corruptElapsed = replay.Snapshots[corruptIndex].ElapsedTime;
+        var corrupted = CorruptTransformData(replay, corruptIndex);
+
+        var corruptedGhost = extractor.ExtractGhost(corrupted, "Racer");
+
+        // Extraction continues past the bad marker rather than aborting or throwing.
+        Assert.NotNull(corruptedGhost);
+
+        // Exactly the corrupt marker is skipped; every other marker still yields a frame.
+        Assert.Equal(baseline!.FrameCount - 1, corruptedGhost!.FrameCount);
+        Assert.DoesNotContain(corruptedGhost.Frames, f => f.ElapsedTime == corruptElapsed);
+        Assert.Contains(baseline.Frames, f => f.ElapsedTime == corruptElapsed);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Records a scripted lap in which a single named "Racer" entity moves along a
+    /// deterministic curve, capturing one snapshot per frame from frame 1 onward.
+    /// </summary>
+    private static ReplayData RecordRace(
+        RestorationTestSerializer serializer,
+        int keyframeInterval,
+        int snapshotFrames)
+    {
+        using var world = new World();
+        var racer = world.Spawn("Racer")
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        var recorder = new ReplayRecorder(
+            world,
+            serializer,
+            new ReplayOptions
+            {
+                RecordChecksums = false,
+                SnapshotInterval = TimeSpan.Zero, // Snapshots captured explicitly below.
+                KeyframeInterval = keyframeInterval,
+            });
+
+        recorder.StartRecording("Race");
+
+        for (int frame = 0; frame <= snapshotFrames; frame++)
+        {
+            recorder.BeginFrame(FrameDelta);
+
+            ref var transform = ref world.Get<Transform3D>(racer);
+            transform.Position = new Vector3(frame * 2f, MathF.Sin(frame * 0.5f), frame * 0.5f);
+            transform.Rotation = Quaternion.CreateFromYawPitchRoll(frame * 0.1f, 0f, 0f);
+
+            // Frame 0 already has the automatic initial snapshot; capture the rest.
+            if (frame > 0)
+            {
+                recorder.CaptureSnapshot();
+            }
+
+            recorder.EndFrame(FrameDelta);
+        }
+
+        var data = recorder.StopRecording();
+        Assert.NotNull(data);
+        return data!;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="replay"/> whose delta marker at
+    /// <paramref name="markerIndex"/> has its Transform3D component data replaced with a
+    /// non-numeric value, so parsing that reconstructed transform fails.
+    /// </summary>
+    private static ReplayData CorruptTransformData(ReplayData replay, int markerIndex)
+    {
+        var marker = replay.Snapshots[markerIndex];
+        var delta = marker.Delta!;
+
+        var badData = JsonDocument.Parse(
+            "{\"position\":{\"x\":\"corrupt\",\"y\":0,\"z\":0}," +
+            "\"rotation\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}," +
+            "\"scale\":{\"x\":1,\"y\":1,\"z\":1}}").RootElement.Clone();
+
+        var modifiedEntities = delta.ModifiedEntities
+            .Select(entityDelta => entityDelta with
+            {
+                ModifiedComponents = entityDelta.ModifiedComponents
+                    .Select(component => component.TypeName.StartsWith(TransformTypeName, StringComparison.Ordinal)
+                        ? component with { Data = badData }
+                        : component)
+                    .ToList(),
+            })
+            .ToList();
+
+        var corruptMarker = marker with { Delta = delta with { ModifiedEntities = modifiedEntities } };
+
+        var snapshots = replay.Snapshots.ToList();
+        snapshots[markerIndex] = corruptMarker;
+        return replay with { Snapshots = snapshots };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **`DeltaSnapshotApplier`** (Core, next to `DeltaRestorer`): world-free delta application — `Apply(WorldSnapshot baseline, DeltaSnapshot) → WorldSnapshot`, operating purely on serialized representations (no serializer, no reflection, inputs immutable). Generally reusable for offline state reconstruction; mirrors `DeltaRestorer`'s lenient semantics.
- **`GhostExtractor`** now walks markers with a running reconstructed snapshot (keyframes reset it, deltas apply onto it) — **full-fidelity ghosts from delta-compressed replays**. Keyframe-only fast path preserved; a broken delta invalidates its chain until the next keyframe (documented); malformed transform data skips just that frame.
- **Racing sample workaround removed**: `KeyframeInterval` back to the default 10 (delta compression on) — sample verifies **107 snapshots → 107 ghost frames** (4.4 KB on disk), smooth trails intact. README lesson rewritten to describe the fixed behavior.

## Test plan
- [x] New tests: interval-10 ghost matches interval-1 ghost frame-for-frame (count/positions/rotations/distance, FloatExtensions tolerances); corrupted mid-chain delta skips exactly one marker and recovers — Replay 609/609, Core 2320/2320 (Core touched)
- [x] Sample runs unattended end-to-end (re-verified)
- [x] Release builds zero warnings (CS1591 enforced); `dotnet format` clean
- [ ] CI green

## Related Issues
Fixes #1035