### PR TITLE
feat(editor): Install built-in gizmo plugins at startup

### DIFF
--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -48,6 +48,8 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
     private readonly EditorLogProvider _logProvider;
     private readonly AssetDatabase _assetDatabase;
     private readonly EditorComponentSerializer _serializer;
+    private readonly KeenEyes.Editor.Plugins.EditorPluginManager _pluginManager;
+    private readonly KeenEyes.Editor.Plugins.Capabilities.ViewportCapability _viewportCapability;
     private PlayModeManager? _playMode;
     private HotReloadService? _hotReload;
     private ReplayPlaybackMode? _replayPlayback;
@@ -176,6 +178,21 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
         {
             _shortcuts.Load(EditorSettings.ShortcutsFilePath);
         }
+
+        // Set up the editor plugin host and register the viewport capability, then install
+        // the built-in gizmo plugins. The plugins register their debug gizmo renderers through
+        // the viewport capability; disposing the plugin manager on shutdown uninstalls them and
+        // removes those renderers again (see Dispose).
+        _viewportCapability = new KeenEyes.Editor.Plugins.Capabilities.ViewportCapability();
+        _pluginManager = new KeenEyes.Editor.Plugins.EditorPluginManager(
+            _worldManager,
+            _selection,
+            _undoRedo,
+            _assetDatabase,
+            _editorWorld,
+            _logProvider);
+        _pluginManager.RegisterCapability<KeenEyes.Editor.Abstractions.Capabilities.IViewportCapability>(_viewportCapability);
+        KeenEyes.Editor.Plugins.BuiltIn.BuiltInGizmoPlugins.Install(_pluginManager);
     }
 
     /// <summary>
@@ -2218,6 +2235,9 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
             _sceneTestBridge.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _sceneTestBridge = null;
         }
+
+        // Uninstall built-in plugins (removes their gizmo renderers from the viewport capability)
+        _pluginManager.Dispose();
 
         _hotReload?.Dispose();
         _replayPlayback?.Dispose();

--- a/editor/KeenEyes.Editor/Application/EditorWorldManager.cs
+++ b/editor/KeenEyes.Editor/Application/EditorWorldManager.cs
@@ -1,5 +1,6 @@
 using KeenEyes.Editor.Assets;
 using KeenEyes.Scenes;
+using Abstractions = KeenEyes.Editor.Abstractions;
 
 namespace KeenEyes.Editor.Application;
 
@@ -7,7 +8,7 @@ namespace KeenEyes.Editor.Application;
 /// Manages the separation between the editor UI world and scene editing worlds.
 /// Uses SceneManager API for scene lifecycle management with a single persistent World.
 /// </summary>
