### PR TITLE
chore: Bump SDK band to 10.0.3xx and Roslyn pair to 5.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup Label="Source Generators">
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup Label="Graphics">

--- a/benchmarks/KeenEyes.AotVsJit.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.AotVsJit.Benchmarks/packages.lock.json
@@ -48,10 +48,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.Diagnostics.NETCore.Client": {
@@ -175,12 +175,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       }
     }

--- a/benchmarks/KeenEyes.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.Benchmarks/packages.lock.json
@@ -48,10 +48,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.Diagnostics.NETCore.Client": {
@@ -173,11 +173,18 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.replay": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
@@ -188,12 +195,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       }
     }

--- a/benchmarks/KeenEyes.Editor.Benchmarks/HierarchyRefreshBenchmarks.cs
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/HierarchyRefreshBenchmarks.cs
@@ -29,7 +29,7 @@ public class HierarchyRefreshBenchmarks
             EntityCount,
             sceneRoot: worldManager.CurrentSceneRoot);
 
-        nodes = new List<HierarchyNode>(EntityCount);
+        nodes = [with(EntityCount)];
     }
 
     [GlobalCleanup]

--- a/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
@@ -67,10 +67,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.Diagnostics.NETCore.Client": {
@@ -644,12 +644,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       },
       "NLayer": {

--- a/benchmarks/KeenEyes.Spatial.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.Spatial.Benchmarks/packages.lock.json
@@ -48,10 +48,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.Diagnostics.NETCore.Client": {
@@ -187,12 +187,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       }
     }

