### PR TITLE
ci: Tune CodeQL config - filter generated code and style-opinion rules

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,17 @@ queries:
   - uses: security-extended
   - uses: security-and-quality
 
+# For compiled languages, paths-ignore does not limit extraction (the whole
+# build is still traced); the codeql-action applies these globs as alert-level
+# result filters, which is exactly what we want: suppress alerts in generated
+# and build-output code that no human maintains.
+paths-ignore:
+  - '**/obj/**'
+  - '**/bin/**'
+  - '**/*.g.cs'
+  - '**/*.generated.cs'
+  - '**/*.Designer.cs'
+
 # Disable specific rules
 query-filters:
   # Disable LINQ suggestion rules - ECS hot paths intentionally avoid LINQ
@@ -20,3 +31,20 @@ query-filters:
   # trusted internal sources (asset paths, config locations), not user input
   - exclude:
       id: cs/path-injection
+  # Same rationale as cs/path-injection above: Path.Combine arguments come
+  # from trusted internal sources (save-slot names are validated upstream by
+  # SlotNameValidator; log/asset paths are engine-constructed), not user input.
+  - exclude:
+      id: cs/path-combine
+  # Disable structural-style suggestions. House style (enforced via
+  # .editorconfig, Roslyn analyzers with TreatWarningsAsErrors, and the Sonar
+  # bypass list in Directory.Build.props - see S3358) prefers explicit if/else
+  # and guard-clause nesting over ternary chains and merged conditions.
+  - exclude:
+      id: cs/nested-if-statements
+  - exclude:
+      id: cs/missed-ternary-operator
+  # Block complexity is already governed by Sonar/Roslyn thresholds at build
+  # time; this metric-style duplicate adds noise without a distinct signal.
+  - exclude:
+      id: cs/complex-block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 0 * * 1' # Run weekly on Monday at midnight UTC
+  workflow_dispatch: # Allow on-demand analysis (e.g. after alert-config changes)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +42,8 @@ jobs:
           filters: |
             code:
               - 'src/**/*.cs'
+              - 'editor/**/*.cs'
+              - 'tools/**/*.cs'
               - 'tests/**/*.cs'
               - 'samples/**/*.cs'
               - 'benchmarks/**/*.cs'


### PR DESCRIPTION
## Summary
- **PR-0 of the security-tab cleanup** (656 open CodeQL alerts, plan approved). Lands first so the next main analysis auto-closes ~157 alerts (141 style-rule + 16 generated-file) and shrinks the fix surface for the follow-up code PRs.
- `codeql-config.yml`: `paths-ignore` for `obj/`/`bin/`/generated files (alert-level result filters for compiled languages), plus `query-filters` excludes with written justifications — `cs/path-combine` (identical trusted-internal-paths rationale to the existing `cs/path-injection` entry; `SlotNameValidator` upstream), `cs/nested-if-statements` + `cs/missed-ternary-operator` (house style mandates explicit if/else; Sonar S3358 already bypassed in `Directory.Build.props`), `cs/complex-block` (duplicates build-time Sonar/Roslyn complexity gates).
- `codeql.yml`: `editor/**`/`tools/**` added to the PR paths-filter (editor-only PRs silently skipped CodeQL until now) and `workflow_dispatch` for on-demand runs.
- Real rules (useless assignments, loss-of-precision, dispose-on-throw, shadowing, etc.) keep full signal — those ~460 alerts get fixed in code in the follow-up PRs.

## Test plan
- [x] Both YAML files parse
- [ ] Post-merge main CodeQL run: obj/ and filtered-rule alerts transition to closed; open count drops ~656 → ~499

## Related Issues
Security-tab cleanup plan (CodeQL alert resolution)