### PR TITLE
fix(core): Resolve CodeQL alerts across src runtime libraries

### DIFF
--- a/src/KeenEyes.AI/Actions/FleeAction.cs
+++ b/src/KeenEyes.AI/Actions/FleeAction.cs
@@ -218,8 +218,10 @@ public sealed class FleeAction : IAIAction
         // Sample positions in a cone away from the threat
         for (int i = 0; i < SampleCount; i++)
         {
-            // Calculate angle offset for this sample
-            float angleOffset = (i - SampleCount / 2) * (MathF.PI / SampleCount);
+            // Calculate angle offset for this sample. Integer division is intentional:
+            // it centers the sample indices on the middle sample.
+            int centerIndex = SampleCount / 2;
+            float angleOffset = (i - centerIndex) * (MathF.PI / SampleCount);
 
             // Rotate the away direction
             var sampleDirection = RotateVector(awayDirection, angleOffset);

--- a/src/KeenEyes.Assets/Assets/AudioClipAsset.cs
+++ b/src/KeenEyes.Assets/Assets/AudioClipAsset.cs
@@ -50,7 +50,7 @@ public sealed class AudioClipAsset : IDisposable
     /// <summary>
     /// Gets the estimated size of the audio data in bytes.
     /// </summary>
-    public long SizeBytes => (long)(Duration.TotalSeconds * SampleRate * Channels * (BitsPerSample / 8));
+    public long SizeBytes => (long)(Duration.TotalSeconds * SampleRate * Channels * (BitsPerSample / 8.0));
 
     /// <summary>
     /// Creates a new audio clip asset.

--- a/src/KeenEyes.Assets/Caching/AssetEntry.cs
+++ b/src/KeenEyes.Assets/Caching/AssetEntry.cs
@@ -64,7 +64,7 @@ internal sealed class AssetEntry(int id, string path, Type assetType)
     /// its dependencies are also released. This prevents memory leaks
     /// for assets that load other assets (e.g., glTF models with textures).
     /// </remarks>
-    public IReadOnlyList<int> Dependencies => dependencies ?? (IReadOnlyList<int>)[];
+    public IReadOnlyList<int> Dependencies => dependencies is null ? [] : dependencies;
 
     /// <summary>
     /// Adds a dependency to this asset.

--- a/src/KeenEyes.Assets/Manifest/AssetManifest.cs
+++ b/src/KeenEyes.Assets/Manifest/AssetManifest.cs
@@ -165,7 +165,7 @@ public sealed class AssetManifest
             return [];
         }
 
-        return info.Dependencies ?? (IReadOnlyList<string>)[];
+        return info.Dependencies ?? [];
     }
 
     /// <summary>

--- a/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
+++ b/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
@@ -70,7 +70,7 @@ internal static class WavDecoder
 
                 var audioData = data.Slice(offset + 8, chunkSize).ToArray();
                 var format = GetAudioFormat(channels, bitsPerSample);
-                var duration = (float)audioData.Length / (sampleRate * channels * (bitsPerSample / 8));
+                var duration = audioData.Length / (sampleRate * channels * (bitsPerSample / 8f));
 
                 return new WavData
                 {

--- a/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
@@ -115,7 +115,7 @@ public sealed class SilkAudioContext : IAudioContext
 
         int channels = format is AudioFormat.Stereo8 or AudioFormat.Stereo16 ? 2 : 1;
         int bitsPerSample = format is AudioFormat.Mono16 or AudioFormat.Stereo16 ? 16 : 8;
-        float duration = (float)data.Length / (sampleRate * channels * (bitsPerSample / 8));
+        float duration = data.Length / (sampleRate * channels * (bitsPerSample / 8f));
 
         return CreateClipInternal(data.ToArray(), format, sampleRate, channels, bitsPerSample, duration);
     }
