### PR TITLE
test: Resolve CodeQL alerts in Debugging/Physics/Testing/Replay tests

### DIFF
--- a/tests/KeenEyes.Debugging.Tests/DebugPluginTests.cs
+++ b/tests/KeenEyes.Debugging.Tests/DebugPluginTests.cs
@@ -600,8 +600,8 @@ public partial class DebugPluginTests
         var plugin = new DebugPlugin();
         world.InstallPlugin(plugin);
 
-        var entity1 = world.Spawn().Build();
-        var entity2 = world.Spawn().Build();
+        _ = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         var tracker = world.GetExtension<MemoryTracker>();
         Assert.NotNull(tracker);
@@ -1140,7 +1140,6 @@ public partial class DebugPluginTests
     {
         // Arrange - disable profiling and GC tracking so no hooks are needed
         using var world = new World();
-        var mockHooks = new MockSystemHookCapability();
         var options = new DebugOptions
         {
             EnableProfiling = false,

--- a/tests/KeenEyes.Debugging.Tests/EntityInspectorTests.cs
+++ b/tests/KeenEyes.Debugging.Tests/EntityInspectorTests.cs
@@ -302,12 +302,12 @@ public partial class EntityInspectorTests
         using var world = new World();
         var inspector = CreateInspector(world);
 
-        var entity1 = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         // Act
         var snapshot1 = inspector.GetAllEntities();
 
-        var entity2 = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         var snapshot2 = inspector.GetAllEntities();
 

--- a/tests/KeenEyes.Debugging.Tests/MemoryTrackerTests.cs
+++ b/tests/KeenEyes.Debugging.Tests/MemoryTrackerTests.cs
@@ -65,9 +65,9 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity1 = world.Spawn().Build();
-        var entity2 = world.Spawn().Build();
-        var entity3 = world.Spawn().Build();
+        _ = world.Spawn().Build();
+        _ = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         // Act
         var stats = tracker.GetMemoryStats();
@@ -84,9 +84,9 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity1 = world.Spawn().Build();
+        _ = world.Spawn().Build();
         var entity2 = world.Spawn().Build();
-        var entity3 = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         world.Despawn(entity2);
 
@@ -105,7 +105,7 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 42 })
             .Build();
 
@@ -124,15 +124,15 @@ public partial class MemoryTrackerTests
         var tracker = new MemoryTracker(world);
 
         // Create entities with different component combinations (different archetypes)
-        var entity1 = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 1 })
             .Build();
 
-        var entity2 = world.Spawn()
+        _ = world.Spawn()
             .With(new LargeComponent())
             .Build();
 
-        var entity3 = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 2 })
             .With(new LargeComponent())
             .Build();
@@ -151,7 +151,7 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 42 })
             .With(new LargeComponent())
             .Build();
@@ -191,8 +191,8 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity1 = world.Spawn().Build();
-        var entity2 = world.Spawn().Build();
+        _ = world.Spawn().Build();
+        _ = world.Spawn().Build();
 
         // Act
         var report = tracker.GetMemoryReport();
@@ -209,10 +209,10 @@ public partial class MemoryTrackerTests
         var tracker = new MemoryTracker(world);
 
         var entity1 = world.Spawn().Build();
-        var entity2 = world.Spawn().Build();
+        _ = world.Spawn().Build();
         world.Despawn(entity1);
 
-        var entity3 = world.Spawn().Build(); // Should reuse entity1
+        _ = world.Spawn().Build(); // Should reuse entity1
 
         // Act
         var report = tracker.GetMemoryReport();
@@ -253,13 +253,13 @@ public partial class MemoryTrackerTests
         using var world = new World();
         var tracker = new MemoryTracker(world);
 
-        var entity = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 42 })
             .Build();
 
         // Execute a query to populate cache
         var query = world.Query<TestComponent>();
-        foreach (var e in query)
+        foreach (var _ in query)
         {
             // Process entity
         }
@@ -533,7 +533,7 @@ public partial class MemoryTrackerTests
 
         var stats2 = tracker.GetMemoryStats();
 
-        var entity2 = world.Spawn()
+        _ = world.Spawn()
             .With(new TestComponent { Value = 2 })
             .Build();
 

