### PR TITLE
chore(samples): Polish sample code to production teaching standards

### DIFF
--- a/samples/KeenEyes.Sample.MassSimulation/Systems.cs
+++ b/samples/KeenEyes.Sample.MassSimulation/Systems.cs
@@ -10,10 +10,10 @@ namespace KeenEyes.Sample.MassSimulation;
 public class MovementSystem : SystemBase
 {
     /// <summary>World bounds width.</summary>
-    public float WorldWidth { get; set; } = 100f;
+    public float WorldWidth { get; init; } = 100f;
 
     /// <summary>World bounds height.</summary>
-    public float WorldHeight { get; set; } = 50f;
+    public float WorldHeight { get; init; } = 50f;
 
     /// <inheritdoc />
     public override void Update(float deltaTime)
@@ -129,16 +129,16 @@ public class CleanupSystem : SystemBase
 public class SpawnerSystem : SystemBase
 {
     /// <summary>Target number of active particles.</summary>
-    public int TargetCount { get; set; } = 100_000;
+    public int TargetCount { get; init; } = 100_000;
 
     /// <summary>Maximum particles to spawn per frame.</summary>
-    public int MaxSpawnPerFrame { get; set; } = 5_000;
+    public int MaxSpawnPerFrame { get; init; } = 5_000;
 
     /// <summary>World width for spawn positions.</summary>
-    public float WorldWidth { get; set; } = 100f;
+    public float WorldWidth { get; init; } = 100f;
 
     /// <summary>World height for spawn positions.</summary>
-    public float WorldHeight { get; set; } = 50f;
+    public float WorldHeight { get; init; } = 50f;
 
     /// <summary>Number of entities spawned in the last update.</summary>
     public int LastSpawnCount { get; private set; }

--- a/samples/KeenEyes.Sample.Physics/Program.cs
+++ b/samples/KeenEyes.Sample.Physics/Program.cs
@@ -335,7 +335,7 @@ void RunRaycastingDemo()
     Console.WriteLine("  Ray 1: Forward (+X direction)");
     if (physics.Raycast(origin, Vector3.UnitX, 50f, out var hit1))
     {
-        var hitName = GetTargetName(targets, hit1.Entity);
+        var hitName = GetTargetName(world, targets, hit1.Entity);
         Console.WriteLine($"    HIT: {hitName}");
         Console.WriteLine($"    Position: ({hit1.Position.X:F2}, {hit1.Position.Y:F2}, {hit1.Position.Z:F2})");
         Console.WriteLine($"    Normal: ({hit1.Normal.X:F2}, {hit1.Normal.Y:F2}, {hit1.Normal.Z:F2})");
@@ -351,7 +351,7 @@ void RunRaycastingDemo()
     Console.WriteLine("  Ray 2: Upward (+Y direction)");
     if (physics.Raycast(origin, Vector3.UnitY, 50f, out var hit2))
     {
-        var hitName = GetTargetName(targets, hit2.Entity);
+        var hitName = GetTargetName(world, targets, hit2.Entity);
         Console.WriteLine($"    HIT: {hitName}");
         Console.WriteLine($"    Position: ({hit2.Position.X:F2}, {hit2.Position.Y:F2}, {hit2.Position.Z:F2})");
         Console.WriteLine($"    Distance: {hit2.Distance:F2}");
@@ -367,7 +367,7 @@ void RunRaycastingDemo()
     var diagonalDir = Vector3.Normalize(new Vector3(5, 0, 5));
     if (physics.Raycast(origin, diagonalDir, 50f, out var hit3))
     {
-        var hitName = GetTargetName(targets, hit3.Entity);
+        var hitName = GetTargetName(world, targets, hit3.Entity);
         Console.WriteLine($"    HIT: {hitName}");
         Console.WriteLine($"    Distance: {hit3.Distance:F2}");
     }
@@ -397,7 +397,7 @@ void RunRaycastingDemo()
     Console.WriteLine($"  Found {overlapping.Count()} entities in sphere:");
     foreach (var entity in overlapping)
     {
-        var name = GetTargetName(targets, entity);
+        var name = GetTargetName(world, targets, entity);
         Console.WriteLine($"    - {name}");
     }
 
@@ -418,7 +418,7 @@ void PrintEntityPosition(World world, Entity entity, string prefix)
     }
 }
 
-string GetTargetName(List<(Entity entity, string name, Vector3 position)> targets, Entity entity)
+string GetTargetName(World world, List<(Entity entity, string name, Vector3 position)> targets, Entity entity)
 {
     foreach (var (e, name, _) in targets)
     {
@@ -428,6 +428,12 @@ string GetTargetName(List<(Entity entity, string name, Vector3 position)> target
         }
     }
 
-    // Check if it's the ground
-    return entity.Id == 1 ? "Ground" : $"Entity {entity.Id}";
+    // Identify the ground by its GroundTag component rather than a hard-coded ID -
+    // entity IDs are an implementation detail and are not stable across runs.
+    if (world.Has<GroundTag>(entity))
+    {
+        return "Ground";
+    }
+
+    return $"Entity {entity.Id}";
 }

--- a/samples/KeenEyes.Sample.Replay/Program.cs
+++ b/samples/KeenEyes.Sample.Replay/Program.cs
@@ -121,10 +121,17 @@ Console.WriteLine($"  Frames recorded: {recorder.RecordedFrameCount}");
 Console.WriteLine($"  Snapshots captured: {recorder.SnapshotCount}");
 Console.WriteLine($"  Elapsed time: {recorder.ElapsedTime.TotalSeconds:F2}s");
 
-// Stop recording and get data
+// Stop recording and get data. StopRecording returns null if no recording was
+// active, so guard against it rather than assuming success with the null-forgiving operator.
 var replayData = recorder.StopRecording();
+if (replayData is null)
+{
+    Console.WriteLine("\nNo active recording to stop - nothing was captured. Exiting.");
+    return;
+}
+
 Console.WriteLine($"\nRecording complete!");
-Console.WriteLine($"  Total frames: {replayData!.FrameCount}");
+Console.WriteLine($"  Total frames: {replayData.FrameCount}");
 Console.WriteLine($"  Total snapshots: {replayData.Snapshots.Count}");
 Console.WriteLine($"  Duration: {replayData.Duration.TotalSeconds:F2}s");
 Console.WriteLine($"  Average FPS: {replayData.AverageFrameRate:F1}");
@@ -271,8 +278,14 @@ for (int frame = 0; frame < 100; frame++)
 
 // Simulate crash - get the buffer contents
 var crashData = crashRecorder.StopRecording();
+if (crashData is null)
+{
+    Console.WriteLine("\nNo active crash recording to stop - nothing was captured. Exiting.");
+    return;
+}
+
 Console.WriteLine($"\nRing buffer captured:");
-Console.WriteLine($"  Frames in buffer: {crashData!.FrameCount}");
+Console.WriteLine($"  Frames in buffer: {crashData.FrameCount}");
 Console.WriteLine($"  First frame number: {crashData.Frames[0].FrameNumber}");
 Console.WriteLine($"  Last frame number: {crashData.Frames[^1].FrameNumber}");
 Console.WriteLine($"  Buffer duration: {crashData.Duration.TotalSeconds:F2}s");

--- a/samples/KeenEyes.Sample.SaveLoad/Program.cs
+++ b/samples/KeenEyes.Sample.SaveLoad/Program.cs
@@ -133,10 +133,24 @@ ref var playerGold = ref world.Get<Gold>(player);
 playerGold.Amount -= 500;
 Console.WriteLine($"Player spent gold, now has: {playerGold.Amount}");
 
-// Kill an enemy
-var firstEnemy = world.Query<Health>().With<Enemy>().First();
-world.Despawn(firstEnemy);
-Console.WriteLine($"Enemy {firstEnemy} was defeated!");
+// Kill an enemy. Query results are never guaranteed, so look the first match up
+// explicitly and report a miss instead of letting First() throw on an empty query.
+Entity? firstEnemy = null;
+foreach (var candidate in world.Query<Health>().With<Enemy>())
+{
+    firstEnemy = candidate;
+    break;
+}
+
+if (firstEnemy is Entity enemyToDefeat)
+{
+    world.Despawn(enemyToDefeat);
+    Console.WriteLine($"Enemy {enemyToDefeat} was defeated!");
+}
+else
+{
+    Console.WriteLine("No enemies found to defeat.");
+}
 
 PrintWorldState(world, "After Gameplay");
 
@@ -161,6 +175,10 @@ try
 }
 catch (Exception ex)
 {
+    // Loading a save file is an application entry point handling external, possibly
+    // corrupt data: deserialization can surface JsonException, NotSupportedException,
+    // and others. A demo like this recovers by reporting the failure and exiting rather
+    // than crashing, so a catch-all is appropriate here.
     Console.WriteLine($"Failed to load snapshot: {ex.Message}");
     Console.WriteLine($"Stack trace: {ex.StackTrace}");
     return;


### PR DESCRIPTION
## Summary
- Batch polish from the retired nightly review's confirmed sample findings — samples are teaching code per CLAUDE.md.
- **Replay**: `replayData!`/`crashData!` null-forgiving replaced with explicit guards + user-facing messages.
- **SaveLoad**: `.First()` → explicit lookup with a miss message; the demo's `catch (Exception)` kept deliberately, now with a comment explaining why a catch-all fits a load entry point handling possibly-corrupt external data.
- **Physics**: `entity.Id == 1 ? "Ground"` magic-id replaced with the `GroundTag` component check the sample already demonstrates.
- **MassSimulation**: six config properties made init-only (verified never mutated post-construction); per-frame stat properties intentionally left `private set`.

## Test plan
- [x] Full solution Release build — 0 warnings, 0 errors (samples compile in slnx)
- [x] `dotnet format KeenEyes.slnx --verify-no-changes` — exit 0
- [x] All four sample projects rebuilt individually during independent verification

## Related Issues
Closes #1052