### PR TITLE
feat(editor): Render IViewportCapability gizmo renderers in ViewportPanel

### DIFF
--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -593,7 +593,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
         var graphicsContext = _editorWorld.GetExtension<IGraphicsContext>();
         var inputContext = _editorWorld.GetExtension<IInputContext>();
         _viewportPanel = ViewportPanel.Create(_editorWorld, topPane, _defaultFont, _worldManager,
-            graphicsContext!, inputContext!);
+            graphicsContext!, inputContext!, _viewportCapability);
 
         // Right panel: Inspector
         _inspectorPanel = InspectorPanel.Create(_editorWorld, topPane, _defaultFont, _worldManager);

--- a/editor/KeenEyes.Editor/Navigation/NavMeshVisualizer.cs
+++ b/editor/KeenEyes.Editor/Navigation/NavMeshVisualizer.cs
@@ -177,34 +177,19 @@ public sealed class NavMeshVisualizer : IGizmoRenderer
             return polygons;
         }
 
-        // Iterate through all polygons in the navmesh
-        int polygonCount = navMesh.PolygonCount;
-
-        // This is a simplified implementation - actual implementation would
-        // iterate through DtNavMesh tiles and polygons
-        // For now, we'll use the public API to get polygon vertices
-        for (uint polyId = 1; polyId <= (uint)polygonCount; polyId++)
+        uint index = 0;
+        foreach (var surface in navMesh.GetPolygonSurfaces())
         {
-            try
-            {
-                var vertices = navMesh.GetPolygonVertices(polyId);
-                if (vertices.Length >= 3)
-                {
-                    // Get area type from polygon
-                    var centroid = CalculateCentroid(vertices);
-                    var areaType = navMesh.GetAreaType(centroid);
+            index++;
 
-                    polygons.Add(new NavMeshPolygon
-                    {
-                        PolygonId = polyId,
-                        Vertices = vertices.ToArray(),
-                        AreaType = areaType
-                    });
-                }
-            }
-            catch
+            if (surface.Vertices.Length >= 3)
             {
-                // Skip invalid polygon IDs
+                polygons.Add(new NavMeshPolygon
+                {
+                    PolygonId = index,
+                    Vertices = surface.Vertices,
+                    AreaType = surface.Area
+                });
             }
         }
 
@@ -267,17 +252,6 @@ public sealed class NavMeshVisualizer : IGizmoRenderer
                 }
             }
         }
-    }
-
-    private static Vector3 CalculateCentroid(ReadOnlySpan<Vector3> vertices)
-    {
-        var sum = Vector3.Zero;
-        foreach (var vertex in vertices)
-        {
-            sum += vertex;
-        }
-
-        return sum / vertices.Length;
     }
 
     private static Dictionary<NavAreaType, Vector4> CreateDefaultAreaColors()

--- a/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
@@ -1,12 +1,16 @@
 using System.Numerics;
 
 using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
 using KeenEyes.Editor.Application;
 using KeenEyes.Editor.Viewport;
 using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Input.Abstractions;
 using KeenEyes.UI.Abstractions;
 using KeenEyes.UI.Widgets;
+
+using Key = KeenEyes.Input.Abstractions.Key;
+using MouseButton = KeenEyes.Input.Abstractions.MouseButton;
 
 namespace KeenEyes.Editor.Panels;
 
@@ -39,6 +43,7 @@ public static class ViewportPanel
     /// <param name="worldManager">The world manager for scene access.</param>
     /// <param name="graphicsContext">The graphics context for rendering.</param>
     /// <param name="inputContext">The input context for camera controls.</param>
+    /// <param name="viewportCapability">The viewport capability providing plugin gizmo renderers.</param>
     /// <returns>The created panel entity.</returns>
     public static Entity Create(
         IWorld editorWorld,
@@ -46,7 +51,8 @@ public static class ViewportPanel
         FontHandle font,
         EditorWorldManager worldManager,
         IGraphicsContext graphicsContext,
-        IInputContext inputContext)
+        IInputContext inputContext,
+        IViewportCapability viewportCapability)
     {
         // Create the main panel container
         var panel = WidgetFactory.CreatePanel(editorWorld, parent, "ViewportPanel", new PanelConfig(
@@ -58,8 +64,8 @@ public static class ViewportPanel
         panelRect.WidthMode = UISizeMode.Fill;
         panelRect.HeightMode = UISizeMode.Fill;
 
-        // Create header with toolbar
-        CreateHeader(editorWorld, panel, font);
+        // Create header with toolbar; returns the container for gizmo visibility toggles
+        var gizmoToggleContainer = CreateHeader(editorWorld, panel, font);
 
         // Create the viewport content area
         var viewportArea = CreateViewportArea(editorWorld, panel);
@@ -83,10 +89,24 @@ public static class ViewportPanel
             InputProvider = inputProvider,
             CameraController = cameraController,
             TransformGizmo = transformGizmo,
+            Capability = viewportCapability,
+            GizmoDrawer = new ViewportGizmoDrawer(),
+            GizmoToggleContainer = gizmoToggleContainer,
+            GizmoToggles = [],
             Font = font,
             IsHovered = false,
             LastViewportSize = Vector2.Zero
         });
+
+        // Surface a visibility toggle for every registered gizmo renderer and keep the
+        // toggles in sync as plugins add or remove renderers.
+        foreach (var renderer in viewportCapability.GetGizmoRenderers())
+        {
+            AddGizmoToggle(editorWorld, panel, renderer, font);
+        }
+
+        viewportCapability.GizmoRendererAdded += renderer => AddGizmoToggle(editorWorld, panel, renderer, font);
+        viewportCapability.GizmoRendererRemoved += renderer => RemoveGizmoToggle(editorWorld, panel, renderer);
 
         // Subscribe to scene events
         worldManager.SceneOpened += scene => OnSceneOpened(editorWorld, panel, scene);
@@ -113,12 +133,21 @@ public static class ViewportPanel
             }
         });
 