-public sealed class EditorWorldManager : IDisposable
+public sealed class EditorWorldManager : Abstractions.IEditorWorldManager, IDisposable
 {
     private readonly World _world;
     private readonly SceneSerializer _sceneSerializer = new();
@@ -15,6 +16,12 @@ public sealed class EditorWorldManager : IDisposable
     private string? _currentScenePath;
     private bool _isDisposed;
     private int _sceneModificationCount;
+
+    // Backing delegates for the IEditorWorldManager events, which use the EventHandler
+    // pattern. They are bridged from the concrete Action-based events in the constructor.
+    private EventHandler<Abstractions.SceneEventArgs>? _sceneOpenedHandlers;
+    private EventHandler? _sceneClosedHandlers;
+    private EventHandler? _sceneModifiedHandlers;
 
     /// <summary>
     /// Creates a new EditorWorldManager with an empty scene.
@@ -24,6 +31,13 @@ public sealed class EditorWorldManager : IDisposable
         _world = new World();
         // Create initial untitled scene
         _currentSceneRoot = _world.Scenes.Spawn("Untitled");
+
+        // Bridge the concrete Action-based scene events to the abstraction's
+        // EventHandler-based events so consumers observing this manager through
+        // IEditorWorldManager receive notifications.
+        SceneOpened += world => _sceneOpenedHandlers?.Invoke(this, new Abstractions.SceneEventArgs(world, _currentScenePath));
+        SceneClosed += () => _sceneClosedHandlers?.Invoke(this, EventArgs.Empty);
+        SceneModified += () => _sceneModifiedHandlers?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -53,6 +67,41 @@ public sealed class EditorWorldManager : IDisposable
     /// Gets whether the current scene has unsaved changes.
     /// </summary>
     public bool HasUnsavedChanges => _sceneModificationCount > 0;
+
+    #region IEditorWorldManager (abstraction) implementation
+
+    /// <inheritdoc />
+    IWorld? Abstractions.IEditorWorldManager.CurrentSceneWorld => CurrentSceneWorld;
+
+    /// <inheritdoc />
+    event EventHandler<Abstractions.SceneEventArgs>? Abstractions.IEditorWorldManager.SceneOpened
+    {
+        add => _sceneOpenedHandlers += value;
+        remove => _sceneOpenedHandlers -= value;
+    }
+
+    /// <inheritdoc />
+    event EventHandler? Abstractions.IEditorWorldManager.SceneClosed
+    {
+        add => _sceneClosedHandlers += value;
+        remove => _sceneClosedHandlers -= value;
+    }
+
+    /// <inheritdoc />
+    event EventHandler? Abstractions.IEditorWorldManager.SceneModified
+    {
+        add => _sceneModifiedHandlers += value;
+        remove => _sceneModifiedHandlers -= value;
+    }
+
+    /// <inheritdoc />
+    bool Abstractions.IEditorWorldManager.LoadScene(string path)
+    {
+        LoadScene(path);
+        return _currentSceneRoot.IsValid;
+    }
+
+    #endregion
 
     /// <summary>
     /// Occurs when a new scene is created or loaded.

--- a/editor/KeenEyes.Editor/Assets/AssetDatabase.cs
+++ b/editor/KeenEyes.Editor/Assets/AssetDatabase.cs
@@ -1,15 +1,23 @@
+using Abstractions = KeenEyes.Editor.Abstractions;
+
 namespace KeenEyes.Editor.Assets;
 
 /// <summary>
 /// Manages asset discovery, caching, and hot reload for the editor.
 /// </summary>
-public sealed class AssetDatabase : IDisposable
+public sealed class AssetDatabase : Abstractions.IAssetDatabase, IDisposable
 {
     private readonly string _projectRoot;
     private readonly Dictionary<string, AssetEntry> _assets = new(StringComparer.OrdinalIgnoreCase);
     private readonly FileSystemWatcher _watcher;
     private readonly Lock _lock = new();
     private bool _isDisposed;
+
+    // Backing delegates for the IAssetDatabase events, which use the abstraction's
+    // asset model. They are bridged from the concrete events in the constructor.
+    private EventHandler<Abstractions.AssetEventArgs>? _abstractionAssetAdded;
+    private EventHandler<Abstractions.AssetEventArgs>? _abstractionAssetRemoved;
+    private EventHandler<Abstractions.AssetEventArgs>? _abstractionAssetModified;
 
     /// <summary>
     /// Raised when an asset is added to the database.
@@ -51,6 +59,12 @@ public sealed class AssetDatabase : IDisposable
         _watcher.Deleted += OnFileDeleted;
         _watcher.Changed += OnFileChanged;
         _watcher.Renamed += OnFileRenamed;
+
+        // Bridge the concrete asset events to the abstraction events so consumers
+        // that observe this database through IAssetDatabase receive notifications.
+        AssetAdded += (_, e) => _abstractionAssetAdded?.Invoke(this, new Abstractions.AssetEventArgs(ToAbstraction(e.Asset)));
+        AssetRemoved += (_, e) => _abstractionAssetRemoved?.Invoke(this, new Abstractions.AssetEventArgs(ToAbstraction(e.Asset)));
+        AssetModified += (_, e) => _abstractionAssetModified?.Invoke(this, new Abstractions.AssetEventArgs(ToAbstraction(e.Asset)));
     }
 
     /// <summary>
@@ -71,6 +85,98 @@ public sealed class AssetDatabase : IDisposable
             }
         }
     }