--- a/tests/KeenEyes.Debugging.Tests/QueryProfilerTests.cs
+++ b/tests/KeenEyes.Debugging.Tests/QueryProfilerTests.cs
@@ -317,7 +317,7 @@ public partial class QueryProfilerTests
         // Execute query multiple times to generate cache hits
         for (int i = 0; i < 5; i++)
         {
-            foreach (var entity in world.Query<TestComponent>())
+            foreach (var _ in world.Query<TestComponent>())
             {
                 // Process
             }
@@ -499,7 +499,7 @@ public partial class QueryProfilerTests
         // Act - Profile actual queries
         profiler.BeginQuery("AllTestComponents");
         var count1 = 0;
-        foreach (var entity in world.Query<TestComponent>())
+        foreach (var _ in world.Query<TestComponent>())
         {
             count1++;
         }
@@ -507,7 +507,7 @@ public partial class QueryProfilerTests
 
         profiler.BeginQuery("AllOtherComponents");
         var count2 = 0;
-        foreach (var entity in world.Query<OtherComponent>())
+        foreach (var _ in world.Query<OtherComponent>())
         {
             count2++;
         }

--- a/tests/KeenEyes.Physics.Tests/CollisionCallbackTests.cs
+++ b/tests/KeenEyes.Physics.Tests/CollisionCallbackTests.cs
@@ -31,14 +31,14 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create two dynamic bodies that should collide
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter(1, 0xFFFFFFFF))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -66,14 +66,14 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create two dynamic bodies with filters that prevent collision
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter(1, 0b0010)) // Layer 1, only collides with layer 2
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -101,14 +101,14 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create overlapping trigger and dynamic body
-        var trigger = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Box(5f, 5f, 5f))
             .With(RigidBody.Static())
             .With(CollisionFilter.Trigger())
             .Build();
 
-        var dynamic = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 1f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -140,14 +140,14 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create two overlapping bodies with different materials
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 1.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(PhysicsMaterial.Rubber)
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Box(10f, 1f, 10f))
             .With(RigidBody.Static())
@@ -175,13 +175,13 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create overlapping bodies without explicit material components
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 1.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Box(10f, 1f, 10f))
             .With(RigidBody.Static())
@@ -212,13 +212,13 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create overlapping box-box collision which will have multiple contact points
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0.8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Box(1f, 1f, 1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Box(5f, 1f, 5f))
             .With(RigidBody.Static())
@@ -249,13 +249,13 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create two overlapping spheres
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(1.5f, 0f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -323,13 +323,13 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create two dynamic bodies that will collide
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -360,13 +360,13 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create bodies without explicit collision filters (should use default)
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
@@ -393,14 +393,14 @@ public class CollisionCallbackTests : IDisposable
         world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Create one body with filter, one without
-        var entityA = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter(1, 0xFFFFFFFF))
             .Build();
 
-        var entityB = world.Spawn()
+        _ = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))

--- a/tests/KeenEyes.Physics.Tests/CollisionEventTests.cs
+++ b/tests/KeenEyes.Physics.Tests/CollisionEventTests.cs
@@ -973,7 +973,7 @@ public class CollisionEventTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
 
         var collisionEvents = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
+        using var subscription = world.Subscribe<CollisionEvent>(e => collisionEvents.Add(e));
 
         // Verify subscription was created
         Assert.NotNull(subscription);
@@ -987,8 +987,6 @@ public class CollisionEventTests : IDisposable
         Assert.Single(collisionEvents);
         Assert.Equal(entity1, collisionEvents[0].EntityA);
         Assert.Equal(entity2, collisionEvents[0].EntityB);
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -998,7 +996,7 @@ public class CollisionEventTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
 
         var startedEvents = new List<CollisionStartedEvent>();
-        var subscription = world.Subscribe<CollisionStartedEvent>(e => startedEvents.Add(e));
+        using var subscription = world.Subscribe<CollisionStartedEvent>(e => startedEvents.Add(e));
 
         // Manually send a started event to verify messaging works
         var entity1 = world.Spawn().Build();
@@ -1007,8 +1005,6 @@ public class CollisionEventTests : IDisposable
 
         // Should have received the event
         Assert.Single(startedEvents);
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -1018,7 +1014,7 @@ public class CollisionEventTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
 
         var endedEvents = new List<CollisionEndedEvent>();
-        var subscription = world.Subscribe<CollisionEndedEvent>(e => endedEvents.Add(e));
+        using var subscription = world.Subscribe<CollisionEndedEvent>(e => endedEvents.Add(e));
 
         // Manually send an ended event to verify messaging works
         var entity1 = world.Spawn().Build();
@@ -1027,8 +1023,6 @@ public class CollisionEventTests : IDisposable
 
         // Should have received the event
         Assert.Single(endedEvents);
-
-        subscription.Dispose();
     }
 
     [Fact]

