### PR TITLE
fix(editor): Prevent zip-slip in plugin extraction and resolve editor CodeQL alerts

### DIFF
--- a/editor/KeenEyes.Cli/Program.cs
+++ b/editor/KeenEyes.Cli/Program.cs
@@ -31,7 +31,7 @@ static Dictionary<string, ICommand> BuildCommands()
 static async Task<int> RunAsync(string[] args, Dictionary<string, ICommand> commands)
 {
     var output = new ConsoleOutput();
-    var cts = new CancellationTokenSource();
+    using var cts = new CancellationTokenSource();
 
     // Handle Ctrl+C
     Console.CancelKeyPress += (_, e) =>

--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -496,7 +496,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
 
     private void CreateMenuBar(Entity canvas)
     {
-        var menuDefs = new (string Label, MenuItemDef[] Items)[]
+        var menuDefs = new (string Label, IEnumerable<MenuItemDef> Items)[]
         {
             ("File", [
                 new MenuItemDef("New Scene", "new_scene", Shortcut: "Ctrl+N"),
@@ -557,7 +557,7 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
         };
 
         WidgetFactory.CreateMenuBar(_editorWorld, canvas, _defaultFont,
-            menuDefs.Select(m => (m.Label, (IEnumerable<MenuItemDef>)m.Items)),
+            menuDefs,
             new MenuBarConfig(
                 Height: 26,
                 BackgroundColor: new Vector4(0.15f, 0.15f, 0.18f, 1f),
@@ -1953,9 +1953,9 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
 
         // Find common parent for duplicated entities
         Entity? parent = null;
-        if (selected.Count == 1 && sceneWorld is KeenEyes.Capabilities.IHierarchyCapability hierarchy)
+        if (selected.Count == 1)
         {
-            parent = hierarchy.GetParent(selected[0]);
+            parent = sceneWorld.GetParent(selected[0]);
         }
 
         var duplicated = _clipboard.Paste(sceneWorld, parent);
@@ -2221,7 +2221,8 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
                 UseShellExecute = true
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (
+            ex is System.ComponentModel.Win32Exception or InvalidOperationException or PlatformNotSupportedException or IOException)
         {
             Console.WriteLine($"Failed to open URL: {ex.Message}");
         }

--- a/editor/KeenEyes.Editor/Assets/SceneSerializer.cs
+++ b/editor/KeenEyes.Editor/Assets/SceneSerializer.cs
@@ -525,7 +525,8 @@ public sealed class SceneSerializer
             // Call it with isTag = false (auto-detected from ITagComponent)
             return genericMethod.Invoke(world.Components, [false]) as ComponentInfo;
         }
-        catch
+        catch (Exception ex) when (
+            ex is ArgumentException or InvalidOperationException or MemberAccessException or TargetInvocationException)
         {
             // Registration failed (type may not be a valid component)
             return null;

--- a/editor/KeenEyes.Editor/Layout/EditorLayout.cs
+++ b/editor/KeenEyes.Editor/Layout/EditorLayout.cs
@@ -409,7 +409,7 @@ public sealed class EditorLayout
         {
             return JsonSerializer.Deserialize<EditorLayout>(json, GetJsonOptions());
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
         {
             return null;
         }

--- a/editor/KeenEyes.Editor/Layout/LayoutManager.cs
+++ b/editor/KeenEyes.Editor/Layout/LayoutManager.cs
@@ -72,7 +72,7 @@ public sealed class LayoutManager
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             Console.WriteLine($"Failed to load layout from {path}: {ex.Message}");
         }
@@ -109,7 +109,7 @@ public sealed class LayoutManager
             File.WriteAllText(path, json);
             _currentLayoutPath = path;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             Console.WriteLine($"Failed to save layout to {path}: {ex.Message}");
         }
@@ -220,7 +220,7 @@ public sealed class LayoutManager
             File.Delete(path);
             return true;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }

--- a/editor/KeenEyes.Editor/Logging/EditorLogProvider.cs
+++ b/editor/KeenEyes.Editor/Logging/EditorLogProvider.cs
@@ -174,10 +174,12 @@ public sealed class EditorLogProvider : ILogProvider, ILogQueryable
     {
         foreach (var entry in _entries)
         {
-            var shouldInclude =
-                (entry.Level >= LogLevel.Error && showErrors) ||
-                (entry.Level == LogLevel.Warning && showWarnings) ||
-                (entry.Level < LogLevel.Warning && showInfo);
+            var shouldInclude = entry.Level switch
+            {
+                >= LogLevel.Error => showErrors,
+                LogLevel.Warning => showWarnings,
+                _ => showInfo,
+            };
 
             if (shouldInclude)
             {

--- a/editor/KeenEyes.Editor/Navigation/NavMeshSerializer.cs
+++ b/editor/KeenEyes.Editor/Navigation/NavMeshSerializer.cs
@@ -223,7 +223,7 @@ public static class NavMeshSerializer
             var magic = reader.ReadBytes(4);
             return magic.AsSpan().SequenceEqual(MagicBytes);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }

--- a/editor/KeenEyes.Editor/Panels/FrameInspectorPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/FrameInspectorPanel.cs
@@ -689,7 +689,7 @@ public static class FrameInspectorPanel
                 _ => null
             };
         }
-        catch
+        catch (OverflowException)
         {
             return null;
         }

--- a/editor/KeenEyes.Editor/Plugins/Installation/PluginInstaller.cs
+++ b/editor/KeenEyes.Editor/Plugins/Installation/PluginInstaller.cs
@@ -138,7 +138,7 @@ public sealed class PluginInstaller
                     {
                         File.Delete(nupkgPath);
                     }
-                    catch
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                     {
                         // Ignore cleanup failures
                     }
@@ -255,7 +255,7 @@ public sealed class PluginInstaller
             var range = VersionRange.Parse(versionRange);
             return range.Satisfies(installed);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or FormatException)
         {
             return false;
         }
@@ -268,7 +268,7 @@ public sealed class PluginInstaller
             var range = VersionRange.Parse(versionRange);
             return range.MinVersion?.ToNormalizedString();
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or FormatException)
         {
             return null;
         }

--- a/editor/KeenEyes.Editor/Plugins/NuGet/NuGetClient.cs
+++ b/editor/KeenEyes.Editor/Plugins/NuGet/NuGetClient.cs
@@ -242,23 +242,7 @@ public sealed class NuGetClient : INuGetClient
         Directory.CreateDirectory(cachePath);
 
         // Extract files
-        foreach (var entry in archive.Entries)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var destinationPath = Path.Combine(cachePath, entry.FullName);
-            var destinationDir = Path.GetDirectoryName(destinationPath);
-
-            if (destinationDir != null)
-            {
-                Directory.CreateDirectory(destinationDir);
-            }
-
-            if (!string.IsNullOrEmpty(entry.Name))
-            {
-                entry.ExtractToFile(destinationPath, overwrite: true);
-            }
-        }
+        ExtractArchiveEntries(archive, cachePath, cancellationToken);
 
         // Create the .nupkg.metadata file that NuGet expects
         var metadataPath = Path.Combine(cachePath, ".nupkg.metadata");
@@ -271,6 +255,56 @@ public sealed class NuGetClient : INuGetClient
             """);
 
         return Task.FromResult(cachePath);
+    }
+
+    /// <summary>
+    /// Extracts all entries from <paramref name="archive"/> into <paramref name="destinationRoot"/>,
+    /// rejecting any entry whose resolved path would escape the destination directory (zip-slip).
+    /// </summary>
+    /// <param name="archive">The archive to extract.</param>
+    /// <param name="destinationRoot">The directory to extract into.</param>
+    /// <param name="cancellationToken">Token to cancel the extraction.</param>
+    /// <exception cref="InvalidDataException">
+    /// Thrown when an archive entry would extract outside <paramref name="destinationRoot"/>.
+    /// </exception>
+    internal static void ExtractArchiveEntries(
+        ZipArchive archive,
+        string destinationRoot,
+        CancellationToken cancellationToken = default)
+    {
+        // Canonicalize the root with a trailing separator so that a sibling
+        // directory like "/target-evil" cannot pass a "/target" prefix check.
+        var canonicalRoot = Path.GetFullPath(destinationRoot);
+
+        if (!canonicalRoot.EndsWith(Path.DirectorySeparatorChar))
+        {
+            canonicalRoot += Path.DirectorySeparatorChar;
+        }
+
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var destinationPath = Path.GetFullPath(Path.Combine(canonicalRoot, entry.FullName));
+
+            if (!destinationPath.StartsWith(canonicalRoot, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"Archive entry '{entry.FullName}' would extract outside the destination directory.");
+            }
+
+            var destinationDir = Path.GetDirectoryName(destinationPath);
+
+            if (destinationDir != null)
+            {
+                Directory.CreateDirectory(destinationDir);
+            }
+
+            if (!string.IsNullOrEmpty(entry.Name))
+            {
+                entry.ExtractToFile(destinationPath, overwrite: true);
+            }
+        }
     }
 
     private static string GetPackageCachePath(string packageId, string version)

--- a/editor/KeenEyes.Editor/Plugins/PluginRepository.cs
+++ b/editor/KeenEyes.Editor/Plugins/PluginRepository.cs
@@ -139,7 +139,7 @@ internal sealed class PluginRepository
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger?.LogWarning($"Error scanning directory '{directory}': {ex.Message}");
         }
@@ -181,7 +181,7 @@ internal sealed class PluginRepository
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             logger?.LogWarning($"Error scanning NuGet cache: {ex.Message}");
         }

--- a/editor/KeenEyes.Editor/Settings/EditorSettings.cs
+++ b/editor/KeenEyes.Editor/Settings/EditorSettings.cs
@@ -544,7 +544,7 @@ public static class EditorSettings
                 CopySettings(loaded, _data);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or NotSupportedException)
         {
             Console.WriteLine($"Failed to load settings: {ex.Message}");
         }
@@ -570,7 +570,7 @@ public static class EditorSettings
             var json = JsonSerializer.Serialize(_data, GetJsonOptions());
             File.WriteAllText(path, json);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
             Console.WriteLine($"Failed to save settings: {ex.Message}");
         }

--- a/editor/KeenEyes.Editor/Shortcuts/ShortcutManager.cs
+++ b/editor/KeenEyes.Editor/Shortcuts/ShortcutManager.cs
@@ -307,7 +307,7 @@ public sealed class ShortcutManager
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
         {
             Console.WriteLine($"Failed to load shortcuts: {ex.Message}");
         }

--- a/editor/KeenEyes.Generators/AssetModels/JsonParser.cs
+++ b/editor/KeenEyes.Generators/AssetModels/JsonParser.cs
@@ -132,7 +132,7 @@ internal static class JsonParser
 
             return scene;
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException or FormatException)
         {
             return null;
         }
@@ -194,7 +194,7 @@ internal static class JsonParser
 
             return prefab;
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException or FormatException)
         {
             return null;
         }
@@ -273,7 +273,7 @@ internal static class JsonParser
 
             return config;
         }
-        catch
+        catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException or FormatException)
         {
             return null;
         }

--- a/editor/KeenEyes.Generators/LinqHotPathAnalyzer.cs
+++ b/editor/KeenEyes.Generators/LinqHotPathAnalyzer.cs
@@ -316,7 +316,7 @@ public sealed class LinqHotPathAnalyzer : DiagnosticAnalyzer
 
         var parts = new System.Collections.Generic.List<string>();
         var current = ns;
-        while (current != null && !current.IsGlobalNamespace)
+        while (!current.IsGlobalNamespace)
         {
             parts.Insert(0, current.Name);
             current = current.ContainingNamespace;

--- a/editor/KeenEyes.Generators/ReplicatedGenerator.cs
+++ b/editor/KeenEyes.Generators/ReplicatedGenerator.cs
@@ -183,7 +183,7 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
     private static FieldSerializationType GetFieldSerializationType(ITypeSymbol type)
     {
         // Check special types first (primitives)
-        var result = type.SpecialType switch
+        FieldSerializationType? result = type.SpecialType switch
         {
             SpecialType.System_Boolean => FieldSerializationType.Bool,
             SpecialType.System_Byte => FieldSerializationType.Byte,
@@ -196,7 +196,7 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
             SpecialType.System_UInt64 => FieldSerializationType.UInt64,
             SpecialType.System_Single => FieldSerializationType.Float,
             SpecialType.System_Double => FieldSerializationType.Double,
-            _ => (FieldSerializationType?)null
+            _ => null
         };
 
         if (result.HasValue)

--- a/editor/KeenEyes.Generators/SceneGenerator.cs
+++ b/editor/KeenEyes.Generators/SceneGenerator.cs
@@ -640,25 +640,25 @@ public sealed class SceneGenerator : IIncrementalGenerator
     private static void GenerateNestedValue(StringBuilder sb, Dictionary<string, object?> nested, string indent)
     {
         // Check for common vector types
-        if (nested.ContainsKey("X") && nested.ContainsKey("Y"))
+        if (nested.TryGetValue("X", out var x) && nested.TryGetValue("Y", out var y))
         {
-            if (nested.ContainsKey("Z"))
+            if (nested.TryGetValue("Z", out var z))
             {
-                if (nested.ContainsKey("W"))
+                if (nested.TryGetValue("W", out var w))
                 {
                     // Vector4 or Quaternion
-                    sb.Append($"new global::System.Numerics.Vector4({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])}, {FormatFloat(nested["Z"])}, {FormatFloat(nested["W"])})");
+                    sb.Append($"new global::System.Numerics.Vector4({FormatFloat(x)}, {FormatFloat(y)}, {FormatFloat(z)}, {FormatFloat(w)})");
                 }
                 else
                 {
                     // Vector3
-                    sb.Append($"new global::System.Numerics.Vector3({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])}, {FormatFloat(nested["Z"])})");
+                    sb.Append($"new global::System.Numerics.Vector3({FormatFloat(x)}, {FormatFloat(y)}, {FormatFloat(z)})");
                 }
             }
             else
             {
                 // Vector2
-                sb.Append($"new global::System.Numerics.Vector2({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])})");
+                sb.Append($"new global::System.Numerics.Vector2({FormatFloat(x)}, {FormatFloat(y)})");
             }
         }
         else

--- a/editor/KeenEyes.Generators/WorldConfigGenerator.cs
+++ b/editor/KeenEyes.Generators/WorldConfigGenerator.cs
@@ -449,22 +449,22 @@ public sealed class WorldConfigGenerator : IIncrementalGenerator
 
     private static void GenerateNestedValue(StringBuilder sb, Dictionary<string, object?> nested, string indent)
     {
-        if (nested.ContainsKey("X") && nested.ContainsKey("Y"))
+        if (nested.TryGetValue("X", out var x) && nested.TryGetValue("Y", out var y))
         {
-            if (nested.ContainsKey("Z"))
+            if (nested.TryGetValue("Z", out var z))
             {
-                if (nested.ContainsKey("W"))
+                if (nested.TryGetValue("W", out var w))
                 {
-                    sb.Append($"new global::System.Numerics.Vector4({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])}, {FormatFloat(nested["Z"])}, {FormatFloat(nested["W"])})");
+                    sb.Append($"new global::System.Numerics.Vector4({FormatFloat(x)}, {FormatFloat(y)}, {FormatFloat(z)}, {FormatFloat(w)})");
                 }
                 else
                 {
-                    sb.Append($"new global::System.Numerics.Vector3({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])}, {FormatFloat(nested["Z"])})");
+                    sb.Append($"new global::System.Numerics.Vector3({FormatFloat(x)}, {FormatFloat(y)}, {FormatFloat(z)})");
                 }
             }
             else
             {
-                sb.Append($"new global::System.Numerics.Vector2({FormatFloat(nested["X"])}, {FormatFloat(nested["Y"])})");
+                sb.Append($"new global::System.Numerics.Vector2({FormatFloat(x)}, {FormatFloat(y)})");
             }
         }
         else

--- a/editor/KeenEyes.Graph.Kesl/Compiler/GraphTraverser.cs
+++ b/editor/KeenEyes.Graph.Kesl/Compiler/GraphTraverser.cs
@@ -56,9 +56,9 @@ public static class GraphTraverser
                 neighbors.Add(connection.TargetNode);
             }
 
-            if (inDegree.ContainsKey(connection.TargetNode))
+            if (inDegree.TryGetValue(connection.TargetNode, out var degree))
             {
-                inDegree[connection.TargetNode]++;
+                inDegree[connection.TargetNode] = degree + 1;
             }
         }
 

--- a/editor/KeenEyes.Graph.Kesl/Preview/CodePreviewPanel.cs
+++ b/editor/KeenEyes.Graph.Kesl/Preview/CodePreviewPanel.cs
@@ -61,7 +61,7 @@ public sealed class CodePreviewPanel
     /// <param name="world">The world containing the graph.</param>
     public void SetGraph(Entity canvas, IWorld world)
     {
-        if (currentCanvas != canvas || currentWorld != world)
+        if (currentCanvas != canvas || !ReferenceEquals(currentWorld, world))
         {
             currentCanvas = canvas;
             currentWorld = world;

--- a/editor/KeenEyes.Graph.Kesl/Preview/ShaderPreviewPanel.cs
+++ b/editor/KeenEyes.Graph.Kesl/Preview/ShaderPreviewPanel.cs
@@ -89,7 +89,7 @@ public sealed class ShaderPreviewPanel
     /// <param name="world">The world containing the graph.</param>
     public void SetCanvas(Entity canvas, IWorld world)
     {
-        if (currentCanvas != canvas || currentWorld != world)
+        if (currentCanvas != canvas || !ReferenceEquals(currentWorld, world))
         {
             currentCanvas = canvas;
             currentWorld = world;

--- a/editor/KeenEyes.Graph.Kesl/Validation/Rules/TypeCompatibilityRule.cs
+++ b/editor/KeenEyes.Graph.Kesl/Validation/Rules/TypeCompatibilityRule.cs
@@ -129,17 +129,10 @@ public sealed class TypeCompatibilityRule : IValidationRule
             return target is PortTypeId.Float2 or PortTypeId.Float3 or PortTypeId.Float4;
         }
 
-        // Int can be promoted to int vector types
+        // Int can be promoted to float or int vector types
         if (source == PortTypeId.Int)
         {
-            return target is PortTypeId.Int2 or PortTypeId.Int3 or PortTypeId.Int4;
-        }
-
-        // Float and Int are interchangeable in shader contexts
-        if ((source == PortTypeId.Float && target == PortTypeId.Int) ||
-            (source == PortTypeId.Int && target == PortTypeId.Float))
-        {
-            return true;
+            return target is PortTypeId.Float or PortTypeId.Int2 or PortTypeId.Int3 or PortTypeId.Int4;
         }
 
         return false;

--- a/editor/KeenEyes.Shaders.Compiler/CodeGen/CSharpBindingGenerator.cs
+++ b/editor/KeenEyes.Shaders.Compiler/CodeGen/CSharpBindingGenerator.cs
@@ -230,7 +230,6 @@ public sealed class CSharpBindingGenerator
 
         // Get component spans
         var writeBindings = new List<QueryBinding>();
-        var readBindings = new List<QueryBinding>();
 
         foreach (var binding in compute.Query.Bindings)
         {
@@ -245,10 +244,6 @@ public sealed class CSharpBindingGenerator
             if (binding.AccessMode == AccessMode.Write)
             {
                 writeBindings.Add(binding);
-            }
-            else
-            {
-                readBindings.Add(binding);
             }
         }
 

--- a/tests/KeenEyes.Editor.Tests/Plugins/NuGetClientExtractionTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/NuGetClientExtractionTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO.Compression;
+using KeenEyes.Editor.Plugins.NuGet;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="NuGetClient.ExtractArchiveEntries"/>, covering normal package
+/// extraction and rejection of zip-slip (path traversal) archive entries.
+/// </summary>
+public sealed class NuGetClientExtractionTests : IDisposable
+{
+    private readonly DirectoryInfo tempRoot;
+
+    public NuGetClientExtractionTests()
+    {
+        tempRoot = Directory.CreateTempSubdirectory("keeneyes-zipslip-tests-");
+    }
+
+    public void Dispose()
+    {
+        tempRoot.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void ExtractArchiveEntries_WithNormalEntries_ExtractsAllFiles()
+    {
+        var destination = Path.Combine(tempRoot.FullName, "extract");
+        Directory.CreateDirectory(destination);
+
+        using var archive = CreateArchive(
+            ("MyPlugin.nuspec", "<package />"),
+            ("lib/net10.0/MyPlugin.dll", "binary-content"));
+
+        NuGetClient.ExtractArchiveEntries(archive, destination, TestContext.Current.CancellationToken);
+
+        Assert.Equal("<package />", File.ReadAllText(Path.Combine(destination, "MyPlugin.nuspec")));
+        Assert.Equal(
+            "binary-content",
+            File.ReadAllText(Path.Combine(destination, "lib", "net10.0", "MyPlugin.dll")));
+    }
+
+    [Fact]
+    public void ExtractArchiveEntries_WithParentTraversalEntry_ThrowsInvalidDataException()
+    {
+        var destination = Path.Combine(tempRoot.FullName, "extract");
+        Directory.CreateDirectory(destination);
+
+        using var archive = CreateArchive(("../evil.dll", "malicious"));
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetClient.ExtractArchiveEntries(archive, destination, TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(Path.Combine(tempRoot.FullName, "evil.dll")));
+    }
+
+    [Fact]
+    public void ExtractArchiveEntries_WithNestedTraversalEntry_ThrowsInvalidDataException()
+    {
+        var destination = Path.Combine(tempRoot.FullName, "extract");
+        Directory.CreateDirectory(destination);
+
+        using var archive = CreateArchive(("lib/../../evil.dll", "malicious"));
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetClient.ExtractArchiveEntries(archive, destination, TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(Path.Combine(tempRoot.FullName, "evil.dll")));
+    }
+
+    [Fact]
+    public void ExtractArchiveEntries_WithRootedEntry_ThrowsInvalidDataException()
+    {
+        var destination = Path.Combine(tempRoot.FullName, "extract");
+        Directory.CreateDirectory(destination);
+
+        var rootedPath = Path.Combine(tempRoot.FullName, "outside", "evil.dll");
+        using var archive = CreateArchive((rootedPath, "malicious"));
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetClient.ExtractArchiveEntries(archive, destination, TestContext.Current.CancellationToken));
+        Assert.False(File.Exists(rootedPath));
+    }
+
+    [Fact]
+    public void ExtractArchiveEntries_WithSiblingPrefixEscape_ThrowsInvalidDataException()
+    {
+        // "../extract-evil/..." resolves to a sibling directory whose name starts with
+        // the destination directory's name; a naive prefix check would let it through.
+        var destination = Path.Combine(tempRoot.FullName, "extract");
+        Directory.CreateDirectory(destination);
+
+        using var archive = CreateArchive(("../extract-evil/evil.dll", "malicious"));
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetClient.ExtractArchiveEntries(archive, destination, TestContext.Current.CancellationToken));
+        Assert.False(Directory.Exists(Path.Combine(tempRoot.FullName, "extract-evil")));
+    }
+
+    private static ZipArchive CreateArchive(params (string EntryName, string Content)[] entries)
+    {
+        var stream = new MemoryStream();
+
+        using (var writer = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (entryName, content) in entries)
+            {
+                var entry = writer.CreateEntry(entryName);
+                using var entryStream = entry.Open();
+                using var textWriter = new StreamWriter(entryStream);
+                textWriter.Write(content);
+            }
+        }
+
+        stream.Position = 0;
+        return new ZipArchive(stream, ZipArchiveMode.Read);
+    }
+}


### PR DESCRIPTION
## Summary
- **Security fix (cs/zipslip):** `NuGetClient` extracted plugin `.nupkg` archives with `Path.Combine(cachePath, entry.FullName)` on untrusted entry names — a crafted package could write files outside the NuGet cache (`../../evil.dll`, absolute paths) during plugin installation. Extraction now canonicalizes the root (trailing-separator guard against sibling-prefix bypass), resolves every entry via `Path.GetFullPath`, and requires an ordinal prefix match **before** any directory creation or file write; escapes throw `InvalidDataException` naming the entry. 5 new tests cover normal extraction plus four escape shapes (relative, nested, absolute, sibling-prefix).
- Editor batch of the CodeQL cleanup (85 alerts): 40 fixed in code — 19 catch-alls narrowed to concrete exception sets, 9 `ContainsKey`→`TryGetValue`, dead-branch removals (incl. folding the KESL `TypeCompatibilityRule`'s unreachable Int↔Float branch into the canonical promotion matrix), disposal and cast fixes.
- 45 dismissal fragments recorded (`dismissals.tsv`) for the deliberate patterns: plugin-isolation catch-all boundaries (loader/installer/hot-reload/CLI command wrappers), collectible-AssemblyLoadContext GC calls, the Interlocked notification counter — these feed the end-of-plan API dismissal pass with written reasons.

## Test plan
- [x] 5 new `NuGetClientExtractionTests` incl. all four escape vectors — pass
- [x] Editor 1297/1297; Editor.Integration 50/50; full suite 14,444 passed / 0 failed
- [x] Build 0 warnings / 0 errors; format verify exit 0 (independently re-verified)

## Related Issues
Security-tab cleanup — editor batch (1 of 7)