### PR TITLE
test: Resolve CodeQL alerts in UI and Spatial tests

### DIFF
--- a/tests/KeenEyes.Spatial.Tests/Partitioning/FrustumCullingTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/FrustumCullingTests.cs
@@ -265,7 +265,7 @@ public class FrustumCullingTests
         for (int i = 0; i < 10; i++)
         {
             var entity = new Entity(i + 1, 0);
-            partitioner.Update(entity, new Vector3(50, 0, i * 5));
+            partitioner.Update(entity, new Vector3(50, 0, i * 5f));
         }
 
         // Create a frustum pointing to the LEFT side (won't overlap entities on right)

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/GridPartitionerAdditionalTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/GridPartitionerAdditionalTests.cs
@@ -110,7 +110,7 @@ public class GridPartitionerAdditionalTests
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(i, 0);
-            partitioner.Update(entity, new Vector3(i * 5, i * 5, i * 5));
+            partitioner.Update(entity, new Vector3(i * 5f, i * 5f, i * 5f));
         }
 
         // Act - Small result buffer to trigger overflow

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/LooseOctreeTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/LooseOctreeTests.cs
@@ -89,7 +89,7 @@ public class LooseOctreeTests : IDisposable
         // Perform multiple small updates
         for (int i = 1; i <= 10; i++)
         {
-            loosePartitioner.Update(entity1, new Vector3(i * 2, i * 2, i * 2));
+            loosePartitioner.Update(entity1, new Vector3(i * 2f, i * 2f, i * 2f));
         }
 
         // Entity should still be queryable
@@ -151,7 +151,7 @@ public class LooseOctreeTests : IDisposable
         // Update entity1 multiple times
         for (int i = 0; i < 5; i++)
         {
-            loosePartitioner.Update(entity1, new Vector3(i * 10, i * 10, i * 10));
+            loosePartitioner.Update(entity1, new Vector3(i * 10f, i * 10f, i * 10f));
         }
 
         // Final position should be (40, 40, 40)
@@ -170,7 +170,7 @@ public class LooseOctreeTests : IDisposable
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(100 + i, 0);
-            loosePartitioner.Update(entity, new Vector3(i * 10, i * 10, i * 10));
+            loosePartitioner.Update(entity, new Vector3(i * 10f, i * 10f, i * 10f));
         }
 
         Assert.Equal(20, loosePartitioner.EntityCount);
@@ -208,9 +208,8 @@ public class LooseOctreeTests : IDisposable
             LoosenessFactor = 2.5f
         };
 
-        var p = new OctreePartitioner(config);
+        using var p = new OctreePartitioner(config);
         Assert.NotNull(p);
-        p.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/LooseQuadtreeTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/LooseQuadtreeTests.cs
@@ -89,7 +89,7 @@ public class LooseQuadtreeTests : IDisposable
         // Perform multiple small updates
         for (int i = 1; i <= 10; i++)
         {
-            loosePartitioner.Update(entity1, new Vector3(i * 2, 0, i * 2));
+            loosePartitioner.Update(entity1, new Vector3(i * 2f, 0, i * 2f));
         }
 
         // Entity should still be queryable
@@ -151,7 +151,7 @@ public class LooseQuadtreeTests : IDisposable
         // Update entity1 multiple times
         for (int i = 0; i < 5; i++)
         {
-            loosePartitioner.Update(entity1, new Vector3(i * 10, 0, i * 10));
+            loosePartitioner.Update(entity1, new Vector3(i * 10f, 0, i * 10f));
         }
 
         // Final position should be (40, 0, 40)
@@ -170,7 +170,7 @@ public class LooseQuadtreeTests : IDisposable
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(100 + i, 0);
-            loosePartitioner.Update(entity, new Vector3(i * 10, 0, i * 10));
+            loosePartitioner.Update(entity, new Vector3(i * 10f, 0, i * 10f));
         }
 
         Assert.Equal(20, loosePartitioner.EntityCount);
@@ -208,9 +208,8 @@ public class LooseQuadtreeTests : IDisposable
             LoosenessFactor = 2.5f
         };
 
-        var p = new QuadtreePartitioner(config);
+        using var p = new QuadtreePartitioner(config);
         Assert.NotNull(p);
-        p.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/NodePoolingTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/NodePoolingTests.cs
@@ -30,7 +30,7 @@ public class NodePoolingTests
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(i + 1, 0);
-            partitioner.Update(entity, new Vector3(i * 10, 0, i * 10));
+            partitioner.Update(entity, new Vector3(i * 10f, 0, i * 10f));
             entities.Add(entity);
         }
 
@@ -67,7 +67,7 @@ public class NodePoolingTests
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(i + 1, 0);
-            partitioner.Update(entity, new Vector3(i * 10, 0, i * 10));
+            partitioner.Update(entity, new Vector3(i * 10f, 0, i * 10f));
             entities.Add(entity);
         }
 
@@ -102,7 +102,7 @@ public class NodePoolingTests
         // Add entities to trigger subdivision
         for (int i = 0; i < 20; i++)
         {
-            partitioner.Update(new Entity(i + 1, 0), new Vector3(i * 10, 0, i * 10));
+            partitioner.Update(new Entity(i + 1, 0), new Vector3(i * 10f, 0, i * 10f));
         }
 
         Assert.Equal(20, partitioner.EntityCount);
@@ -115,7 +115,7 @@ public class NodePoolingTests
         // Add new entities - should reuse pooled nodes
         for (int i = 0; i < 20; i++)
         {
-            partitioner.Update(new Entity(i + 100, 0), new Vector3(i * 10, 0, i * 10));
+            partitioner.Update(new Entity(i + 100, 0), new Vector3(i * 10f, 0, i * 10f));
         }
 
         Assert.Equal(20, partitioner.EntityCount);
@@ -139,12 +139,10 @@ public class NodePoolingTests
         for (int cycle = 0; cycle < 5; cycle++)
         {
             // Add entities to trigger subdivision
-            var entities = new List<Entity>();
             for (int i = 0; i < 20; i++)
             {
                 var entity = new Entity(cycle * 100 + i + 1, 0);
-                partitioner.Update(entity, new Vector3(i * 10, 0, i * 10));
-                entities.Add(entity);
+                partitioner.Update(entity, new Vector3(i * 10f, 0, i * 10f));
             }
 
             Assert.Equal(20, partitioner.EntityCount);
@@ -181,7 +179,7 @@ public class NodePoolingTests
         {
             var entity = new Entity(i + 1, 0);
             // Cluster entities in a small area to force deep tree
-            partitioner.Update(entity, new Vector3(i * 2, 0, i * 2));
+            partitioner.Update(entity, new Vector3(i * 2f, 0, i * 2f));
             entities.Add(entity);
         }
 
@@ -222,7 +220,7 @@ public class NodePoolingTests
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(i + 1, 0);
-            partitioner.Update(entity, new Vector3(i * 10, i * 10, i * 10));
+            partitioner.Update(entity, new Vector3(i * 10f, i * 10f, i * 10f));
             entities.Add(entity);
         }
 
