### PR TITLE
chore: Drop ImageSharp by removing the unused WebP texture fallback

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,6 @@
     <PackageVersion Include="SharpGLTF.Core" Version="1.0.6" />
     <PackageVersion Include="NVorbis" Version="0.10.5" />
     <PackageVersion Include="NLayer" Version="2.0.1" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="Pfim" Version="0.11.4" />
   </ItemGroup>
   <ItemGroup Label="Editor">

--- a/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
+++ b/benchmarks/KeenEyes.Editor.Benchmarks/packages.lock.json
@@ -318,7 +318,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -736,12 +735,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/editor/KeenEyes.Cli/packages.lock.json
+++ b/editor/KeenEyes.Cli/packages.lock.json
@@ -173,7 +173,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -575,12 +574,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/editor/KeenEyes.Editor/packages.lock.json
+++ b/editor/KeenEyes.Editor/packages.lock.json
@@ -198,7 +198,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -550,12 +549,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/editor/KeenEyes.Generators/AssetConstantsGenerator.cs
+++ b/editor/KeenEyes.Generators/AssetConstantsGenerator.cs
@@ -36,7 +36,7 @@ public sealed class AssetConstantsGenerator : IIncrementalGenerator
     private static readonly HashSet<string> KnownAssetExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         // Textures
-        ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".webp", ".dds",
+        ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".dds",
         // Audio
         ".wav", ".ogg", ".mp3", ".flac",
         // Fonts

