### PR TITLE
fix(build): Make Shaders.Generator.IntegrationTests loadable by dotnet format

### DIFF
--- a/tests/KeenEyes.Shaders.Generator.IntegrationTests/GeneratorIntegrationTests.cs
+++ b/tests/KeenEyes.Shaders.Generator.IntegrationTests/GeneratorIntegrationTests.cs
@@ -1,60 +1,235 @@
+using System.Reflection;
+using System.Text;
 using KeenEyes.Shaders;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 
 namespace KeenEyes.Shaders.Generator.IntegrationTests;
 
 /// <summary>
-/// Integration tests verifying that the KESL source generator produces valid C# code.
+/// Integration tests verifying that the KESL source generator produces valid, compilable
+/// C# bindings from a real <c>.kesl</c> file.
 /// </summary>
+/// <remarks>
+/// The generator is driven explicitly in-process via <see cref="CSharpGeneratorDriver"/>
+/// (the same approach used by <c>KeenEyes.Generators.Tests</c>) rather than relying on
+/// build-time generator output. This keeps the project loadable by MSBuildWorkspace
+/// (<c>dotnet format</c>), which does not materialize generator output produced by an
+/// analyzer-via-<c>ProjectReference</c> and therefore used to fail solution-wide format
+/// verification with CS0246 on the generated types (issue #1026).
+///
+/// The generated syntax trees are compiled against the stub types in <c>GpuStubs.cs</c>
+/// (referenced through this test assembly) and loaded, so the assertions still exercise
+/// real generated type metadata and runtime behavior.
+/// </remarks>
 public class GeneratorIntegrationTests
 {
+    private const string GeneratedNamespace = "KeenEyes.Shaders.Generator.IntegrationTests";
+    private const string ShaderTypeName = GeneratedNamespace + ".UpdatePhysicsShader";
+    private const string GlslSourceTypeName = GeneratedNamespace + ".UpdatePhysicsGlslSource";
+
+    private static readonly Lazy<GeneratorRun> lazyRun = new(RunGenerator);
+    private static readonly Lazy<Assembly> lazyCompiledAssembly = new(() => CompileAndLoad(lazyRun.Value));
+
+    [Fact]
+    public void Generator_ProducesNoErrorDiagnostics()
+    {
+        var run = lazyRun.Value;
+
+        Assert.DoesNotContain(run.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Generator_EmitsShaderAndGlslSourceFiles()
+    {
+        var run = lazyRun.Value;
+
+        // One file for the shader class, one for the embedded GLSL source constant.
+        Assert.Contains(run.GeneratedSources, s => s.Contains("class UpdatePhysicsShader"));
+        Assert.Contains(run.GeneratedSources, s => s.Contains("class UpdatePhysicsGlslSource"));
+    }
+
+    [Fact]
+    public void GeneratedCode_CompilesWithoutErrors()
+    {
+        // Exercises CompileAndLoad, which asserts the emit produced no errors.
+        Assert.NotNull(lazyCompiledAssembly.Value);
+    }
+
     [Fact]
     public void GeneratedShaderClass_Exists()
     {
-        // The source generator should create UpdatePhysicsShader from Physics.kesl
-        var shaderType = typeof(UpdatePhysicsShader);
+        var shaderType = lazyCompiledAssembly.Value.GetType(ShaderTypeName);
 
         Assert.NotNull(shaderType);
-        Assert.Equal("UpdatePhysicsShader", shaderType.Name);
+        Assert.Equal("UpdatePhysicsShader", shaderType!.Name);
     }
 
     [Fact]
     public void GeneratedGlslSource_ContainsShaderCode()
     {
-        // The source generator should create UpdatePhysicsGlslSource with the GLSL code
-        var glslSource = UpdatePhysicsGlslSource.Source;
+        var glslType = lazyCompiledAssembly.Value.GetType(GlslSourceTypeName);
+        Assert.NotNull(glslType);
+
+        var sourceField = glslType!.GetField("Source", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(sourceField);
+
+        var glslSource = (string?)sourceField!.GetRawConstantValue();
 
         Assert.NotNull(glslSource);
-        Assert.Contains("#version 450", glslSource);
-        Assert.Contains("Position", glslSource);
-        Assert.Contains("Velocity", glslSource);
-        Assert.Contains("deltaTime", glslSource);
+        Assert.Contains("#version 450", glslSource!);
+        Assert.Contains("Position", glslSource!);
+        Assert.Contains("Velocity", glslSource!);
+        Assert.Contains("deltaTime", glslSource!);
     }
 
     [Fact]
     public void GeneratedShaderClass_HasExpectedMembers()
     {
-        // Verify the shader class has the expected methods/properties
-        var shaderType = typeof(UpdatePhysicsShader);
+        var shaderType = lazyCompiledAssembly.Value.GetType(ShaderTypeName);
+        Assert.NotNull(shaderType);
 
-        // Should have a constructor that takes IGpuDevice
-        var constructor = shaderType.GetConstructor([typeof(IGpuDevice)]);
+        // Should have a constructor that takes IGpuDevice.
+        var constructor = shaderType!.GetConstructor([typeof(IGpuDevice)]);
         Assert.NotNull(constructor);
     }
 
     [Fact]
     public void GeneratedShaderClass_CanBeInstantiated()
     {
-        // Verify we can create an instance of the generated shader
-        var device = new MockGpuDevice();
-        var shader = new UpdatePhysicsShader(device);
+        var shaderType = lazyCompiledAssembly.Value.GetType(ShaderTypeName);
+        Assert.NotNull(shaderType);
+
+        var shader = Activator.CreateInstance(shaderType!, new MockGpuDevice());
+
         Assert.NotNull(shader);
     }
 
     [Fact]
     public void GeneratedShaderClass_ImplementsIGpuComputeSystem()
     {
-        // Verify the shader implements the GPU compute system interface
-        var shaderType = typeof(UpdatePhysicsShader);
+        var shaderType = lazyCompiledAssembly.Value.GetType(ShaderTypeName);
+        Assert.NotNull(shaderType);
+
         Assert.True(typeof(IGpuComputeSystem).IsAssignableFrom(shaderType));
+    }
+
+    /// <summary>
+    /// Runs the KESL source generator over the embedded <c>Physics.kesl</c> file.
+    /// </summary>
+    private static GeneratorRun RunGenerator()
+    {
+        var keslSource = ReadEmbeddedKesl();
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+
+        // The generator only reads the assembly name off the compilation to pick the
+        // generated namespace, so an otherwise minimal compilation is sufficient. The
+        // namespace is chosen so the generated types can see the stub component and GPU
+        // types (declared in GpuStubs.cs under this same namespace / its ancestors).
+        var inputCompilation = CSharpCompilation.Create(
+            assemblyName: GeneratedNamespace,
+            syntaxTrees: [],
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        AdditionalText keslFile = new InMemoryAdditionalText("Physics.kesl", keslSource);
+
+        var driver = CSharpGeneratorDriver.Create(
+            generators: [new KeslSourceGenerator().AsSourceGenerator()],
+            additionalTexts: [keslFile],
+            parseOptions: parseOptions);
+
+        var runResult = driver.RunGenerators(inputCompilation).GetRunResult();
+
+        var trees = runResult.GeneratedTrees;
+        var sources = trees.Select(t => t.GetText().ToString()).ToList();
+
+        return new GeneratorRun(trees, sources, runResult.Diagnostics);
+    }
+
+    /// <summary>
+    /// Compiles the generator output against the stub types in this test assembly and
+    /// loads the resulting assembly, asserting that emit produced no errors.
+    /// </summary>
+    private static Assembly CompileAndLoad(GeneratorRun run)
+    {
+        var references = GetReferences();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "GeneratedShaders_" + Guid.NewGuid().ToString("N"),
+            syntaxTrees: run.GeneratedTrees,
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var emitResult = compilation.Emit(ms);
+
+        var errors = emitResult.Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        Assert.True(
+            errors.Count == 0,
+            "Generated code failed to compile:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors));
+
+        ms.Position = 0;
+        return Assembly.Load(ms.ToArray());
+    }
+
+    /// <summary>
+    /// Builds the metadata references needed to compile the generated code: the framework
+    /// assemblies plus this test assembly (which supplies the GPU / component stub types).
+    /// </summary>
+    private static List<MetadataReference> GetReferences()
+    {
+        var references = new Dictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
+
+        var trustedAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (var path in trustedAssemblies.Split(Path.PathSeparator))
+        {
+            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
+            {
+                references[Path.GetFileName(path)] = MetadataReference.CreateFromFile(path);
+            }
+        }
+
+        // Ensure the stub types (GpuStubs.cs) are referenced; this overwrites any TPA entry
+        // with the same file name so there is never a duplicate reference.
+        var testAssemblyPath = typeof(GeneratorIntegrationTests).Assembly.Location;
+        references[Path.GetFileName(testAssemblyPath)] = MetadataReference.CreateFromFile(testAssemblyPath);
+
+        return references.Values.ToList();
+    }
+
+    private static string ReadEmbeddedKesl()
+    {
+        var assembly = typeof(GeneratorIntegrationTests).Assembly;
+        using var stream = assembly.GetManifestResourceStream("Physics.kesl")
+            ?? throw new InvalidOperationException("Embedded KESL resource 'Physics.kesl' was not found.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Captures the result of a single generator run.
+    /// </summary>
+    private sealed record GeneratorRun(
+        IReadOnlyList<SyntaxTree> GeneratedTrees,
+        IReadOnlyList<string> GeneratedSources,
+        IReadOnlyList<Diagnostic> Diagnostics);
+
+    /// <summary>
+    /// A minimal in-memory <see cref="AdditionalText"/> used to feed KESL source to the generator.
+    /// </summary>
+    private sealed class InMemoryAdditionalText(string path, string text) : AdditionalText
+    {
+        private readonly string text = text;
+
+        public override string Path { get; } = path;
+
+        public override SourceText GetText(CancellationToken cancellationToken = default)
+            => SourceText.From(text, Encoding.UTF8);
     }
 }

--- a/tests/KeenEyes.Shaders.Generator.IntegrationTests/KeenEyes.Shaders.Generator.IntegrationTests.csproj
+++ b/tests/KeenEyes.Shaders.Generator.IntegrationTests/KeenEyes.Shaders.Generator.IntegrationTests.csproj
@@ -8,20 +8,32 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Reference the shader generator as an analyzer -->
+  <!--
+    Reference the generator and its compiler as ordinary assemblies (not analyzers).
+    The integration tests drive the KESL source generator explicitly in-process via
+    CSharpGeneratorDriver (see GeneratorIntegrationTests), rather than relying on
+    build-time generator output. This mirrors tests/KeenEyes.Generators.Tests and,
+    critically, lets MSBuildWorkspace (dotnet format) load the project: a build-time
+    generator referenced as an analyzer-via-ProjectReference is not materialized by
+    the workspace, which previously produced CS0246 on the generated types and broke
+    solution-wide `dotnet format` verification (issue #1026).
+  -->
   <ItemGroup>
     <ProjectReference Include="..\..\editor\KeenEyes.Shaders.Generator\KeenEyes.Shaders.Generator.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
-    <!-- Also reference the compiler so the generator can load it -->
+                      OutputItemType="None"
+                      ReferenceOutputAssembly="true" />
     <ProjectReference Include="..\..\editor\KeenEyes.Shaders.Compiler\KeenEyes.Shaders.Compiler.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      OutputItemType="None"
+                      ReferenceOutputAssembly="true" />
   </ItemGroup>
 
-  <!-- Include .kesl files as AdditionalFiles for the generator -->
   <ItemGroup>
-    <AdditionalFiles Include="Shaders\*.kesl" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <!-- The KESL source is embedded so the tests can feed it to the generator at runtime. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Shaders\Physics.kesl" LogicalName="Physics.kesl" />
   </ItemGroup>
 
 </Project>

--- a/tests/KeenEyes.Shaders.Generator.IntegrationTests/packages.lock.json
+++ b/tests/KeenEyes.Shaders.Generator.IntegrationTests/packages.lock.json
@@ -8,6 +8,16 @@
         "resolved": "3.0.4",
         "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
       },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
       "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Direct",
         "requested": "[18.9.0, )",
@@ -88,6 +98,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
       },
       "Microsoft.DiaSymReader": {
         "type": "Transitive",
@@ -190,6 +208,21 @@
           "xunit.v3.extensibility.core": "[3.2.2]",
           "xunit.v3.runner.common": "[3.2.2]"
         }
+      },
+      "keeneyes.shaders.compiler": {
+        "type": "Project"
+      },
+      "keeneyes.shaders.generator": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "30ffAcvc+M4xXFN06dg2bKyH5eXgJQmyuB5H5cpC47559rQV5x7vZRyyC/YakNLQtBG3IdW/ZAyLCMeDBGDxXg=="
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Root cause**: the integration-test project consumed the KESL generator as a same-solution analyzer `ProjectReference` and depended on build-time-generated types (`UpdatePhysicsShader`) — which MSBuildWorkspace (what `dotnet format` uses) never materializes, so solution-wide format died on CS0246 regardless of actual style state.
- **Fix**: restructured to the `Generators.Tests` pattern — the tests drive `KeslSourceGenerator` in-process via `CSharpGeneratorDriver`, compile the generated trees, and load the emitted assembly. All original assertions preserved (type/GLSL/ctor/instantiation/interface) plus new ones (no diagnostics, both files emitted, clean compile): 8 tests. The project now has ordinary project references and no build-time generated-type dependency, so the workspace loads it cleanly.
- **Proof**: `dotnet format KeenEyes.slnx --verify-no-changes` → exit **0** (true exit code, captured unpiped). Full slnx Release build: 0 warnings/0 errors.
- `build.yml` needed no change — the #1022-era exclusion was already superseded on main by the build-before-format step; this PR removes the underlying reason both existed.

## Test plan
- [x] 8/8 integration tests pass (independently re-verified); project-scoped format clean
- [x] Solution-wide format exit 0; full solution Release build clean
- [ ] CI green — the Format Check job is itself the definitive regression test for this fix

## Related Issues
Fixes #1026