@@ -259,7 +257,7 @@ public class NodePoolingTests
         for (int i = 0; i < 20; i++)
         {
             var entity = new Entity(i + 1, 0);
-            partitioner.Update(entity, new Vector3(i * 10, i * 10, i * 10));
+            partitioner.Update(entity, new Vector3(i * 10f, i * 10f, i * 10f));
             entities.Add(entity);
         }
 
@@ -294,7 +292,7 @@ public class NodePoolingTests
         // Add entities to trigger subdivision
         for (int i = 0; i < 20; i++)
         {
-            partitioner.Update(new Entity(i + 1, 0), new Vector3(i * 10, i * 10, i * 10));
+            partitioner.Update(new Entity(i + 1, 0), new Vector3(i * 10f, i * 10f, i * 10f));
         }
 
         Assert.Equal(20, partitioner.EntityCount);
@@ -307,7 +305,7 @@ public class NodePoolingTests
         // Add new entities - should reuse pooled nodes
         for (int i = 0; i < 20; i++)
         {
-            partitioner.Update(new Entity(i + 100, 0), new Vector3(i * 10, i * 10, i * 10));
+            partitioner.Update(new Entity(i + 100, 0), new Vector3(i * 10f, i * 10f, i * 10f));
         }
 
         Assert.Equal(20, partitioner.EntityCount);
@@ -331,12 +329,10 @@ public class NodePoolingTests
         for (int cycle = 0; cycle < 5; cycle++)
         {
             // Add entities to trigger subdivision
-            var entities = new List<Entity>();
             for (int i = 0; i < 20; i++)
             {
                 var entity = new Entity(cycle * 100 + i + 1, 0);
-                partitioner.Update(entity, new Vector3(i * 10, i * 10, i * 10));
-                entities.Add(entity);
+                partitioner.Update(entity, new Vector3(i * 10f, i * 10f, i * 10f));
             }
 
             Assert.Equal(20, partitioner.EntityCount);
@@ -373,7 +369,7 @@ public class NodePoolingTests
         {
             var entity = new Entity(i + 1, 0);
             // Cluster entities in a small area to force deep tree
-            partitioner.Update(entity, new Vector3(i * 2, i * 2, i * 2));
+            partitioner.Update(entity, new Vector3(i * 2f, i * 2f, i * 2f));
             entities.Add(entity);
         }
 

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/OctreePartitionerTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/OctreePartitionerTests.cs
@@ -473,19 +473,19 @@ public class OctreePartitionerTests : IDisposable
             MaxDepth = 1,  // Shallow tree to keep entities in one node
             MaxEntitiesPerNode = 100  // Allow many entities per node
         };
-        using var partitioner = new OctreePartitioner(config);
+        using var simdPartitioner = new OctreePartitioner(config);
 
         var entities = new List<Entity>();
         for (int i = 0; i < 50; i++)
         {
             var entity = new Entity(i + 1, 0);
-            var pos = new Vector3(i * 2, 0, 0);  // Spread entities along X axis
-            partitioner.Update(entity, pos);
+            var pos = new Vector3(i * 2f, 0, 0);  // Spread entities along X axis
+            simdPartitioner.Update(entity, pos);
             entities.Add(entity);
         }
 
         // Query a bounds that includes all entities
-        var results = partitioner.QueryBounds(new Vector3(-10, -10, -10), new Vector3(200, 10, 10)).ToList();
+        var results = simdPartitioner.QueryBounds(new Vector3(-10, -10, -10), new Vector3(200, 10, 10)).ToList();
 
         // Should find all 50 entities
         Assert.Equal(50, results.Count);
@@ -506,19 +506,19 @@ public class OctreePartitionerTests : IDisposable
             MaxDepth = 1,  // Shallow tree to keep entities in one node
             MaxEntitiesPerNode = 200  // Allow many entities per node
         };
-        using var partitioner = new OctreePartitioner(config);
+        using var simdPartitioner = new OctreePartitioner(config);
 
         var entities = new List<Entity>();
         for (int i = 0; i < 150; i++)
         {
             var entity = new Entity(i + 1, 0);
-            var pos = new Vector3(i * 2, 0, 0);  // Spread entities along X axis
-            partitioner.Update(entity, pos);
+            var pos = new Vector3(i * 2f, 0, 0);  // Spread entities along X axis
+            simdPartitioner.Update(entity, pos);
             entities.Add(entity);
         }
 
         // Query a bounds that includes all entities
-        var results = partitioner.QueryBounds(new Vector3(-10, -10, -10), new Vector3(400, 10, 10)).ToList();
+        var results = simdPartitioner.QueryBounds(new Vector3(-10, -10, -10), new Vector3(400, 10, 10)).ToList();
 
         // Should find all 150 entities
         Assert.Equal(150, results.Count);

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/QuadtreePartitionerTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/QuadtreePartitionerTests.cs
@@ -469,19 +469,19 @@ public class QuadtreePartitionerTests : IDisposable
             MaxDepth = 1,  // Shallow tree to keep entities in one node
             MaxEntitiesPerNode = 100  // Allow many entities per node
         };
-        using var partitioner = new QuadtreePartitioner(config);
+        using var simdPartitioner = new QuadtreePartitioner(config);
 
         var entities = new List<Entity>();
         for (int i = 0; i < 50; i++)
         {
             var entity = new Entity(i + 1, 0);
-            var pos = new Vector3(i * 2, 0, 0);  // Spread entities along X axis
-            partitioner.Update(entity, pos);
+            var pos = new Vector3(i * 2f, 0, 0);  // Spread entities along X axis
+            simdPartitioner.Update(entity, pos);
             entities.Add(entity);
         }
 
         // Query a bounds that includes all entities
-        var results = partitioner.QueryBounds(new Vector3(-10, 0, -10), new Vector3(200, 0, 10)).ToList();
+        var results = simdPartitioner.QueryBounds(new Vector3(-10, 0, -10), new Vector3(200, 0, 10)).ToList();
 
         // Should find all 50 entities
         Assert.Equal(50, results.Count);
