### PR TITLE
feat(editor): Wire ViewportPanel.Render into the editor frame loop

### DIFF
--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -303,17 +303,37 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
 
     private void OnEditorUpdate(float deltaTime)
     {
-        // Clear the framebuffer before rendering
-        _graphics?.Clear(ClearMask.ColorBuffer);
+        ComposeFrame(_graphics, _editorWorld, _viewportPanel, deltaTime);
+    }
 
-        // Update viewport for camera controls and gizmo interaction
-        if (_viewportPanel.IsValid)
+    /// <summary>
+    /// Composes a single editor frame: framebuffer clear, then the 3D viewport pass
+    /// (scene entities, transform gizmo, and plugin gizmo renderers), then the editor
+    /// systems including the UI render pass.
+    /// </summary>
+    /// <remarks>
+    /// The viewport pass must run before the UI pass: <see cref="ViewportPanel.Render"/>
+    /// begins with a full-framebuffer clear (the graphics context has no scissored
+    /// clear), so running it first guarantees the clear can never wipe already-drawn
+    /// UI. The UI pass then paints every panel around the viewport area, whose
+    /// background is transparent so the 3D scene rendered beneath it stays visible.
+    /// </remarks>
+    internal static void ComposeFrame(IGraphicsContext? graphics, World editorWorld, Entity viewportPanel, float deltaTime)
+    {
+        // Clear the framebuffer; also covers frames where the viewport pass early-returns.
+        graphics?.Clear(ClearMask.ColorBuffer);
+
+        if (viewportPanel.IsValid)
         {
-            ViewportPanel.Update(_editorWorld, _viewportPanel, deltaTime);
+            // Update viewport for camera controls and gizmo interaction
+            ViewportPanel.Update(editorWorld, viewportPanel, deltaTime);
+
+            // 3D viewport pass: scene, selection gizmo, and plugin gizmo renderers
+            ViewportPanel.Render(editorWorld, viewportPanel);
         }
 
-        // Run all systems (including UIRenderSystem which draws the UI)
-        _editorWorld.Update(deltaTime);
+        // Run all systems (including UIRenderSystem which draws the UI on top)
+        editorWorld.Update(deltaTime);
     }
 
     private void OnSceneOpened(World sceneWorld)

--- a/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
@@ -235,6 +235,13 @@ public static class ViewportPanel
     /// <summary>
     /// Renders the viewport scene.
     /// </summary>
+    /// <remarks>
+    /// Must run before the UI render pass each frame: the graphics context has no
+    /// scissored clear, so the <see cref="IGraphicsContext.Clear"/> below wipes the
+    /// entire framebuffer. <see cref="EditorApplication"/> composes the frame as
+    /// clear → this pass → UI pass, and the viewport area's UI background is
+    /// transparent so the scene rendered here stays visible beneath the UI.
+    /// </remarks>
     /// <param name="editorWorld">The editor world.</param>
     /// <param name="panel">The viewport panel entity.</param>
     public static void Render(IWorld editorWorld, Entity panel)
@@ -270,7 +277,8 @@ public static class ViewportPanel
             return;
         }
 
-        // Set viewport and clear
+        // Set viewport and clear. The clear affects the whole framebuffer, which is
+        // safe only because this pass runs before any UI is drawn this frame.
         graphics.SetViewport(viewportX, viewportY, viewportWidth, viewportHeight);
         graphics.SetClearColor(EditorColors.ViewportBackground);
         graphics.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
@@ -342,6 +350,13 @@ public static class ViewportPanel
             graphics.SetCulling(true, CullFaceMode.Back);
             graphics.SetBlending(false);
         }
+
+        // Hand the context back to the UI pass: full-window viewport with the 2D
+        // pipeline state the UI renderer expects (the 2D renderer manages its own
+        // blend state but not viewport or culling).
+        graphics.SetViewport(0, 0, graphics.Width, graphics.Height);
+        graphics.SetDepthTest(false);
+        graphics.SetCulling(false);
     }
 
     /// <summary>