+
+    #region IAssetDatabase (abstraction) implementation
+
+    /// <inheritdoc />
+    IReadOnlyDictionary<string, Abstractions.AssetEntry> Abstractions.IAssetDatabase.AllAssets
+    {
+        get
+        {
+            lock (_lock)
+            {
+                var result = new Dictionary<string, Abstractions.AssetEntry>(_assets.Count, StringComparer.OrdinalIgnoreCase);
+                foreach (var pair in _assets)
+                {
+                    result[pair.Key] = ToAbstraction(pair.Value);
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    event EventHandler<Abstractions.AssetEventArgs>? Abstractions.IAssetDatabase.AssetAdded
+    {
+        add => _abstractionAssetAdded += value;
+        remove => _abstractionAssetAdded -= value;
+    }
+
+    /// <inheritdoc />
+    event EventHandler<Abstractions.AssetEventArgs>? Abstractions.IAssetDatabase.AssetRemoved
+    {
+        add => _abstractionAssetRemoved += value;
+        remove => _abstractionAssetRemoved -= value;
+    }
+
+    /// <inheritdoc />
+    event EventHandler<Abstractions.AssetEventArgs>? Abstractions.IAssetDatabase.AssetModified
+    {
+        add => _abstractionAssetModified += value;
+        remove => _abstractionAssetModified -= value;
+    }
+
+    /// <inheritdoc />
+    Abstractions.AssetEntry? Abstractions.IAssetDatabase.GetAsset(string relativePath)
+    {
+        var entry = GetAsset(relativePath);
+        return entry is null ? null : ToAbstraction(entry);
+    }
+
+    /// <inheritdoc />
+    IEnumerable<Abstractions.AssetEntry> Abstractions.IAssetDatabase.GetAssetsByType(Abstractions.AssetType assetType)
+    {
+        return GetAssetsByType(ToConcrete(assetType)).Select(ToAbstraction);
+    }
+
+    private static Abstractions.AssetEntry ToAbstraction(AssetEntry entry)
+    {
+        return new Abstractions.AssetEntry(
+            entry.RelativePath,
+            entry.FullPath,
+            entry.Name,
+            ToAbstraction(entry.Type),
+            entry.LastModified);
+    }
+
+    private static Abstractions.AssetType ToAbstraction(AssetType type) => type switch
+    {
+        AssetType.Scene => Abstractions.AssetType.Scene,
+        AssetType.Prefab => Abstractions.AssetType.Prefab,
+        AssetType.WorldConfig => Abstractions.AssetType.WorldConfig,
+        AssetType.Shader => Abstractions.AssetType.Shader,
+        AssetType.Texture => Abstractions.AssetType.Texture,
+        AssetType.Audio => Abstractions.AssetType.Audio,
+        AssetType.Script => Abstractions.AssetType.Script,
+        AssetType.Data => Abstractions.AssetType.Data,
+        _ => Abstractions.AssetType.Unknown
+    };
+
+    private static AssetType ToConcrete(Abstractions.AssetType type) => type switch
+    {
+        Abstractions.AssetType.Scene => AssetType.Scene,
+        Abstractions.AssetType.Prefab => AssetType.Prefab,
+        Abstractions.AssetType.WorldConfig => AssetType.WorldConfig,
+        Abstractions.AssetType.Shader => AssetType.Shader,
+        Abstractions.AssetType.Texture => AssetType.Texture,
+        Abstractions.AssetType.Audio => AssetType.Audio,
+        Abstractions.AssetType.Script => AssetType.Script,
+        Abstractions.AssetType.Data => AssetType.Data,
+        _ => AssetType.Unknown
+    };
+
+    #endregion
 
     /// <summary>
     /// Performs an initial scan of the project directory.

--- a/editor/KeenEyes.Editor/Plugins/BuiltIn/BuiltInGizmoPlugins.cs
+++ b/editor/KeenEyes.Editor/Plugins/BuiltIn/BuiltInGizmoPlugins.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Animation;
+using KeenEyes.Editor.Navigation;
+
+namespace KeenEyes.Editor.Plugins.BuiltIn;
+
+/// <summary>
+/// Installs the editor's built-in gizmo plugins.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These plugins register debug gizmo renderers through <c>IViewportCapability</c>:
+/// <list type="bullet">
+///   <item><description><see cref="NavigationEditorPlugin"/> - navigation mesh visualization.</description></item>
+///   <item><description><see cref="AnimationEditorPlugin"/> - skeleton and IK chain visualization.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The editor installs these unconditionally at startup and relies on
+/// <see cref="EditorPluginManager.ShutdownAll"/> for uninstall symmetry, which removes
+/// each plugin's renderers from the viewport capability.
+/// </para>
+/// </remarks>
+internal static class BuiltInGizmoPlugins
+{
+    /// <summary>
+    /// Installs every built-in gizmo plugin into the supplied plugin manager.
+    /// </summary>
+    /// <param name="manager">The plugin manager that hosts the built-in plugins.</param>
+    internal static void Install(EditorPluginManager manager)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+
+        manager.InstallPlugin(new NavigationEditorPlugin());
+        manager.InstallPlugin(new AnimationEditorPlugin());
+    }
+}

--- a/editor/KeenEyes.Editor/Plugins/Capabilities/ViewportCapability.cs
+++ b/editor/KeenEyes.Editor/Plugins/Capabilities/ViewportCapability.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions.Capabilities;
+
+namespace KeenEyes.Editor.Plugins.Capabilities;
+
+/// <summary>
+/// Default in-memory implementation of <see cref="IViewportCapability"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Acts as the registry the editor exposes to plugins for viewport customization.
+/// Plugins add gizmo renderers, overlays, and pick handlers here during initialization
+/// and remove them during shutdown; the viewport render path enumerates the registered
+/// entries to draw them.
+/// </para>
+/// </remarks>
+internal sealed class ViewportCapability : IViewportCapability
+{
+    private readonly List<IGizmoRenderer> gizmoRenderers = [];
+    private readonly Dictionary<string, IViewportOverlay> overlays = [];
+    private readonly List<IPickHandler> pickHandlers = [];
+
+    /// <inheritdoc />
+    public event Action<IGizmoRenderer>? GizmoRendererAdded;
+
+    /// <inheritdoc />
+    public event Action<IGizmoRenderer>? GizmoRendererRemoved;
+
+    /// <inheritdoc />
+    public void AddGizmoRenderer(IGizmoRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        if (gizmoRenderers.Contains(renderer))
+        {
+            return;
+        }
+
+        gizmoRenderers.Add(renderer);
+        GizmoRendererAdded?.Invoke(renderer);
+    }
+
+    /// <inheritdoc />
+    public void RemoveGizmoRenderer(IGizmoRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        if (gizmoRenderers.Remove(renderer))
+        {
+            GizmoRendererRemoved?.Invoke(renderer);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<IGizmoRenderer> GetGizmoRenderers()
+    {
+        // Return a snapshot so callers can iterate while renderers mutate the registry.
+        return gizmoRenderers.ToArray();
+    }
+
+    /// <inheritdoc />
+    public void AddOverlay(string id, IViewportOverlay overlay)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        ArgumentNullException.ThrowIfNull(overlay);
+
+        overlays[id] = overlay;
+    }
+
+    /// <inheritdoc />
+    public bool RemoveOverlay(string id)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        return overlays.Remove(id);
+    }
+
+    /// <inheritdoc />
+    public void SetOverlayVisible(string id, bool visible)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        if (overlays.TryGetValue(id, out var overlay))
+        {
+            overlay.IsVisible = visible;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsOverlayVisible(string id)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        return overlays.TryGetValue(id, out var overlay) && overlay.IsVisible;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetOverlayIds()
+    {
+        return overlays.Keys.ToArray();
+    }
+
+    /// <inheritdoc />
+    public void AddPickHandler(IPickHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (pickHandlers.Contains(handler))
+        {
+            return;
+        }
+
+        pickHandlers.Add(handler);
+    }
+
+    /// <inheritdoc />
+    public void RemovePickHandler(IPickHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        pickHandlers.Remove(handler);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<IPickHandler> GetPickHandlers()
+    {
+        // Highest priority first so the viewport can offer picks in precedence order.
+        return pickHandlers.OrderByDescending(handler => handler.Priority).ToArray();
+    }
+}

--- a/tests/KeenEyes.Editor.Tests/Plugins/BuiltInGizmoPluginsTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/BuiltInGizmoPluginsTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Application;
+using KeenEyes.Editor.Assets;
+using KeenEyes.Editor.Commands;
+using KeenEyes.Editor.Plugins;
+using KeenEyes.Editor.Plugins.BuiltIn;
+using KeenEyes.Editor.Plugins.Capabilities;
+using KeenEyes.Editor.Selection;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests that the editor installs its built-in gizmo plugins during startup and that their
+/// gizmo renderers are reachable through the viewport capability and removed on shutdown.
+/// </summary>
+public sealed class BuiltInGizmoPluginsTests : IDisposable
+{
+    private readonly World editorWorld = new();
+    private readonly EditorWorldManager worldManager = new();
+    private readonly SelectionManager selection = new();
+    private readonly UndoRedoManager undoRedo = new();
+    private readonly AssetDatabase assets;
+    private readonly DirectoryInfo tempProjectRoot;
+
+    public BuiltInGizmoPluginsTests()
+    {
+        tempProjectRoot = Directory.CreateTempSubdirectory("keeneyes-gizmo-plugins-");
+        assets = new AssetDatabase(tempProjectRoot.FullName);
+    }
+
+    public void Dispose()
+    {
+        assets.Dispose();
+        worldManager.Dispose();
+        editorWorld.Dispose();
+
+        try
+        {
+            tempProjectRoot.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of the temporary project directory.
+        }
+    }
+
+    /// <summary>
+    /// Builds a plugin host wired the same way <see cref="EditorApplication"/> wires it at
+    /// startup: a manager backed by the editor services with the viewport capability registered.
+    /// </summary>
+    private EditorPluginManager CreateBootEquivalentManager(out ViewportCapability viewport)
+    {
+        var manager = new EditorPluginManager(worldManager, selection, undoRedo, assets, editorWorld, logProvider: null);
+        viewport = new ViewportCapability();
+        manager.RegisterCapability<IViewportCapability>(viewport);
+        return manager;
+    }
+
+    [Fact]
+    public void Install_AfterBootInit_InstallsNavigationAndAnimationPlugins()
+    {
+        using var manager = CreateBootEquivalentManager(out _);
+
+        BuiltInGizmoPlugins.Install(manager);
+
+        Assert.True(manager.HasPlugin("Navigation"));
+        Assert.True(manager.HasPlugin("Animation"));
+    }
+
+    [Fact]
+    public void Install_AfterBootInit_RegistersAllGizmoRenderersInViewportCapability()
+    {
+        using var manager = CreateBootEquivalentManager(out var viewport);
+
+        BuiltInGizmoPlugins.Install(manager);
+
+        var rendererIds = viewport.GetGizmoRenderers().Select(r => r.Id).ToList();
+
+        Assert.Equal(3, rendererIds.Count);
+        Assert.Contains("navmesh-visualizer", rendererIds);
+        Assert.Contains("skeleton-gizmo", rendererIds);
+        Assert.Contains("ik-gizmo", rendererIds);
+    }
+
+    [Fact]
+    public void ShutdownAll_RemovesGizmoRenderersFromViewportCapability()
+    {
+        using var manager = CreateBootEquivalentManager(out var viewport);
+        BuiltInGizmoPlugins.Install(manager);
+        Assert.NotEmpty(viewport.GetGizmoRenderers());
+
+        manager.ShutdownAll();
+
+        Assert.Empty(viewport.GetGizmoRenderers());
+        Assert.False(manager.HasPlugin("Navigation"));
+        Assert.False(manager.HasPlugin("Animation"));
+    }
+
+    [Fact]
+    public void Dispose_RemovesGizmoRenderersFromViewportCapability()
+    {
+        var manager = CreateBootEquivalentManager(out var viewport);
+        BuiltInGizmoPlugins.Install(manager);
+        Assert.NotEmpty(viewport.GetGizmoRenderers());
+
+        manager.Dispose();
+
+        Assert.Empty(viewport.GetGizmoRenderers());
+    }
+
+    [Fact]
+    public void Install_WithNullManager_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => BuiltInGizmoPlugins.Install(null!));
+    }
+}

--- a/tests/KeenEyes.Editor.Tests/Plugins/Capabilities/ViewportCapabilityTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/Capabilities/ViewportCapabilityTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Plugins.Capabilities;
+
+namespace KeenEyes.Editor.Tests.Plugins.Capabilities;
+
+/// <summary>
+/// Tests for <see cref="ViewportCapability"/>, the registry the editor exposes to plugins
+/// for viewport gizmo renderers, overlays, and pick handlers.
+/// </summary>
+public sealed class ViewportCapabilityTests
+{
+    #region Gizmo Renderer Tests
+
+    [Fact]
+    public void AddGizmoRenderer_RegistersRendererAndRaisesEvent()
+    {
+        var capability = new ViewportCapability();
+        var renderer = new FakeGizmoRenderer("a");
+        IGizmoRenderer? added = null;
+        capability.GizmoRendererAdded += r => added = r;
+
+        capability.AddGizmoRenderer(renderer);
+
+        Assert.Same(renderer, Assert.Single(capability.GetGizmoRenderers()));
+        Assert.Same(renderer, added);
+    }
+
+    [Fact]
+    public void AddGizmoRenderer_SameRendererTwice_RegistersOnce()
+    {
+        var capability = new ViewportCapability();
+        var renderer = new FakeGizmoRenderer("a");
+        var addedCount = 0;
+        capability.GizmoRendererAdded += _ => addedCount++;
+
+        capability.AddGizmoRenderer(renderer);
+        capability.AddGizmoRenderer(renderer);
+
+        Assert.Single(capability.GetGizmoRenderers());
+        Assert.Equal(1, addedCount);
+    }
+
+    [Fact]
+    public void RemoveGizmoRenderer_RemovesRendererAndRaisesEvent()
+    {
+        var capability = new ViewportCapability();
+        var renderer = new FakeGizmoRenderer("a");
+        capability.AddGizmoRenderer(renderer);
+        IGizmoRenderer? removed = null;
+        capability.GizmoRendererRemoved += r => removed = r;
+
+        capability.RemoveGizmoRenderer(renderer);
+
+        Assert.Empty(capability.GetGizmoRenderers());
+        Assert.Same(renderer, removed);
+    }
+
+    [Fact]
+    public void RemoveGizmoRenderer_NotRegistered_DoesNotRaiseEvent()
+    {
+        var capability = new ViewportCapability();
+        var removedCount = 0;
+        capability.GizmoRendererRemoved += _ => removedCount++;
+
+        capability.RemoveGizmoRenderer(new FakeGizmoRenderer("a"));
+
+        Assert.Equal(0, removedCount);
+    }
+
+    [Fact]
+    public void GetGizmoRenderers_ReturnsSnapshotSafeToMutateDuring()
+    {
+        var capability = new ViewportCapability();
+        capability.AddGizmoRenderer(new FakeGizmoRenderer("a"));
+        capability.AddGizmoRenderer(new FakeGizmoRenderer("b"));
+
+        // Enumerating the snapshot while mutating the registry must not throw.
+        foreach (var renderer in capability.GetGizmoRenderers())
+        {
+            capability.RemoveGizmoRenderer(renderer);
+        }
+
+        Assert.Empty(capability.GetGizmoRenderers());
+    }
+
+    #endregion
+
+    #region Overlay Tests
+
+    [Fact]
+    public void AddOverlay_ThenSetVisible_TogglesOverlayVisibility()
+    {
+        var capability = new ViewportCapability();
+        var overlay = new FakeOverlay { IsVisible = false };
+
+        capability.AddOverlay("grid", overlay);
+        capability.SetOverlayVisible("grid", true);
+
+        Assert.True(capability.IsOverlayVisible("grid"));
+        Assert.Contains("grid", capability.GetOverlayIds());
+    }
+
+    [Fact]
+    public void RemoveOverlay_RemovesRegisteredOverlay()
+    {
+        var capability = new ViewportCapability();
+        capability.AddOverlay("grid", new FakeOverlay());
+
+        Assert.True(capability.RemoveOverlay("grid"));
+        Assert.False(capability.RemoveOverlay("grid"));
+        Assert.Empty(capability.GetOverlayIds());
+    }
+
+    [Fact]
+    public void IsOverlayVisible_UnknownOverlay_ReturnsFalse()
+    {
+        var capability = new ViewportCapability();
+
+        Assert.False(capability.IsOverlayVisible("missing"));
+    }
+
+    #endregion
+
+    #region Pick Handler Tests
+
+    [Fact]
+    public void GetPickHandlers_ReturnsHandlersOrderedByPriorityDescending()
+    {
+        var capability = new ViewportCapability();
+        var low = new FakePickHandler(1);
+        var high = new FakePickHandler(10);
+        capability.AddPickHandler(low);
+        capability.AddPickHandler(high);
+
+        var ordered = capability.GetPickHandlers().ToList();
+
+        Assert.Equal(new IPickHandler[] { high, low }, ordered);
+    }
+
+    [Fact]
+    public void RemovePickHandler_RemovesRegisteredHandler()
+    {
+        var capability = new ViewportCapability();
+        var handler = new FakePickHandler(1);
+        capability.AddPickHandler(handler);
+
+        capability.RemovePickHandler(handler);
+
+        Assert.Empty(capability.GetPickHandlers());
+    }
+
+    #endregion
+
+    #region Fakes
+
+    private sealed class FakeGizmoRenderer(string id) : IGizmoRenderer
+    {
+        public string Id { get; } = id;
+        public string DisplayName => Id;
+        public bool IsEnabled { get; set; } = true;
+        public int Order => 0;
+
+        public void Render(GizmoRenderContext context)
+        {
+        }
+
+        public bool ShouldRender(Entity entity, IWorld sceneWorld) => true;
+    }
+
+    private sealed class FakeOverlay : IViewportOverlay
+    {
+        public bool IsVisible { get; set; }
+        public int Order => 0;
+
+        public void Render(OverlayRenderContext context)
+        {
+        }
+    }
+
+    private sealed class FakePickHandler(int priority) : IPickHandler
+    {
+        public int Priority { get; } = priority;
+
+        public PickResult? TryPick(PickContext context) => null;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **Built-in gizmo plugins (`NavigationEditorPlugin` + `AnimationEditorPlugin`) now install unconditionally at `EditorApplication` construction** via the intended `EditorPluginManager` seam, with uninstall symmetry on `Dispose` — settings-gating rejected as complexity without a user-facing choice (rationale in the code).
- **Finished the dormant #646 integration this required**: the plugin host was never instantiated outside tests and **no concrete `IViewportCapability` existed** — added `ViewportCapability` (renderer registry with events/dedup/snapshot enumeration, overlays, pick handlers) and completed the missing `IEditorWorldManager`/`IAssetDatabase` implementations (explicit members bridging the two parallel asset/event models; no changes to existing raise sites).
- `BuiltInGizmoPlugins.Install(manager)` is the single source of truth for startup and tests.

## Test plan
- [x] 16 new tests (boot-equivalent install → all three renderers `navmesh-visualizer`/`skeleton-gizmo`/`ik-gizmo` present; ShutdownAll + Dispose both remove; capability add/dedup/remove/events/enumeration/pick-handler ordering) — editor suite 1266/1266
- [x] Release build zero warnings; `dotnet format` clean
- [ ] CI green

## Related Issues
Fixes #1019. **Honest scope note:** renderers are installed, tracked, and reachable through the capability — but the live `ViewportPanel` does not yet enumerate `GetGizmoRenderers()` in its render loop (it predates the capability system and only draws `TransformGizmo`). Painting them per-frame is a distinct render-loop integration, filed as a follow-up.