### PR TITLE
feat(navigation): Publish off-mesh link events for crowd agents

### DIFF
--- a/src/KeenEyes.Navigation.Abstractions/ICrowdNavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Abstractions/ICrowdNavigationProvider.cs
@@ -75,7 +75,9 @@ public interface ICrowdNavigationProvider : INavigationProvider
     /// Gets the simulated state of a crowd agent.
     /// </summary>
     /// <param name="entity">The registered crowd agent entity.</param>
-    /// <param name="state">The agent's simulated position and velocities.</param>
+    /// <param name="state">
+    /// The agent's simulated position, velocities, and off-mesh traversal state.
+    /// </param>
     /// <returns>True if the entity is registered in the crowd.</returns>
     bool TryGetCrowdAgentState(Entity entity, out CrowdAgentState state);
 }
@@ -86,7 +88,22 @@ public interface ICrowdNavigationProvider : INavigationProvider
 /// <param name="Position">The agent's simulated position on the navigation mesh.</param>
 /// <param name="Velocity">The agent's actual velocity after avoidance and collision resolution.</param>
 /// <param name="DesiredVelocity">The agent's desired velocity before avoidance was applied.</param>
+/// <param name="IsTraversingOffMeshLink">
+/// True while the crowd simulation is animating the agent across an off-mesh
+/// connection instead of steering it along the walkable surface.
+/// </param>
+/// <param name="OffMeshLinkStart">
+/// The world-space entry point of the off-mesh connection being traversed.
+/// Only meaningful while <paramref name="IsTraversingOffMeshLink"/> is true.
+/// </param>
+/// <param name="OffMeshLinkEnd">
+/// The world-space exit point of the off-mesh connection being traversed.
+/// Only meaningful while <paramref name="IsTraversingOffMeshLink"/> is true.
+/// </param>
 public readonly record struct CrowdAgentState(
     Vector3 Position,
     Vector3 Velocity,
-    Vector3 DesiredVelocity);
+    Vector3 DesiredVelocity,
+    bool IsTraversingOffMeshLink,
+    Vector3 OffMeshLinkStart,
+    Vector3 OffMeshLinkEnd);

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastCrowdManager.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastCrowdManager.cs
@@ -205,7 +205,9 @@ public sealed class DotRecastCrowdManager : IDisposable
     /// Gets the simulated state of a registered crowd agent.
     /// </summary>
     /// <param name="entity">The registered crowd agent entity.</param>
-    /// <param name="state">The agent's simulated position and velocities.</param>
+    /// <param name="state">
+    /// The agent's simulated position, velocities, and off-mesh traversal state.
+    /// </param>
     /// <returns>True if the entity is registered in the crowd.</returns>
     public bool TryGetAgentState(Entity entity, out CrowdAgentState state)
     {
@@ -215,10 +217,18 @@ public sealed class DotRecastCrowdManager : IDisposable
             return false;
         }
 
+        var agent = entry.Agent;
+        var animation = agent.animation;
+        bool traversingLink = agent.state == DtCrowdAgentState.DT_CROWDAGENT_STATE_OFFMESH
+            && animation.active;
+
         state = new CrowdAgentState(
-            ToVector3(entry.Agent.npos),
-            ToVector3(entry.Agent.vel),
-            ToVector3(entry.Agent.dvel));
+            ToVector3(agent.npos),
+            ToVector3(agent.vel),
+            ToVector3(agent.dvel),
+            traversingLink,
+            traversingLink ? ToVector3(animation.startPos) : Vector3.Zero,
+            traversingLink ? ToVector3(animation.endPos) : Vector3.Zero);
         return true;
     }
 

--- a/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using KeenEyes.Common;
 using KeenEyes.Navigation.Abstractions;
 using KeenEyes.Navigation.Abstractions.Components;
+using KeenEyes.Navigation.Events;
 
 namespace KeenEyes.Navigation.Systems;
 