@@ -535,8 +550,11 @@ public static class ViewportPanel
 
     private static Entity CreateViewportArea(IWorld world, Entity panel)
     {
+        // Transparent background: the 3D scene is rendered into this region before
+        // the UI pass runs (see EditorApplication frame composition), so the UI must
+        // not paint over it. The scene pass clears the region to ViewportBackground.
         var viewportArea = WidgetFactory.CreatePanel(world, panel, "ViewportArea", new PanelConfig(
-            BackgroundColor: EditorColors.ViewportBackground
+            BackgroundColor: Vector4.Zero
         ));
 
         ref var viewportRect = ref world.Get<UIRect>(viewportArea);

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
@@ -134,6 +134,18 @@ public sealed class MockGraphicsContext : IGraphicsContext
     public MockContextRenderState RenderState { get; } = new();
 
     /// <summary>
+    /// Gets the ordered log of render-state and draw operations, enabling verification
+    /// of call ordering across a frame (e.g. clears relative to draw calls).
+    /// </summary>
+    /// <remarks>
+    /// Records <see cref="Clear"/>, <see cref="SetViewport"/>, <see cref="SetDepthTest"/>,
+    /// <see cref="SetBlending"/>, <see cref="SetCulling"/>, <see cref="BindShader"/>,
+    /// <see cref="DrawMesh"/>, and <see cref="DrawMeshInstanced"/>. Tests may append
+    /// their own entries to interleave external events with graphics calls.
+    /// </remarks>
+    public List<string> CallLog { get; } = [];
+
+    /// <summary>
     /// Gets the dictionary of uniform values set on the current shader.
     /// </summary>
     public Dictionary<string, object> UniformValues { get; } = [];
@@ -250,6 +262,7 @@ public sealed class MockGraphicsContext : IGraphicsContext
     /// <inheritdoc />
     public void DrawMesh(MeshHandle handle)
     {
+        CallLog.Add($"DrawMesh({handle.Id})");
         MeshDrawCalls.Add(new MeshDrawCall(
             handle,
             boundShader,
@@ -379,6 +392,7 @@ public sealed class MockGraphicsContext : IGraphicsContext
     /// <inheritdoc />
     public void BindShader(ShaderHandle handle)
     {
+        CallLog.Add($"BindShader({handle.Id})");
         boundShader = handle;
         UniformValues.Clear();
     }
@@ -450,6 +464,7 @@ public sealed class MockGraphicsContext : IGraphicsContext
     /// <inheritdoc />
     public void DrawMeshInstanced(MeshHandle mesh, InstanceBufferHandle instances, int instanceCount)
     {
+        CallLog.Add($"DrawMeshInstanced({mesh.Id}, {instanceCount})");
         InstancedMeshDrawCalls.Add(new InstancedMeshDrawCall(
             mesh,
             instances,
@@ -477,6 +492,7 @@ public sealed class MockGraphicsContext : IGraphicsContext
     /// <inheritdoc />
     public void Clear(ClearMask mask)
     {
+        CallLog.Add($"Clear({mask})");
         RenderState.LastClearMask = mask;
         RenderState.ClearCount++;
     }
@@ -484,24 +500,28 @@ public sealed class MockGraphicsContext : IGraphicsContext
     /// <inheritdoc />
     public void SetViewport(int x, int y, int width, int height)
     {
+        CallLog.Add($"SetViewport({x}, {y}, {width}, {height})");
         RenderState.Viewport = (x, y, width, height);
     }
 
     /// <inheritdoc />
     public void SetDepthTest(bool enabled)
     {
+        CallLog.Add($"SetDepthTest({enabled})");
         RenderState.DepthTestEnabled = enabled;
     }
 
     /// <inheritdoc />
     public void SetBlending(bool enabled)
     {
+        CallLog.Add($"SetBlending({enabled})");
         RenderState.BlendingEnabled = enabled;
     }
 
     /// <inheritdoc />
     public void SetCulling(bool enabled, CullFaceMode mode = CullFaceMode.Back)
     {
+        CallLog.Add($"SetCulling({enabled})");
         RenderState.CullingEnabled = enabled;
         RenderState.CullFaceMode = mode;
     }
@@ -668,6 +688,7 @@ public sealed class MockGraphicsContext : IGraphicsContext
         InstanceBuffers.Clear();
         MeshDrawCalls.Clear();
         InstancedMeshDrawCalls.Clear();
+        CallLog.Clear();
         UniformValues.Clear();
         RenderTargets.Clear();
         CubemapRenderTargets.Clear();
@@ -680,12 +701,13 @@ public sealed class MockGraphicsContext : IGraphicsContext
     }
 
     /// <summary>
-    /// Clears only the draw calls, keeping resources.
+    /// Clears only the draw calls and the ordered call log, keeping resources.
     /// </summary>
     public void ClearDrawCalls()
     {
         MeshDrawCalls.Clear();
         InstancedMeshDrawCalls.Clear();
+        CallLog.Clear();
     }
 
     private MeshHandle AllocateMeshHandle()

--- a/tests/KeenEyes.Editor.Tests/Application/EditorFrameCompositionTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Application/EditorFrameCompositionTests.cs
@@ -1,0 +1,339 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Numerics;
+
+using KeenEyes.Common;
+using KeenEyes.Editor.Abstractions.Capabilities;
+using KeenEyes.Editor.Application;
+using KeenEyes.Editor.Panels;
+using KeenEyes.Editor.Plugins.Capabilities;
+using KeenEyes.Editor.Viewport;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Testing.Graphics;
+using KeenEyes.Testing.Input;
+using KeenEyes.UI;
+using KeenEyes.UI.Abstractions;
+
+namespace KeenEyes.Editor.Tests.Application;
+
+/// <summary>
+/// Tests for the editor's per-frame composition order: framebuffer clear, then the
+/// 3D viewport pass (scene content followed by the gizmo pass), then the UI pass.
+/// The ordering is verified against a recording mock graphics context shared with
+/// a recording 2D renderer so cross-pass ordering is observable in a single log.
+/// </summary>
+public sealed class EditorFrameCompositionTests
+{
+    private const int SceneMeshId = 777;
+
+    #region Frame Ordering Tests
+
+    [Fact]
+    public void ComposeFrame_WithOpenSceneAndGizmoRenderer_DrawsSceneThenGizmosThenUi()
+    {
+        using var fixture = new FrameFixture();
+
+        EditorApplication.ComposeFrame(fixture.Graphics, fixture.EditorWorld, fixture.Panel, 0.016f);
+
+        var log = fixture.Graphics.CallLog;
+        var sceneDraw = log.IndexOf($"DrawMesh({SceneMeshId})");
+        var gizmoDraw = log.IndexOf($"DrawMesh({fixture.GizmoCubeMeshId})");
+        var firstUiDraw = log.FindIndex(entry => entry.StartsWith("UI:", StringComparison.Ordinal));
+
+        Assert.True(sceneDraw >= 0, "Scene mesh draw call was not recorded");
+        Assert.True(gizmoDraw > sceneDraw, "Gizmo pass did not execute after scene content");
+        Assert.True(firstUiDraw > gizmoDraw, "UI pass did not execute after the gizmo pass");
+    }
+
+    [Fact]
+    public void ComposeFrame_WithOpenScene_DoesNotClearAfterUiDrawCalls()
+    {
+        using var fixture = new FrameFixture();
+
+        EditorApplication.ComposeFrame(fixture.Graphics, fixture.EditorWorld, fixture.Panel, 0.016f);
+
+        var log = fixture.Graphics.CallLog;
+        var lastClear = log.FindLastIndex(entry => entry.StartsWith("Clear(", StringComparison.Ordinal));
+        var firstUiDraw = log.FindIndex(entry => entry.StartsWith("UI:", StringComparison.Ordinal));
+
+        Assert.True(lastClear >= 0, "No framebuffer clear was recorded");
+        Assert.True(firstUiDraw >= 0, "No UI draw calls were recorded");
+        Assert.True(lastClear < firstUiDraw, "The framebuffer was cleared after UI draw calls");
+    }
+
+    [Fact]
+    public void ComposeFrame_AfterViewportPass_RestoresFullWindowStateBeforeUiPass()
+    {
+        using var fixture = new FrameFixture();
+
+        EditorApplication.ComposeFrame(fixture.Graphics, fixture.EditorWorld, fixture.Panel, 0.016f);
+
+        var log = fixture.Graphics.CallLog;
+        var gizmoDraw = log.IndexOf($"DrawMesh({fixture.GizmoCubeMeshId})");
+        var restoreViewport = log.LastIndexOf("SetViewport(0, 0, 800, 600)");
+        var firstUiDraw = log.FindIndex(entry => entry.StartsWith("UI:", StringComparison.Ordinal));
+
+        Assert.True(restoreViewport > gizmoDraw, "Full-window viewport was not restored after the gizmo pass");
+        Assert.True(restoreViewport < firstUiDraw, "Full-window viewport was not restored before the UI pass");
+        Assert.False(fixture.Graphics.RenderState.DepthTestEnabled);
+        Assert.False(fixture.Graphics.RenderState.CullingEnabled);
+    }
+
+    [Fact]
+    public void ComposeFrame_WithoutViewportPanel_ClearsOnceBeforeUiPass()
+    {
+        using var fixture = new FrameFixture(createViewportPanel: false);
+
+        EditorApplication.ComposeFrame(fixture.Graphics, fixture.EditorWorld, Entity.Null, 0.016f);
+
+        var log = fixture.Graphics.CallLog;
+        var clears = log.Where(entry => entry.StartsWith("Clear(", StringComparison.Ordinal)).ToList();
+        var firstUiDraw = log.FindIndex(entry => entry.StartsWith("UI:", StringComparison.Ordinal));
+
+        Assert.Single(clears);
+        Assert.True(firstUiDraw > log.FindIndex(entry => entry.StartsWith("Clear(", StringComparison.Ordinal)));
+        Assert.DoesNotContain(log, entry => entry.StartsWith("DrawMesh(", StringComparison.Ordinal));
+    }
+
+    #endregion
+
+    #region Viewport Area Compositing Tests
+
+    [Fact]
+    public void Create_ViewportArea_HasTransparentBackground()
+    {
+        using var editorWorld = new World();
+        using var worldManager = new EditorWorldManager();
+        using var graphics = new MockGraphicsContext();
+        var inputContext = new MockInputContext();
+        var capability = new ViewportCapability();
+        var root = editorWorld.Spawn().Build();
+
+        var panel = ViewportPanel.Create(
+            editorWorld, root, default, worldManager, graphics, inputContext, capability);
+
+        ref readonly var state = ref editorWorld.Get<ViewportPanelState>(panel);
+        ref readonly var style = ref editorWorld.Get<UIStyle>(state.ViewportArea);
+        Assert.True(
+            style.BackgroundColor.W.IsApproximatelyZero(),
+            "Viewport area background must be transparent so the scene pass beneath the UI stays visible");
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    /// <summary>
+    /// Builds a headless editor frame: an editor world running <see cref="UIRenderSystem"/>
+    /// with a recording 2D renderer, a UI canvas with an opaque panel, and a viewport panel
+    /// whose scene world contains one renderable entity and one capability gizmo renderer.
+    /// All draw and state calls are recorded, in order, into the mock graphics call log.
+    /// </summary>
+    private sealed class FrameFixture : IDisposable
+    {
+        public World EditorWorld { get; }
+
+        public EditorWorldManager WorldManager { get; }
+
+        public MockGraphicsContext Graphics { get; }
+
+        public Entity Panel { get; }
+
+        public int GizmoCubeMeshId =>
+            Graphics.Meshes.Single(pair => pair.Value.IsCube).Key.Id;
+
+        public FrameFixture(bool createViewportPanel = true)
+        {
+            EditorWorld = new World();
+            WorldManager = new EditorWorldManager();
+            Graphics = new MockGraphicsContext();
+
+            // UI pass: render system plus a recording renderer that appends into the
+            // same ordered log as the graphics context.
+            EditorWorld.SetExtension<I2DRenderer>(new RecordingUiRenderer(Graphics.CallLog));
+            EditorWorld.AddSystem(new UIRenderSystem());
+            CreateUiCanvas();
+
+            if (!createViewportPanel)
+            {
+                Panel = Entity.Null;
+                return;
+            }
+
+            // Scene world with one renderable entity so the scene pass emits a draw call.
+            WorldManager.NewScene();
+            var cube = WorldManager.CreateEntity("Cube");
+            WorldManager.World.Add(cube, Transform3D.Identity);
+            WorldManager.World.Add(cube, new Renderable(SceneMeshId, 0));
+
+            // Capability with one gizmo renderer that draws through the real drawer.
+            var capability = new ViewportCapability();
+            capability.AddGizmoRenderer(new LineGizmoRenderer());
+
+            Panel = CreateViewportPanelEntity(capability);
+        }
+
+        private void CreateUiCanvas()
+        {
+            var canvas = EditorWorld.Spawn()
+                .With(UIElement.Default)
+                .With(UIRect.Stretch())
+                .With(new UIRootTag())
+                .With(new UIStyle { BackgroundColor = new Vector4(0.2f, 0.2f, 0.2f, 1f) })
+                .Build();
+
+            ref var rect = ref EditorWorld.Get<UIRect>(canvas);
+            rect.ComputedBounds = new Rectangle(0, 0, 800, 600);
+        }
+
+        private Entity CreateViewportPanelEntity(ViewportCapability capability)
+        {
+            var viewportArea = EditorWorld.Spawn()
+                .With(new UIRect { ComputedBounds = new Rectangle(10, 10, 400, 300) })
+                .Build();
+
+            var cameraController = new EditorCameraController();
+            cameraController.Reset();
+
+            var panel = EditorWorld.Spawn().Build();
+            EditorWorld.Add(panel, new ViewportPanelState
+            {
+                ViewportArea = viewportArea,
+                WorldManager = WorldManager,
+                GraphicsContext = Graphics,
+                InputProvider = new EditorInputProvider(new MockInputContext()),
+                CameraController = cameraController,
+                TransformGizmo = new TransformGizmo(),
+                Capability = capability,
+                GizmoDrawer = new ViewportGizmoDrawer(),
+                GizmoToggleContainer = Entity.Null,
+                GizmoToggles = [],
+                Font = default,
+                IsHovered = false,
+                LastViewportSize = Vector2.Zero
+            });
+
+            return panel;
+        }
+
+        public void Dispose()
+        {
+            WorldManager.Dispose();
+            EditorWorld.Dispose();
+            Graphics.Dispose();
+        }
+    }
+
+    private sealed class LineGizmoRenderer : IGizmoRenderer
+    {
+        public string Id => "test-line-gizmo";
+
+        public string DisplayName => "Test Line Gizmo";
+
+        public bool IsEnabled { get; set; } = true;
+
+        public int Order => 0;
+
+        public void Render(GizmoRenderContext context)
+            => context.Drawer.DrawLine(Vector3.Zero, Vector3.UnitX, new Vector4(1f, 0f, 0f, 1f));
+
+        public bool ShouldRender(Entity entity, IWorld sceneWorld) => true;
+    }
+
+    /// <summary>
+    /// An <see cref="I2DRenderer"/> that appends UI draw operations into the shared
+    /// ordered call log so their ordering relative to graphics calls can be asserted.
+    /// </summary>
+    private sealed class RecordingUiRenderer(List<string> callLog) : I2DRenderer
+    {
+        public void Begin() => callLog.Add("UI:Begin");
+
+        public void Begin(in Matrix4x4 projection) => callLog.Add("UI:Begin");
+
+        public void End() => callLog.Add("UI:End");
+
+        public void Flush()
+        {
+        }
+
+        public void FillRect(float x, float y, float width, float height, Vector4 color)
+            => callLog.Add("UI:FillRect");
+
+        public void FillRect(in Rectangle rect, Vector4 color)
+            => callLog.Add("UI:FillRect");
+
+        public void DrawRect(float x, float y, float width, float height, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawRect");
+
+        public void DrawRect(in Rectangle rect, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawRect");
+
+        public void FillRoundedRect(float x, float y, float width, float height, float radius, Vector4 color)
+            => callLog.Add("UI:FillRoundedRect");
+
+        public void DrawRoundedRect(float x, float y, float width, float height, float radius, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawRoundedRect");
+
+        public void DrawLine(float x1, float y1, float x2, float y2, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawLine");
+
+        public void DrawLine(Vector2 start, Vector2 end, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawLine");
+
+        public void DrawLineStrip(ReadOnlySpan<Vector2> points, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawLineStrip");
+
+        public void DrawPolygon(ReadOnlySpan<Vector2> points, Vector4 color, float thickness = 1f)
+            => callLog.Add("UI:DrawPolygon");
+
+        public void FillCircle(float centerX, float centerY, float radius, Vector4 color, int segments = 32)
+            => callLog.Add("UI:FillCircle");
+
+        public void DrawCircle(float centerX, float centerY, float radius, Vector4 color, float thickness = 1f, int segments = 32)
+            => callLog.Add("UI:DrawCircle");
+
+        public void FillEllipse(float centerX, float centerY, float radiusX, float radiusY, Vector4 color, int segments = 32)
+            => callLog.Add("UI:FillEllipse");
+
+        public void DrawEllipse(float centerX, float centerY, float radiusX, float radiusY, Vector4 color, float thickness = 1f, int segments = 32)
+            => callLog.Add("UI:DrawEllipse");
+
+        public void DrawTexture(TextureHandle texture, float x, float y, Vector4? tint = null)
+            => callLog.Add("UI:DrawTexture");
+
+        public void DrawTexture(TextureHandle texture, float x, float y, float width, float height, Vector4? tint = null)
+            => callLog.Add("UI:DrawTexture");
+
+        public void DrawTextureRegion(TextureHandle texture, in Rectangle destRect, in Rectangle sourceRect, Vector4? tint = null)
+            => callLog.Add("UI:DrawTextureRegion");
+
+        public void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, float rotation, Vector2 origin, Vector4? tint = null)
+            => callLog.Add("UI:DrawTextureRotated");
+
+        public void DrawTextureRotated(TextureHandle texture, in Rectangle destRect, in Rectangle sourceRect, float rotation, Vector2 origin, Vector4? tint = null)
+            => callLog.Add("UI:DrawTextureRotated");
+
+        public void PushClip(in Rectangle rect)
+        {
+        }
+
+        public void PopClip()
+        {
+        }
+
+        public void ClearClip()
+        {
+        }
+
+        public void SetBatchHint(int count)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
+++ b/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\KeenEyes.Logging\KeenEyes.Logging.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Replay\KeenEyes.Replay.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsContextTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsContextTests.cs
@@ -474,6 +474,69 @@ public class MockGraphicsContextTests
 
     #endregion
 
+    #region Call Log
+
+    [Fact]
+    public void CallLog_RecordsOperationsInOrder()
+    {
+        using var context = new MockGraphicsContext();
+        var mesh = context.CreateQuad();
+
+        context.Clear(ClearMask.ColorBuffer);
+        context.SetViewport(10, 20, 300, 400);
+        context.BindShader(context.UnlitShader);
+        context.DrawMesh(mesh);
+        context.SetDepthTest(false);
+
+        Assert.Equal(
+            [
+                "Clear(ColorBuffer)",
+                "SetViewport(10, 20, 300, 400)",
+                $"BindShader({context.UnlitShader.Id})",
+                $"DrawMesh({mesh.Id})",
+                "SetDepthTest(False)"
+            ],
+            context.CallLog);
+    }
+
+    [Fact]
+    public void CallLog_AllowsInterleavingExternalEntries()
+    {
+        using var context = new MockGraphicsContext();
+
+        context.Clear(ClearMask.ColorBuffer);
+        context.CallLog.Add("External:Event");
+        context.SetViewport(0, 0, 800, 600);
+
+        Assert.Equal(1, context.CallLog.IndexOf("External:Event"));
+    }
+
+    [Fact]
+    public void Reset_ClearsCallLog()
+    {
+        using var context = new MockGraphicsContext();
+        context.Clear(ClearMask.ColorBuffer);
+
+        context.Reset();
+
+        Assert.Empty(context.CallLog);
+    }
+
+    [Fact]
+    public void ClearDrawCalls_ClearsCallLog()
+    {
+        using var context = new MockGraphicsContext();
+        var mesh = context.CreateQuad();
+        context.DrawMesh(mesh);
+
+        context.ClearDrawCalls();
+
+        Assert.Empty(context.CallLog);
+        Assert.NotEmpty(context.Meshes);
+    }
+
+    #endregion
+
     #region Reset and Dispose
 
     [Fact]


### PR DESCRIPTION
## Summary
- Completes the #1050/#1068 chain: the viewport render path (scene → transform gizmo → capability gizmo pass) now actually runs each frame instead of being dormant.
- **Design: single-framebuffer painter's order, no RTT** — frame is `Clear` → viewport pass → UI pass. RTT was rejected as a much larger change (render-target plumbing, resize handling, compositing blit) for no functional gain, since the 2D UI renderer already manages its own state and skips alpha-0 backgrounds.
- The panel's full-screen `Clear` survives but is now positionally safe (always precedes any UI drawing, doubling as the viewport background/depth clear); the ViewportArea widget background became transparent so the UI pass doesn't paint over the scene; `Render` restores full-window viewport + UI-expected state on exit. The frame-level clear covers early-return frames (no scene, zero bounds).
- Frame body extracted to `internal EditorApplication.ComposeFrame(...)` so tests assert the *production* ordering, not a copy.
- `MockGraphicsContext` (src/, fully documented) gained an ordered `CallLog` shared with a recording 2D renderer, enabling call-order assertions.

## Test plan
- [x] 5 new `EditorFrameCompositionTests`: scene draw → gizmo draw → UI draw ordering; last `Clear` strictly precedes first UI draw; viewport/state restoration between passes; no-panel path clears exactly once; transparent viewport background
- [x] 4 new `MockGraphicsContext` CallLog tests
- [x] Full suite 14,501 total / 0 failed; Editor 1292, Testing 1446 independently re-verified; build 0 warnings / 0 errors; format verify exit 0
- [ ] **Manual (needs a display/GPU — deliberately not faked in the headless sandbox):** launch the editor with a scene open and confirm live pixels via TestBridge `capture_screenshot` — gizmos in the viewport, UI intact

## Related Issues
Fixes #1069