@@ -502,19 +502,19 @@ public class QuadtreePartitionerTests : IDisposable
             MaxDepth = 1,  // Shallow tree to keep entities in one node
             MaxEntitiesPerNode = 200  // Allow many entities per node
         };
-        using var partitioner = new QuadtreePartitioner(config);
+        using var simdPartitioner = new QuadtreePartitioner(config);
 
         var entities = new List<Entity>();
         for (int i = 0; i < 150; i++)
         {
             var entity = new Entity(i + 1, 0);
-            var pos = new Vector3(i * 2, 0, 0);  // Spread entities along X axis
-            partitioner.Update(entity, pos);
+            var pos = new Vector3(i * 2f, 0, 0);  // Spread entities along X axis
+            simdPartitioner.Update(entity, pos);
             entities.Add(entity);
         }
 
         // Query a bounds that includes all entities
-        var results = partitioner.QueryBounds(new Vector3(-10, 0, -10), new Vector3(400, 0, 10)).ToList();
+        var results = simdPartitioner.QueryBounds(new Vector3(-10, 0, -10), new Vector3(400, 0, 10)).ToList();
 
         // Should find all 150 entities
         Assert.Equal(150, results.Count);

--- a/tests/KeenEyes.Spatial.Tests/SimdHelpersTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/SimdHelpersTests.cs
@@ -81,7 +81,7 @@ public class SimdHelpersTests
         var positions = new Vector3[20];
         for (int i = 0; i < 20; i++)
         {
-            positions[i] = new Vector3(i * 2, 0, 0);
+            positions[i] = new Vector3(i * 2f, 0, 0);
         }
 
         Span<int> results = stackalloc int[20];

--- a/tests/KeenEyes.Spatial.Tests/SpatialPluginTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/SpatialPluginTests.cs
@@ -587,9 +587,9 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_RegistersSpatialQueryApiExtension()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new SpatialPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -601,9 +601,9 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_RegistersSpatialUpdateSystem()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new SpatialPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -614,9 +614,9 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_RegistersSpatialIndexedComponent()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new SpatialPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -626,9 +626,9 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_SpatialUpdateSystem_HasNegativeOrder()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new SpatialPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -641,10 +641,10 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_WithGridStrategy_CreatesSpatialQueryApi()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new SpatialConfig { Strategy = SpatialStrategy.Grid };
         var plugin = new SpatialPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -655,10 +655,10 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_WithQuadtreeStrategy_CreatesSpatialQueryApi()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new SpatialConfig { Strategy = SpatialStrategy.Quadtree };
         var plugin = new SpatialPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -669,10 +669,10 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_WithOctreeStrategy_CreatesSpatialQueryApi()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var config = new SpatialConfig { Strategy = SpatialStrategy.Octree };
         var plugin = new SpatialPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -683,9 +683,9 @@ public class SpatialPluginTests : IDisposable
     [Fact]
     public void Install_RegistersExactlyOneSystem()
     {
-        using var world = new World();
+        using var pluginWorld = new World();
         var plugin = new SpatialPlugin();
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, pluginWorld);
 
         plugin.Install(context);
 
@@ -699,10 +699,10 @@ public class SpatialPluginTests : IDisposable
 
         foreach (var strategy in strategies)
         {
-            using var world = new World();
+            using var pluginWorld = new World();
             var config = new SpatialConfig { Strategy = strategy };
             var plugin = new SpatialPlugin(config);
-            var context = new MockPluginContext(plugin, world);
+            var context = new MockPluginContext(plugin, pluginWorld);
 
             plugin.Install(context);
 

--- a/tests/KeenEyes.Spatial.Tests/SpatialQueryApiEnhancedTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/SpatialQueryApiEnhancedTests.cs
@@ -268,7 +268,7 @@ public class SpatialQueryApiEnhancedTests : IDisposable
         tempWorld.InstallPlugin(new SpatialPlugin());
         var tempSpatial = tempWorld.GetExtension<SpatialQueryApi>();
 
-        var entity = tempWorld.Spawn()
+        _ = tempWorld.Spawn()
             .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
             .WithTag<SpatialIndexed>()
             .Build();

--- a/tests/KeenEyes.Spatial.Tests/SpatialQueryApiExtendedTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/SpatialQueryApiExtendedTests.cs
@@ -402,14 +402,12 @@ public partial class SpatialQueryApiExtendedTests : IDisposable
 
         var spatial = world.GetExtension<SpatialQueryApi>();
 
-        var entities = new List<Entity>();
         for (int i = 0; i < 10; i++)
         {
-            var entity = world.Spawn()
+            _ = world.Spawn()
                 .With(new Transform3D(new Vector3(i * 100f, 0, 0), Quaternion.Identity, Vector3.One))
                 .WithTag<SpatialIndexed>()
                 .Build();
-            entities.Add(entity);
         }
 
         world.Update(0.016f);

--- a/tests/KeenEyes.UI.Tests/DockLayoutTests.cs
+++ b/tests/KeenEyes.UI.Tests/DockLayoutTests.cs
@@ -43,10 +43,9 @@ public sealed class DockLayoutTests
         world.InstallPlugin(new UIPlugin());
 
         var container = CreateDockContainer(world);
-        ref readonly var dockContainer = ref world.Get<UIDockContainer>(container);
 
         // Create a panel docked to the left zone
-        var panel = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIRect())
             .With(new UIDockPanel
@@ -63,8 +62,7 @@ public sealed class DockLayoutTests
         var layout = DockLayout.CaptureLayout(world, container);
 
         Assert.NotNull(layout);
-        Assert.True(layout.Zones.ContainsKey(DockZone.Left));
-        var leftZone = layout.Zones[DockZone.Left];
+        Assert.True(layout.Zones.TryGetValue(DockZone.Left, out var leftZone));
         Assert.Single(leftZone.Panels);
         Assert.Equal("TestPanel", leftZone.Panels[0].PanelId);
     }
@@ -78,7 +76,7 @@ public sealed class DockLayoutTests
         var container = CreateDockContainer(world);
 
         // Create a floating panel