@@ -24,9 +25,18 @@ namespace KeenEyes.Navigation.Systems;
 /// </remarks>
 internal sealed class CrowdSteeringSystem : SystemBase
 {
+    /// <summary>
+    /// The endpoints and area type of an off-mesh traversal in progress,
+    /// captured when the traversal starts so the completion event reports the
+    /// same values.
+    /// </summary>
+    private readonly record struct ActiveTraversal(Vector3 Start, Vector3 End, NavAreaType AreaType);
+
     private readonly Dictionary<Entity, Vector3> requestedTargets = [];
-    private readonly List<Entity> staleTargets = [];
+    private readonly Dictionary<Entity, ActiveTraversal> activeTraversals = [];
+    private readonly List<Entity> staleEntities = [];
     private ICrowdNavigationProvider? crowdProvider;
+    private NavigationConfig? config;
 
     /// <inheritdoc/>
     protected override void OnInitialize()
@@ -35,6 +45,8 @@ internal sealed class CrowdSteeringSystem : SystemBase
         {
             throw new InvalidOperationException("CrowdSteeringSystem requires NavigationContext extension.");
         }
+
+        config = ctx.Config;
 
         // Crowd support is optional; without it this system does nothing and
         // crowd agents degrade to plain waypoint steering.
@@ -109,7 +121,14 @@ internal sealed class CrowdSteeringSystem : SystemBase
         {
             ref var agent = ref World.Get<NavMeshAgent>(entity);
 
-            if (agent.IsStopped || !crowdProvider!.TryGetCrowdAgentState(entity, out var state))
+            if (!crowdProvider!.TryGetCrowdAgentState(entity, out var state))
+            {
+                continue;
+            }
+
+            PublishTraversalTransitions(entity, in state);
+
+            if (agent.IsStopped)
             {
                 continue;
             }
@@ -139,23 +158,94 @@ internal sealed class CrowdSteeringSystem : SystemBase
         crowdProvider!.ResetCrowdMoveTarget(entity);
     }
 
+    /// <summary>
+    /// Sends <see cref="OffMeshLinkTraversalStarted"/> and
+    /// <see cref="OffMeshLinkTraversalCompleted"/> events when the crowd
+    /// simulation moves an agent onto or off an off-mesh connection, mirroring
+    /// the events plain agents receive from <see cref="NavMeshAgentSystem"/>.
+    /// </summary>
+    private void PublishTraversalTransitions(Entity entity, in CrowdAgentState state)
+    {
+        bool wasTraversing = activeTraversals.TryGetValue(entity, out var traversal);
+
+        if (state.IsTraversingOffMeshLink && !wasTraversing)
+        {
+            var areaType = ResolveLinkAreaType(state.OffMeshLinkStart, state.OffMeshLinkEnd);
+            activeTraversals[entity] = new ActiveTraversal(state.OffMeshLinkStart, state.OffMeshLinkEnd, areaType);
+            World.Send(new OffMeshLinkTraversalStarted(entity, state.OffMeshLinkStart, state.OffMeshLinkEnd, areaType));
+        }
+        else if (!state.IsTraversingOffMeshLink && wasTraversing)
+        {
+            activeTraversals.Remove(entity);
+            World.Send(new OffMeshLinkTraversalCompleted(entity, traversal.Start, traversal.End, traversal.AreaType));
+        }
+    }
+
+    /// <summary>
+    /// Resolves the area type for a traversal by matching the traversal
+    /// endpoints against <see cref="OffMeshLink"/> components in the world,
+    /// falling back to <see cref="NavAreaType.OffMeshLink"/> when the mesh was
+    /// baked from definitions that are not present in this world.
+    /// </summary>
+    private NavAreaType ResolveLinkAreaType(Vector3 start, Vector3 end)
+    {
+        foreach (var linkEntity in World.Query<OffMeshLink>())
+        {
+            ref readonly var link = ref World.Get<OffMeshLink>(linkEntity);
+
+            // Link endpoints are snapped onto the mesh during the build, so
+            // matching uses a tolerance derived from each link's radius.
+            float tolerance = link.Radius + config!.WaypointReachDistance;
+            float toleranceSq = tolerance * tolerance;
+
+            bool forward =
+                Vector3.DistanceSquared(link.Start, start) <= toleranceSq &&
+                Vector3.DistanceSquared(link.End, end) <= toleranceSq;
+            bool reverse = link.Bidirectional &&
+                Vector3.DistanceSquared(link.End, start) <= toleranceSq &&
+                Vector3.DistanceSquared(link.Start, end) <= toleranceSq;
+
+            if (forward || reverse)
+            {
+                return link.AreaType;
+            }
+        }
+
+        return NavAreaType.OffMeshLink;
+    }
+
     private void PruneStaleTargets()
     {
         // Entities removed from the crowd (destroyed or component removed)
-        // must not leak requested-target entries.
+        // must not leak requested-target or active-traversal entries.
         foreach (var entity in requestedTargets.Keys)
         {
             if (!crowdProvider!.TryGetCrowdAgentState(entity, out _))
             {
-                staleTargets.Add(entity);
+                staleEntities.Add(entity);
             }
         }
 
-        foreach (var entity in staleTargets)
+        foreach (var entity in staleEntities)
         {
             requestedTargets.Remove(entity);
         }
 
-        staleTargets.Clear();
+        staleEntities.Clear();
+
+        foreach (var entity in activeTraversals.Keys)
+        {
+            if (!crowdProvider!.TryGetCrowdAgentState(entity, out _))
+            {
+                staleEntities.Add(entity);
+            }
+        }
+
+        foreach (var entity in staleEntities)
+        {
+            activeTraversals.Remove(entity);
+        }
+
+        staleEntities.Clear();
     }
 }

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/OffMeshLinkTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/OffMeshLinkTests.cs
@@ -344,5 +344,89 @@ public class OffMeshLinkTests
         Assert.True(position.X > 14f, $"Agent did not reach the far slab (X = {position.X})");
     }
 