@@ -358,12 +358,16 @@ public sealed class SilkAudioContext : IAudioContext
     /// <inheritdoc />
     public void PauseAll()
     {
+        if (device is null)
+        {
+            return;
+        }
+
         foreach (var (soundId, instance) in activeSounds)
         {
-            var state = device?.GetSourceState(instance.SourceId);
-            if (state == AudioPlayState.Playing)
+            if (device.GetSourceState(instance.SourceId) == AudioPlayState.Playing)
             {
-                device?.PauseSource(instance.SourceId);
+                device.PauseSource(instance.SourceId);
                 pausedByPauseAll.Add(soundId);
             }
         }

--- a/src/KeenEyes.Core/SaveManager.cs
+++ b/src/KeenEyes.Core/SaveManager.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Text.Json;
 using KeenEyes.Serialization;
 
 namespace KeenEyes;
@@ -183,8 +184,9 @@ internal sealed class SaveManager
             var fileData = File.ReadAllBytes(filePath);
             return SaveFileFormat.ReadMetadata(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
         {
+            // Unreadable or corrupt slot files are treated as missing.
             return null;
         }
     }
@@ -223,9 +225,9 @@ internal sealed class SaveManager
                     slotInfo = SaveFileFormat.ReadMetadata(fileData);
                 }
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
             {
-                // Skip invalid files
+                // Skip unreadable or corrupt files
             }
 
             if (slotInfo is not null)
@@ -255,8 +257,9 @@ internal sealed class SaveManager
             var fileData = File.ReadAllBytes(filePath);
             return SaveFileFormat.IsValidFormat(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException)
         {
+            // Unreadable slot files are treated as missing.
             return false;
         }
     }
@@ -367,8 +370,9 @@ internal sealed class SaveManager
             var fileData = File.ReadAllBytes(filePath);
             return SaveFileFormat.Validate(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
         {
+            // Unreadable or corrupt slot files fail validation.
             return null;
         }
     }
@@ -655,8 +659,9 @@ internal sealed class SaveManager
             var fileData = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
             return SaveFileFormat.ReadMetadata(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
         {
+            // Unreadable or corrupt slot files are treated as missing.
             return null;
         }
     }
@@ -689,9 +694,9 @@ internal sealed class SaveManager
                     result.Add(slotInfo);
                 }
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
             {
-                // Skip invalid files
+                // Skip unreadable or corrupt files
             }
         }
 
@@ -796,8 +801,9 @@ internal sealed class SaveManager
             var fileData = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
             return SaveFileFormat.Validate(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
         {
+            // Unreadable or corrupt slot files fail validation.
             return null;
         }
     }

--- a/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
@@ -453,8 +453,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
             var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
 
             var port = nodeType.InputPorts[i];
-            var portColor = GetportColor(port.TypeId);
-            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, portColor);
+            var typedPortColor = GetportColor(port.TypeId);
+            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, typedPortColor);
         }
 
         // Draw output ports (right edge)
@@ -465,8 +465,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
             var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
 
             var port = nodeType.OutputPorts[i];
-            var portColor = GetportColor(port.TypeId);
-            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, portColor);
+            var typedPortColor = GetportColor(port.TypeId);
+            renderer!.FillCircle(screenPos.X, screenPos.Y, portRadius, typedPortColor);
         }
     }
 
@@ -530,8 +530,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
             {
                 var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
                 var port = nodeType.InputPorts[i];
-                var portColor = GetportColor(port.TypeId);
-                renderer!.FillCircle(screenPos.X, screenPos.Y, stubRadius, portColor);
+                var typedPortColor = GetportColor(port.TypeId);
+                renderer!.FillCircle(screenPos.X, screenPos.Y, stubRadius, typedPortColor);
             }
         }
 
@@ -542,8 +542,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
             {
                 var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
                 var port = nodeType.OutputPorts[i];
-                var portColor = GetportColor(port.TypeId);
-                renderer!.FillCircle(screenPos.X, screenPos.Y, stubRadius, portColor);
+                var typedPortColor = GetportColor(port.TypeId);
+                renderer!.FillCircle(screenPos.X, screenPos.Y, stubRadius, typedPortColor);
             }
         }
     }