--- a/editor/KeenEyes.Cli/packages.lock.json
+++ b/editor/KeenEyes.Cli/packages.lock.json
@@ -319,6 +319,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -357,7 +358,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -450,6 +452,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/editor/KeenEyes.Editor/Assets/AssetDatabase.cs
+++ b/editor/KeenEyes.Editor/Assets/AssetDatabase.cs
@@ -8,7 +8,7 @@ namespace KeenEyes.Editor.Assets;
 public sealed class AssetDatabase : Abstractions.IAssetDatabase, IDisposable
 {
     private readonly string _projectRoot;
-    private readonly Dictionary<string, AssetEntry> _assets = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, AssetEntry> _assets = [with(StringComparer.OrdinalIgnoreCase)];
     private readonly FileSystemWatcher _watcher;
     private readonly Lock _lock = new();
     private bool _isDisposed;

--- a/editor/KeenEyes.Editor/Panels/ProjectPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/ProjectPanel.cs
@@ -353,7 +353,7 @@ public static class ProjectPanel
     private sealed class FolderNode
     {
         public string Name { get; }
-        public Dictionary<string, FolderNode> SubFolders { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, FolderNode> SubFolders { get; } = [with(StringComparer.OrdinalIgnoreCase)];
         public List<AssetEntry> Assets { get; } = [];
 
         public FolderNode(string name)

--- a/editor/KeenEyes.Editor/Plugins/BuiltIn/ProjectPlugin.cs
+++ b/editor/KeenEyes.Editor/Plugins/BuiltIn/ProjectPlugin.cs
@@ -393,7 +393,7 @@ internal sealed class ProjectPanelImpl : IEditorPanel
     private sealed class FolderNode
     {
         public string Name { get; }
-        public Dictionary<string, FolderNode> SubFolders { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, FolderNode> SubFolders { get; } = [with(StringComparer.OrdinalIgnoreCase)];
         public List<AssetEntry> Assets { get; } = [];
 
         public FolderNode(string name)

--- a/editor/KeenEyes.Editor/Plugins/Installation/PluginUninstaller.cs
+++ b/editor/KeenEyes.Editor/Plugins/Installation/PluginUninstaller.cs
@@ -197,7 +197,7 @@ public sealed class PluginUninstaller
 
             // Build uninstall order (dependents first, then target)
             var uninstallOrder = new List<string>();
-            BuildUninstallOrder(packageId, uninstallOrder, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            BuildUninstallOrder(packageId, uninstallOrder, [with(StringComparer.OrdinalIgnoreCase)]);
 
             // Uninstall in order
             foreach (var id in uninstallOrder)
@@ -226,7 +226,7 @@ public sealed class PluginUninstaller
     public IReadOnlyList<string> PreviewCascadeUninstall(string packageId)
     {
         var uninstallOrder = new List<string>();
-        BuildUninstallOrder(packageId, uninstallOrder, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        BuildUninstallOrder(packageId, uninstallOrder, [with(StringComparer.OrdinalIgnoreCase)]);
         return uninstallOrder;
     }
 

--- a/editor/KeenEyes.Editor/Plugins/PluginLoadContext.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginLoadContext.cs
@@ -53,8 +53,9 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
         // Assemblies that should be loaded from the host context to ensure
         // type identity across plugin boundaries. Plugins reference the same
         // IEditorPlugin, IEditorContext, etc. as the host.
-        sharedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
+        sharedAssemblies =
+        [
+with(StringComparer.OrdinalIgnoreCase),
             // KeenEyes assemblies
             "KeenEyes.Core",
             "KeenEyes.Abstractions",
@@ -63,7 +64,7 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
             "KeenEyes.Editor.Abstractions",
 
             // System assemblies are handled by the default context automatically
-        };
+        ];
     }
 
     /// <inheritdoc/>

--- a/editor/KeenEyes.Editor/Plugins/Registry/PluginRegistryData.cs
+++ b/editor/KeenEyes.Editor/Plugins/Registry/PluginRegistryData.cs
@@ -20,7 +20,7 @@ internal sealed class PluginRegistryData
     /// Gets or sets the installed plugins.
     /// </summary>
     [JsonPropertyName("plugins")]
-    public Dictionary<string, InstalledPluginEntry> Plugins { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, InstalledPluginEntry> Plugins { get; set; } = [with(StringComparer.OrdinalIgnoreCase)];
 
     /// <summary>
     /// Gets or sets the configured sources.

--- a/editor/KeenEyes.Editor/Plugins/Security/PermissionManager.cs
+++ b/editor/KeenEyes.Editor/Plugins/Security/PermissionManager.cs
@@ -13,9 +13,9 @@ namespace KeenEyes.Editor.Plugins.Security;
 internal sealed class PermissionManager
 {
     private readonly string storePath;
-    private readonly Dictionary<string, PluginPermission> grants = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, PluginPermission> declaredRequired = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Dictionary<string, PluginPermission> declaredOptional = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, PluginPermission> grants = [with(StringComparer.OrdinalIgnoreCase)];
+    private readonly Dictionary<string, PluginPermission> declaredRequired = [with(StringComparer.OrdinalIgnoreCase)];
+    private readonly Dictionary<string, PluginPermission> declaredOptional = [with(StringComparer.OrdinalIgnoreCase)];
     private readonly IEditorPluginLogger? logger;
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/editor/KeenEyes.Editor/Plugins/Security/TrustedPublisherStore.cs
+++ b/editor/KeenEyes.Editor/Plugins/Security/TrustedPublisherStore.cs
@@ -12,7 +12,7 @@ namespace KeenEyes.Editor.Plugins.Security;
 internal sealed class TrustedPublisherStore
 {
     private readonly string storePath;
-    private readonly Dictionary<string, TrustedPublisher> publishers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, TrustedPublisher> publishers = [with(StringComparer.OrdinalIgnoreCase)];
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,

--- a/editor/KeenEyes.Editor/Shortcuts/ShortcutManager.cs
+++ b/editor/KeenEyes.Editor/Shortcuts/ShortcutManager.cs
@@ -8,7 +8,7 @@ namespace KeenEyes.Editor.Shortcuts;
 /// </summary>
 public sealed class ShortcutManager
 {
-    private readonly Dictionary<string, ShortcutBinding> _bindings = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ShortcutBinding> _bindings = [with(StringComparer.OrdinalIgnoreCase)];
     private readonly Dictionary<KeyCombination, string> _shortcutToAction = [];
     private KeyModifiers _currentModifiers;
 

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -358,7 +358,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {

--- a/editor/KeenEyes.Generators/packages.lock.json
+++ b/editor/KeenEyes.Generators/packages.lock.json
@@ -10,20 +10,20 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.6.0",
-          "System.Numerics.Vectors": "4.6.0",
-          "System.Reflection.Metadata": "9.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]",
+          "System.Buffers": "4.6.1",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Memory": "4.6.3",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Reflection.Metadata": "10.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
           "System.Text.Encoding.CodePages": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.6.0"
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "NETStandard.Library": {
@@ -66,18 +66,18 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.6.0",
-          "System.Numerics.Vectors": "4.6.0",
-          "System.Reflection.Metadata": "9.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "System.Buffers": "4.6.1",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Memory": "4.6.3",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Reflection.Metadata": "10.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
           "System.Text.Encoding.CodePages": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.6.0"
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -92,11 +92,11 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w==",
+        "resolved": "10.0.1",
+        "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g==",
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Memory": "4.6.3",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "System.IO.Pipelines": {
@@ -126,11 +126,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "ANiqLu3DxW9kol/hMmTWbt3414t9ftdIuiIU7j80okq2YzAueo120M442xk1kDJWtmZTqWQn7wHDvMRipVOEOQ==",
+        "resolved": "10.0.1",
+        "contentHash": "zpcfT/wacPPhE17zcudozlxQtWN/84qyiMyZNGLnK4cj2IMBtLsZYwYjVnALUhPliwyUVj/P7kaZvBWYBCnf2Q==",
         "dependencies": {
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.5.5"
+          "System.Collections.Immutable": "10.0.1"
         }
       },
       "System.Runtime.CompilerServices.Unsafe": {

--- a/editor/KeenEyes.Graph.Kesl/packages.lock.json
+++ b/editor/KeenEyes.Graph.Kesl/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/editor/KeenEyes.Shaders.Generator/packages.lock.json
+++ b/editor/KeenEyes.Shaders.Generator/packages.lock.json
@@ -10,20 +10,20 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.6.0",
-          "System.Numerics.Vectors": "4.6.0",
-          "System.Reflection.Metadata": "9.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]",
+          "System.Buffers": "4.6.1",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Memory": "4.6.3",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Reflection.Metadata": "10.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
           "System.Text.Encoding.CodePages": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.6.0"
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "NETStandard.Library": {
@@ -43,18 +43,18 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.6.0",
-          "System.Numerics.Vectors": "4.6.0",
-          "System.Reflection.Metadata": "9.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "System.Buffers": "4.6.1",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Memory": "4.6.3",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Reflection.Metadata": "10.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
           "System.Text.Encoding.CodePages": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.6.0"
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -64,46 +64,45 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
+        "resolved": "4.6.1",
+        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w==",
+        "resolved": "10.0.1",
+        "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g==",
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Memory": "4.6.3",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "OEkbBQoklHngJ8UD8ez2AERSk2g+/qpAaSWWCBFbpH727HxDq5ydVkuncBaKcKfwRqXGWx64dS6G1SUScMsitg==",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
         "dependencies": {
-          "System.Buffers": "4.6.0",
-          "System.Numerics.Vectors": "4.6.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0"
+          "System.Buffers": "4.6.1",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "System.Numerics.Vectors": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "t+SoieZsRuEyiw/J+qXUbolyO219tKQQI0+2/YI+Qv7YdGValA6WiuokrNKqjrTNsy5ABWU11bdKOzUdheteXg=="
+        "resolved": "4.6.1",
+        "contentHash": "sQxefTnhagrhoq2ReR0D/6K0zJcr9Hrd6kikeXsA1I8kOCboTavcUC4r7TSfpKFeE163uMuxZcyfO1mGO3EN8Q=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "ANiqLu3DxW9kol/hMmTWbt3414t9ftdIuiIU7j80okq2YzAueo120M442xk1kDJWtmZTqWQn7wHDvMRipVOEOQ==",
+        "resolved": "10.0.1",
+        "contentHash": "zpcfT/wacPPhE17zcudozlxQtWN/84qyiMyZNGLnK4cj2IMBtLsZYwYjVnALUhPliwyUVj/P7kaZvBWYBCnf2Q==",
         "dependencies": {
-          "System.Collections.Immutable": "9.0.0",
-          "System.Memory": "4.5.5"
+          "System.Collections.Immutable": "10.0.1"
         }
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.1.0",
-        "contentHash": "5o/HZxx6RVqYlhKSq8/zronDkALJZUT2Vz0hx43f0gwe8mwlM0y2nYlqdBwLMzr262Bwvpikeb/yEwkAa5PADg=="
+        "resolved": "6.1.2",
+        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
@@ -116,10 +115,10 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg==",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.1.0"
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "keeneyes.shaders.compiler": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   },

--- a/samples/KeenEyes.Sample.Aot/packages.lock.json
+++ b/samples/KeenEyes.Sample.Aot/packages.lock.json
@@ -4,15 +4,15 @@
     "net10.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "6X601g2HeszsEPWAj/LSmA28v1M5ZQgPBYbKfZm9WsLNzYf1fKiivX3US6FKhTdp9b2l19iMw1P7hO4jnBhK5w=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -28,6 +28,22 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.10"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WRjSRBfv6A6UjgjO8EQuLe9xqdICpkQx1hACUziCw4B2uGL+2jVhkFLq/G7rxRr3MGvqLo9B+nNdfIJ/5CYN7A=="
       }
     }
   }

--- a/samples/KeenEyes.Sample.Racing/packages.lock.json
+++ b/samples/KeenEyes.Sample.Racing/packages.lock.json
@@ -23,11 +23,18 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.replay": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       }
     }

--- a/samples/KeenEyes.Sample.Replay/packages.lock.json
+++ b/samples/KeenEyes.Sample.Replay/packages.lock.json
@@ -23,11 +23,18 @@
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
       },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.replay": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       }
     }

--- a/samples/KeenEyes.Sample.UI/packages.lock.json
+++ b/samples/KeenEyes.Sample.UI/packages.lock.json
@@ -304,7 +304,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {

--- a/src/KeenEyes.AI/packages.lock.json
+++ b/src/KeenEyes.AI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Animation/Data/AnimationClip.cs
+++ b/src/KeenEyes.Animation/Data/AnimationClip.cs
@@ -41,7 +41,7 @@ public enum WrapMode
 /// </remarks>
 public sealed class AnimationClip
 {
-    private readonly Dictionary<string, BoneTrack> boneTracks = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, BoneTrack> boneTracks = [with(StringComparer.Ordinal)];
 
     /// <summary>
     /// Gets or sets the name of this animation clip.

--- a/src/KeenEyes.Animation/packages.lock.json
+++ b/src/KeenEyes.Animation/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Assets/Manifest/AssetManifest.cs
+++ b/src/KeenEyes.Assets/Manifest/AssetManifest.cs
@@ -54,7 +54,7 @@ public sealed class AssetManifest
         Assets = assets;
 
         // Build lookup dictionary
-        assetsByPath = new Dictionary<string, AssetInfo>(StringComparer.OrdinalIgnoreCase);
+        assetsByPath = [with(StringComparer.OrdinalIgnoreCase)];
         foreach (var asset in assets)
         {
             assetsByPath[asset.Path] = asset;
@@ -204,7 +204,7 @@ public sealed class AssetManifest
             {
                 TotalAssets = Statistics.TotalAssets,
                 TotalSize = Statistics.TotalSize,
-                ByType = new Dictionary<string, int>(Statistics.ByType)
+                ByType = [with(Statistics.ByType)]
             }
         };
 

--- a/src/KeenEyes.Assets/packages.lock.json
+++ b/src/KeenEyes.Assets/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "NLayer": {
         "type": "Direct",

--- a/src/KeenEyes.Audio.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Audio.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Audio.Silk/packages.lock.json
+++ b/src/KeenEyes.Audio.Silk/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Silk.NET.OpenAL": {
         "type": "Direct",

--- a/src/KeenEyes.Audio/packages.lock.json
+++ b/src/KeenEyes.Audio/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Common/packages.lock.json
+++ b/src/KeenEyes.Common/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeChunk.cs
@@ -79,7 +79,7 @@ public sealed class ArchetypeChunk : IDisposable
         ArchetypeId = archetypeId;
         Capacity = capacity;
         entities = new Entity[capacity];
-        entityIdToIndex = new Dictionary<int, int>(capacity);
+        entityIdToIndex = [with(capacity)];
         componentArrays = [];
 
         foreach (var info in componentInfos)

--- a/src/KeenEyes.Core/packages.lock.json
+++ b/src/KeenEyes.Core/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Graph.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Graph.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Graph/packages.lock.json
+++ b/src/KeenEyes.Graph/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Graphics.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Graphics.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Graphics.Silk/packages.lock.json
+++ b/src/KeenEyes.Graphics.Silk/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Silk.NET.Maths": {
         "type": "Direct",

--- a/src/KeenEyes.Graphics/packages.lock.json
+++ b/src/KeenEyes.Graphics/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Input.Abstractions/Actions/ActionMapProvider.cs
+++ b/src/KeenEyes.Input.Abstractions/Actions/ActionMapProvider.cs
@@ -27,7 +27,7 @@ namespace KeenEyes.Input.Abstractions;
 /// </example>
 public sealed class ActionMapProvider : IActionMapProvider
 {
-    private readonly Dictionary<string, InputActionMap> maps = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, InputActionMap> maps = [with(StringComparer.OrdinalIgnoreCase)];
     private readonly List<InputActionMap> mapList = [];
     private InputActionMap? activeMap;
 

--- a/src/KeenEyes.Input.Abstractions/Actions/InputActionMap.cs
+++ b/src/KeenEyes.Input.Abstractions/Actions/InputActionMap.cs
@@ -32,7 +32,7 @@ namespace KeenEyes.Input.Abstractions;
 /// </example>
 public sealed class InputActionMap
 {
-    private readonly Dictionary<string, InputAction> actions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, InputAction> actions = [with(StringComparer.OrdinalIgnoreCase)];
     private bool enabled = true;
 
     /// <summary>

--- a/src/KeenEyes.Input.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Input.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Input.Silk/packages.lock.json
+++ b/src/KeenEyes.Input.Silk/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Silk.NET.Input": {
         "type": "Direct",

--- a/src/KeenEyes.Input/packages.lock.json
+++ b/src/KeenEyes.Input/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Localization/DictionaryStringSource.cs
+++ b/src/KeenEyes.Localization/DictionaryStringSource.cs
@@ -35,7 +35,7 @@ public sealed class DictionaryStringSource : IStringSource
 
         translations = new Dictionary<Locale, Dictionary<string, string>>
         {
-            [locale] = new Dictionary<string, string>(strings)
+            [locale] = [with(strings)]
         };
     }
 
@@ -50,7 +50,7 @@ public sealed class DictionaryStringSource : IStringSource
         this.translations = [];
         foreach (var (locale, strings) in translations)
         {
-            this.translations[locale] = new Dictionary<string, string>(strings);
+            this.translations[locale] = [with(strings)];
         }
     }
 

--- a/src/KeenEyes.Localization/packages.lock.json
+++ b/src/KeenEyes.Localization/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Logging/packages.lock.json
+++ b/src/KeenEyes.Logging/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Navigation.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Navigation.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Navigation.DotRecast/packages.lock.json
+++ b/src/KeenEyes.Navigation.DotRecast/packages.lock.json
@@ -41,9 +41,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Navigation.Grid/AStarPathfinder.cs
+++ b/src/KeenEyes.Navigation.Grid/AStarPathfinder.cs
@@ -53,7 +53,7 @@ public sealed class AStarPathfinder
             : grid.CellCount;
 
         nodePool = new PathNode[poolSize];
-        nodeIndices = new Dictionary<int, int>(poolSize);
+        nodeIndices = [with(poolSize)];
         openSet = new PriorityQueue<int, float>(poolSize);
 
         // Initialize area costs to 1.0

--- a/src/KeenEyes.Navigation.Grid/packages.lock.json
+++ b/src/KeenEyes.Navigation.Grid/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Navigation/packages.lock.json
+++ b/src/KeenEyes.Navigation/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Network.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Network.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Network.Transport.Tcp/packages.lock.json
+++ b/src/KeenEyes.Network.Transport.Tcp/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Network.Transport.Udp/packages.lock.json
+++ b/src/KeenEyes.Network.Transport.Udp/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Network/Replication/RewindScope.cs
+++ b/src/KeenEyes.Network/Replication/RewindScope.cs
@@ -49,7 +49,7 @@ public ref struct RewindScope
     internal RewindScope(IWorld world, List<(Entity Entity, Type Type, object Live, object Historical)> swaps)
     {
         this.world = world;
-        originals = new List<(Entity, Type, object)>(swaps.Count);
+        originals = [with(swaps.Count)];
 
         // Phase 1: record the exact live boxed values first, so restore is byte-for-byte.
         foreach (var (entity, type, live, _) in swaps)

--- a/src/KeenEyes.Network/packages.lock.json
+++ b/src/KeenEyes.Network/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Particles/packages.lock.json
+++ b/src/KeenEyes.Particles/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Persistence/packages.lock.json
+++ b/src/KeenEyes.Persistence/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Physics/Core/CollisionEventManager.cs
+++ b/src/KeenEyes.Physics/Core/CollisionEventManager.cs
@@ -91,7 +91,7 @@ internal sealed class CollisionEventManager(IWorld world)
     private readonly Dictionary<CollisionPairKey, bool> pairTriggerStatus = [];
 
     // Reusable list for entity removal (avoids allocation during RemoveEntity)
-    private readonly List<CollisionPairKey> removalBuffer = new(16);
+    private readonly List<CollisionPairKey> removalBuffer = [with(16)];
 
     /// <summary>
     /// Records a collision from the narrow phase callback.

--- a/src/KeenEyes.Physics/packages.lock.json
+++ b/src/KeenEyes.Physics/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Platform.Silk.Abstractions/packages.lock.json
+++ b/src/KeenEyes.Platform.Silk.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Silk.NET.Input": {
         "type": "Direct",

--- a/src/KeenEyes.Platform.Silk/packages.lock.json
+++ b/src/KeenEyes.Platform.Silk/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Silk.NET.Input": {
         "type": "Direct",

--- a/src/KeenEyes.Replay/ReplayPlayer.cs
+++ b/src/KeenEyes.Replay/ReplayPlayer.cs
@@ -2126,13 +2126,13 @@ public sealed class ReplayPlayer : IDisposable
             }
 
             // Copy handlers to avoid holding lock during invocation
-            handlersCopy = new Dictionary<InputEventType, List<Action<InputEvent>>>(inputHandlers.Count);
+            handlersCopy = [with(inputHandlers.Count)];
             foreach (var kvp in inputHandlers)
             {
                 handlersCopy[kvp.Key] = [.. kvp.Value];
             }
 
-            customHandlersCopy = new Dictionary<string, List<Delegate>>(customInputHandlers.Count);
+            customHandlersCopy = [with(customInputHandlers.Count)];
             foreach (var kvp in customInputHandlers)
             {
                 customHandlersCopy[kvp.Key] = [.. kvp.Value];
@@ -2215,13 +2215,13 @@ public sealed class ReplayPlayer : IDisposable
             }
 
             // Copy handlers to avoid holding lock during invocation
-            handlersCopy = new Dictionary<InputEventType, List<Action<InputEvent>>>(inputHandlers.Count);
+            handlersCopy = [with(inputHandlers.Count)];
             foreach (var kvp in inputHandlers)
             {
                 handlersCopy[kvp.Key] = [.. kvp.Value];
             }
 
-            customHandlersCopy = new Dictionary<string, List<Delegate>>(customInputHandlers.Count);
+            customHandlersCopy = [with(customInputHandlers.Count)];
             foreach (var kvp in customInputHandlers)
             {
                 customHandlersCopy[kvp.Key] = [.. kvp.Value];

--- a/src/KeenEyes.Runtime/packages.lock.json
+++ b/src/KeenEyes.Runtime/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Shaders/packages.lock.json
+++ b/src/KeenEyes.Shaders/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.Spatial/packages.lock.json
+++ b/src/KeenEyes.Spatial/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.TestBridge.Abstractions/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.TestBridge.Client/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Client/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -96,7 +96,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {

--- a/src/KeenEyes.TestBridge.Ipc/packages.lock.json
+++ b/src/KeenEyes.TestBridge.Ipc/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -96,7 +96,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {

--- a/src/KeenEyes.TestBridge/packages.lock.json
+++ b/src/KeenEyes.TestBridge/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -102,7 +102,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge.abstractions": {

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
@@ -253,8 +253,8 @@ public sealed class MockGraphicsContext : IGraphicsContext
         MeshDrawCalls.Add(new MeshDrawCall(
             handle,
             boundShader,
-            new Dictionary<int, TextureHandle>(boundTextures),
-            new Dictionary<string, object>(UniformValues)));
+            [with(boundTextures)],
+            [with(UniformValues)]));
     }
 
     #endregion
@@ -455,8 +455,8 @@ public sealed class MockGraphicsContext : IGraphicsContext
             instances,
             instanceCount,
             boundShader,
-            new Dictionary<int, TextureHandle>(boundTextures),
-            new Dictionary<string, object>(UniformValues)));
+            [with(boundTextures)],
+            [with(UniformValues)]));
     }
 
     private InstanceBufferHandle AllocateInstanceBufferHandle()

--- a/src/KeenEyes.UI.Abstractions/packages.lock.json
+++ b/src/KeenEyes.UI.Abstractions/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/src/KeenEyes.UI/packages.lock.json
+++ b/src/KeenEyes.UI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup Label="Source Generators">
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)..\'))" />
 </Project>

--- a/tests/KeenEyes.AotCompatibility.Tests/packages.lock.json
+++ b/tests/KeenEyes.AotCompatibility.Tests/packages.lock.json
@@ -4,15 +4,15 @@
     "net10.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "6X601g2HeszsEPWAj/LSmA28v1M5ZQgPBYbKfZm9WsLNzYf1fKiivX3US6FKhTdp9b2l19iMw1P7hO4jnBhK5w=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "keeneyes.abstractions": {
         "type": "Project"
@@ -22,6 +22,22 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
         }
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.10"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WRjSRBfv6A6UjgjO8EQuLe9xqdICpkQx1hACUziCw4B2uGL+2jVhkFLq/G7rxRr3MGvqLo9B+nNdfIJ/5CYN7A=="
       }
     }
   }