-        var panel = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIRect())
             .With(new UIDockPanel
@@ -112,7 +110,7 @@ public sealed class DockLayoutTests
 
         var container = CreateDockContainer(world);
 
-        var panel = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIRect())
             .With(new UIDockPanel
@@ -127,8 +125,7 @@ public sealed class DockLayoutTests
         var layout = DockLayout.CaptureLayout(world, container, entity => $"custom_{entity.Id}");
 
         Assert.NotNull(layout);
-        Assert.True(layout.Zones.ContainsKey(DockZone.Left));
-        var leftZone = layout.Zones[DockZone.Left];
+        Assert.True(layout.Zones.TryGetValue(DockZone.Left, out var leftZone));
         Assert.Single(leftZone.Panels);
         Assert.StartsWith("custom_", leftZone.Panels[0].PanelId);
     }
@@ -415,7 +412,7 @@ public sealed class DockLayoutTests
         var container = CreateDockContainer(world);
 
         // Create panels in different states
-        var dockedPanel = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIRect())
             .With(new UIDockPanel
@@ -429,7 +426,7 @@ public sealed class DockLayoutTests
             })
             .Build();
 
-        var floatingPanel = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIRect())
             .With(new UIDockPanel
@@ -489,8 +486,8 @@ public sealed class DockLayoutTests
         var layout = DockLayout.CaptureLayout(world, container);
 
         Assert.NotNull(layout);
-        Assert.True(layout.Zones.ContainsKey(DockZone.Center));
-        Assert.Equal(3, layout.Zones[DockZone.Center].Panels.Count);
+        Assert.True(layout.Zones.TryGetValue(DockZone.Center, out var centerZone));
+        Assert.Equal(3, centerZone.Panels.Count);
     }
 
     [Fact]

--- a/tests/KeenEyes.UI.Tests/UIAccordionSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIAccordionSystemTests.cs
@@ -16,7 +16,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Click header to expand
         SimulateClick(world, headers[0]);
@@ -33,7 +33,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Expand first
         SimulateClick(world, headers[0]);
@@ -54,7 +54,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Click header to expand
         SimulateClick(world, headers[0]);
@@ -72,7 +72,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Expand first
         SimulateClick(world, headers[0]);
@@ -94,7 +94,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, _, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Find arrow element
         Entity arrow = Entity.Null;
@@ -122,7 +122,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, _, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Find arrow element
         Entity arrow = Entity.Null;
@@ -156,7 +156,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: false);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: false);
 
         // Expand first section
         SimulateClick(world, headers[0]);
@@ -180,7 +180,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: true);
 
         // Expand first section
         SimulateClick(world, headers[0]);
@@ -449,7 +449,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 3, allowMultiple: false);
+        var (_, sections, headers) = CreateAccordion(world, 3, allowMultiple: false);
 
         // Expand first section
         SimulateClick(world, headers[0]);
@@ -620,7 +620,7 @@ public class UIAccordionSystemTests
         var system = new UIAccordionSystem();
         world.AddSystem(system);
 
-        var (accordion, sections, headers) = CreateAccordion(world, 1, allowMultiple: true);
+        var (_, sections, _) = CreateAccordion(world, 1, allowMultiple: true);
 
         // Don't simulate click
         system.Update(0);
@@ -658,7 +658,7 @@ public class UIAccordionSystemTests
             // Create header
             headers[i] = world.Spawn()
                 .With(UIElement.Default)
-                .With(UIRect.Fixed(0, i * 40, 300, 40))
+                .With(UIRect.Fixed(0, i * 40f, 300, 40))
                 .With(new UIAccordionHeaderTag())
                 .With(UIInteractable.Clickable())
                 .Build();

--- a/tests/KeenEyes.UI.Tests/UIDataGridSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIDataGridSystemTests.cs
@@ -1426,8 +1426,8 @@ public class UIDataGridSystemTests
             new DataGridColumnDef("ID"),
             new DataGridColumnDef("Name"));
         var grid = WidgetFactory.CreateDataGrid(world, config);
-        var row1 = WidgetFactory.AddDataGridRow(world, grid, ["1", "Alice"]);
-        var row2 = WidgetFactory.AddDataGridRow(world, grid, ["2", "Bob"]);
+        _ = WidgetFactory.AddDataGridRow(world, grid, ["1", "Alice"]);
+        _ = WidgetFactory.AddDataGridRow(world, grid, ["2", "Bob"]);
 
         // Select first row
         system.SelectRowByIndex(grid, 0);
@@ -1709,13 +1709,11 @@ public class UIDataGridSystemTests
         var grid = WidgetFactory.CreateDataGrid(world, "ID", "Name");
 
         // Find and despawn the sort indicator
-        Entity columnEntity = Entity.Null;
         foreach (var col in world.Query<UIDataGridColumn>())
         {
             ref readonly var column = ref world.Get<UIDataGridColumn>(col);
             if (column.DataGrid == grid && column.ColumnIndex == 0)
             {
-                columnEntity = col;
                 if (world.IsAlive(column.SortIndicator))
                 {
                     world.Despawn(column.SortIndicator);

--- a/tests/KeenEyes.UI.Tests/UIDatePickerSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIDatePickerSystemTests.cs
@@ -1521,7 +1521,7 @@ public class UIDatePickerSystemTests
         world.AddSystem(system);
 
         var initialDate = new DateTime(2024, 6, 15);
-        var picker = CreateDatePickerWithDays(world, initialDate);
+        _ = CreateDatePickerWithDays(world, initialDate);
         layout.Update(0);
 
         UIDateChangedEvent? receivedEvent = null;
@@ -1558,7 +1558,7 @@ public class UIDatePickerSystemTests
         world.AddSystem(system);
 
         var initialDate = new DateTime(2024, 6, 15);
-        var picker = CreateDatePickerWithDays(world, initialDate);
+        _ = CreateDatePickerWithDays(world, initialDate);
         layout.Update(0);
 
         UIDateChangedEvent? receivedEvent = null;
@@ -1690,7 +1690,7 @@ public class UIDatePickerSystemTests
         world.AddSystem(system);
 
         var initialDate = new DateTime(2024, 6, 15);
-        var picker = CreateDatePickerWithStyledDays(world, initialDate);
+        _ = CreateDatePickerWithStyledDays(world, initialDate);
         layout.Update(0);
 
         // Count initially selected days
@@ -1749,7 +1749,7 @@ public class UIDatePickerSystemTests
         world.AddSystem(system);
 
         var initialDate = new DateTime(2024, 6, 15);
-        var picker = CreateDatePickerWithStyledDays(world, initialDate);
+        _ = CreateDatePickerWithStyledDays(world, initialDate);
         layout.Update(0);
 
         // Find the currently selected day
@@ -2154,7 +2154,7 @@ public class UIDatePickerSystemTests
         {
             var dayCell = world.Spawn()
                 .With(UIElement.Default)
-                .With(UIRect.Fixed((day % 7) * 32, (day / 7) * 32, 32, 32))
+                .With(UIRect.Fixed((day % 7) * 32f, (day / 7) * 32f, 32, 32))
                 .With(new UICalendarDay(picker, day, initialValue.Month, initialValue.Year)
                 {
                     IsCurrentMonth = true,
@@ -2298,7 +2298,7 @@ public class UIDatePickerSystemTests
         {
             var dayCell = world.Spawn()
                 .With(UIElement.Default)
-                .With(UIRect.Fixed((day % 7) * 32, (day / 7) * 32, 32, 32))
+                .With(UIRect.Fixed((day % 7) * 32f, (day / 7) * 32f, 32, 32))
                 .With(new UICalendarDay(picker, day, initialValue.Month, initialValue.Year)
                 {
                     IsCurrentMonth = true,

--- a/tests/KeenEyes.UI.Tests/UIDockSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIDockSystemTests.cs
@@ -371,12 +371,12 @@ public class UIDockSystemTests
             .With(new UIHiddenTag())
             .Build();
 
-        var tab0 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel0, tabGroup) { Index = 0 })
             .Build();
 
-        var tab1 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel1, tabGroup) { Index = 1 })
             .Build();
@@ -2025,12 +2025,12 @@ public class UIDockSystemTests
             .With(new UIHiddenTag())
             .Build();
 
-        var tab0 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel0, tabGroup) { Index = 0 })
             .Build();
 
-        var tab1 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel1, tabGroup) { Index = 1 })
             .Build();
@@ -2401,12 +2401,12 @@ public class UIDockSystemTests
             // No UIElement
             .Build();
 
-        var tab0 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel0, tabGroup) { Index = 0 })
             .Build();
 