--- a/tests/KeenEyes.Physics.Tests/PhysicsCollisionCoverageTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsCollisionCoverageTests.cs
@@ -96,7 +96,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .Build();
 
         // Subscribe to collision events
-        var subscription = world.Subscribe<CollisionEvent>(collision =>
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
         {
             if ((collision.EntityA == entity1 && collision.EntityB == entity2) ||
                 (collision.EntityA == entity2 && collision.EntityB == entity1))
@@ -110,8 +110,6 @@ public class PhysicsCollisionCoverageTests : IDisposable
         {
             physics.Step(1f / 60f);
         }
-
-        subscription.Dispose();
 
         // Should have detected collision since filters match
         Assert.True(collisionDetected || physics.HasPhysicsBody(entity1));
@@ -143,7 +141,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .With(RigidBody.Dynamic(1f))
             .Build();
 
-        var subscription = world.Subscribe<CollisionEvent>(collision =>
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
         {
             // Subscribe to verify no crash occurs with triggers
         });
@@ -153,8 +151,6 @@ public class PhysicsCollisionCoverageTests : IDisposable
         {
             physics.Step(1f / 60f);
         }
-
-        subscription.Dispose();
 
         // Trigger event might be detected depending on timing
         // At minimum, both entities should still exist
@@ -255,7 +251,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .Build();
 
         var collisionEvents = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(collision =>
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
         {
             collisionEvents.Add(collision);
         });
@@ -266,10 +262,11 @@ public class PhysicsCollisionCoverageTests : IDisposable
             physics.Step(1f / 60f);
         }
 
-        subscription.Dispose();
-
-        // Should have recorded collision events (may be multiple contacts)
-        // At minimum, verify the simulation ran without errors
+        // Any recorded collision events must reference the two simulated bodies
+        // (collision timing is not guaranteed, so the collection may be empty)
+        Assert.All(collisionEvents, e => Assert.True(
+            e.EntityA == entity1 || e.EntityA == entity2 ||
+            e.EntityB == entity1 || e.EntityB == entity2));
         Assert.True(physics.HasPhysicsBody(entity1));
         Assert.True(physics.HasPhysicsBody(entity2));
     }

--- a/tests/KeenEyes.Physics.Tests/PhysicsForcedCollisionTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsForcedCollisionTests.cs
@@ -26,7 +26,7 @@ public class PhysicsForcedCollisionTests : IDisposable
         var physics = world.GetExtension<PhysicsWorld>();
 
         var collisions = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
+        using var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
 
         // Ground
         _ = world.Spawn()
@@ -52,8 +52,6 @@ public class PhysicsForcedCollisionTests : IDisposable
             physics.Step(1f / 60f);
         }
 
-        subscription.Dispose();
-
         // Should have generated collision events
         Assert.True(collisions.Count > 0 || physics.HasPhysicsBody(sphere));
     }
@@ -66,7 +64,7 @@ public class PhysicsForcedCollisionTests : IDisposable
         var physics = world.GetExtension<PhysicsWorld>();
 
         var collisions = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
+        using var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
 
         // Two spheres moving toward each other
         var sphere1 = world.Spawn()
@@ -88,8 +86,6 @@ public class PhysicsForcedCollisionTests : IDisposable
         {
             physics.Step(1f / 60f);
         }
-
-        subscription.Dispose();
 
         // Should have detected collision or at least both bodies exist
         Assert.True(collisions.Count > 0 || (physics.HasPhysicsBody(sphere1) && physics.HasPhysicsBody(sphere2)));