+    [Fact]
+    public void Update_CrowdAgentPathIncludesOffMeshLink_TraversesLinkAndFiresEvents()
+    {
+        var mesh = BuildTwoSlabMesh([TwoSlabLink()]);
+        using var provider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+
+        using var world = new World();
+        world.InstallPlugin(new NavigationPlugin(new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = provider
+        }));
+
+        var events = new List<string>();
+        var started = new List<OffMeshLinkTraversalStarted>();
+        var completed = new List<OffMeshLinkTraversalCompleted>();
+
+        using var startedSub = world.Subscribe<OffMeshLinkTraversalStarted>(evt =>
+        {
+            started.Add(evt);
+            events.Add("started");
+        });
+        using var completedSub = world.Subscribe<OffMeshLinkTraversalCompleted>(evt =>
+        {
+            completed.Add(evt);
+            events.Add("completed");
+        });
+
+        // A matching link entity lets the crowd traversal resolve its area type.
+        var linkComponent = OffMeshLink.Create(linkStart, linkEnd);
+        linkComponent.Radius = 1f;
+        world.Spawn().With(linkComponent).Build();
+
+        var agentComponent = NavMeshAgent.Create();
+        agentComponent.StoppingDistance = 0.5f;
+        var crowdComponent = CrowdAgent.Create();
+        crowdComponent.Radius = 0.6f;
+        var agent = world.Spawn()
+            .With(new Transform3D(new Vector3(3f, 0f, 5f), Quaternion.Identity, Vector3.One))
+            .With(agentComponent)
+            .With(crowdComponent)
+            .Build();
+
+        var context = world.GetExtension<NavigationContext>();
+        context.SetDestination(agent, new Vector3(21f, 0f, 5f));
+
+        bool sawTraversalState = false;
+        for (int i = 0; i < 1000; i++)
+        {
+            world.Update(TimeStep);
+
+            if (provider.TryGetCrowdAgentState(agent, out var state) && state.IsTraversingOffMeshLink)
+            {
+                sawTraversalState = true;
+            }
+
+            if (world.Get<NavMeshAgent>(agent).IsStopped && !world.Get<NavMeshAgent>(agent).PathPending)
+            {
+                break;
+            }
+        }
+
+        // The entity was steered by the crowd simulation, not plain steering.
+        Assert.Equal(1, provider.CrowdAgentCount);
+
+        Assert.True(sawTraversalState, "Crowd agent never entered the off-mesh traversal state");
+        Assert.Single(started);
+        Assert.Single(completed);
+        Assert.Equal(["started", "completed"], events);
+
+        Assert.Equal(agent, started[0].Entity);
+        Assert.Equal(agent, completed[0].Entity);
+        Assert.Equal(NavAreaType.OffMeshLink, started[0].AreaType);
+        Assert.Equal(NavAreaType.OffMeshLink, completed[0].AreaType);
+        Assert.Equal(started[0].Start, completed[0].Start);
+        Assert.Equal(started[0].End, completed[0].End);
+        Assert.True(Vector3.Distance(started[0].Start, linkStart) < 1.5f);
+        Assert.True(Vector3.Distance(started[0].End, linkEnd) < 1.5f);
+
+        // The agent must have crossed the gap onto the far slab.
+        var position = world.Get<Transform3D>(agent).Position;
+        Assert.True(position.X > 14f, $"Crowd agent did not reach the far slab (X = {position.X})");
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary
- Crowd-simulated agents (`CrowdAgent`) now surface off-mesh link traversal the same way plain `NavMeshAgent`s do — closing the gap noted as future work in #1037.
- `CrowdAgentState` gains `IsTraversingOffMeshLink` / `OffMeshLinkStart` / `OffMeshLinkEnd`, populated by `DotRecastCrowdManager` from `DtCrowd`'s own traversal state machine (`DT_CROWDAGENT_STATE_OFFMESH` + its animation; verified against the actual DotRecast 2026.1.3 assembly). DtCrowd advances the traversal itself, so no manual lerp duplication.
- `CrowdSteeringSystem` publishes the identical `OffMeshLinkTraversalStarted`/`Completed` events on state edges, with endpoints captured at start and `AreaType` resolved by the same endpoint-matching rule the plain-agent path uses. No duplicate events (plain system already skips crowd agents), and tracking entries are pruned with the existing pruning pass.
- Known inherent parity gap, documented: traversal *duration* is DtCrowd's animation timing, so `CostModifier` doesn't slow crowd traversal — events and area typing are identical.

## Test plan
- [x] New `Update_CrowdAgentPathIncludesOffMeshLink_TraversesLinkAndFiresEvents` mirrors the plain-agent disconnected-slabs test: asserts crowd steering engaged, traversal state observed, exactly one started/completed pair in order with matching payloads, and the agent reaches the far slab
- [x] Navigation.DotRecast 114 passed / 0 failed (52 pre-existing geometry skips); Navigation 46/46; Abstractions 127/127
- [x] Full Release build 0 warnings / 0 errors; format verify exit 0 (independently re-verified)

## Related Issues
Closes #1055