-        var tab1 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel1, tabGroup) { Index = 1 })
             .Build();
@@ -2434,7 +2434,7 @@ public class UIDockSystemTests
             .With(UIElement.Default)
             .Build();
 
-        var tab = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIDockTab(panel, tabGroup) { Index = 1 })
             .Build();

--- a/tests/KeenEyes.UI.Tests/UIFocusSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIFocusSystemTests.cs
@@ -103,7 +103,7 @@ public class UIFocusSystemTests
 
         var canvas = uiContext.CreateCanvas();
         var button1 = CreateButton(world, canvas, 0);
-        var button2 = CreateButton(world, canvas, 1);
+        _ = CreateButton(world, canvas, 1);
 
         // Press Tab with no focus
         input.PressKey(Key.Tab);
@@ -196,7 +196,7 @@ public class UIFocusSystemTests
         world.AddSystem(system);
 
         // No focusable elements
-        var canvas = uiContext.CreateCanvas();
+        _ = uiContext.CreateCanvas();
 
         // Press Tab
         input.PressKey(Key.Tab);
@@ -500,7 +500,7 @@ public class UIFocusSystemTests
         world.AddSystem(system);
 
         var canvas = uiContext.CreateCanvas();
-        var button1 = CreateButton(world, canvas, 0);
+        _ = CreateButton(world, canvas, 0);
         var button2 = CreateButton(world, canvas, 1);
 
         // Press Shift+Tab with no focus (should focus last element)
@@ -550,7 +550,7 @@ public class UIFocusSystemTests
         var canvas = uiContext.CreateCanvas();
         var button1 = CreateButton(world, canvas, 0);
         var button2 = CreateButton(world, canvas, 1);
-        var button3 = CreateButton(world, canvas, 2);
+        _ = CreateButton(world, canvas, 2);
 
         // Press Tab
         input.PressKey(Key.Tab);

--- a/tests/KeenEyes.UI.Tests/UIHitTesterTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIHitTesterTests.cs
@@ -296,7 +296,7 @@ public class UIHitTesterTests
         var hitTester = new UIHitTester(world);
 
         // Create an invisible root canvas
-        var invisibleRoot = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = false, RaycastTarget = true })
             .With(new UIRect { ComputedBounds = new Rectangle(0, 0, 1280, 720) })
             .With(new UIRootTag())
@@ -314,7 +314,7 @@ public class UIHitTesterTests
         var hitTester = new UIHitTester(world);
 
         // Create a hidden root canvas
-        var hiddenRoot = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRect { ComputedBounds = new Rectangle(0, 0, 1280, 720) })
             .With(new UIRootTag())
@@ -333,7 +333,7 @@ public class UIHitTesterTests
         var hitTester = new UIHitTester(world);
 
         // Create an invisible root canvas
-        var invisibleRoot = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = false, RaycastTarget = true })
             .With(new UIRect { ComputedBounds = new Rectangle(0, 0, 1280, 720) })
             .With(new UIRootTag())
@@ -351,7 +351,7 @@ public class UIHitTesterTests
         var hitTester = new UIHitTester(world);
 
         // Create a hidden root canvas
-        var hiddenRoot = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRect { ComputedBounds = new Rectangle(0, 0, 1280, 720) })
             .With(new UIRootTag())
@@ -530,7 +530,7 @@ public class UIHitTesterTests
         var hitTester = new UIHitTester(world);
 
         // First root
-        var root1 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRect { ComputedBounds = new Rectangle(0, 0, 500, 500), LocalZIndex = 0 })
             .With(new UIRootTag())
@@ -587,7 +587,7 @@ public class UIHitTesterTests
         using var world = new World();
         var hitTester = new UIHitTester(world);
 
-        var root = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRect { ComputedBounds = new Rectangle(100, 100, 200, 200) })
             .With(new UIRootTag())

--- a/tests/KeenEyes.UI.Tests/UIInputSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIInputSystemTests.cs
@@ -198,7 +198,7 @@ public class UIInputSystemTests
         var system = new UIInputSystem();
         world.AddSystem(system);
 
-        var button = CreateButton(world, uiContext.CreateCanvas(), 100, 100, 200, 100);
+        _ = CreateButton(world, uiContext.CreateCanvas(), 100, 100, 200, 100);
         layoutSystem.Update(0); // Compute bounds after creating elements
 
         UIClickEvent? receivedEvent = null;

--- a/tests/KeenEyes.UI.Tests/UIMenuSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIMenuSystemTests.cs
@@ -788,7 +788,7 @@ public class UIMenuSystemTests
         ref var parentMenuState = ref world.Get<UIMenu>(parentMenu);
         parentMenuState.OpenSubmenu = submenu1;
 
-        var menuItem1 = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIMenuItem { Menu = parentMenu, IsEnabled = true, Submenu = submenu1 })
             .Build();