-        // Subscribe to click for entity picking
+        // Subscribe to click for entity picking and gizmo visibility toggles
         editorWorld.Subscribe<UIClickEvent>(e =>
         {
-            if (e.Element == viewportArea && e.Button == MouseButton.Left)
+            if (e.Button != MouseButton.Left)
+            {
+                return;
+            }
+
+            if (e.Element == viewportArea)
             {
                 OnViewportClick(editorWorld, panel, e.Position);
+            }
+            else
+            {
+                HandleGizmoToggleClick(editorWorld, panel, e.Element);
             }
         });
 
@@ -282,6 +311,37 @@ public static class ViewportPanel
                 projectionMatrix,
                 state.CameraController.Position);
         }
+
+        // Render plugin gizmo renderers registered through the viewport capability
+        if (sceneWorld is not null && state.Capability is not null && state.GizmoDrawer is not null)
+        {
+            state.GizmoDrawer.Begin(
+                graphics,
+                viewMatrix,
+                projectionMatrix,
+                state.CameraController.Position,
+                viewportHeight);
+
+            var context = new GizmoRenderContext
+            {
+                SceneWorld = sceneWorld,
+                SelectedEntities = state.WorldManager.SelectedEntity.IsValid
+                    ? [state.WorldManager.SelectedEntity]
+                    : [],
+                ViewMatrix = viewMatrix,
+                ProjectionMatrix = projectionMatrix,
+                CameraPosition = state.CameraController.Position,
+                Bounds = new ViewportBounds(viewportX, viewportY, viewportWidth, viewportHeight),
+                Drawer = state.GizmoDrawer
+            };
+
+            // Gizmos use translucent colors and arbitrary winding; restore scene state after
+            graphics.SetBlending(true);
+            graphics.SetCulling(false);
+            GizmoRendererPass.Render(state.Capability.GetGizmoRenderers(), context);
+            graphics.SetCulling(true, CullFaceMode.Back);
+            graphics.SetBlending(false);
+        }
     }
 
     /// <summary>
@@ -326,7 +386,7 @@ public static class ViewportPanel
         state.CameraController.SetPresetView(preset);
     }
 
-    private static void CreateHeader(IWorld world, Entity panel, FontHandle font)
+    private static Entity CreateHeader(IWorld world, Entity panel, FontHandle font)
     {
         var header = WidgetFactory.CreatePanel(world, panel, "ViewportHeader", new PanelConfig(
             Height: 28,
@@ -353,12 +413,124 @@ public static class ViewportPanel
             BackgroundColor: Vector4.Zero
         ));
 
+        // Container for per-renderer gizmo visibility toggles
+        var gizmoToggles = WidgetFactory.CreatePanel(world, toolbar, "GizmoToggles", new PanelConfig(
+            Direction: LayoutDirection.Horizontal,
+            Spacing: 4,
+            BackgroundColor: Vector4.Zero
+        ));
+
         // Camera mode indicator label
         WidgetFactory.CreateLabel(world, toolbar, "CameraModeLabel", "Orbit", font, new LabelConfig(
             FontSize: 11,
             TextColor: EditorColors.TextLight,
             HorizontalAlign: TextAlignH.Right
         ));
+
+        return gizmoToggles;
+    }
+
+    /// <summary>
+    /// Creates a visibility toggle button for a gizmo renderer in the viewport header.
+    /// </summary>
+    internal static void AddGizmoToggle(IWorld editorWorld, Entity panel, IGizmoRenderer renderer, FontHandle font)
+    {
+        if (!editorWorld.Has<ViewportPanelState>(panel))
+        {
+            return;
+        }
+
+        ref readonly var state = ref editorWorld.Get<ViewportPanelState>(panel);
+        if (state.GizmoToggles is null || state.GizmoToggles.ContainsValue(renderer))
+        {
+            return;
+        }
+
+        var toggle = WidgetFactory.CreateButton(
+            editorWorld,
+            state.GizmoToggleContainer,
+            $"GizmoToggle_{renderer.Id}",
+            renderer.DisplayName,
+            font,
+            new ButtonConfig(
+                Width: 72,
+                Height: 18,
+                FontSize: 10,
+                CornerRadius: 3
+            ));
+
+        state.GizmoToggles[toggle] = renderer;
+        UpdateGizmoToggleVisual(editorWorld, toggle, renderer.IsEnabled);
+    }
+
+    /// <summary>
+    /// Removes the visibility toggle button for a gizmo renderer.
+    /// </summary>
+    internal static void RemoveGizmoToggle(IWorld editorWorld, Entity panel, IGizmoRenderer renderer)
+    {
+        if (!editorWorld.Has<ViewportPanelState>(panel))
+        {
+            return;
+        }
+
+        ref readonly var state = ref editorWorld.Get<ViewportPanelState>(panel);
+        if (state.GizmoToggles is null)
+        {
+            return;
+        }
+
+        var toggle = Entity.Null;
+        foreach (var (entity, candidate) in state.GizmoToggles)
+        {
+            if (ReferenceEquals(candidate, renderer))
+            {
+                toggle = entity;
+                break;
+            }
+        }
+
+        if (!toggle.IsValid)
+        {
+            return;
+        }
+
+        state.GizmoToggles.Remove(toggle);
+        editorWorld.Despawn(toggle);
+    }
+
+    /// <summary>
+    /// Toggles the associated gizmo renderer when a visibility toggle button is clicked.
+    /// </summary>
+    internal static void HandleGizmoToggleClick(IWorld editorWorld, Entity panel, Entity clicked)
+    {
+        if (!editorWorld.Has<ViewportPanelState>(panel))
+        {
+            return;
+        }
+
+        ref readonly var state = ref editorWorld.Get<ViewportPanelState>(panel);
+        if (state.GizmoToggles is null || !state.GizmoToggles.TryGetValue(clicked, out var renderer))
+        {
+            return;
+        }
+
+        renderer.IsEnabled = !renderer.IsEnabled;
+        UpdateGizmoToggleVisual(editorWorld, clicked, renderer.IsEnabled);
+    }
+
+    private static void UpdateGizmoToggleVisual(IWorld editorWorld, Entity toggle, bool isEnabled)
+    {
+        if (editorWorld.Has<UIStyle>(toggle))
+        {
+            ref var style = ref editorWorld.Get<UIStyle>(toggle);
+            style.BackgroundColor = isEnabled ? EditorColors.Primary : EditorColors.LightPanel;
+        }
+
+        if (editorWorld.Has<UIText>(toggle))
+        {
+            ref var text = ref editorWorld.Get<UIText>(toggle);
+            text.Color = isEnabled ? EditorColors.TextWhite : EditorColors.TextMuted;
+        }
     }
 
     private static Entity CreateViewportArea(IWorld world, Entity panel)