@@ -137,7 +133,7 @@ public class PhysicsForcedCollisionTests : IDisposable
         var physics = world.GetExtension<PhysicsWorld>();
 
         var triggerEvents = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(e =>
+        using var subscription = world.Subscribe<CollisionEvent>(e =>
         {
             if (e.IsTrigger)
             {
@@ -166,8 +162,6 @@ public class PhysicsForcedCollisionTests : IDisposable
         {
             physics.Step(1f / 60f);
         }
-
-        subscription.Dispose();
 
         // Trigger events might be detected, or at minimum no crash
         Assert.True(triggerEvents.Count >= 0);
@@ -222,7 +216,7 @@ public class PhysicsForcedCollisionTests : IDisposable
         var physics = world.GetExtension<PhysicsWorld>();
 
         var collisions = new List<CollisionEvent>();
-        var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
+        using var subscription = world.Subscribe<CollisionEvent>(e => collisions.Add(e));
 
         // Ground
         _ = world.Spawn()
@@ -246,8 +240,6 @@ public class PhysicsForcedCollisionTests : IDisposable
         {
             physics.Step(1f / 60f);
         }
-
-        subscription.Dispose();
 
         // Should have generated many collision events from stacking
         Assert.True(collisions.Count >= 0);  // At least no crash

--- a/tests/KeenEyes.Physics.Tests/PhysicsPluginTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsPluginTests.cs
@@ -354,9 +354,9 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_RegistersPhysicsWorldExtension()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new PhysicsPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -368,9 +368,9 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_RegistersPhysicsStepSystem()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new PhysicsPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -381,10 +381,10 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_WithInterpolation_RegistersPhysicsSyncSystem()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new PhysicsConfig { EnableInterpolation = true };
         var plugin = new PhysicsPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -395,10 +395,10 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_WithoutInterpolation_DoesNotRegisterPhysicsSyncSystem()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new PhysicsConfig { EnableInterpolation = false };
         var plugin = new PhysicsPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -408,9 +408,9 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_RegistersPhysicsComponents()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new PhysicsPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -423,14 +423,14 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_CreatesPhysicsWorldWithConfig()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new PhysicsConfig
         {
             FixedTimestep = 1f / 120f,
             Gravity = new Vector3(0, -20f, 0)
         };
         var plugin = new PhysicsPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -442,9 +442,9 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_SystemRegistrationOrder_PhysicsStepHasOrderZero()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new PhysicsPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -456,9 +456,9 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_DefaultConfig_RegistersBothSystems()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new PhysicsPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -472,10 +472,10 @@ public class PhysicsPluginTests : IDisposable
     [Fact]
     public void Install_WithAllFeatures_RegistersBothSystems()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new PhysicsConfig { EnableInterpolation = true };
         var plugin = new PhysicsPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostManagerTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostManagerTests.cs
@@ -508,7 +508,7 @@ public class GhostManagerTests
     public void Dispose_DisposesAllPlayers()
     {
         // Arrange
-        var manager = new GhostManager();
+        using var manager = new GhostManager();
         manager.AddGhost("ghost1", CreateTestGhostData());
         var player = manager.GetPlayer("ghost1");
 
@@ -523,7 +523,7 @@ public class GhostManagerTests
     public void Dispose_CanBeCalledMultipleTimes()
     {
         // Arrange
-        var manager = new GhostManager();
+        using var manager = new GhostManager();
         manager.AddGhost("ghost1", CreateTestGhostData());
 
         // Act & Assert - should not throw

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostPlayerTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostPlayerTests.cs
@@ -711,7 +711,7 @@ public class GhostPlayerTests
     public void Dispose_CanBeCalledMultipleTimes()
     {
         // Arrange
-        var player = new GhostPlayer();
+        using var player = new GhostPlayer();
         player.Load(CreateTestGhostData());
 
         // Act & Assert - should not throw
@@ -723,7 +723,7 @@ public class GhostPlayerTests
     public void Dispose_ThrowsOnSubsequentOperations()
     {
         // Arrange
-        var player = new GhostPlayer();
+        using var player = new GhostPlayer();
         player.Load(CreateTestGhostData());
         player.Dispose();
 

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostTrailTests.cs
@@ -260,7 +260,7 @@ public class GhostTrailTests
     [Fact]
     public void GetTrailPoints_AfterDispose_ThrowsObjectDisposed()
     {
-        var player = new GhostPlayer();
+        using var player = new GhostPlayer();
         player.Load(CreateTestGhostData());
         player.Dispose();
 

--- a/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
@@ -935,7 +935,7 @@ public class ReplayInputTests
         {
             recorder.BeginFrame(0.016f);
             recorder.RecordKeyDown($"Key{frame}");
-            recorder.RecordMouseMove(new Vector2(frame * 10, frame * 20));
+            recorder.RecordMouseMove(new Vector2(frame * 10f, frame * 20f));
             recorder.EndFrame(0.016f);
         }
         var replayData = recorder.StopRecording();
@@ -962,7 +962,7 @@ public class ReplayInputTests
         for (int i = 0; i < 10; i++)
         {
             Assert.Equal($"Key{i}", keyEvents[i].Key);
-            Assert.Equal(new Vector2(i * 10, i * 20), mouseEvents[i].Position);
+            Assert.Equal(new Vector2(i * 10f, i * 20f), mouseEvents[i].Position);
         }
     }
 

--- a/tests/KeenEyes.Replay.Tests/ReplayPlaybackPluginTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayPlaybackPluginTests.cs
@@ -159,7 +159,7 @@ public class ReplayPlaybackPluginTests
         world.InstallPlugin(playbackPlugin);
 
         var serializer = new MockComponentSerializer();
-        var recordingPlugin = new ReplayPlugin(serializer);
+        _ = new ReplayPlugin(serializer);
 
         // Note: This test assumes ReplayPlugin also checks for ReplayPlayer
         // If it doesn't, we just verify the playback plugin installed correctly
@@ -459,7 +459,7 @@ public class ReplayPlaybackPluginTests
         // Act
         player.LoadReplay(emptyReplay);
         player.Play();
-        var changed = player.Update(0.016f);
+        _ = player.Update(0.016f);
 
         // Assert - should immediately stop with no changes
         Assert.Equal(PlaybackState.Stopped, player.State);

--- a/tests/KeenEyes.Replay.Tests/ReplayPlayerEventTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayPlayerEventTests.cs
@@ -701,8 +701,8 @@ public class ReplayPlayerEventTests
         {
             // Try to access player state from within event handler
             // This would deadlock if events were fired inside the lock
-            var state = player.State;
-            var frame = player.CurrentFrame;
+            _ = player.State;
+            _ = player.CurrentFrame;
             completed = true;
         };
 

--- a/tests/KeenEyes.Replay.Tests/ReplayPlayerTimelineTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayPlayerTimelineTests.cs
@@ -223,7 +223,7 @@ public class ReplayPlayerTimelineTests
     public void Step_WhenDisposed_ThrowsObjectDisposedException()
     {
         // Arrange
-        var player = new ReplayPlayer();
+        using var player = new ReplayPlayer();
         player.LoadReplay(CreateTestReplay(100));
         player.Dispose();
 
@@ -371,7 +371,7 @@ public class ReplayPlayerTimelineTests
     public void SeekToFrame_WhenDisposed_ThrowsObjectDisposedException()
     {
         // Arrange
-        var player = new ReplayPlayer();
+        using var player = new ReplayPlayer();
         player.LoadReplay(CreateTestReplay(100));
         player.Dispose();
 
@@ -535,7 +535,7 @@ public class ReplayPlayerTimelineTests
     public void SeekToTime_WhenDisposed_ThrowsObjectDisposedException()
     {
         // Arrange
-        var player = new ReplayPlayer();
+        using var player = new ReplayPlayer();
         player.LoadReplay(CreateTestReplay(100));
         player.Dispose();
 
@@ -666,7 +666,7 @@ public class ReplayPlayerTimelineTests
     public void GetNearestSnapshot_WhenDisposed_ThrowsObjectDisposedException()
     {
         // Arrange
-        var player = new ReplayPlayer();
+        using var player = new ReplayPlayer();
         player.LoadReplay(CreateTestReplay(100));
         player.Dispose();
 
@@ -739,7 +739,7 @@ public class ReplayPlayerTimelineTests
         player.SeekToFrame(100);
         player.Step(10);
         player.Step(-5);
-        var snapshot = player.GetNearestSnapshot(player.CurrentFrame);
+        _ = player.GetNearestSnapshot(player.CurrentFrame);
         player.SeekToTime(TimeSpan.FromMilliseconds(500));
         player.Stop();
 

--- a/tests/KeenEyes.Replay.Tests/WorldChecksumTests.cs
+++ b/tests/KeenEyes.Replay.Tests/WorldChecksumTests.cs
@@ -220,7 +220,7 @@ public class WorldChecksumTests
     public void Calculate_WithNullSnapshot_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => WorldChecksum.Calculate((WorldSnapshot)null!));
+        Assert.Throws<ArgumentNullException>(() => WorldChecksum.Calculate(null!));
     }
 
     [Fact]

--- a/tests/KeenEyes.Testing.Tests/Capabilities/MockSystemHookCapabilityTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Capabilities/MockSystemHookCapabilityTests.cs
@@ -12,7 +12,7 @@ public class MockSystemHookCapabilityTests
     {
         var capability = new MockSystemHookCapability();
 
-        var subscription = capability.AddSystemHook(beforeHook: (_, _) => { });
+        _ = capability.AddSystemHook(beforeHook: (_, _) => { });
 
         Assert.Equal(1, capability.HookCount);
         Assert.True(capability.WasHookAdded);
@@ -24,7 +24,7 @@ public class MockSystemHookCapabilityTests
     {
         var capability = new MockSystemHookCapability();
 
-        var subscription = capability.AddSystemHook(afterHook: (_, _) => { });
+        _ = capability.AddSystemHook(afterHook: (_, _) => { });
 
         Assert.Equal(1, capability.HookCount);
         Assert.True(capability.HasAfterHook);
@@ -35,7 +35,7 @@ public class MockSystemHookCapabilityTests
     {
         var capability = new MockSystemHookCapability();
 
-        var subscription = capability.AddSystemHook(
+        _ = capability.AddSystemHook(
             beforeHook: (_, _) => { },
             afterHook: (_, _) => { });
 
@@ -49,7 +49,7 @@ public class MockSystemHookCapabilityTests
     {
         var capability = new MockSystemHookCapability();
 
-        var subscription = capability.AddSystemHook(
+        _ = capability.AddSystemHook(
             beforeHook: (_, _) => { },
             phase: SystemPhase.Update);
 
@@ -210,8 +210,8 @@ public class MockSystemHookCapabilityTests
     public void Clear_DisposesSubscriptions()
     {
         var capability = new MockSystemHookCapability();
-        var sub1 = capability.AddSystemHook(beforeHook: (_, _) => { });
-        var sub2 = capability.AddSystemHook(afterHook: (_, _) => { });
+        _ = capability.AddSystemHook(beforeHook: (_, _) => { });
+        _ = capability.AddSystemHook(afterHook: (_, _) => { });
 
         capability.Clear();
 

--- a/tests/KeenEyes.Testing.Tests/ComponentAssertionsTests.cs
+++ b/tests/KeenEyes.Testing.Tests/ComponentAssertionsTests.cs
@@ -13,7 +13,7 @@ public partial class ComponentAssertionsTests
 
         public readonly bool Equals(TestComponent other) => Value == other.Value;
         public override readonly bool Equals(object? obj) => obj is TestComponent other && Equals(other);
-        public override readonly int GetHashCode() => Value.GetHashCode();
+        public override readonly int GetHashCode() => HashCode.Combine(Value);
         public override readonly string ToString() => $"TestComponent {{ Value = {Value} }}";
     }
 

--- a/tests/KeenEyes.Testing.Tests/Encryption/MockEncryptionProviderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Encryption/MockEncryptionProviderTests.cs
@@ -221,7 +221,7 @@ public class MockEncryptionProviderTests
     {
         var provider = new MockEncryptionProvider { ShouldFailEncrypt = true };
 
-        try { provider.Encrypt([1, 2, 3]); } catch { }
+        Should.Throw<InvalidOperationException>(() => provider.Encrypt([1, 2, 3]));
 
         provider.EncryptCount.ShouldBe(1);
     }

--- a/tests/KeenEyes.Testing.Tests/EntityAssertionsTests.cs
+++ b/tests/KeenEyes.Testing.Tests/EntityAssertionsTests.cs
@@ -298,7 +298,7 @@ public class EntityAssertionsTests
     {
         var entity = new Entity(0, 1);
 
-        Should.Throw<ArgumentNullException>(() => entity.ShouldBeAlive((World)null!));
+        Should.Throw<ArgumentNullException>(() => entity.ShouldBeAlive((IWorld)null!));
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class EntityAssertionsTests
     {
         var entity = new Entity(0, 1);
 
-        Should.Throw<ArgumentNullException>(() => entity.ShouldHaveComponent<TestPosition>((World)null!));
+        Should.Throw<ArgumentNullException>(() => entity.ShouldHaveComponent<TestPosition>((IWorld)null!));
     }
 
     [Fact]

--- a/tests/KeenEyes.Testing.Tests/Graphics/Mock2DRendererTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/Mock2DRendererTests.cs
@@ -505,7 +505,7 @@ public class Mock2DRendererTests
     [Fact]
     public void Dispose_ResetsState()
     {
-        var renderer = new Mock2DRenderer();
+        using var renderer = new Mock2DRenderer();
         renderer.Begin();
         renderer.FillRect(0, 0, 10, 10, Vector4.One);
 
@@ -518,7 +518,7 @@ public class Mock2DRendererTests
     [Fact]
     public void Dispose_CanBeCalledMultipleTimes()
     {
-        var renderer = new Mock2DRenderer();
+        using var renderer = new Mock2DRenderer();
 
         renderer.Dispose();
         renderer.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockFontManagerTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockFontManagerTests.cs
@@ -449,7 +449,7 @@ public class MockFontManagerTests
     [Fact]
     public void Dispose_ReleasesAllFonts()
     {
-        var fontManager = new MockFontManager();
+        using var fontManager = new MockFontManager();
         fontManager.LoadFont("test.ttf", 16);
 
         fontManager.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsContextTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsContextTests.cs
@@ -585,7 +585,7 @@ public class MockGraphicsContextTests
     [Fact]
     public void Dispose_CanBeCalledMultipleTimes()
     {
-        var context = new MockGraphicsContext();
+        using var context = new MockGraphicsContext();
 
         context.Dispose();
         context.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsDeviceTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockGraphicsDeviceTests.cs
@@ -874,7 +874,7 @@ public class MockGraphicsDeviceTests
     [Fact]
     public void Dispose_CanBeCalledMultipleTimes()
     {
-        var device = new MockGraphicsDevice();
+        using var device = new MockGraphicsDevice();
 
         device.Dispose();
         device.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockTextRendererTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockTextRendererTests.cs
@@ -335,7 +335,7 @@ public class MockTextRendererTests
     [Fact]
     public void Dispose_ResetsState()
     {
-        var renderer = new MockTextRenderer();
+        using var renderer = new MockTextRenderer();
         var font = new FontHandle(1);
         renderer.DrawText(font, "Test", 0, 0, new Vector4(1, 1, 1, 1));
 

--- a/tests/KeenEyes.Testing.Tests/Graphics/MockWindowTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Graphics/MockWindowTests.cs
@@ -442,7 +442,7 @@ public class MockWindowTests
     [Fact]
     public void Dispose_CanBeCalledMultipleTimes()
     {
-        var window = new MockWindow();
+        using var window = new MockWindow();
         window.CreateDevice();
 
         window.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Input/InputRecorderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Input/InputRecorderTests.cs
@@ -351,7 +351,7 @@ public class InputRecorderTests
     public void Dispose_UnsubscribesFromEvents()
     {
         using var input = new MockInputContext();
-        var recorder = new InputRecorder(input);
+        using var recorder = new InputRecorder(input);
         recorder.StartRecording();
 
         var initialCount = recorder.CurrentRecording!.Count;
@@ -371,7 +371,7 @@ public class InputRecorderTests
     public void Dispose_CanBeCalledMultipleTimes()
     {
         using var input = new MockInputContext();
-        var recorder = new InputRecorder(input);
+        using var recorder = new InputRecorder(input);
 
         recorder.Dispose();
         recorder.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Logging/MockLogProviderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Logging/MockLogProviderTests.cs
@@ -284,7 +284,7 @@ public class MockLogProviderTests
     [Fact]
     public void Dispose_ClearsEntries()
     {
-        var provider = new MockLogProvider();
+        using var provider = new MockLogProvider();
         provider.Log(LogLevel.Info, "Cat", "Message", null);
 
         provider.Dispose();

--- a/tests/KeenEyes.Testing.Tests/Network/MockNetworkContextTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Network/MockNetworkContextTests.cs
@@ -434,7 +434,7 @@ public class MockNetworkContextTests
     [Fact]
     public void Dispose_ResetsState()
     {
-        var network = new MockNetworkContext();
+        using var network = new MockNetworkContext();
         network.Connect("server:7777");
         network.SimulateConnect();
 

--- a/tests/KeenEyes.Testing.Tests/Platform/MockLoopProviderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Platform/MockLoopProviderTests.cs
@@ -333,7 +333,7 @@ public class MockLoopProviderTests
     [Fact]
     public void Dispose_CallsReset()
     {
-        var loop = new MockLoopProvider();
+        using var loop = new MockLoopProvider();
         loop.Initialize();
         loop.Run();
         loop.TriggerUpdate(0.016f);

--- a/tests/KeenEyes.Testing.Tests/SnapshotTests.cs
+++ b/tests/KeenEyes.Testing.Tests/SnapshotTests.cs
@@ -337,7 +337,7 @@ public partial class SnapshotTests
     {
         // Arrange
         using var world = new World();
-        var entity1 = world.Spawn().With(new Position { X = 10, Y = 20 }).Build();
+        _ = world.Spawn().With(new Position { X = 10, Y = 20 }).Build();
         var entity2 = world.Spawn().With(new Position { X = 30, Y = 40 }).Build();
         var snapshot1 = WorldSnapshot.Create(world);
 

--- a/tests/KeenEyes.Testing.Tests/SystemRecorderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/SystemRecorderTests.cs
@@ -560,15 +560,15 @@ public class SystemRecorderTests : IDisposable
         var system = new TestSystem();
         world.AddSystem(system);
 
-        using var recorder = new SystemRecorder();
-        recorder.AttachTo(world);
+        using var attachedRecorder = new SystemRecorder();
+        attachedRecorder.AttachTo(world);
 
         // Act
         world.Update(0.016f);
 
         // Assert
-        recorder.ShouldHaveCalledSystem<TestSystem>();
-        Assert.Equal(0.016f, recorder.Calls[0].DeltaTime);
+        attachedRecorder.ShouldHaveCalledSystem<TestSystem>();
+        Assert.Equal(0.016f, attachedRecorder.Calls[0].DeltaTime);
     }
 
     [Fact]
@@ -579,8 +579,8 @@ public class SystemRecorderTests : IDisposable
         var system = new TestSystem();
         world.AddSystem(system);
 
-        using var recorder = new SystemRecorder();
-        recorder.AttachTo(world);
+        using var attachedRecorder = new SystemRecorder();
+        attachedRecorder.AttachTo(world);
 
         // Act
         world.Update(0.016f);
@@ -588,7 +588,7 @@ public class SystemRecorderTests : IDisposable
         world.Update(0.016f);
 
         // Assert
-        recorder.ShouldHaveCalledSystemTimes<TestSystem>(3);
+        attachedRecorder.ShouldHaveCalledSystemTimes<TestSystem>(3);
     }
 
     [Fact]
@@ -599,15 +599,15 @@ public class SystemRecorderTests : IDisposable
         var system = new TestSystem();
         world.AddSystem(system);
 
-        var recorder = new SystemRecorder();
-        recorder.AttachTo(world);
+        using var attachedRecorder = new SystemRecorder();
+        attachedRecorder.AttachTo(world);
 
         // Act - dispose recorder
-        recorder.Dispose();
+        attachedRecorder.Dispose();
         world.Update(0.016f);
 
         // Assert - no calls recorded after dispose
-        Assert.Equal(0, recorder.TotalCallCount);
+        Assert.Equal(0, attachedRecorder.TotalCallCount);
     }
 
     #endregion
@@ -686,21 +686,21 @@ public class SystemRecorderTests : IDisposable
     public void TestWorldBuilder_WithSystemRecording_DisposesOnTestWorldDispose()
     {
         // Arrange
-        var testWorld = new TestWorldBuilder()
+        using var testWorld = new TestWorldBuilder()
             .WithSystemRecording()
             .WithSystem<TestSystem>()
             .WithManualTime()
             .Build();
 
-        var recorder = testWorld.SystemRecorder!;
+        var attachedRecorder = testWorld.SystemRecorder!;
         testWorld.Step();
-        Assert.Equal(1, recorder.TotalCallCount);
+        Assert.Equal(1, attachedRecorder.TotalCallCount);
 
         // Act
         testWorld.Dispose();
 
         // Assert - recorder is disposed but existing calls are preserved
-        Assert.Equal(1, recorder.TotalCallCount);
+        Assert.Equal(1, attachedRecorder.TotalCallCount);
     }
 
     #endregion

--- a/tests/KeenEyes.Testing.Tests/TestWorldBuilderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/TestWorldBuilderTests.cs
@@ -473,7 +473,7 @@ public class TestWorldBuilderTests
         var builder = new TestWorldBuilder();
 
         Should.Throw<ArgumentNullException>(() =>
-            builder.WithTestBridge((Func<World, KeenEyes.Testing.Input.MockInputContext?, KeenEyes.TestBridge.ITestBridge>)null!));
+            builder.WithTestBridge(null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Test batch (4 of 7) of the CodeQL cleanup: 155 alerts — 117 fixed, 38 recorded for dismissal ("used in tests": intentional GC-pressure allocations, deterministic `GC.Collect`, Equals-contract-under-test, explicit-Dispose-under-test).
- Fixes: unused spawn bindings → `_ =`, `using var` on leaked subscriptions (verified Dispose idempotency in source before converting dispose-behavior tests), 13 shadowing renames, float literals, `TryGetValue`, one weak `try{}catch{}` replaced with `Should.Throw<InvalidOperationException>`.
- One test strengthened rather than deleted: `Collision_RecordsCollisionEvents`'s never-read collection became an `Assert.All` validating event↔entity correctness.
- **Latent weak test flagged**: that same test still can't assert any collision fires (config doesn't deterministically collide within 120 steps) — noted for follow-up rather than papered over.

## Test plan
- [x] Physics 379, Debugging 222, Testing 1446, Replay 614 — all 0 failed (independently re-verified post-rebase)
- [x] Release build 0 warnings / 0 errors; format verify exit 0

## Related Issues
Security-tab cleanup — tests DPTR batch (4 of 7)