@@ -753,8 +753,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
                 var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
 
                 var port = nodeType.InputPorts[i];
-                var portColor = GetportColor(port.TypeId);
-                var ghostportColor = new Vector4(portColor.X, portColor.Y, portColor.Z, 0.5f);
+                var typedPortColor = GetportColor(port.TypeId);
+                var ghostportColor = new Vector4(typedPortColor.X, typedPortColor.Y, typedPortColor.Z, 0.5f);
                 renderer.FillCircle(screenPos.X, screenPos.Y, portRadius, ghostportColor);
             }
 
@@ -766,8 +766,8 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
                 var screenPos = GraphTransform.CanvasToScreen(canvasPos, canvasData.Pan, canvasData.Zoom, origin);
 
                 var port = nodeType.OutputPorts[i];
-                var portColor = GetportColor(port.TypeId);
-                var ghostportColor = new Vector4(portColor.X, portColor.Y, portColor.Z, 0.5f);
+                var typedPortColor = GetportColor(port.TypeId);
+                var ghostportColor = new Vector4(typedPortColor.X, typedPortColor.Y, typedPortColor.Z, 0.5f);
                 renderer.FillCircle(screenPos.X, screenPos.Y, portRadius, ghostportColor);
             }
         }

--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -52,7 +52,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     private int indexCount;
     private uint currentTexture;
     private bool isBatching;
-    private Matrix4x4 projection;
+    private Matrix4x4 screenProjection;
     private Vector2 screenSize;
     private bool disposed;
 
@@ -286,7 +286,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     private void UpdateProjection()
     {
         // Orthographic projection: (0,0) at top-left, Y increasing downward
-        projection = Matrix4x4.CreateOrthographicOffCenter(0, screenSize.X, screenSize.Y, 0, -1, 1);
+        screenProjection = Matrix4x4.CreateOrthographicOffCenter(0, screenSize.X, screenSize.Y, 0, -1, 1);
     }
 
     #region I2DRenderer Implementation
@@ -294,7 +294,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     /// <inheritdoc />
     public void Begin()
     {
-        Begin(projection);
+        Begin(screenProjection);
     }
 
     /// <inheritdoc />
@@ -343,7 +343,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Ensure our shader and state are active (may have been changed by other renderers)
         device.UseProgram(shaderProgram);
-        device.UniformMatrix4(projectionLocation, projection);
+        device.UniformMatrix4(projectionLocation, screenProjection);
         device.Uniform1(textureLocation, 0);
         device.Enable(RenderCapability.Blend);
         device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
@@ -718,9 +718,9 @@ public sealed class Silk2DRenderer : I2DRenderer
 
     #endregion
 
-    private void EnsureCapacity(int vertexCount, int indexCount)
+    private void EnsureCapacity(int additionalVertices, int additionalIndices)
     {
-        if (this.vertexCount + vertexCount > MaxVertices || this.indexCount + indexCount > MaxIndices)
+        if (vertexCount + additionalVertices > MaxVertices || indexCount + additionalIndices > MaxIndices)
         {
             Flush();
         }
@@ -743,7 +743,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Setup rounded rect shader
         device.UseProgram(roundedRectShaderProgram);
-        device.UniformMatrix4(roundedRectProjectionLocation, projection);
+        device.UniformMatrix4(roundedRectProjectionLocation, screenProjection);
         device.Enable(RenderCapability.Blend);
         device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
 
@@ -765,7 +765,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Restore regular shader for subsequent draws
         device.UseProgram(shaderProgram);
-        device.UniformMatrix4(projectionLocation, projection);
+        device.UniformMatrix4(projectionLocation, screenProjection);
         device.Uniform1(textureLocation, 0);
     }
 