--- a/tests/KeenEyes.Cli.Tests/packages.lock.json
+++ b/tests/KeenEyes.Cli.Tests/packages.lock.json
@@ -504,6 +504,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -542,7 +543,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -635,6 +637,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
@@ -497,6 +497,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -535,7 +536,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -628,6 +630,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Editor.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Tests/packages.lock.json
@@ -497,6 +497,7 @@
         "dependencies": {
           "DotRecast.Detour": "[2026.1.3, )",
           "DotRecast.Detour.Crowd": "[2026.1.3, )",
+          "DotRecast.Detour.TileCache": "[2026.1.3, )",
           "DotRecast.Recast": "[2026.1.3, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
@@ -535,7 +536,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -628,6 +630,16 @@
         "contentHash": "TvdiyfG3wpcAOX12Pt/iAGtYNyHbGPa8SyYDJjivN0n2pt//8Llr3eHzOP7Gbkln0fFUTgCjTiaIoEE0rXV2XA==",
         "dependencies": {
           "DotRecast.Detour": "2026.1.3"
+        }
+      },
+      "DotRecast.Detour.TileCache": {
+        "type": "CentralTransitive",
+        "requested": "[2026.1.3, )",
+        "resolved": "2026.1.3",
+        "contentHash": "pI8rQyTb86TMUA65msqts6d8brQ5m0x/zkALqwrUZkpmrJS3Rx1CEh/yM2EFgCfLBz9xt/Oi7MyT3cjUP5LjOA==",
+        "dependencies": {
+          "DotRecast.Detour": "2026.1.3",
+          "DotRecast.Recast": "2026.1.3"
         }
       },
       "DotRecast.Recast": {

--- a/tests/KeenEyes.Generators.Tests/packages.lock.json
+++ b/tests/KeenEyes.Generators.Tests/packages.lock.json
@@ -20,16 +20,16 @@
       },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "ojTMowxK2X0QPNSixGLI5RBgBQLgo1Blwyct4+HWCVYLXT4iKCyVKKmGjxw4h0AvPzGgd0XfWzSGKJk/jS2LkA==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