--- a/editor/KeenEyes.Generators/AssetPathAnalyzer.cs
+++ b/editor/KeenEyes.Generators/AssetPathAnalyzer.cs
@@ -89,7 +89,7 @@ public sealed class AssetPathAnalyzer : DiagnosticAnalyzer
     // Extension to asset type mapping
     private static readonly Dictionary<string, string[]> TypeToExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["TextureAsset"] = [".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".webp", ".dds"],
+        ["TextureAsset"] = [".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".dds"],
         ["AudioClipAsset"] = [".wav", ".ogg", ".mp3", ".flac"],
         ["FontAsset"] = [".ttf", ".otf"],
         ["MeshAsset"] = [".gltf", ".glb"],
@@ -102,7 +102,7 @@ public sealed class AssetPathAnalyzer : DiagnosticAnalyzer
     private static readonly HashSet<string> KnownAssetExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         // Textures
-        ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".webp", ".dds",
+        ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".dds",
         // Audio
         ".wav", ".ogg", ".mp3", ".flac",
         // Fonts

--- a/samples/KeenEyes.Sample.Showcase/packages.lock.json
+++ b/samples/KeenEyes.Sample.Showcase/packages.lock.json
@@ -124,7 +124,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -326,12 +325,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/samples/KeenEyes.Sample.UI/packages.lock.json
+++ b/samples/KeenEyes.Sample.UI/packages.lock.json
@@ -134,7 +134,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -453,12 +452,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.Assets/KeenEyes.Assets.csproj
+++ b/src/KeenEyes.Assets/KeenEyes.Assets.csproj
@@ -26,7 +26,6 @@
 		<PackageReference Include="SharpGLTF.Core" />
 		<PackageReference Include="NVorbis" />
 		<PackageReference Include="NLayer" />
-		<PackageReference Include="SixLabors.ImageSharp" />
 		<PackageReference Include="Pfim" />
 	</ItemGroup>
 

--- a/src/KeenEyes.Assets/Loaders/TextureLoader.cs
+++ b/src/KeenEyes.Assets/Loaders/TextureLoader.cs
@@ -1,18 +1,15 @@
 using KeenEyes.Graphics.Abstractions;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using StbImageSharp;
 
 namespace KeenEyes.Assets;
 
 /// <summary>
-/// Loader for image texture assets using StbImageSharp and ImageSharp.
+/// Loader for image texture assets using StbImageSharp.
 /// </summary>
 /// <remarks>
 /// <para>
 /// <see cref="TextureLoader"/> loads common image formats (PNG, JPG, BMP, TGA, etc.)
-/// using the StbImageSharp library, a pure C# port of stb_image.h. WebP images are
-/// loaded using SixLabors.ImageSharp which provides pure C# WebP decoding.
+/// using the StbImageSharp library, a pure C# port of stb_image.h.
 /// </para>
 /// <para>
 /// Loaded images are uploaded to the GPU via <see cref="IGraphicsContext"/> and wrapped
@@ -24,7 +21,7 @@ public sealed class TextureLoader : IAssetLoader<TextureAsset>
     private readonly IGraphicsContext graphics;
 
     /// <inheritdoc />
-    public IReadOnlyList<string> Extensions => [".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".webp"];
+    public IReadOnlyList<string> Extensions => [".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr"];
 
     /// <summary>
     /// Creates a new texture loader.
@@ -40,38 +37,10 @@ public sealed class TextureLoader : IAssetLoader<TextureAsset>
     /// <inheritdoc />
     public TextureAsset Load(Stream stream, AssetLoadContext context)
     {
-        var extension = Path.GetExtension(context.Path).ToLowerInvariant();
-
-        // WebP files use ImageSharp for decoding
-        if (extension == ".webp")
-        {
-            return LoadWebP(stream);
-        }
-
-        // Other formats use StbImageSharp
         var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 
         // Create GPU texture
         var handle = graphics.CreateTexture(image.Width, image.Height, image.Data);
-
-        return new TextureAsset(
-            handle,
-            image.Width,
-            image.Height,
-            TextureFormat.Rgba8,
-            graphics);
-    }
-
-    private TextureAsset LoadWebP(Stream stream)
-    {
-        using var image = Image.Load<Rgba32>(stream);
-
-        // Copy pixel data to byte array
-        var pixelData = new byte[image.Width * image.Height * 4];
-        image.CopyPixelDataTo(pixelData);
-
-        // Create GPU texture
-        var handle = graphics.CreateTexture(image.Width, image.Height, pixelData);
 
         return new TextureAsset(
             handle,

--- a/src/KeenEyes.Assets/packages.lock.json
+++ b/src/KeenEyes.Assets/packages.lock.json
@@ -32,12 +32,6 @@
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
       },
-      "SixLabors.ImageSharp": {
-        "type": "Direct",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
-      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[10.29.0.143774, )",

--- a/src/KeenEyes.Localization/LocalizedAssetResolver.cs
+++ b/src/KeenEyes.Localization/LocalizedAssetResolver.cs
@@ -34,7 +34,7 @@ public sealed class LocalizedAssetResolver(string rootPath, LocalizationConfig c
 {
     private readonly string rootPath = rootPath ?? string.Empty;
     private readonly LocalizationConfig config = config ?? LocalizationConfig.Default;
-    private readonly string[] commonExtensions = [".png", ".jpg", ".jpeg", ".webp", ".wav", ".ogg", ".mp3", ".ttf", ".otf"];
+    private readonly string[] commonExtensions = [".png", ".jpg", ".jpeg", ".wav", ".ogg", ".mp3", ".ttf", ".otf"];
 
     /// <inheritdoc />
     public string? Resolve(string assetKey, Locale locale)

--- a/src/KeenEyes.Localization/packages.lock.json
+++ b/src/KeenEyes.Localization/packages.lock.json
@@ -44,7 +44,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -110,12 +109,6 @@
         "requested": "[1.0.6, )",
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.UI/packages.lock.json
+++ b/src/KeenEyes.UI/packages.lock.json
@@ -38,7 +38,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -121,12 +120,6 @@
         "requested": "[1.0.6, )",
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Assets.Tests/TextureLoaderTests.cs
+++ b/tests/KeenEyes.Assets.Tests/TextureLoaderTests.cs
@@ -63,21 +63,21 @@ public class TextureLoaderTests
     }
 
     [Fact]
-    public void TextureLoader_Extensions_ContainsWebP()
+    public void TextureLoader_Extensions_DoesNotContainWebP()
     {
         var graphics = new MockGraphicsContext();
         var loader = new TextureLoader(graphics);
 
-        Assert.Contains(".webp", loader.Extensions);
+        Assert.DoesNotContain(".webp", loader.Extensions);
     }
 
     [Fact]
-    public void TextureLoader_Extensions_HasNineFormats()
+    public void TextureLoader_Extensions_HasEightFormats()
     {
         var graphics = new MockGraphicsContext();
         var loader = new TextureLoader(graphics);
 
-        Assert.Equal(9, loader.Extensions.Count);
+        Assert.Equal(8, loader.Extensions.Count);
     }
 
     [Fact]

--- a/tests/KeenEyes.Assets.Tests/packages.lock.json
+++ b/tests/KeenEyes.Assets.Tests/packages.lock.json
@@ -215,7 +215,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -312,12 +311,6 @@
         "requested": "[1.0.6, )",
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Cli.Tests/packages.lock.json
+++ b/tests/KeenEyes.Cli.Tests/packages.lock.json
@@ -358,7 +358,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -760,12 +759,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Integration.Tests/packages.lock.json
@@ -351,7 +351,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -753,12 +752,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Editor.Tests/packages.lock.json
+++ b/tests/KeenEyes.Editor.Tests/packages.lock.json
@@ -351,7 +351,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -753,12 +752,6 @@
           "Silk.NET.Windowing.Common": "2.23.0",
           "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Localization.Tests/packages.lock.json
+++ b/tests/KeenEyes.Localization.Tests/packages.lock.json
@@ -215,7 +215,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -337,12 +336,6 @@
         "requested": "[1.0.6, )",
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.UI.Tests/packages.lock.json
+++ b/tests/KeenEyes.UI.Tests/packages.lock.json
@@ -215,7 +215,6 @@
           "NVorbis": "[0.10.5, )",
           "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -349,12 +348,6 @@
         "requested": "[1.0.6, )",
         "resolved": "1.0.6",
         "contentHash": "m3qIvUnpvRRfQ0fp0TFfpPk+vsHkCIOf/uIVJ19fe9dwa29KCO/PeHVXKAph8nsFxFLXitTIIqCa5W8JGLMhBg=="
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary
- Completes the **final part of #1023** (per decision: replace the fallback rather than provision ImageSharp 4 license keys).
- Survey result that drove the approach: **nothing in the repo uses WebP** — no `.webp` asset in source, no sample/doc loads one, and the only test asserted the extension was listed. The gate-free decoder landscape is also poor (stale Windows-only libwebp wrappers, or ~8 MB/RID of SkiaSharp natives for one format), so the fallback is removed instead of swapped.
- `TextureLoader`: WebP branch and `.webp` extension removed (8 formats remain via StbImageSharp; `KeenEyes.Assets` stays pure managed).
- `.webp` removed from `LocalizedAssetResolver` and the asset-constants generator lists — the engine no longer advertises a format it can't decode.
- `SixLabors.ImageSharp` package reference + central pin removed; 14 lockfiles shed the transitive entries.
- Tests updated: `Extensions_DoesNotContainWebP`, count 9 → 8.

## Test plan
- [x] Full Release build — 0 warnings, 0 errors
- [x] Full suite: 14,394 passed / 0 failed (`--max-parallel-test-modules 1`)
- [x] `dotnet format KeenEyes.slnx --verify-no-changes` — exit 0

## Related Issues
Closes #1023