@@ -909,7 +909,7 @@ public class UIMenuSystemTests
         world.AddSystem(menuSystem);
 
         // Menu without UIElement
-        var menu = world.Spawn()
+        _ = world.Spawn()
             .With(new UIMenu { IsOpen = true })
             .Build();
 
@@ -931,7 +931,7 @@ public class UIMenuSystemTests
         var menuSystem = new UIMenuSystem();
         world.AddSystem(menuSystem);
 
-        var menu = world.Spawn()
+        _ = world.Spawn()
             .With(new UIElement { Visible = true })
             .With(new UIMenu { IsOpen = true })
             .With(new UIHiddenTag())

--- a/tests/KeenEyes.UI.Tests/UIPropertyGridSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIPropertyGridSystemTests.cs
@@ -309,7 +309,7 @@ public class UIPropertyGridSystemTests
         var propertyGridSystem = new UIPropertyGridSystem();
         world.AddSystem(propertyGridSystem);
 
-        var nonCategoryElement = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIInteractable.Clickable())
             .Build();

--- a/tests/KeenEyes.UI.Tests/UIRadialMenuSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIRadialMenuSystemTests.cs
@@ -293,7 +293,7 @@ public class UIRadialMenuSystemTests
             .With(new UIRadialMenu { IsOpen = true, SelectedIndex = 0, SliceCount = 4 })
             .Build();
 
-        var slice = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRadialSlice(radialMenu, 0) { IsEnabled = false })
             .Build();
@@ -330,7 +330,7 @@ public class UIRadialMenuSystemTests
             })
             .Build();
 
-        var slice = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(new UIRadialSlice(radialMenu, 0)
             {

--- a/tests/KeenEyes.UI.Tests/UIScrollbarSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIScrollbarSystemTests.cs
@@ -196,7 +196,7 @@ public class UIScrollbarSystemTests
         world.AddSystem(system);
 
         var layout = SetupLayout(world);
-        var (scrollView, thumb) = CreateVerticalScrollView(world, 200, 400, 800);
+        var (_, thumb) = CreateVerticalScrollView(world, 200, 400, 800);
         layout.Update(0);
 
         // Delete thumb entity
@@ -215,7 +215,7 @@ public class UIScrollbarSystemTests
         var system = new UIScrollbarSystem();
         world.AddSystem(system);
 
-        var layout = SetupLayout(world);
+        _ = SetupLayout(world);
 
         // Create an element without UIScrollbarThumb component
         var element = world.Spawn()

--- a/tests/KeenEyes.UI.Tests/UISliderSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UISliderSystemTests.cs
@@ -275,7 +275,7 @@ public class UISliderSystemTests
     public void Slider_ClickOnNonSlider_DoesNothing()
     {
         using var world = new World();
-        var layout = SetupLayout(world);
+        _ = SetupLayout(world);
         var system = new UISliderSystem();
         world.AddSystem(system);
 
@@ -294,7 +294,7 @@ public class UISliderSystemTests
     public void Slider_DragOnNonSlider_DoesNothing()
     {
         using var world = new World();
-        var layout = SetupLayout(world);
+        _ = SetupLayout(world);
         var system = new UISliderSystem();
         world.AddSystem(system);
 

--- a/tests/KeenEyes.UI.Tests/UITabSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UITabSystemTests.cs
@@ -17,7 +17,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 3);
+        var (tabView, tabButtons, _) = CreateTabView(world, 3);
 
         // Click second tab
         SimulateClick(world, tabButtons[1]);
@@ -34,7 +34,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 3);
+        var (_, tabButtons, panels) = CreateTabView(world, 3);
 
         // Click third tab
         SimulateClick(world, tabButtons[2]);
@@ -53,7 +53,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 3, initialTab: 0);
+        var (_, tabButtons, panels) = CreateTabView(world, 3, initialTab: 0);
 
         // First panel should be visible initially
         Assert.True(world.Get<UIElement>(panels[0]).Visible);
@@ -74,7 +74,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 2, initialTab: 0);
+        var (_, tabButtons, panels) = CreateTabView(world, 2, initialTab: 0);
 
         // Second panel should have hidden tag initially
         Assert.True(world.Has<UIHiddenTag>(panels[1]));
@@ -116,7 +116,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 2);
+        var (_, tabButtons, _) = CreateTabView(world, 2);
 
         // Click second tab
         SimulateClick(world, tabButtons[1]);
@@ -142,7 +142,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 2, initialTab: 0);
+        var (_, tabButtons, _) = CreateTabView(world, 2, initialTab: 0);
 
         // Click second tab
         SimulateClick(world, tabButtons[1]);
@@ -172,7 +172,7 @@ public class UITabSystemTests
         var system = new UITabSystem();
         world.AddSystem(system);
 
-        var (tabView, tabButtons, panels) = CreateTabView(world, 2);
+        var (tabView, tabButtons, _) = CreateTabView(world, 2);
 
         // Delete tab view
         world.Despawn(tabView);
@@ -222,7 +222,7 @@ public class UITabSystemTests
         {
             tabButtons[i] = world.Spawn()
                 .With(UIElement.Default)
-                .With(UIRect.Fixed(i * 100, 0, 100, 30))
+                .With(UIRect.Fixed(i * 100f, 0, 100, 30))
                 .With(new UITabButton(i, tabView))
                 .With(UIInteractable.Clickable())
                 .With(new UIStyle())

--- a/tests/KeenEyes.UI.Tests/UIToastSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIToastSystemTests.cs
@@ -106,15 +106,13 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         toastSystem.DismissToast(toast, wasManual: true);
 
         Assert.NotNull(receivedEvent);
         Assert.Equal(toast, receivedEvent.Value.Toast);
         Assert.True(receivedEvent.Value.WasManual);
-
-        subscription.Dispose();
     }
 
     #endregion
@@ -163,7 +161,7 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         // Advance time past duration
         toastSystem.Update(1.5f);
@@ -172,8 +170,6 @@ public class UIToastSystemTests
         Assert.Equal(toast, receivedEvent.Value.Toast);
         Assert.False(receivedEvent.Value.WasManual);
         Assert.False(world.IsAlive(toast));
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -251,14 +247,12 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         world.Send(new UIClickEvent(toast, new Vector2(50, 50), MouseButton.Left));
 
         Assert.NotNull(receivedEvent);
         Assert.True(receivedEvent.Value.WasManual);
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -279,14 +273,12 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         world.Send(new UIClickEvent(toast, new Vector2(50, 50), MouseButton.Left));
 
         Assert.Null(receivedEvent);
         Assert.True(world.IsAlive(toast));
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -312,14 +304,12 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         world.Send(new UIClickEvent(closeButton, new Vector2(10, 10), MouseButton.Left));
 
         Assert.NotNull(receivedEvent);
         Assert.True(receivedEvent.Value.WasManual);