-          "System.Composition": "9.0.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.6.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.6.0]",
+          "System.Composition": "10.0.1"
         }
       },
       "Microsoft.Testing.Extensions.CodeCoverage": {
@@ -139,10 +139,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.CodeAnalysis.SourceGenerators.Testing": {
@@ -157,13 +157,13 @@
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "resolved": "5.6.0",
+        "contentHash": "ILscYALZ5u7MRl2paiiSqn23/5qiy3vvcqBEP/C7RnGJtQQKKtPz5vEBtvDeDTaLzB9/w9d/bxfRYnaq5Pz00g==",
         "dependencies": {
           "Humanizer.Core": "2.14.1",
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
-          "System.Composition": "9.0.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]",
+          "System.Composition": "10.0.1"
         }
       },
       "Microsoft.DiaSymReader": {
@@ -273,50 +273,50 @@
       },
       "System.Composition": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "resolved": "10.0.1",
+        "contentHash": "DJkqaWQfho/ReTzKcZD3zJJ6K4GcS154k+T0UCPMBNIOZ2U/lNpyiiWZ6Etw0onWyTH1K+yhICsdmwA5xy2aPQ==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0",
-          "System.Composition.Convention": "9.0.0",
-          "System.Composition.Hosting": "9.0.0",
-          "System.Composition.Runtime": "9.0.0",
-          "System.Composition.TypedParts": "9.0.0"
+          "System.Composition.AttributedModel": "10.0.1",
+          "System.Composition.Convention": "10.0.1",
+          "System.Composition.Hosting": "10.0.1",
+          "System.Composition.Runtime": "10.0.1",
+          "System.Composition.TypedParts": "10.0.1"
         }
       },
       "System.Composition.AttributedModel": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+        "resolved": "10.0.1",