--- a/src/KeenEyes.Graphics.Silk/Text/SilkTextRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Text/SilkTextRenderer.cs
@@ -148,7 +148,7 @@ internal sealed class SilkTextRenderer(IGraphicsDevice device, SilkFontManager f
 
         // Calculate total height for vertical alignment
         int lineCount = breaks.Count + 1;
-        float totalHeight = lineCount * lineHeight;
+        float totalHeight = lineCount * (float)lineHeight;
 
         // Determine starting Y based on vertical alignment
         float startY = alignV switch

--- a/src/KeenEyes.Localization/TextShaping/ArabicTextShaper.cs
+++ b/src/KeenEyes.Localization/TextShaping/ArabicTextShaper.cs
@@ -176,9 +176,9 @@ public sealed class ArabicTextShaper : ITextShaper
         // Arabic Unicode range: U+0600-U+06FF (Arabic)
         // Also check U+FB50-U+FDFF (Arabic Presentation Forms-A)
         // And U+FE70-U+FEFF (Arabic Presentation Forms-B)
-        return (c >= '\u0600' && c <= '\u06FF') ||
-               (c >= '\uFB50' && c <= '\uFDFF') ||
-               (c >= '\uFE70' && c <= '\uFEFF');
+        return c is (>= '\u0600' and <= '\u06FF')
+            or (>= '\uFB50' and <= '\uFDFF')
+            or (>= '\uFE70' and <= '\uFEFF');
     }
 
     /// <summary>

--- a/src/KeenEyes.Localization/TextShaping/BidirectionalTextShaper.cs
+++ b/src/KeenEyes.Localization/TextShaping/BidirectionalTextShaper.cs
@@ -206,10 +206,10 @@ public sealed class BidirectionalTextShaper : ITextShaper
     {
         // Arabic: U+0600-U+06FF, U+FB50-U+FDFF, U+FE70-U+FEFF
         // Hebrew: U+0590-U+05FF
-        return (c >= '\u0600' && c <= '\u06FF') ||
-               (c >= '\uFB50' && c <= '\uFDFF') ||
-               (c >= '\uFE70' && c <= '\uFEFF') ||
-               (c >= '\u0590' && c <= '\u05FF');
+        return c is (>= '\u0600' and <= '\u06FF')
+            or (>= '\uFB50' and <= '\uFDFF')
+            or (>= '\uFE70' and <= '\uFEFF')
+            or (>= '\u0590' and <= '\u05FF');
     }
 
     private static bool IsNeutralCharacter(char c)

--- a/src/KeenEyes.Navigation.Grid/GridCoordinate.cs
+++ b/src/KeenEyes.Navigation.Grid/GridCoordinate.cs
@@ -123,8 +123,8 @@ public readonly record struct GridCoordinate(int X, int Y)
     /// <returns>The straight-line distance.</returns>
     public float EuclideanDistance(GridCoordinate other)
     {
-        int dx = X - other.X;
-        int dy = Y - other.Y;
+        float dx = X - other.X;
+        float dy = Y - other.Y;
         return MathF.Sqrt(dx * dx + dy * dy);
     }
 

--- a/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
+++ b/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
@@ -681,7 +681,7 @@ public sealed class UdpTransport : INetworkTransport
         {
             socket.Send(packet, endpoint);
         }
-        catch
+        catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
         {
             // Ignore send errors during disconnect
         }
@@ -755,7 +755,7 @@ public sealed class UdpTransport : INetworkTransport
             var pending = kvp.Value;
             var elapsed = (now - pending.SendTime).TotalMilliseconds;
 