-
-        subscription.Dispose();
     }
 
     #endregion
@@ -417,14 +407,12 @@ public class UIToastSystemTests
             .Build();
 
         UIToastShownEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastShownEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastShownEvent>(e => receivedEvent = e);
 
         toastSystem.ShowToast(toast);
 
         Assert.NotNull(receivedEvent);
         Assert.Equal(toast, receivedEvent.Value.Toast);
-
-        subscription.Dispose();
     }
 
     #endregion
@@ -617,15 +605,13 @@ public class UIToastSystemTests
             .Build();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         world.Send(new UIClickEvent(toast, new Vector2(50, 50), MouseButton.Left));
 
         // Should be null because toast is already closing
         Assert.Null(receivedEvent);
         Assert.True(world.IsAlive(toast));
-
-        subscription.Dispose();
     }
 
     [Fact]
@@ -682,15 +668,13 @@ public class UIToastSystemTests
         toastSystem.Dispose();
 
         UIToastDismissedEvent? receivedEvent = null;
-        var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
+        using var subscription = world.Subscribe<UIToastDismissedEvent>(e => receivedEvent = e);
 
         // Click should not dismiss toast anymore (subscription disposed)
         world.Send(new UIClickEvent(toast, new Vector2(50, 50), MouseButton.Left));
 
         Assert.Null(receivedEvent);
         Assert.True(world.IsAlive(toast));
-
-        subscription.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.UI.Tests/UITooltipSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UITooltipSystemTests.cs
@@ -43,7 +43,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -98,7 +98,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -135,7 +135,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -174,7 +174,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -633,7 +633,7 @@ public class UITooltipSystemTests
         tooltipSystem.Dispose();
 
         // System should be inactive after dispose
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -659,7 +659,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())
@@ -698,7 +698,7 @@ public class UITooltipSystemTests
         var tooltipSystem = new UITooltipSystem();
         world.AddSystem(tooltipSystem);
 
-        var canvas = world.Spawn()
+        _ = world.Spawn()
             .With(UIElement.Default)
             .With(UIRect.Stretch())
             .With(new UIRootTag())

--- a/tests/KeenEyes.UI.Tests/UITreeViewSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UITreeViewSystemTests.cs
@@ -17,7 +17,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, nodes, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Click expand arrow
         SimulateClick(world, arrows[0]);
@@ -34,7 +34,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, nodes, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Expand first
         SimulateClick(world, arrows[0]);
@@ -55,7 +55,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, nodes, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Click to expand
         SimulateClick(world, arrows[0]);
@@ -73,7 +73,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, nodes, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Expand then collapse
         SimulateClick(world, arrows[0]);
@@ -93,7 +93,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, _, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Click to expand
         SimulateClick(world, arrows[0]);
@@ -110,7 +110,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: true);
+        var (_, _, arrows) = CreateTreeView(world, hasChildren: true);
 
         // Expand then collapse
         SimulateClick(world, arrows[0]);
@@ -129,7 +129,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, arrows) = CreateTreeView(world, hasChildren: false);
 
         // Click arrow on node without children
         SimulateClick(world, arrows[0]);
@@ -150,7 +150,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Click node to select
         SimulateClick(world, nodes[0]);