+        "contentHash": "mRxYvpCVPAeuLEk0c0kxWJVjbW1/HUoxCgYotOj9eDeQiYcTDOMdCQApsTrHYMN3pHBA8WoF00KGolG632Etaw=="
       },
       "System.Composition.Convention": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "resolved": "10.0.1",
+        "contentHash": "dYynUByfVBzYDheNPGxS8UN8AvG/4tXf/coSs1odHOyoh4etv1kad/FrLWLMq4f8NO49NV20Xu+0/y613woTUA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0"
+          "System.Composition.AttributedModel": "10.0.1"
         }
       },
       "System.Composition.Hosting": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "resolved": "10.0.1",
+        "contentHash": "4UGmyBdKWEN1nkqspJlji/nV7XIVm6KGlOC2So0mtM/gKvaNgLz+tUkcbY+6Zpr7dr6ohX1S5yl0RLID5otRHw==",
         "dependencies": {
-          "System.Composition.Runtime": "9.0.0"
+          "System.Composition.Runtime": "10.0.1"
         }
       },
       "System.Composition.Runtime": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+        "resolved": "10.0.1",
+        "contentHash": "TVfys1gnUIhmXuYfFzyez0fOkDyELe9UwlxYeVlq6FmqmWmt1ouF0OQJ+6ozkHbkaop7uBUaXw7Qb+/o0m+nMg=="
       },
       "System.Composition.TypedParts": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "resolved": "10.0.1",