@@ -599,6 +771,10 @@ internal struct ViewportPanelState : IComponent
     public EditorInputProvider InputProvider;
     public EditorCameraController CameraController;
     public TransformGizmo TransformGizmo;
+    public IViewportCapability Capability;
+    public ViewportGizmoDrawer GizmoDrawer;
+    public Entity GizmoToggleContainer;
+    public Dictionary<Entity, IGizmoRenderer> GizmoToggles;
     public FontHandle Font;
     public bool IsHovered;
     public Vector2 LastViewportSize;

--- a/editor/KeenEyes.Editor/Viewport/GizmoRendererPass.cs
+++ b/editor/KeenEyes.Editor/Viewport/GizmoRendererPass.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions.Capabilities;
+
+namespace KeenEyes.Editor.Viewport;
+
+/// <summary>
+/// Executes the viewport's plugin gizmo render pass over the renderers registered
+/// with the viewport capability.
+/// </summary>
+/// <remarks>
+/// Renderers run in ascending <see cref="IGizmoRenderer.Order"/> (ties keep registration
+/// order). A renderer is skipped when it is disabled or when no entity in the scene world
+/// satisfies its <see cref="IGizmoRenderer.ShouldRender"/> check.
+/// </remarks>
+internal static class GizmoRendererPass
+{
+    /// <summary>
+    /// Renders all applicable gizmo renderers with the supplied context.
+    /// </summary>
+    /// <param name="renderers">The registered gizmo renderers.</param>
+    /// <param name="context">The render context for the current frame.</param>
+    internal static void Render(IEnumerable<IGizmoRenderer> renderers, GizmoRenderContext context)
+    {
+        foreach (var renderer in renderers.OrderBy(r => r.Order))
+        {
+            if (!renderer.IsEnabled)
+            {
+                continue;
+            }
+
+            if (HasRenderableContent(renderer, context.SceneWorld))
+            {
+                renderer.Render(context);
+            }
+        }
+    }
+
+    private static bool HasRenderableContent(IGizmoRenderer renderer, IWorld sceneWorld)
+    {
+        foreach (var entity in sceneWorld.GetAllEntities())
+        {
+            if (renderer.ShouldRender(entity, sceneWorld))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/editor/KeenEyes.Editor/Viewport/ViewportGizmoDrawer.cs
+++ b/editor/KeenEyes.Editor/Viewport/ViewportGizmoDrawer.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Resources;
+
+namespace KeenEyes.Editor.Viewport;
+
+/// <summary>
+/// Draws gizmo primitives into the viewport using the solid shader.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lines and points are approximated with stretched cubes - the same technique
+/// <see cref="TransformGizmo"/> uses - because the graphics context has no
+/// immediate-mode line API. Pixel sizes are converted to world units from the
+/// camera distance and the projection's vertical field of view.
+/// </para>
+/// <para>
+/// Call <see cref="Begin"/> once per frame before any renderer draws; it binds the
+/// solid shader and captures the camera state used for pixel-to-world conversion.
+/// </para>
+/// </remarks>
+internal sealed class ViewportGizmoDrawer : IGizmoDrawer
+{
+    private const float FallbackWorldUnitsPerPixel = 0.01f;
+    private const float MinCameraDistance = 0.01f;
+
+    private IGraphicsContext? graphics;
+    private MeshHandle cubeMesh;
+    private MeshHandle triangleMesh;
+    private bool meshesCreated;
+
+    private Vector3 cameraPosition;
+    private float projectionScaleY;
+    private float viewportHeight;
+
+    /// <summary>
+    /// Prepares the drawer for a frame: creates meshes on first use, binds the solid
+    /// shader, and uploads the view and projection matrices.
+    /// </summary>
+    internal void Begin(
+        IGraphicsContext graphicsContext,
+        in Matrix4x4 viewMatrix,
+        in Matrix4x4 projectionMatrix,
+        Vector3 camera,
+        float viewportHeightPixels)
+    {
+        graphics = graphicsContext;
+        cameraPosition = camera;
+        projectionScaleY = projectionMatrix.M22;
+        viewportHeight = viewportHeightPixels;
+
+        EnsureMeshes(graphicsContext);
+
+        graphicsContext.BindShader(graphicsContext.SolidShader);
+        graphicsContext.SetUniform("uView", viewMatrix);
+        graphicsContext.SetUniform("uProjection", projectionMatrix);
+    }
+
+    /// <inheritdoc />
+    public void DrawTriangle(Vector3 v0, Vector3 v1, Vector3 v2, Vector4 color)
+    {
+        if (graphics is null || !meshesCreated)
+        {
+            return;
+        }
+
+        var edge1 = v1 - v0;
+        var edge2 = v2 - v0;
+        var normal = Vector3.Cross(edge1, edge2);
+        if (normal.LengthSquared().IsApproximatelyZero())
+        {
+            return;
+        }
+
+        normal = Vector3.Normalize(normal);
+
+        // Map the canonical unit triangle (origin, +X, +Y) onto (v0, v1, v2):
+        // matrix rows are the target basis vectors, translation is v0.
+        var model = new Matrix4x4(
+            edge1.X, edge1.Y, edge1.Z, 0f,
+            edge2.X, edge2.Y, edge2.Z, 0f,
+            normal.X, normal.Y, normal.Z, 0f,
+            v0.X, v0.Y, v0.Z, 1f);
+
+        DrawMesh(triangleMesh, model, color);
+    }
+
+    /// <inheritdoc />
+    public void DrawLine(Vector3 start, Vector3 end, Vector4 color, float width = 1.0f)
+    {
+        if (graphics is null || !meshesCreated)
+        {
+            return;
+        }
+
+        var direction = end - start;
+        var length = direction.Length();
+        if (length.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        var center = (start + end) * 0.5f;
+        var thickness = MathF.Max(width, 1f) * WorldUnitsPerPixel(center);
+
+        var model =
+            Matrix4x4.CreateScale(thickness, thickness, length) *
+            Matrix4x4.CreateFromQuaternion(CreateRotationFromDirection(direction / length)) *
+            Matrix4x4.CreateTranslation(center);
+
+        DrawMesh(cubeMesh, model, color);
+    }
+
+    /// <inheritdoc />
+    public void DrawPoint(Vector3 position, Vector4 color, float size = 4.0f)
+    {
+        if (graphics is null || !meshesCreated)
+        {
+            return;
+        }
+
+        var worldSize = MathF.Max(size, 1f) * WorldUnitsPerPixel(position);
+        var model =
+            Matrix4x4.CreateScale(worldSize) *
+            Matrix4x4.CreateTranslation(position);
+
+        DrawMesh(cubeMesh, model, color);
+    }
+
+    /// <inheritdoc />
+    public void DrawWireBox(Vector3 min, Vector3 max, Vector4 color, float lineWidth = 1.0f)
+    {
+        var v000 = new Vector3(min.X, min.Y, min.Z);
+        var v100 = new Vector3(max.X, min.Y, min.Z);
+        var v010 = new Vector3(min.X, max.Y, min.Z);
+        var v110 = new Vector3(max.X, max.Y, min.Z);
+        var v001 = new Vector3(min.X, min.Y, max.Z);
+        var v101 = new Vector3(max.X, min.Y, max.Z);
+        var v011 = new Vector3(min.X, max.Y, max.Z);
+        var v111 = new Vector3(max.X, max.Y, max.Z);
+
+        // Bottom face
+        DrawLine(v000, v100, color, lineWidth);
+        DrawLine(v100, v101, color, lineWidth);
+        DrawLine(v101, v001, color, lineWidth);
+        DrawLine(v001, v000, color, lineWidth);
+
+        // Top face
+        DrawLine(v010, v110, color, lineWidth);
+        DrawLine(v110, v111, color, lineWidth);
+        DrawLine(v111, v011, color, lineWidth);
+        DrawLine(v011, v010, color, lineWidth);
+
+        // Vertical edges
+        DrawLine(v000, v010, color, lineWidth);
+        DrawLine(v100, v110, color, lineWidth);
+        DrawLine(v101, v111, color, lineWidth);
+        DrawLine(v001, v011, color, lineWidth);
+    }
+
+    /// <inheritdoc />
+    public void DrawWireSphere(Vector3 center, float radius, Vector4 color, int segments = 16)
+    {
+        if (segments < 3 || radius.IsApproximatelyZero())
+        {
+            return;
+        }
+
+        DrawCircle(center, radius, Vector3.UnitX, Vector3.UnitY, color, segments);
+        DrawCircle(center, radius, Vector3.UnitX, Vector3.UnitZ, color, segments);
+        DrawCircle(center, radius, Vector3.UnitY, Vector3.UnitZ, color, segments);
+    }
+
+    /// <inheritdoc />
+    public void DrawText(Vector3 position, string text, Vector4 color)
+    {
+        // The viewport has no world-space text rendering path yet.
+    }
+
+    private void DrawCircle(Vector3 center, float radius, Vector3 axisA, Vector3 axisB, Vector4 color, int segments)
+    {
+        var previous = center + axisA * radius;
+        for (var i = 1; i <= segments; i++)
+        {
+            var angle = i * MathF.PI * 2f / segments;
+            var point = center +
+                axisA * (MathF.Cos(angle) * radius) +
+                axisB * (MathF.Sin(angle) * radius);
+
+            DrawLine(previous, point, color);
+            previous = point;
+        }
+    }
+
+    private void EnsureMeshes(IGraphicsContext graphicsContext)
+    {
+        if (meshesCreated || !graphicsContext.IsInitialized)
+        {
+            return;
+        }
+
+        cubeMesh = graphicsContext.CreateCube(1f);
+
+        // Canonical unit triangle in the XY plane; DrawTriangle maps it onto arbitrary
+        // vertices via the model matrix. Vertex matches the layout CreateMesh expects.
+        Span<Vertex> vertices =
+        [
+            new(Vector3.Zero, Vector3.UnitZ, Vector2.Zero),
+            new(Vector3.UnitX, Vector3.UnitZ, Vector2.Zero),
+            new(Vector3.UnitY, Vector3.UnitZ, Vector2.Zero),
+        ];
+
+        triangleMesh = graphicsContext.CreateMesh(MemoryMarshal.AsBytes(vertices), 3, [0u, 1u, 2u]);
+        meshesCreated = true;
+    }
+
+    private void DrawMesh(MeshHandle mesh, in Matrix4x4 model, Vector4 color)
+    {
+        graphics!.SetUniform("uModel", model);
+        graphics.SetUniform("uColor", color);
+        graphics.BindMesh(mesh);
+        graphics.DrawMesh(mesh);
+    }
+
+    private float WorldUnitsPerPixel(Vector3 position)
+    {
+        if (viewportHeight <= 0f || projectionScaleY.IsApproximatelyZero())
+        {
+            return FallbackWorldUnitsPerPixel;
+        }
+
+        var distance = MathF.Max(Vector3.Distance(cameraPosition, position), MinCameraDistance);
+        return 2f * distance / (projectionScaleY * viewportHeight);
+    }
+
+    private static Quaternion CreateRotationFromDirection(Vector3 direction)
+    {
+        var forward = direction;
+        var up = Vector3.UnitY;
+
+        if (MathF.Abs(Vector3.Dot(forward, up)) > 0.999f)
+        {
+            up = Vector3.UnitZ;
+        }
+
+        var right = Vector3.Normalize(Vector3.Cross(up, forward));
+        up = Vector3.Cross(forward, right);
+
+        var m = new Matrix4x4(
+            right.X, right.Y, right.Z, 0,
+            up.X, up.Y, up.Z, 0,
+            forward.X, forward.Y, forward.Z, 0,
+            0, 0, 0, 1);
+
+        return Quaternion.CreateFromRotationMatrix(m);
+    }
+}

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
@@ -284,6 +284,49 @@ public sealed class NavMeshData : INavigationMesh
     }
 
     /// <summary>
+    /// Enumerates the boundary polygons of the mesh for visualization.
+    /// </summary>
+    /// <returns>The vertex loop and area type of every walkable polygon, in tile order.</returns>
+    /// <remarks>
+    /// Off-mesh connection polygons carry no surface geometry and are skipped.
+    /// </remarks>
+    public IEnumerable<NavMeshPolygonSurface> GetPolygonSurfaces()
+    {
+        int maxTiles = navMesh.GetMaxTiles();
+
+        for (int i = 0; i < maxTiles; i++)
+        {
+            var tile = navMesh.GetTile(i);
+            if (tile?.data == null)
+            {
+                continue;
+            }
+
+            int polyCount = tile.data.header.polyCount;
+            for (int p = 0; p < polyCount; p++)
+            {
+                var poly = tile.data.polys[p];
+                if (poly.GetPolyType() == DtPolyTypes.DT_POLYTYPE_OFFMESH_CONNECTION)
+                {
+                    continue;
+                }
+
+                var vertices = new Vector3[poly.vertCount];
+                for (int v = 0; v < poly.vertCount; v++)
+                {
+                    int vertIndex = poly.verts[v] * 3;
+                    vertices[v] = new Vector3(
+                        tile.data.verts[vertIndex],
+                        tile.data.verts[vertIndex + 1],
+                        tile.data.verts[vertIndex + 2]);
+                }
+
+                yield return new NavMeshPolygonSurface(vertices, (NavAreaType)poly.GetArea());
+            }
+        }
+    }
+
+    /// <summary>
     /// Deserializes a NavMeshData from a byte array.
     /// </summary>
     /// <param name="data">The serialized data.</param>
@@ -364,3 +407,10 @@ public sealed class NavMeshData : INavigationMesh
         public int NextInt32() => random.Next();
     }
 }
+
+/// <summary>
+/// A polygon surface extracted from a navigation mesh for visualization.
+/// </summary>
+/// <param name="Vertices">The polygon's boundary vertex loop.</param>
+/// <param name="Area">The polygon's area type.</param>
+public readonly record struct NavMeshPolygonSurface(Vector3[] Vertices, NavAreaType Area);

--- a/tests/KeenEyes.Editor.Tests/Panels/ViewportPanelGizmoToggleTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Panels/ViewportPanelGizmoToggleTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Panels;
+
+namespace KeenEyes.Editor.Tests.Panels;
+
+/// <summary>
+/// Tests for the per-renderer gizmo visibility toggles surfaced in the viewport header.
+/// </summary>
+public sealed class ViewportPanelGizmoToggleTests
+{
+    [Fact]
+    public void AddGizmoToggle_WithRenderer_CreatesToggleMappedToRenderer()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("skeleton-gizmo");
+
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+
+        ref readonly var state = ref world.Get<ViewportPanelState>(panel);
+        var pair = Assert.Single(state.GizmoToggles);
+        Assert.True(world.IsAlive(pair.Key));
+        Assert.Same(renderer, pair.Value);
+    }
+
+    [Fact]
+    public void AddGizmoToggle_WithSameRendererTwice_CreatesSingleToggle()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("skeleton-gizmo");
+
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+
+        ref readonly var state = ref world.Get<ViewportPanelState>(panel);
+        Assert.Single(state.GizmoToggles);
+    }
+
+    [Fact]
+    public void HandleGizmoToggleClick_OnToggleEntity_DisablesRenderer()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("ik-gizmo");
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+        var toggle = GetToggleEntity(world, panel);
+
+        ViewportPanel.HandleGizmoToggleClick(world, panel, toggle);
+
+        Assert.False(renderer.IsEnabled);
+    }
+
+    [Fact]
+    public void HandleGizmoToggleClick_Twice_RestoresEnabledState()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("ik-gizmo");
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+        var toggle = GetToggleEntity(world, panel);
+
+        ViewportPanel.HandleGizmoToggleClick(world, panel, toggle);
+        ViewportPanel.HandleGizmoToggleClick(world, panel, toggle);
+
+        Assert.True(renderer.IsEnabled);
+    }
+
+    [Fact]
+    public void HandleGizmoToggleClick_OnUnrelatedEntity_DoesNotChangeRenderer()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("navmesh-visualizer");
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+        var unrelated = world.Spawn().Build();
+
+        ViewportPanel.HandleGizmoToggleClick(world, panel, unrelated);
+
+        Assert.True(renderer.IsEnabled);
+    }
+
+    [Fact]
+    public void RemoveGizmoToggle_WithExistingToggle_DespawnsToggleEntity()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("skeleton-gizmo");
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+        var toggle = GetToggleEntity(world, panel);
+
+        ViewportPanel.RemoveGizmoToggle(world, panel, renderer);
+
+        Assert.False(world.IsAlive(toggle));
+        ref readonly var state = ref world.Get<ViewportPanelState>(panel);
+        Assert.Empty(state.GizmoToggles);
+    }
+
+    [Fact]
+    public void RemoveGizmoToggle_WithUnknownRenderer_LeavesExistingToggles()
+    {
+        using var world = new World();
+        var panel = CreatePanelWithState(world);
+        var renderer = new FakeGizmoRenderer("skeleton-gizmo");
+        ViewportPanel.AddGizmoToggle(world, panel, renderer, default);
+
+        ViewportPanel.RemoveGizmoToggle(world, panel, new FakeGizmoRenderer("other"));
+
+        ref readonly var state = ref world.Get<ViewportPanelState>(panel);
+        Assert.Single(state.GizmoToggles);
+    }
+
+    #region Test Helpers
+
+    private static Entity CreatePanelWithState(World world)
+    {
+        var container = world.Spawn().Build();
+        var panel = world.Spawn().Build();
+
+        world.Add(panel, new ViewportPanelState
+        {
+            GizmoToggleContainer = container,
+            GizmoToggles = []
+        });
+
+        return panel;
+    }
+
+    private static Entity GetToggleEntity(World world, Entity panel)
+    {
+        ref readonly var state = ref world.Get<ViewportPanelState>(panel);
+        return state.GizmoToggles.Keys.Single();
+    }
+
+    private sealed class FakeGizmoRenderer(string id) : IGizmoRenderer
+    {
+        public string Id { get; } = id;
+
+        public string DisplayName => Id;
+
+        public bool IsEnabled { get; set; } = true;
+
+        public int Order => 0;
+
+        public void Render(GizmoRenderContext context)
+        {
+        }
+
+        public bool ShouldRender(Entity entity, IWorld sceneWorld) => true;
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Editor.Tests/Viewport/GizmoRendererPassTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Viewport/GizmoRendererPassTests.cs
@@ -1,0 +1,318 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Numerics;
+
+using KeenEyes.Animation;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.IK;
+using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Application;
+using KeenEyes.Editor.Assets;
+using KeenEyes.Editor.Commands;
+using KeenEyes.Editor.Navigation;
+using KeenEyes.Editor.Plugins;
+using KeenEyes.Editor.Plugins.BuiltIn;
+using KeenEyes.Editor.Plugins.Capabilities;
+using KeenEyes.Editor.Selection;
+using KeenEyes.Editor.Viewport;
+using KeenEyes.Navigation.DotRecast;
+
+namespace KeenEyes.Editor.Tests.Viewport;
+
+/// <summary>
+/// Tests for the viewport gizmo render pass that enumerates capability-registered
+/// gizmo renderers each frame.
+/// </summary>
+public sealed class GizmoRendererPassTests : IDisposable
+{
+    private readonly World editorWorld = new();
+    private readonly EditorWorldManager worldManager = new();
+    private readonly SelectionManager selection = new();
+    private readonly UndoRedoManager undoRedo = new();
+    private readonly AssetDatabase assets;
+    private readonly DirectoryInfo tempProjectRoot;
+
+    public GizmoRendererPassTests()
+    {
+        tempProjectRoot = Directory.CreateTempSubdirectory("keeneyes-gizmo-pass-");
+        assets = new AssetDatabase(tempProjectRoot.FullName);
+    }
+
+    public void Dispose()
+    {
+        assets.Dispose();
+        worldManager.Dispose();
+        editorWorld.Dispose();
+
+        try
+        {
+            tempProjectRoot.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of the temporary project directory.
+        }
+    }
+
+    #region Built-In Renderer Tests
+
+    [Fact]
+    public void Render_WithBuiltInPluginsAndIKNavMeshContent_RecordsBuiltInDrawCalls()
+    {
+        using var manager = CreateBootEquivalentManager(out var viewport);
+        BuiltInGizmoPlugins.Install(manager);
+
+        // Scene world containing a skeleton with an IK chain and target
+        using var sceneWorld = CreateIKWorld(new Vector3(1.5f, 0f, 0f));
+
+        // Give the navmesh visualizer a baked navmesh so it has content to draw
+        var visualizer = Assert.IsType<NavMeshVisualizer>(
+            viewport.GetGizmoRenderers().Single(r => r.Id == "navmesh-visualizer"));
+        visualizer.SetNavMesh(BuildTestNavMesh());
+
+        var drawer = new RecordingGizmoDrawer();
+
+        GizmoRendererPass.Render(viewport.GetGizmoRenderers(), CreateContext(sceneWorld, drawer));
+
+        // NavMesh surfaces arrive as triangles, skeleton bones as points and wire
+        // spheres, and bone/IK chain connections as lines.
+        Assert.NotEmpty(drawer.Triangles);
+        Assert.NotEmpty(drawer.Points);
+        Assert.NotEmpty(drawer.Spheres);
+        Assert.NotEmpty(drawer.Lines);
+    }
+
+    [Fact]
+    public void Render_WithBuiltInPluginsAndEmptyScene_RecordsNoDrawCalls()
+    {
+        using var manager = CreateBootEquivalentManager(out var viewport);
+        BuiltInGizmoPlugins.Install(manager);
+
+        using var sceneWorld = new World();
+        sceneWorld.Spawn().With(Transform3D.Identity).Build();
+
+        var drawer = new RecordingGizmoDrawer();
+
+        GizmoRendererPass.Render(viewport.GetGizmoRenderers(), CreateContext(sceneWorld, drawer));
+
+        Assert.Empty(drawer.Triangles);
+        Assert.Empty(drawer.Points);
+        Assert.Empty(drawer.Spheres);
+        Assert.Empty(drawer.Lines);
+    }
+
+    #endregion
+
+    #region Enumeration Behavior Tests
+
+    [Fact]
+    public void Render_WithEnabledMatchingRenderer_InvokesRenderer()
+    {
+        using var sceneWorld = new World();
+        sceneWorld.Spawn().With(Transform3D.Identity).Build();
+
+        var renderer = new FakeGizmoRenderer("fake", order: 0);
+
+        GizmoRendererPass.Render([renderer], CreateContext(sceneWorld, new RecordingGizmoDrawer()));
+
+        Assert.Equal(1, renderer.RenderCount);
+    }
+
+    [Fact]
+    public void Render_WithDisabledRenderer_SkipsRenderer()
+    {
+        using var sceneWorld = new World();
+        sceneWorld.Spawn().With(Transform3D.Identity).Build();
+
+        var renderer = new FakeGizmoRenderer("fake", order: 0) { IsEnabled = false };
+
+        GizmoRendererPass.Render([renderer], CreateContext(sceneWorld, new RecordingGizmoDrawer()));
+
+        Assert.Equal(0, renderer.RenderCount);
+    }
+
+    [Fact]
+    public void Render_WithNoMatchingEntity_SkipsRenderer()
+    {
+        using var sceneWorld = new World();
+        sceneWorld.Spawn().With(Transform3D.Identity).Build();
+
+        var renderer = new FakeGizmoRenderer("fake", order: 0) { ShouldRenderResult = false };
+
+        GizmoRendererPass.Render([renderer], CreateContext(sceneWorld, new RecordingGizmoDrawer()));
+
+        Assert.Equal(0, renderer.RenderCount);
+    }
+
+    [Fact]
+    public void Render_WithMultipleRenderers_InvokesInAscendingOrder()
+    {
+        using var sceneWorld = new World();
+        sceneWorld.Spawn().With(Transform3D.Identity).Build();
+
+        var callOrder = new List<string>();
+        var late = new FakeGizmoRenderer("late", order: 100) { CallLog = callOrder };
+        var early = new FakeGizmoRenderer("early", order: -5) { CallLog = callOrder };
+
+        GizmoRendererPass.Render([late, early], CreateContext(sceneWorld, new RecordingGizmoDrawer()));
+
+        Assert.Equal(["early", "late"], callOrder);
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    /// <summary>
+    /// Builds a plugin host wired the same way <see cref="EditorApplication"/> wires it at
+    /// startup: a manager backed by the editor services with the viewport capability registered.
+    /// </summary>
+    private EditorPluginManager CreateBootEquivalentManager(out ViewportCapability viewport)
+    {
+        var manager = new EditorPluginManager(worldManager, selection, undoRedo, assets, editorWorld, logProvider: null);
+        viewport = new ViewportCapability();
+        manager.RegisterCapability<IViewportCapability>(viewport);
+        return manager;
+    }
+
+    /// <summary>
+    /// Builds a world with the AnimationPlugin (IK enabled), a three-bone arm chain whose
+    /// end effector references a target placed at <paramref name="targetPosition"/>.
+    /// </summary>
+    private static World CreateIKWorld(Vector3 targetPosition)
+    {
+        var world = new World();
+        world.InstallPlugin(new AnimationPlugin(new AnimationConfig { EnableIK = true }));
+
+        var root = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(IKRig.Default)
+            .Build();
+
+        var upper = CreateBone(world, "Upper", root, Vector3.Zero, root.Id);
+        var lower = CreateBone(world, "Lower", upper, Vector3.UnitX, root.Id);
+        var hand = CreateBone(world, "Hand", lower, Vector3.UnitX, root.Id);
+
+        var targetEntity = world.Spawn()
+            .With(IKTarget.AtPosition(targetPosition))
+            .With(new Transform3D(targetPosition, Quaternion.Identity, Vector3.One))
+            .Build();
+
+        var manager = world.GetExtension<IKManager>();
+        var chainId = manager.RegisterChain(
+            IKChainDefinition.TwoBone("Arm", "Upper", "Lower", "Hand", Vector3.UnitZ));
+
+        world.Add(hand, IKChainReference.ForChain(chainId, targetEntity.Id));
+
+        return world;
+    }
+
+    private static Entity CreateBone(World world, string name, Entity parent, Vector3 localPosition, int skeletonRootId)
+    {
+        var bone = world.Spawn()
+            .With(new Transform3D(localPosition, Quaternion.Identity, Vector3.One))
+            .With(BoneReference.Create(name, skeletonRootId))
+            .Build();
+
+        world.SetParent(bone, parent);
+        return bone;
+    }
+
+    /// <summary>
+    /// Bakes a small box navmesh with settings sized for test geometry.
+    /// </summary>
+    private static NavMeshData BuildTestNavMesh()
+    {
+        var config = new NavMeshConfig
+        {
+            CellSize = 0.3f,
+            CellHeight = 0.2f,
+            AgentHeight = 2.0f,
+            AgentRadius = 0.6f,
+            MaxClimbHeight = 0.9f,
+            MaxSlopeAngle = 45.0f,
+            MinRegionArea = 8,
+            MergeRegionArea = 20,
+            MaxEdgeLength = 12,
+            MaxSimplificationError = 1.3f,
+            MaxVertsPerPoly = 6,
+            DetailSampleDistance = 6.0f,
+            DetailSampleMaxError = 1.0f,
+            UseTiles = false
+        };
+
+        var builder = new DotRecastMeshBuilder(config);
+        return builder.BuildBox(new Vector3(0f, 0f, 0f), new Vector3(20f, 0.5f, 20f));
+    }
+
+    private static GizmoRenderContext CreateContext(World sceneWorld, IGizmoDrawer drawer) => new()
+    {
+        SceneWorld = sceneWorld,
+        SelectedEntities = [],
+        ViewMatrix = Matrix4x4.Identity,
+        ProjectionMatrix = Matrix4x4.Identity,
+        CameraPosition = Vector3.Zero,
+        Bounds = new ViewportBounds(0f, 0f, 800f, 600f),
+        Drawer = drawer,
+    };
+
+    private sealed class FakeGizmoRenderer(string id, int order) : IGizmoRenderer
+    {
+        public string Id { get; } = id;
+
+        public string DisplayName => Id;
+
+        public bool IsEnabled { get; set; } = true;
+
+        public int Order { get; } = order;
+
+        public bool ShouldRenderResult { get; init; } = true;
+
+        public int RenderCount { get; private set; }
+
+        public List<string>? CallLog { get; init; }
+
+        public void Render(GizmoRenderContext context)
+        {
+            RenderCount++;
+            CallLog?.Add(Id);
+        }
+
+        public bool ShouldRender(Entity entity, IWorld sceneWorld) => ShouldRenderResult;
+    }
+
+    private sealed class RecordingGizmoDrawer : IGizmoDrawer
+    {
+        public List<(Vector3 V0, Vector3 V1, Vector3 V2, Vector4 Color)> Triangles { get; } = [];
+
+        public List<(Vector3 Start, Vector3 End, Vector4 Color)> Lines { get; } = [];
+
+        public List<(Vector3 Position, Vector4 Color)> Points { get; } = [];
+
+        public List<(Vector3 Center, float Radius, Vector4 Color)> Spheres { get; } = [];
+
+        public void DrawTriangle(Vector3 v0, Vector3 v1, Vector3 v2, Vector4 color)
+            => Triangles.Add((v0, v1, v2, color));
+
+        public void DrawLine(Vector3 start, Vector3 end, Vector4 color, float width = 1f)
+            => Lines.Add((start, end, color));
+
+        public void DrawPoint(Vector3 position, Vector4 color, float size = 4f)
+            => Points.Add((position, color));
+
+        public void DrawWireBox(Vector3 min, Vector3 max, Vector4 color, float lineWidth = 1f)
+        {
+        }
+
+        public void DrawWireSphere(Vector3 center, float radius, Vector4 color, int segments = 16)
+            => Spheres.Add((center, radius, color));
+
+        public void DrawText(Vector3 position, string text, Vector4 color)
+        {
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshDataTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshDataTests.cs
@@ -253,4 +253,36 @@ public class NavMeshDataTests
     }
 
     #endregion
+
+    #region GetPolygonSurfaces Tests
+
+    [Fact]
+    public void GetPolygonSurfaces_WithBuiltMesh_ReturnsOneSurfacePerPolygon()
+    {
+        Assert.NotNull(navMesh);
+
+        var surfaces = navMesh.GetPolygonSurfaces().ToList();
+
+        Assert.Equal(navMesh.PolygonCount, surfaces.Count);
+        Assert.All(surfaces, surface => Assert.True(surface.Vertices.Length >= 3));
+    }
+
+    [Fact]
+    public void GetPolygonSurfaces_WithBuiltMesh_VerticesLieWithinMeshBounds()
+    {
+        Assert.NotNull(navMesh);
+        var (min, max) = navMesh.Bounds;
+
+        foreach (var surface in navMesh.GetPolygonSurfaces())
+        {
+            foreach (var vertex in surface.Vertices)
+            {
+                Assert.InRange(vertex.X, min.X - 0.001f, max.X + 0.001f);
+                Assert.InRange(vertex.Y, min.Y - 0.001f, max.Y + 0.001f);
+                Assert.InRange(vertex.Z, min.Z - 0.001f, max.Z + 0.001f);
+            }
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Final step of the #1019 → #646 gizmo chain (#1050): `ViewportPanel` now runs a `GizmoRendererPass` that enumerates the capability's registered renderers in stable `Order`, honoring `IsEnabled` and `ShouldRender`, against the scene world's `GizmoRenderContext`.
- New graphics-backed `ViewportGizmoDrawer`: lines/points/wire shapes as stretched unit cubes via the solid shader (the `TransformGizmo` technique); `DrawTriangle` maps a canonical unit triangle through a basis-matrix transform; pixel→world sizing from camera distance + projection M22. `DrawText` is a documented no-op (no world-space text path exists yet).
- Per-renderer visibility toggles in the viewport header, populated from `GetGizmoRenderers()` and kept live via the capability's add/remove events.
- **Drive-by production bug fix (empirically verified):** `NavMeshData.GetPolygonVertices(uint)` could never receive a valid DotRecast polygon ref (refs exceed 32 bits), so `NavMeshVisualizer` always collected zero polygons — the built-in navmesh gizmo could never have drawn. Replaced with a new documented `NavMeshData.GetPolygonSurfaces()` that walks tiles directly; the dead ref-guessing try/catch loop is gone.
- Scope note: nothing in the editor frame loop invokes `ViewportPanel.Render` yet (pre-existing); tracked separately in a follow-up issue.

## Test plan
- [x] Flagship headless test: built-in plugins installed boot-equivalently, scene with a 3-bone IK arm + real baked navmesh, recording `IGizmoDrawer` asserts triangles (navmesh), points/spheres (bones), lines (IK/edges) — plus empty-scene, disabled, no-match, and ordering tests (6 total)
- [x] 7 toggle-behavior tests (add/dedupe/flip/restore/remove)
- [x] 2 new `GetPolygonSurfaces` tests against a baked mesh (not skipped)
- [x] Editor 1279/1279; Navigation.DotRecast 115 passed / 0 failed; full Release build 0 warnings / 0 errors; format verify exit 0 (independently re-verified)

## Related Issues
Fixes #1050