@@ -167,7 +167,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (treeView, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Click node to select
         SimulateClick(world, nodes[0]);
@@ -184,7 +184,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Select first node
         SimulateClick(world, nodes[0]);
@@ -208,7 +208,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Click to select
         SimulateClick(world, nodes[0]);
@@ -226,7 +226,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Select first then second (deselects first)
         SimulateClick(world, nodes[0]);
@@ -294,7 +294,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (treeView, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         UITreeNodeSelectedEvent? receivedEvent = null;
         world.Subscribe<UITreeNodeSelectedEvent>(e => receivedEvent = e);
@@ -314,7 +314,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (treeView, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         UITreeNodeDoubleClickedEvent? receivedEvent = null;
         world.Subscribe<UITreeNodeDoubleClickedEvent>(e => receivedEvent = e);
@@ -554,7 +554,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Select first node
         SimulateClick(world, nodes[0]);
@@ -575,7 +575,7 @@ public class UITreeViewSystemTests
         var system = new UITreeViewSystem();
         world.AddSystem(system);
 
-        var (treeView, nodes, arrows) = CreateTreeView(world, hasChildren: false);
+        var (_, nodes, _) = CreateTreeView(world, hasChildren: false);
 
         // Select first node
         SimulateClick(world, nodes[0]);
@@ -751,7 +751,7 @@ public class UITreeViewSystemTests
             // Create node
             nodes[i] = world.Spawn()
                 .With(UIElement.Default)
-                .With(UIRect.Fixed(0, i * 30, 300, 30))
+                .With(UIRect.Fixed(0, i * 30f, 300, 30))
                 .With(new UITreeNode(treeView, Entity.Null, 0, $"Node {i + 1}")
                 {
                     HasChildren = hasChildren,

--- a/tests/KeenEyes.UI.Tests/WidgetFactoryDisplayTests.cs
+++ b/tests/KeenEyes.UI.Tests/WidgetFactoryDisplayTests.cs
@@ -574,7 +574,7 @@ public class WidgetFactoryDisplayTests
         var parent = CreateRootEntity(world);
         var tabs = new[] { new TabConfig("Tab1"), new TabConfig("Tab2") };
 
-        var (tabView, contentPanels) = WidgetFactory.CreateTabView(world, parent, "MyTabs", tabs, testFont);
+        var (tabView, _) = WidgetFactory.CreateTabView(world, parent, "MyTabs", tabs, testFont);
 
         // Find tab bar by name
         var children = world.GetChildren(tabView).ToList();
@@ -593,7 +593,7 @@ public class WidgetFactoryDisplayTests
         var parent = CreateRootEntity(world);
         var tabs = new[] { new TabConfig("Tab1"), new TabConfig("Tab2") };
 
-        var (tabView, contentPanels) = WidgetFactory.CreateTabView(world, parent, tabs, testFont);
+        var (_, contentPanels) = WidgetFactory.CreateTabView(world, parent, tabs, testFont);
 
         // First panel should be visible, second should be hidden
         ref readonly var panel0Element = ref world.Get<UIElement>(contentPanels[0]);
@@ -989,7 +989,7 @@ public class WidgetFactoryDisplayTests
         var parent = CreateRootEntity(world);
         var config = new ScrollViewConfig(ShowVerticalScrollbar: true);
 
-        var (scrollView, _) = WidgetFactory.CreateScrollView(world, parent, config);
+        _ = WidgetFactory.CreateScrollView(world, parent, config);
 
         // Find thumb
         var thumbs = world.Query<UIScrollbarThumb>().ToList();
@@ -1008,7 +1008,7 @@ public class WidgetFactoryDisplayTests
         var parent = CreateRootEntity(world);
         var config = new ScrollViewConfig(ShowVerticalScrollbar: true, ShowHorizontalScrollbar: true);
 
-        var (scrollView, _) = WidgetFactory.CreateScrollView(world, parent, config);
+        _ = WidgetFactory.CreateScrollView(world, parent, config);
 
         // Find thumbs
         var thumbs = world.Query<UIScrollbarThumb>().ToList();

--- a/tests/KeenEyes.UI.Tests/WidgetFactoryInputAdvancedTests.cs
+++ b/tests/KeenEyes.UI.Tests/WidgetFactoryInputAdvancedTests.cs
@@ -412,7 +412,7 @@ public class WidgetFactoryInputAdvancedTests
         var parent = CreateRootEntity(world);
         var config = new DatePickerConfig(Mode: DatePickerMode.Date);
 
-        var picker = WidgetFactory.CreateDatePicker(world, parent, testFont, "DatePicker", config);
+        _ = WidgetFactory.CreateDatePicker(world, parent, testFont, "DatePicker", config);
 
         // Should have prev and next buttons in the header
         // Find by searching for entities with name pattern
@@ -441,7 +441,7 @@ public class WidgetFactoryInputAdvancedTests
         var parent = CreateRootEntity(world);
         var config = new DatePickerConfig(Mode: DatePickerMode.Date);
 
-        var picker = WidgetFactory.CreateDatePicker(world, parent, testFont, "DatePicker", config);
+        _ = WidgetFactory.CreateDatePicker(world, parent, testFont, "DatePicker", config);
 
         // Find prev button and verify it's clickable
         Entity prevButton = Entity.Null;

--- a/tests/KeenEyes.UI.Tests/WidgetFactoryPropertyGridTests.cs
+++ b/tests/KeenEyes.UI.Tests/WidgetFactoryPropertyGridTests.cs
@@ -410,7 +410,7 @@ public class WidgetFactoryPropertyGridTests
             })
         };
 
-        var grid = WidgetFactory.CreatePropertyGridWithCategories(world, parent, testFont, categories);
+        _ = WidgetFactory.CreatePropertyGridWithCategories(world, parent, testFont, categories);
 
         // Find categories and verify expanded state
         var categoryCount = 0;
@@ -465,7 +465,7 @@ public class WidgetFactoryPropertyGridTests
             new PropertyDef("id", "ID", PropertyType.String, IsReadOnly: true)
         };
 
-        var grid = WidgetFactory.CreatePropertyGridFlat(world, parent, testFont, properties);
+        _ = WidgetFactory.CreatePropertyGridFlat(world, parent, testFont, properties);
 
         foreach (var entity in world.Query<UIPropertyRow>())
         {

--- a/tests/KeenEyes.UI.Tests/WidgetFactoryTreeViewToastWindowTests.cs
+++ b/tests/KeenEyes.UI.Tests/WidgetFactoryTreeViewToastWindowTests.cs
@@ -660,7 +660,7 @@ public class WidgetFactoryTreeViewToastWindowTests
         using var world = new World();
         var parent = CreateRootEntity(world);
 
-        var (window, contentPanel) = WidgetFactory.CreateWindow(world, parent, "Test Window", testFont);
+        var (window, _) = WidgetFactory.CreateWindow(world, parent, "Test Window", testFont);
 
         Assert.True(world.Has<UIElement>(window));
         Assert.True(world.Has<UIRect>(window));
@@ -675,7 +675,7 @@ public class WidgetFactoryTreeViewToastWindowTests
         using var world = new World();
         var parent = CreateRootEntity(world);
 
-        var (window, contentPanel) = WidgetFactory.CreateWindow(world, parent, "Test Window", testFont);
+        var (_, contentPanel) = WidgetFactory.CreateWindow(world, parent, "Test Window", testFont);
 
         Assert.True(contentPanel.IsValid);
         Assert.True(world.IsAlive(contentPanel));
@@ -816,7 +816,7 @@ public class WidgetFactoryTreeViewToastWindowTests
         using var world = new World();
         var parent = CreateRootEntity(world);
 
-        var (container, firstPane, secondPane) = WidgetFactory.CreateSplitter(world, parent);
+        var (container, _, _) = WidgetFactory.CreateSplitter(world, parent);
 
         Assert.True(world.Has<UIElement>(container));
         Assert.True(world.Has<UIRect>(container));
@@ -829,7 +829,7 @@ public class WidgetFactoryTreeViewToastWindowTests
         using var world = new World();
         var parent = CreateRootEntity(world);
 
-        var (container, firstPane, secondPane) = WidgetFactory.CreateSplitter(world, parent);
+        var (_, firstPane, secondPane) = WidgetFactory.CreateSplitter(world, parent);
 
         Assert.True(firstPane.IsValid);
         Assert.True(secondPane.IsValid);


### PR DESCRIPTION
## Summary
- Test batch (5 of 7) of the CodeQL cleanup: 202 alerts — 186 fixed, 16 recorded for dismissal.
- Fixes: 94 unused locals (tuple discards / `_ =` / dead-local removal), 63 float literals on int arithmetic feeding `Vector3`/`UIRect`, 10 `using var` conversions, 13 shadowing renames, `TryGetValue` in DockLayoutTests, 3 write-only collections removed.
- Dismissal-bound: 14 explicit mid-method `Dispose()` calls that are the behavior under test (objects owned by `using var world`, so cleanup is already exception-safe), and 2 intentional integer-bucketing divisions in the partitioner scale-tier tests where a fractional result would break the test.

## Test plan
- [x] UI 1993 passed / 0 failed (1 pre-existing skip); Spatial 496 / 0 failed — independently re-verified post-rebase
- [x] Release build 0 warnings / 0 errors; format verify exit 0

## Related Issues
Security-tab cleanup — tests UI+Spatial batch (5 of 7)