+        "contentHash": "koSfjkdQZfgQr3SyiSIBboDn+GiR0vZ3x9Uek9FJbXK0w5AiATV8KrnMEP8B8OAlO+Y3zQf0CPCNzwH+VIYDKg==",
         "dependencies": {
-          "System.Composition.AttributedModel": "9.0.0",
-          "System.Composition.Hosting": "9.0.0",
-          "System.Composition.Runtime": "9.0.0"
+          "System.Composition.AttributedModel": "10.0.1",
+          "System.Composition.Hosting": "10.0.1",
+          "System.Composition.Runtime": "10.0.1"
         }
       },
       "System.Management": {
@@ -411,7 +411,7 @@
       "keeneyes.generators": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )"
+          "Microsoft.CodeAnalysis.CSharp": "[5.6.0, )"
         }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
@@ -422,12 +422,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       },
       "NuGet.Configuration": {

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
@@ -96,8 +96,16 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "PHeuDm2tC6wJPEQvleUr2kNQaIMNqSf3aEbzkIPlZyQ0+0SYI9SwXVLdGD1NPBI+xB+Vb2lxZKhrFlIf9kP9WA=="
+        "resolved": "10.5.2",
+        "contentHash": "Ei+YWV9Ybnps7pR1dgjlG29gelXEwZkhLVAcWmKe6HvXS6LNBYgSdWiY3Hk9OZXYtK34rv/NtLWBQYQGOBQYPQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -378,11 +386,11 @@
       },
       "ModelContextProtocol.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0-preview.1",