-            if (elapsed > ResendIntervalMs * pending.Attempts)
+            if (elapsed > (double)ResendIntervalMs * pending.Attempts)
             {
                 if (pending.Attempts >= MaxResendAttempts)
                 {

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -523,11 +523,11 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
                 continue;
             }
 
-            // Reject silently: wrong owner, non-owner-authoritative component, or a
-            // component the server entity does not already have.
-            if (!ownsEntity
+            // Reject silently: wrong owner (existingTypes is only collected for the
+            // owning client), non-owner-authoritative component, or a component the
+            // server entity does not already have.
+            if (existingTypes is null
                 || !ownerAuth.Contains(componentType)
-                || existingTypes is null
                 || !existingTypes.Contains(componentType))
             {
                 continue;

--- a/src/KeenEyes.Parallelism/ParallelProfiler.cs
+++ b/src/KeenEyes.Parallelism/ParallelProfiler.cs
@@ -204,7 +204,7 @@ public sealed class ParallelProfiler(ParallelSystemScheduler scheduler) : IDispo
 
         // Calculate parallel efficiency
         var totalSystemTime = systemTimings.Values.Sum(t => t.TotalTicks);
-        var avgFrameTime = frameCount > 0 ? totalFrameTime / frameCount : 0;
+        var avgFrameTime = frameCount > 0 ? (double)totalFrameTime / frameCount : 0;
         var parallelEfficiency = avgFrameTime > 0 && totalSystemTime > 0
             ? Math.Min(1.0, (double)totalSystemTime / (avgFrameTime * frameCount) / Environment.ProcessorCount)
             : 0;

--- a/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
+++ b/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using KeenEyes.Persistence.Encryption;
 using KeenEyes.Serialization;
 
@@ -342,8 +343,9 @@ public sealed class EncryptedPersistenceApi
             var fileData = File.ReadAllBytes(filePath);
             return SaveFileFormat.ReadMetadata(fileData);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
         {
+            // Unreadable or corrupt slot files are treated as missing.
             return null;
         }
     }
@@ -368,9 +370,9 @@ public sealed class EncryptedPersistenceApi
                 var fileData = File.ReadAllBytes(file);
                 info = SaveFileFormat.ReadMetadata(fileData);
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)
             {
-                // Skip invalid files
+                // Skip unreadable or corrupt files
             }
 
             if (info is not null)

--- a/src/KeenEyes.Replay/Ghost/GhostFileFormat.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostFileFormat.cs
@@ -146,8 +146,8 @@ public static class GhostFileFormat
         // Write compressed data
         writer.Write(compressedData);
 
-        // Write checksum if enabled
-        if (options.IncludeChecksum && checksum is not null)
+        // Write checksum if enabled (non-null only when options.IncludeChecksum is set)
+        if (checksum is not null)
         {
             var checksumValue = uint.Parse(checksum, System.Globalization.NumberStyles.HexNumber);
             writer.Write(checksumValue);

--- a/src/KeenEyes.Replay/ReplayFileFormat.cs
+++ b/src/KeenEyes.Replay/ReplayFileFormat.cs
@@ -153,8 +153,8 @@ public static class ReplayFileFormat
         // Write compressed data
         writer.Write(compressedData);
 
-        // Write checksum if enabled
-        if (options.IncludeChecksum && checksum is not null)
+        // Write checksum if enabled (non-null only when options.IncludeChecksum is set)
+        if (checksum is not null)
         {
             var checksumValue = uint.Parse(checksum, System.Globalization.NumberStyles.HexNumber);
             writer.Write(checksumValue);

--- a/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
+++ b/src/KeenEyes.TestBridge.Client/TestBridgeClient.cs
@@ -639,7 +639,7 @@ public sealed class TestBridgeClient : ITestBridge, IAsyncDisposable
                 tcs.TrySetResult(response);
             }
         }
-        catch
+        catch (JsonException)
         {
             // Ignore malformed messages
         }

--- a/src/KeenEyes.TestBridge/State/StateControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/State/StateControllerImpl.cs
@@ -12,8 +12,8 @@ namespace KeenEyes.TestBridge.State;
 /// </summary>
 internal sealed class StateControllerImpl(World world) : IStateController
 {
-    private readonly IInspectionCapability? inspectionCapability = world as IInspectionCapability;
-    private readonly IStatisticsCapability? statisticsCapability = world as IStatisticsCapability;
+    private readonly IInspectionCapability inspectionCapability = world;
+    private readonly IStatisticsCapability statisticsCapability = world;
     private ILogController? logController;
 
     // Frame timing for performance metrics
@@ -158,22 +158,12 @@ internal sealed class StateControllerImpl(World world) : IStateController
 
     public async Task<WorldStats> GetWorldStatsAsync()
     {
-        long memoryBytes = 0;
-        int archetypeCount = 0;
-        int componentTypeCount = 0;
         int pluginCount = 0;
 
-        if (statisticsCapability != null)
-        {
-            var memStats = statisticsCapability.GetMemoryStats();
-            memoryBytes = memStats.EstimatedComponentBytes;
-            archetypeCount = memStats.ArchetypeCount;
-        }
-
-        if (inspectionCapability != null)
-        {
-            componentTypeCount = inspectionCapability.GetRegisteredComponents().Count();
-        }
+        var memStats = statisticsCapability.GetMemoryStats();
+        var memoryBytes = memStats.EstimatedComponentBytes;
+        var archetypeCount = memStats.ArchetypeCount;
+        var componentTypeCount = inspectionCapability.GetRegisteredComponents().Count();
 
         // Count systems (we'll need to estimate this)
         var systemCount = systemTimes.Count;

--- a/src/KeenEyes.Testing/Logging/LogAssertions.cs
+++ b/src/KeenEyes.Testing/Logging/LogAssertions.cs
@@ -225,8 +225,8 @@ public static class LogAssertions
     {
         var matches = provider.Entries.Where(e =>
             e.Properties != null &&
-            e.Properties.ContainsKey(propertyName) &&
-            (propertyValue == null || Equals(e.Properties[propertyName], propertyValue)));
+            e.Properties.TryGetValue(propertyName, out var actualValue) &&
+            (propertyValue == null || Equals(actualValue, propertyValue)));
 
         if (!matches.Any())
         {

--- a/src/KeenEyes.Testing/Snapshots/EntitySnapshot.cs
+++ b/src/KeenEyes.Testing/Snapshots/EntitySnapshot.cs
@@ -107,7 +107,7 @@ public sealed class EntitySnapshot
         {
             return (T)Convert.ChangeType(value!, typeof(T));
         }
-        catch
+        catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
         {
             return default;
         }

--- a/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIColorPickerSystem.cs
@@ -440,7 +440,7 @@ public sealed class UIColorPickerSystem : SystemBase
             color = new Vector4(r / 255f, g / 255f, b / 255f, a / 255f);
             return true;
         }
-        catch
+        catch (Exception ex) when (ex is FormatException or OverflowException or ArgumentException)
         {
             return false;
         }


### PR DESCRIPTION
## Summary
- src batch of the CodeQL cleanup: all 183 manifest alerts handled — 46 fixed in code, 137 recorded for dismissal with per-site written reasons (`dismissals.tsv`).
- **SaveManager modernization**: all 7 bare `catch { }` save-probe patterns (plus 2 twins in `EncryptedPersistenceApi`) became typed filters — `catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or EndOfStreamException or JsonException)` — matching the in-repo `SaveFileFormat.Validate` model. Deliberate behavioral improvement worth reviewer attention: async variants now **propagate `OperationCanceledException`** instead of misreporting cancellation as "slot missing".
- Loss-of-precision fixes (13), local-shadows renames (9, incl. a Silk2DRenderer field rename chosen over a parameter rename that would trip Sonar S927), dead-branch removals, narrowed catches where thrown types are knowable (`Convert.ChangeType`, hex parsing, UDP disconnect).
- Verified-empirically false positives: the 49 `(T?)(object?)` upcasts in `TestBridgeClient.DeserializeResponse<T>` are language-required (scratch-compile proves CS0030 without the object intermediate). TestBridge controller catch-alls (54) are the IPC error-contract boundary (exceptions → `*Result.Fail` for the remote caller) — dismissal-bound, not fixable.
- One intentional integer division (`FleeAction` sample-index centering) made explicit with a named local + comment rather than converted to float.

## Test plan
- [x] Full suite 14,439 passed / 0 failed / 62 skipped (independently re-verified)
- [x] Release build 0 warnings / 0 errors (CS1591 tier — docs intact); format verify exit 0
- [x] No lockfile churn; 25 files

## Related Issues
Security-tab cleanup — src batch (3 of 7)