### PR TITLE
ci: Filter generated code from CodeQL SARIF before upload

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -106,7 +106,30 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
 
+      # paths-ignore in codeql-config.yml does not filter results for compiled
+      # languages (the tracer extracts everything the build compiles, including
+      # source-generator output emitted under obj/). Analyze without uploading,
+      # strip generated/build-output paths from the SARIF, then upload.
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
+          upload: failure-only
+          output: sarif-results
+
+      - name: Filter generated code from SARIF
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -**/obj/**
+            -**/bin/**
+            -**/*.g.cs
+            -**/*.generated.cs
+            -**/*.Designer.cs
+          input: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results/${{ matrix.language }}.sarif
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-results/${{ matrix.language }}.sarif


### PR DESCRIPTION
## Summary
- Follow-up to #1071: the fresh analysis (first since 2025-12-29) proved `paths-ignore` in the CodeQL config does **not** filter results for compiled languages — 757 of 1,810 open alerts sit in `obj/` source-generator output (744 are `cs/useless-cast-to-self` inside System.Text.Json generated serializers).
- Implements the plan's documented fallback: `analyze` with `upload: failure-only` → `advanced-security/filter-sarif` strips `obj/`, `bin/`, `*.g.cs`, `*.generated.cs`, `*.Designer.cs` → `upload-sarif` uploads the filtered results.
- On the next main analysis the 757 generated-code alerts auto-close, leaving ~1,053 real alerts for the fix batches.

## Test plan
- [x] Workflow YAML parses
- [ ] Post-merge main run: zero `obj/` paths among open alerts

## Related Issues
Security-tab cleanup (PR-0b)