-        "contentHash": "33V1Druluweou6x2LN6MSMbhiwHOYZxTUEJ1okFKjYDRIthctTVe0EJi//nifl4MRld2b5D5LnuV9sezz54p6g==",
+        "resolved": "1.4.1",
+        "contentHash": "G/hOBZkJsvF3MSy0sOvXdxca5uRe2Sb4xk7xRuTWNZI45khVBjOLo6nSzGilctIICavNVxbxUF908fLYI9RxkQ==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.5.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "System.CodeDom": {
@@ -517,7 +525,7 @@
         "dependencies": {
           "KeenEyes.TestBridge.Client": "[1.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.10, )",
-          "ModelContextProtocol": "[0.5.0-preview.1, )"
+          "ModelContextProtocol": "[1.4.1, )"
         }
       },
       "keeneyes.navigation": {
@@ -550,7 +558,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {
@@ -635,12 +644,13 @@
       },
       "ModelContextProtocol": {
         "type": "CentralTransitive",
-        "requested": "[0.5.0-preview.1, )",
-        "resolved": "0.5.0-preview.1",
-        "contentHash": "QJpuNEnMZLJmvASbZ2nvMqENTZk3HYF83IihoHs3EJ5vTlz4sYjji9bXh2HP5UxpXIdHGn0iuHu0X2Tpq2zilw==",
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "mP5hvBpoWe5EbWBqHWD09A4Dy6Pq+/vV2dumOV4uegCZcg+yqf8q8wrxtuZ3EQyXEJn9jzsnoiI/qyfJAihlZQ==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "ModelContextProtocol.Core": "0.5.0-preview.1"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "ModelContextProtocol.Core": "1.4.1"
         }
       },
       "StbImageWriteSharp": {

--- a/tests/KeenEyes.Shaders.Generator.IntegrationTests/packages.lock.json
+++ b/tests/KeenEyes.Shaders.Generator.IntegrationTests/packages.lock.json
@@ -10,12 +10,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "r1DrKQ/L0xTw03wJrLr36AMQNslyaeEKBFyFmQcOKa8HX3YvmhY//JEUafb6IR/m0gmaUVCfBTWitKJRNb7YAA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
-          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "Microsoft.CodeAnalysis.Common": "[5.6.0]"
         }
       },
       "Microsoft.Testing.Extensions.CodeCoverage": {
@@ -101,10 +101,10 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "resolved": "5.6.0",
+        "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
         }
       },
       "Microsoft.DiaSymReader": {
@@ -215,7 +215,7 @@
       "keeneyes.shaders.generator": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[5.0.0, )"
+          "Microsoft.CodeAnalysis.CSharp": "[5.6.0, )"
         }
       },
       "Microsoft.CodeAnalysis.Analyzers": {

--- a/tests/KeenEyes.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.TestBridge.Tests/packages.lock.json
@@ -279,7 +279,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {

--- a/tests/KeenEyes.Testing.Tests/packages.lock.json
+++ b/tests/KeenEyes.Testing.Tests/packages.lock.json
@@ -273,7 +273,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {

--- a/tools/KeenEyes.Lsp.Kesl/packages.lock.json
+++ b/tools/KeenEyes.Lsp.Kesl/packages.lock.json
@@ -4,15 +4,15 @@
     "net10.0": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "6X601g2HeszsEPWAj/LSmA28v1M5ZQgPBYbKfZm9WsLNzYf1fKiivX3US6FKhTdp9b2l19iMw1P7hO4jnBhK5w=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "OlcegtpIM8XB7OKBuKrO77ttGRPlGd4F1OBGKda409nwwGZeTWyK9/8WGrgni2zynkZXi/w+H2gjP5uj4zfoJg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -22,6 +22,22 @@
       },
       "keeneyes.shaders.compiler": {
         "type": "Project"
+      }
+    },
+    "net10.0/linux-x64": {
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g==",
+        "dependencies": {
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.10"
+        }
+      },
+      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "WRjSRBfv6A6UjgjO8EQuLe9xqdICpkQx1hACUziCw4B2uGL+2jVhkFLq/G7rxRr3MGvqLo9B+nNdfIJ/5CYN7A=="
       }
     }
   }

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -34,12 +34,13 @@
       },
       "ModelContextProtocol": {
         "type": "Direct",
-        "requested": "[0.5.0-preview.1, )",
-        "resolved": "0.5.0-preview.1",
-        "contentHash": "QJpuNEnMZLJmvASbZ2nvMqENTZk3HYF83IihoHs3EJ5vTlz4sYjji9bXh2HP5UxpXIdHGn0iuHu0X2Tpq2zilw==",
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "mP5hvBpoWe5EbWBqHWD09A4Dy6Pq+/vV2dumOV4uegCZcg+yqf8q8wrxtuZ3EQyXEJn9jzsnoiI/qyfJAihlZQ==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "ModelContextProtocol.Core": "0.5.0-preview.1"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "ModelContextProtocol.Core": "1.4.1"
         }
       },
       "SonarAnalyzer.CSharp": {
@@ -50,8 +51,16 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "PHeuDm2tC6wJPEQvleUr2kNQaIMNqSf3aEbzkIPlZyQ0+0SYI9SwXVLdGD1NPBI+xB+Vb2lxZKhrFlIf9kP9WA=="
+        "resolved": "10.5.2",
+        "contentHash": "Ei+YWV9Ybnps7pR1dgjlG29gelXEwZkhLVAcWmKe6HvXS6LNBYgSdWiY3Hk9OZXYtK34rv/NtLWBQYQGOBQYPQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -305,11 +314,11 @@
       },
       "ModelContextProtocol.Core": {
         "type": "Transitive",
-        "resolved": "0.5.0-preview.1",
-        "contentHash": "33V1Druluweou6x2LN6MSMbhiwHOYZxTUEJ1okFKjYDRIthctTVe0EJi//nifl4MRld2b5D5LnuV9sezz54p6g==",
+        "resolved": "1.4.1",
+        "contentHash": "G/hOBZkJsvF3MSy0sOvXdxca5uRe2Sb4xk7xRuTWNZI45khVBjOLo6nSzGilctIICavNVxbxUF908fLYI9RxkQ==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.5.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "System.Diagnostics.EventLog": {
@@ -399,7 +408,8 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
-          "KeenEyes.Core": "[1.0.0, )"
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.testbridge": {


### PR DESCRIPTION
## Summary
- Executes **parts 1 and 2** of #1023 (deliberate SDK feature-band bump + the Roslyn pair gated on it). Part 3 (ImageSharp 4) stays deferred on the licensing-mechanics decision.
- `global.json`: `10.0.100` → `10.0.300` (`rollForward: latestPatch`) — same band-pin policy from #1020, moved to the current band. CI follows automatically via `global-json-file`.
- Fixed all **27 IDE0028 sites** the newer analyzers flag — the 5 known from the issue plus sites in code merged since it was filed. The analyzer's preferred rewrite is C# 14 collection-expression arguments (`[with(capacity)]`, `[with(StringComparer.OrdinalIgnoreCase)]`), which pass straight through to the same constructors — capacity, comparer, and copy-constructor semantics are unchanged. Applied via `dotnet format analyzers --diagnostics IDE0028` (analyzer-preferred fixes, not hand rewrites), then validated by full build.
- `Microsoft.CodeAnalysis.CSharp` / `.Workspaces` 5.0.0 → 5.6.0; both generator projects build clean (no CS8032, no new RS diagnostics).
- All `packages.lock.json` regenerated (`--force-evaluate`; ILLink 10.0.9 → 10.0.10 follows the SDK).

## Test plan
- [x] `dotnet build KeenEyes.slnx -c Release` — 0 warnings, 0 errors
- [x] Full suite: **14,394 passed, 0 failed** (61 skipped), `--max-parallel-test-modules 1`
- [x] `dotnet format KeenEyes.slnx --verify-no-changes` — exit 0 (unmasked)
- [ ] CI green on the new band

## Related Issues
Part of #1023 (parts 1–2; ImageSharp remains, will keep the issue open)