### PR TITLE
test: Resolve CodeQL alerts in remaining test projects

### DIFF
--- a/tests/KeenEyes.AI.Tests/AIPluginTests.cs
+++ b/tests/KeenEyes.AI.Tests/AIPluginTests.cs
@@ -53,7 +53,7 @@ public class AIPluginTests
         // Should not throw - component is registered
         Should.NotThrow(() =>
         {
-            var entity = world.Spawn()
+            world.Spawn()
                 .With(StateMachineComponent.Create(fsm))
                 .Build();
         });
@@ -75,7 +75,7 @@ public class AIPluginTests
         // Should not throw - component is registered
         Should.NotThrow(() =>
         {
-            var entity = world.Spawn()
+            world.Spawn()
                 .With(BehaviorTreeComponent.Create(bt))
                 .Build();
         });
@@ -99,7 +99,7 @@ public class AIPluginTests
         // Should not throw - component is registered
         Should.NotThrow(() =>
         {
-            var entity = world.Spawn()
+            world.Spawn()
                 .With(UtilityComponent.Create(ai))
                 .Build();
         });
@@ -143,7 +143,7 @@ public class AIPluginTests
             Root = node
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(BehaviorTreeComponent.Create(bt))
             .Build();
 
@@ -171,7 +171,7 @@ public class AIPluginTests
             ]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(UtilityComponent.Create(ai))
             .Build();
 

--- a/tests/KeenEyes.AI.Tests/BehaviorTree/BehaviorTreeSystemTests.cs
+++ b/tests/KeenEyes.AI.Tests/BehaviorTree/BehaviorTreeSystemTests.cs
@@ -77,7 +77,7 @@ public class BehaviorTreeSystemTests
         var component = BehaviorTreeComponent.Create(bt);
         component.Enabled = false;
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -98,7 +98,7 @@ public class BehaviorTreeSystemTests
             Enabled = true
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -123,7 +123,7 @@ public class BehaviorTreeSystemTests
             Root = child
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(BehaviorTreeComponent.Create(bt))
             .Build();
 
@@ -246,7 +246,7 @@ public class BehaviorTreeSystemTests
             Root = child
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(BehaviorTreeComponent.Create(bt))
             .Build();
 
@@ -271,11 +271,11 @@ public class BehaviorTreeSystemTests
         var bt1 = new AI.BehaviorTree.BehaviorTree { Name = "Test1", Root = child1 };
         var bt2 = new AI.BehaviorTree.BehaviorTree { Name = "Test2", Root = child2 };
 
-        var entity1 = world.Spawn()
+        world.Spawn()
             .With(BehaviorTreeComponent.Create(bt1))
             .Build();
 
-        var entity2 = world.Spawn()
+        world.Spawn()
             .With(BehaviorTreeComponent.Create(bt2))
             .Build();
 

--- a/tests/KeenEyes.AI.Tests/FSM/StateMachineSystemTests.cs
+++ b/tests/KeenEyes.AI.Tests/FSM/StateMachineSystemTests.cs
@@ -79,7 +79,7 @@ public class StateMachineSystemTests
         var component = StateMachineComponent.Create(fsm);
         component.Enabled = false;
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -100,7 +100,7 @@ public class StateMachineSystemTests
             Enabled = true
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -127,7 +127,7 @@ public class StateMachineSystemTests
             States = [new State { Name = "Idle", OnEnterActions = [action] }]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(StateMachineComponent.Create(fsm))
             .Build();
 
@@ -221,7 +221,7 @@ public class StateMachineSystemTests
             ]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(StateMachineComponent.Create(fsm))
             .Build();
 
@@ -351,7 +351,7 @@ public class StateMachineSystemTests
             States = [new State { Name = "Idle", OnUpdateActions = [updateAction] }]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(StateMachineComponent.Create(fsm))
             .Build();
 
@@ -387,7 +387,7 @@ public class StateMachineSystemTests
             ]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(StateMachineComponent.Create(fsm))
             .Build();
 

--- a/tests/KeenEyes.AI.Tests/Utility/UtilityActionTests.cs
+++ b/tests/KeenEyes.AI.Tests/Utility/UtilityActionTests.cs
@@ -256,7 +256,6 @@ public class UtilityActionTests
             ]
         };
 
-        var score1 = action1.CalculateScore(entity, blackboard, world);
         var score2 = action2.CalculateScore(entity, blackboard, world);
 
         // Score2 should be compensated upward to be more fair

--- a/tests/KeenEyes.AI.Tests/Utility/UtilitySystemTests.cs
+++ b/tests/KeenEyes.AI.Tests/Utility/UtilitySystemTests.cs
@@ -89,7 +89,7 @@ public class UtilitySystemTests
         var component = UtilityComponent.Create(ai);
         component.Enabled = false;
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -110,7 +110,7 @@ public class UtilitySystemTests
             Enabled = true
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -178,7 +178,7 @@ public class UtilitySystemTests
             ]
         };
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(UtilityComponent.Create(ai))
             .Build();
 
@@ -283,7 +283,7 @@ public class UtilitySystemTests
         var component = UtilityComponent.Create(ai);
         component.EvaluationInterval = 1.0f;
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -328,7 +328,7 @@ public class UtilitySystemTests
         var component = UtilityComponent.Create(ai);
         component.EvaluationInterval = 0.5f;
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -401,7 +401,7 @@ public class UtilitySystemTests
         var component = UtilityComponent.Create(ai);
         component.EvaluationInterval = 10f; // Long interval
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(component)
             .Build();
 
@@ -497,11 +497,11 @@ public class UtilitySystemTests
             ]
         };
 
-        var entity1 = world.Spawn()
+        world.Spawn()
             .With(UtilityComponent.Create(ai1))
             .Build();
 
-        var entity2 = world.Spawn()
+        world.Spawn()
             .With(UtilityComponent.Create(ai2))
             .Build();
 

--- a/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
+++ b/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
@@ -346,7 +346,7 @@ public class AnimationSystemTests : IDisposable
         clip.Events.AddEvent(0.6f, "event3");
         var clipId = manager.RegisterClip(clip);
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(AnimationPlayer.ForClip(clipId))
             .Build();
 

--- a/tests/KeenEyes.AotCompatibility.Tests/Program.cs
+++ b/tests/KeenEyes.AotCompatibility.Tests/Program.cs
@@ -154,7 +154,7 @@ Test("Query With filter", () =>
     }
 
     var enemyCount = 0;
-    foreach (var entity in world.Query<Position>().With<EnemyTag>())
+    foreach (var _ in world.Query<Position>().With<EnemyTag>())
     {
         enemyCount++;
     }
@@ -189,7 +189,7 @@ Test("Query Without filter", () =>
     }
 
     var movingCount = 0;
-    foreach (var entity in world.Query<Position>().Without<FrozenTag>())
+    foreach (var _ in world.Query<Position>().Without<FrozenTag>())
     {
         movingCount++;
     }
@@ -285,7 +285,7 @@ Test("System registration and execution", () =>
 // Test 12: WorldBuilder
 Test("WorldBuilder with factory delegates", () =>
 {
-    var world = new WorldBuilder()
+    using var world = new WorldBuilder()
         .WithSystem<MovementSystem>()
         .Build();
 
@@ -308,7 +308,6 @@ Test("WorldBuilder with factory delegates", () =>
         }
     }
 
-    world.Dispose();
 });
 
 // Test 13: Singletons

--- a/tests/KeenEyes.Assets.Tests/AssetHandleTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetHandleTests.cs
@@ -145,14 +145,13 @@ public class AssetHandleTests : IDisposable
     {
         var path = testDir.CreateFile("refcount.txt", "content");
         var original = manager.Load<TestAsset>(path);
-        var acquired = original.Acquire();
+        using var acquired = original.Acquire();
 
         original.Dispose();
 
         // Asset should still be loaded because acquired holds a reference
         Assert.True(manager.IsLoaded(path));
 
-        acquired.Dispose();
     }
 
     [Fact]
@@ -181,7 +180,7 @@ public class AssetHandleTests : IDisposable
     [Fact]
     public void Dispose_ReleasesReference()
     {
-        var aggressiveManager = new AssetManager(new AssetsConfig
+        using var aggressiveManager = new AssetManager(new AssetsConfig
         {
             RootPath = testDir.RootPath,
             CachePolicy = CachePolicy.Aggressive
@@ -195,7 +194,6 @@ public class AssetHandleTests : IDisposable
         handle.Dispose();
 
         Assert.True(asset.IsDisposed);
-        aggressiveManager.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Assets.Tests/AssetManagerTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetManagerTests.cs
@@ -96,7 +96,7 @@ public class AssetManagerTests : IDisposable
     {
         manager.RegisterLoader(new SlowLoader(500));
         var path = testDir.CreateFile("slow.slow", "Slow Content");
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         var loadTask = manager.LoadAsync<TestAsset>(path, cancellationToken: cts.Token);
         cts.Cancel();
@@ -201,13 +201,12 @@ public class AssetManagerTests : IDisposable
         var path = testDir.CreateFile("ref.txt", "content");
 
         var h1 = manager.Load<TestAsset>(path);
-        var h2 = manager.Load<TestAsset>(path);
+        using var h2 = manager.Load<TestAsset>(path);
         var asset = h1.Asset!;
 
         h1.Dispose();
         Assert.False(asset.IsDisposed); // Still referenced by h2
 
-        h2.Dispose();
         // Asset may or may not be disposed depending on cache policy
     }
 
@@ -216,12 +215,11 @@ public class AssetManagerTests : IDisposable
     {
         var path = testDir.CreateFile("acquire.txt", "content");
         var original = manager.Load<TestAsset>(path);
-        var acquired = original.Acquire();
+        using var acquired = original.Acquire();
 
         original.Dispose();
         Assert.True(manager.IsLoaded(path)); // Still loaded due to acquired handle
 
-        acquired.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Assets.Tests/AssetResolutionSystemTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetResolutionSystemTests.cs
@@ -43,12 +43,11 @@ public class AssetResolutionSystemTests : IDisposable
     public void Initialize_WithoutAssetManager_DisablesSystem()
     {
         using var worldWithoutAssets = new World();
-        var sys = new AssetResolutionSystem();
+        using var sys = new AssetResolutionSystem();
         sys.Initialize(worldWithoutAssets);
 
         Assert.False(sys.Enabled);
 
-        sys.Dispose();
     }
 
     #endregion
@@ -67,7 +66,7 @@ public class AssetResolutionSystemTests : IDisposable
     public void Enabled_WhenFalse_UpdateDoesNothing()
     {
         var path = testDir.CreateFile("disabled.txt", "content");
-        var entity = world.Spawn()
+        world.Spawn()
             .With(new AssetRef<TestAsset> { Path = path })
             .Build();
 
@@ -143,7 +142,7 @@ public class AssetResolutionSystemTests : IDisposable
     {
         assetManager.RegisterLoader(new SlowLoader(100));
         var path = testDir.CreateFile("pending.slow", "content");
-        var entity = world.Spawn()
+        world.Spawn()
             .With(new AssetRef<TestAsset> { Path = path })
             .Build();
 
@@ -167,12 +166,11 @@ public class AssetResolutionSystemTests : IDisposable
     [Fact]
     public void Update_WithNullWorld_DoesNothing()
     {
-        var sys = new AssetResolutionSystem();
+        using var sys = new AssetResolutionSystem();
         // Don't call Initialize - world will be null
 
         sys.Update(0.016f); // Should not throw
 
-        sys.Dispose();
     }
 
     #endregion
@@ -247,7 +245,7 @@ public class AssetResolutionSystemTests : IDisposable
         // Pre-load the asset
         using var preloaded = assetManager.Load<RawAsset>(path);
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(new AssetRef<RawAsset> { Path = path, HandleId = preloaded.Id })
             .Build();
 

--- a/tests/KeenEyes.Assets.Tests/AssetsPluginTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetsPluginTests.cs
@@ -65,7 +65,7 @@ public class AssetsPluginTests : IDisposable
         var plugin = new AssetsPlugin(new AssetsConfig { RootPath = testDir.RootPath });
         world.InstallPlugin(plugin);
 
-        var manager = world.GetExtension<AssetManager>();
+        _ = world.GetExtension<AssetManager>();
         // MeshLoader should be registered, but we can't easily test without valid glTF file
     }
 

--- a/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
@@ -121,7 +121,7 @@ public class BuiltInAssetTests
         var handle = new TextureHandle(42);
         var mockGraphics = new MockGraphicsContext();
 
-        var asset = new TextureAsset(handle, 256, 128, TextureFormat.Rgba8, mockGraphics);
+        using var asset = new TextureAsset(handle, 256, 128, TextureFormat.Rgba8, mockGraphics);
         asset.Dispose();
         asset.Dispose(); // Should not throw
     }

--- a/tests/KeenEyes.Assets.Tests/CachePolicyTests.cs
+++ b/tests/KeenEyes.Assets.Tests/CachePolicyTests.cs
@@ -33,7 +33,7 @@ public class CachePolicyTests : IDisposable
         var path2 = testDir.CreateFile("new.txt", new string('b', 100));
 
         // Load old first, then new
-        var h1 = manager.Load<TestAsset>(path1);
+        using var h1 = manager.Load<TestAsset>(path1);
         Thread.Sleep(10); // Ensure different timestamps
         var h2 = manager.Load<TestAsset>(path2);
 
@@ -145,7 +145,7 @@ public class CachePolicyTests : IDisposable
 
         var path = testDir.CreateFile("multi.txt", "content");
         var h1 = manager.Load<TestAsset>(path);
-        var h2 = manager.Load<TestAsset>(path);
+        using var h2 = manager.Load<TestAsset>(path);
         var asset = h1.Asset!;
 
         h1.Dispose();

--- a/tests/KeenEyes.Assets.Tests/FontLoaderTests.cs
+++ b/tests/KeenEyes.Assets.Tests/FontLoaderTests.cs
@@ -115,9 +115,8 @@ public class FontLoaderTests : IDisposable
         var fontData = new byte[] { 0x00, 0x01, 0x00, 0x00 };
         var path = testDir.CreateFile("fonts/TestFont.ttf", fontData);
 
-        var handle = manager.Load<FontAsset>(path);
+        using var handle = manager.Load<FontAsset>(path);
         var fontHandle = handle.Asset!.Handle;
-        var asset = handle.Asset;
 
         Assert.True(fontManager.IsValid(fontHandle));
 

--- a/tests/KeenEyes.Assets.Tests/HotReloadTests.cs
+++ b/tests/KeenEyes.Assets.Tests/HotReloadTests.cs
@@ -102,7 +102,6 @@ public class HotReloadTests : IDisposable
         // Create a file that will fail to parse on reload
         var path = testDir.CreateFile("error.txt", "valid content");
         using var handle = manager.Load<TestAsset>(path);
-        var originalContent = handle.Asset!.Content;
 
         // We can't easily simulate a loader error, but the behavior is tested
         await manager.ReloadAsync(path);

--- a/tests/KeenEyes.Assets.Tests/StreamingManagerTests.cs
+++ b/tests/KeenEyes.Assets.Tests/StreamingManagerTests.cs
@@ -275,7 +275,7 @@ public class StreamingManagerTests : IDisposable
         streaming.Queue<TestAsset>("cancel.slow");
         streaming.Start();
 
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         cts.CancelAfter(50);
 
         // WaitForCompletionAsync catches cancellation and returns gracefully

--- a/tests/KeenEyes.Editor.Integration.Tests/SceneWorkflowTests.cs
+++ b/tests/KeenEyes.Editor.Integration.Tests/SceneWorkflowTests.cs
@@ -265,7 +265,7 @@ public class SceneWorkflowTests : IDisposable
         using (var world = new World())
         {
             var oldParent = world.Spawn("OldParent").Build();
-            var newParent = world.Spawn("NewParent").Build();
+            world.Spawn("NewParent").Build();
             var child = world.Spawn("Child").Build();
             world.SetParent(child, oldParent);
             serializer.Save(world, "Scene", filePath);
@@ -314,7 +314,6 @@ public class SceneWorkflowTests : IDisposable
 
         // Save after commands
         serializer.Save(world, "AfterCommands", afterCommandsPath);
-        var afterCommandsCount = world.EntityCount;
 
         // Undo all
         manager.Undo();

--- a/tests/KeenEyes.Editor.Tests/Assets/SceneSerializerTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Assets/SceneSerializerTests.cs
@@ -261,11 +261,10 @@ public class SceneSerializerTests : IDisposable
     [Fact]
     public void Load_ReturnsSceneName()
     {
-        var sourceWorld = new World();
+        using var sourceWorld = new World();
         sourceWorld.Spawn("Entity").Build();
         var filePath = Path.Combine(tempDir, "test.kescene");
         serializer.Save(sourceWorld, "MyScene", filePath);
-        sourceWorld.Dispose();
 
         var loadedName = SceneSerializer.Load(world, filePath);
 
@@ -275,12 +274,11 @@ public class SceneSerializerTests : IDisposable
     [Fact]
     public void Load_RestoresEntities()
     {
-        var sourceWorld = new World();
+        using var sourceWorld = new World();
         sourceWorld.Spawn("Entity1").Build();
         sourceWorld.Spawn("Entity2").Build();
         var filePath = Path.Combine(tempDir, "test.kescene");
         serializer.Save(sourceWorld, "TestScene", filePath);
-        sourceWorld.Dispose();
 
         SceneSerializer.Load(world, filePath);
 
@@ -318,7 +316,7 @@ public class SceneSerializerTests : IDisposable
 
         serializer.Save(world, "Test", filePath);
 
-        var newWorld = new World();
+        using var newWorld = new World();
         SceneSerializer.Load(newWorld, filePath);
 
         var names = newWorld.GetAllEntities()
@@ -330,7 +328,6 @@ public class SceneSerializerTests : IDisposable
         Assert.Contains("Beta", names);
         Assert.Contains("Gamma", names);
 
-        newWorld.Dispose();
     }
 
     [Fact]
@@ -343,7 +340,7 @@ public class SceneSerializerTests : IDisposable
 
         serializer.Save(world, "Test", filePath);
 
-        var newWorld = new World();
+        using var newWorld = new World();
         SceneSerializer.Load(newWorld, filePath);
 
         var loadedChild = newWorld.GetAllEntities()
@@ -353,7 +350,6 @@ public class SceneSerializerTests : IDisposable
         Assert.True(loadedParent.IsValid);
         Assert.Equal("Parent", newWorld.GetName(loadedParent));
 
-        newWorld.Dispose();
     }
 
     [Fact]
@@ -364,12 +360,11 @@ public class SceneSerializerTests : IDisposable
 
         var sceneData = serializer.CaptureScene(world, "TestScene");
 
-        var newWorld = new World();
+        using var newWorld = new World();
         SceneSerializer.RestoreScene(newWorld, sceneData);
 
         Assert.Equal(world.EntityCount, newWorld.EntityCount);
 
-        newWorld.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
@@ -316,7 +316,7 @@ public class HotReloadManagerTests
         try
         {
             using var world = new World();
-            var manager = new HotReloadManager(tempProject, world);
+            using var manager = new HotReloadManager(tempProject, world);
             manager.StartWatching();
             manager.Dispose();
 
@@ -335,7 +335,7 @@ public class HotReloadManagerTests
         try
         {
             using var world = new World();
-            var manager = new HotReloadManager(tempProject, world);
+            using var manager = new HotReloadManager(tempProject, world);
 
             manager.Dispose();
             manager.Dispose(); // Should not throw

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
@@ -302,7 +302,7 @@ public class HotReloadServiceTests : IDisposable
         try
         {
             using var world = new World();
-            var service = new HotReloadService(world);
+            using var service = new HotReloadService(world);
 
             EditorSettings.GameProjectPath = tempProject;
             service.Initialize();

--- a/tests/KeenEyes.Editor.Tests/Plugins/BuiltInGizmoPluginsTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/BuiltInGizmoPluginsTests.cs
@@ -102,7 +102,7 @@ public sealed class BuiltInGizmoPluginsTests : IDisposable
     [Fact]
     public void Dispose_RemovesGizmoRenderersFromViewportCapability()
     {
-        var manager = CreateBootEquivalentManager(out var viewport);
+        using var manager = CreateBootEquivalentManager(out var viewport);
         BuiltInGizmoPlugins.Install(manager);
         Assert.NotEmpty(viewport.GetGizmoRenderers());
 

--- a/tests/KeenEyes.Editor.Tests/Plugins/EditorPluginManagerLoggingTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/EditorPluginManagerLoggingTests.cs
@@ -35,7 +35,7 @@ public sealed class EditorPluginManagerLoggingTests : IDisposable
         world.Dispose();
     }
 
-    private EditorPluginManager CreateManager(ILogProvider? logProvider = null)
+    private EditorPluginManager CreateManager(ILogProvider? provider = null)
     {
         return new EditorPluginManager(
             worldManager,
@@ -43,7 +43,7 @@ public sealed class EditorPluginManagerLoggingTests : IDisposable
             undoRedo,
             assets,
             world,
-            logProvider);
+            provider);
     }
 
     #region LogInfo Tests
@@ -65,7 +65,7 @@ public sealed class EditorPluginManagerLoggingTests : IDisposable
     [Fact]
     public void LogInfo_WithoutLogProvider_DoesNotThrow()
     {
-        using var manager = CreateManager(logProvider: null);
+        using var manager = CreateManager(provider: null);
 
         // Should not throw - falls back to Console.WriteLine
         var exception = Record.Exception(() =>
@@ -94,7 +94,7 @@ public sealed class EditorPluginManagerLoggingTests : IDisposable
     [Fact]
     public void LogWarning_WithoutLogProvider_DoesNotThrow()
     {
-        using var manager = CreateManager(logProvider: null);
+        using var manager = CreateManager(provider: null);
 
         var exception = Record.Exception(() =>
             ((IEditorPluginLogger)manager).LogWarning("Warning message"));
@@ -122,7 +122,7 @@ public sealed class EditorPluginManagerLoggingTests : IDisposable
     [Fact]
     public void LogError_WithoutLogProvider_DoesNotThrow()
     {
-        using var manager = CreateManager(logProvider: null);
+        using var manager = CreateManager(provider: null);
 
         var exception = Record.Exception(() =>
             ((IEditorPluginLogger)manager).LogError("Error message"));

--- a/tests/KeenEyes.Editor.Tests/Settings/EditorSettingsTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Settings/EditorSettingsTests.cs
@@ -383,7 +383,7 @@ public class EditorSettingsTests
     [Fact]
     public void Load_NonExistentFile_UsesDefaults()
     {
-        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
         ResetSettingsForTest();
 
         EditorSettings.Load(path);

--- a/tests/KeenEyes.Generators.Tests/BundleGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/BundleGeneratorTests.cs
@@ -1015,7 +1015,7 @@ public class BundleGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         // Should report circular reference diagnostic
         Assert.Contains(diagnostics, d => d.Id.Contains("KEEN") && d.GetMessage().Contains("circular"));
@@ -1040,7 +1040,7 @@ public class BundleGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         // Should report diagnostic that bundles must be structs
         Assert.Contains(diagnostics, d => d.Severity == DiagnosticSeverity.Error);

--- a/tests/KeenEyes.Generators.Tests/MixinGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/MixinGeneratorTests.cs
@@ -156,7 +156,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN027" && d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics.Select(d => d.GetMessage()), msg => msg.Contains("circular"));
@@ -188,7 +188,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN029" && d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics.Select(d => d.GetMessage()), msg => msg.Contains("conflicting"));
@@ -216,7 +216,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN029" && d.Severity == DiagnosticSeverity.Error);
     }
@@ -241,7 +241,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN026" && d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics.Select(d => d.GetMessage()), msg => msg.Contains("must be a struct"));
@@ -267,7 +267,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN026" && d.Severity == DiagnosticSeverity.Error);
     }
@@ -661,7 +661,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN027" && d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics.Select(d => d.GetMessage()), msg => msg.Contains("circular"));
@@ -739,7 +739,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         // Should detect the cycle: A -> B -> D -> A
         Assert.Contains(diagnostics, d => d.Id == "KEEN027" && d.Severity == DiagnosticSeverity.Error);
@@ -784,7 +784,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         Assert.Contains(diagnostics, d => d.Id == "KEEN027" && d.Severity == DiagnosticSeverity.Error);
         Assert.Contains(diagnostics.Select(d => d.GetMessage()), msg => msg.Contains("circular"));
@@ -948,7 +948,7 @@ public class MixinGeneratorTests
             }
             """;
 
-        var (diagnostics, generatedTrees) = RunGenerator(source);
+        var (diagnostics, _) = RunGenerator(source);
 
         // Should report diagnostic for invalid mixin type
         Assert.Contains(diagnostics, d => d.Id.Contains("KEEN") && d.Severity >= DiagnosticSeverity.Warning);

--- a/tests/KeenEyes.Graph.Kesl.Tests/Compiler/GraphTraverserTests.cs
+++ b/tests/KeenEyes.Graph.Kesl.Tests/Compiler/GraphTraverserTests.cs
@@ -24,7 +24,7 @@ public class GraphTraverserTests
         using var builder = new TestGraphBuilder();
         var constant = builder.CreateFloatConstant(1.0f);
         var add = builder.CreateAddNode();
-        var compute = builder.CreateComputeShader();
+        builder.CreateComputeShader();
 
         // constant -> add -> compute (via execute port)
         builder.Connect(constant, 0, add, 0);

--- a/tests/KeenEyes.Graph.Kesl.Tests/Preview/ShaderExecutorTests.cs
+++ b/tests/KeenEyes.Graph.Kesl.Tests/Preview/ShaderExecutorTests.cs
@@ -17,7 +17,7 @@ public class ShaderExecutorTests
     public void Compile_ValidGraph_ReturnsTrue()
     {
         using var builder = new TestGraphBuilder();
-        var shader = builder.CreateComputeShader("TestShader");
+        builder.CreateComputeShader("TestShader");
         builder.CreateQueryBinding("Position", AccessMode.Write);
         builder.CreateQueryBinding("Velocity", AccessMode.Read);
 

--- a/tests/KeenEyes.Graph.Kesl.Tests/Preview/ShaderPreviewPanelTests.cs
+++ b/tests/KeenEyes.Graph.Kesl.Tests/Preview/ShaderPreviewPanelTests.cs
@@ -298,9 +298,9 @@ public class ShaderPreviewPanelTests
         using var builder = new TestGraphBuilder();
 
         // Create a physics update shader
-        var shader = builder.CreateComputeShader("PhysicsUpdate");
-        var posBinding = builder.CreateQueryBinding("Position", AccessMode.Write);
-        var velBinding = builder.CreateQueryBinding("Velocity", AccessMode.Read);
+        builder.CreateComputeShader("PhysicsUpdate");
+        builder.CreateQueryBinding("Position", AccessMode.Write);
+        builder.CreateQueryBinding("Velocity", AccessMode.Read);
 
         var panel = new ShaderPreviewPanel { DeltaTime = 1.0f };
         panel.SetCanvas(builder.Canvas, builder.World);

--- a/tests/KeenEyes.Logging.Tests/EcsLoggingPluginTests.cs
+++ b/tests/KeenEyes.Logging.Tests/EcsLoggingPluginTests.cs
@@ -96,7 +96,7 @@ public class EcsLoggingPluginTests
         world.InstallPlugin(plugin);
         provider.Clear(); // Clear any installation logs
 
-        var entity = world.Spawn("TestEntity").Build();
+        world.Spawn("TestEntity").Build();
 
         provider.ContainsCategory("ECS.Entity").ShouldBeTrue();
         provider.ContainsMessage("created").ShouldBeTrue();
@@ -195,7 +195,7 @@ public class EcsLoggingPluginTests
         plugin.EnableComponentLogging<TestPosition>();
         provider.Clear();
 
-        var entity = world.Spawn().With(new TestPosition { X = 1, Y = 2 }).Build();
+        world.Spawn().With(new TestPosition { X = 1, Y = 2 }).Build();
 
         var componentLogs = provider.GetByCategory("ECS.Component");
         componentLogs.Count.ShouldBeGreaterThanOrEqualTo(1);
@@ -256,7 +256,7 @@ public class EcsLoggingPluginTests
         // Note: Not calling EnableComponentLogging<TestPosition>()
         provider.Clear();
 
-        var entity = world.Spawn().With(new TestPosition { X = 1, Y = 2 }).Build();
+        world.Spawn().With(new TestPosition { X = 1, Y = 2 }).Build();
 
         var componentLogs = provider.GetByCategory("ECS.Component");
         componentLogs.Count.ShouldBe(0);
@@ -276,7 +276,7 @@ public class EcsLoggingPluginTests
         plugin.EnableComponentLogging<TestVelocity>();
         provider.Clear();
 
-        var entity = world.Spawn()
+        world.Spawn()
             .With(new TestPosition { X = 1, Y = 2 })
             .With(new TestVelocity { X = 3, Y = 4 })
             .Build();
@@ -328,7 +328,7 @@ public class EcsLoggingPluginTests
         provider.Clear();
 
         // This should NOT be logged (Debug < Warning)
-        var entity = world.Spawn().Build();
+        world.Spawn().Build();
 
         var entityLogs = provider.GetByCategory("ECS.Entity");
         entityLogs.Count.ShouldBe(0);

--- a/tests/KeenEyes.Logging.Tests/Providers/RingBufferLogProviderTests.cs
+++ b/tests/KeenEyes.Logging.Tests/Providers/RingBufferLogProviderTests.cs
@@ -420,7 +420,6 @@ public class RingBufferLogProviderTests
     public void Query_ByTimeRange_ReturnsMatchingEntries()
     {
         using var provider = new RingBufferLogProvider();
-        var baseTime = DateTime.Now;
 
         provider.Log(LogLevel.Info, "Test", "Message 1", null);
         Thread.Sleep(50);
@@ -590,7 +589,7 @@ public class RingBufferLogProviderTests
     [Fact]
     public void Dispose_ClearsEntries()
     {
-        var provider = new RingBufferLogProvider();
+        using var provider = new RingBufferLogProvider();
         provider.Log(LogLevel.Info, "Test", "Message", null);
 
         provider.Dispose();

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockProcessController.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Mocks/MockProcessController.cs
@@ -143,9 +143,9 @@ internal sealed class MockProcessController : IProcessController
     /// </summary>
     public void AddStdout(int processId, string output)
     {
-        if (stdoutBuffers.ContainsKey(processId))
+        if (stdoutBuffers.TryGetValue(processId, out var existing))
         {
-            stdoutBuffers[processId] += output;
+            stdoutBuffers[processId] = existing + output;
         }
     }
 
@@ -154,9 +154,9 @@ internal sealed class MockProcessController : IProcessController
     /// </summary>
     public void AddStderr(int processId, string output)
     {
-        if (stderrBuffers.ContainsKey(processId))
+        if (stderrBuffers.TryGetValue(processId, out var existing))
         {
-            stderrBuffers[processId] += output;
+            stderrBuffers[processId] = existing + output;
         }
     }
 }

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
@@ -391,7 +391,7 @@ public class DotRecastProviderTests : IDisposable
     public void Dispose_MarksNotReady()
     {
         var mesh = TestHelper.BuildTestNavMesh();
-        var tempProvider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+        using var tempProvider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
 
         Assert.True(tempProvider.IsReady);
 
@@ -415,7 +415,7 @@ public class DotRecastProviderTests : IDisposable
     public void Dispose_CancelsPendingRequests()
     {
         var mesh = TestHelper.BuildTestNavMesh();
-        var tempProvider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
+        using var tempProvider = new DotRecastProvider(mesh, TestHelper.CreateTestConfig());
         var request = tempProvider.RequestPath(
             new Vector3(5f, 0, 5f),
             new Vector3(15f, 0, 15f),

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
@@ -396,7 +396,7 @@ public class GridNavigationProviderTests : IDisposable
     [Fact]
     public void Dispose_MarksNotReady()
     {
-        var tempProvider = new GridNavigationProvider(GridConfig.Default);
+        using var tempProvider = new GridNavigationProvider(GridConfig.Default);
         Assert.True(tempProvider.IsReady);
 
         tempProvider.Dispose();
@@ -417,7 +417,7 @@ public class GridNavigationProviderTests : IDisposable
     [Fact]
     public void Dispose_CancelsPendingRequests()
     {
-        var tempProvider = new GridNavigationProvider(GridConfig.Default);
+        using var tempProvider = new GridNavigationProvider(GridConfig.Default);
         var request = tempProvider.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
 
         tempProvider.Dispose();

--- a/tests/KeenEyes.Navigation.Grid.Tests/NavigationGridTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/NavigationGridTests.cs
@@ -84,9 +84,9 @@ public class NavigationGridTests
     {
         var grid = new NavigationGrid(10, 10, 1f);
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(10, 5)]; });
-        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(5, 10)]; });
-        Assert.Throws<ArgumentOutOfRangeException>(() => { var _ = grid[new GridCoordinate(-1, 5)]; });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { _ = grid[new GridCoordinate(10, 5)]; });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { _ = grid[new GridCoordinate(5, 10)]; });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { _ = grid[new GridCoordinate(-1, 5)]; });
     }
 
     [Fact]

--- a/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
@@ -137,7 +137,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_RegistersNavMeshAgentComponent()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         // Use custom provider to avoid dependency on GridNavigationPlugin
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
@@ -150,7 +150,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -160,7 +160,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_RegistersNavMeshObstacleComponent()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -172,7 +172,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -186,7 +186,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_RegistersPathRequestSystem()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -198,7 +198,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -209,7 +209,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_WithSteeringEnabled_RegistersNavMeshAgentSystem()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -222,7 +222,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -232,7 +232,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_WithSteeringDisabled_DoesNotRegisterNavMeshAgentSystem()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -245,7 +245,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -255,7 +255,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_WithDynamicObstaclesEnabled_RegistersObstacleUpdateSystem()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -268,7 +268,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 
@@ -278,7 +278,7 @@ public class NavigationPluginTests : IDisposable
     [Fact]
     public void Install_WithDynamicObstaclesDisabled_DoesNotRegisterObstacleUpdateSystem()
     {
-        using var world = new World();
+        using var testWorld = new World();
 
         var gridConfig = GridConfig.WithSize(100, 100, 1f);
         var customProvider = new GridNavigationProvider(gridConfig);
@@ -291,7 +291,7 @@ public class NavigationPluginTests : IDisposable
         };
 
         var plugin = new NavigationPlugin(config);
-        var context = new MockPluginContext(plugin, world);
+        var context = new MockPluginContext(plugin, testWorld);
 
         plugin.Install(context);
 

--- a/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
+++ b/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
@@ -273,7 +273,6 @@ public class BitReaderTests
     public void ReadBits_ZeroBits_ThrowsArgumentOutOfRange()
     {
         byte[] data = [0xFF];
-        var reader = new BitReader(data);
 
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ReadBitsHelper(data, 0));
         Assert.Equal("bits", ex.ParamName);

--- a/tests/KeenEyes.Network.Tests/NetworkMessageProtocolTests.cs
+++ b/tests/KeenEyes.Network.Tests/NetworkMessageProtocolTests.cs
@@ -416,7 +416,6 @@ public class NetworkMessageProtocolTests
 
         // Write multiple messages
         writer.WriteHeader(MessageType.Ping, 1);
-        var pingEnd = writer.BytesWritten;
 
         Span<byte> buffer2 = stackalloc byte[256];
         var writer2 = new NetworkMessageWriter(buffer2);

--- a/tests/KeenEyes.Network.Tests/UdpTransportTests.cs
+++ b/tests/KeenEyes.Network.Tests/UdpTransportTests.cs
@@ -135,44 +135,36 @@ public class UdpTransportTests
     [Fact]
     public async Task ClientConnected_RaisedOnServerWhenClientConnects()
     {
-        var server = new UdpTransport();
-        var client = new UdpTransport();
+        using var server = new UdpTransport();
+        using var client = new UdpTransport();
 
+        await server.ListenAsync(0);
+        var port = server.LocalPort;
+
+        int? connectedClientId = null;
+        server.ClientConnected += id => connectedClientId = id;
+
+        using var cts = new CancellationTokenSource(2000);
         try
         {
-            await server.ListenAsync(0);
-            var port = server.LocalPort;
-
-            int? connectedClientId = null;
-            server.ClientConnected += id => connectedClientId = id;
-
-            using var cts = new CancellationTokenSource(2000);
-            try
-            {
-                await client.ConnectAsync("127.0.0.1", port, cts.Token);
-            }
-            catch (TimeoutException)
-            {
-                Assert.Skip("UDP networking not available in this environment");
-                return;
-            }
-            catch (OperationCanceledException)
-            {
-                Assert.Skip("UDP networking not available in this environment");
-                return;
-            }
-
-            await Task.Delay(100);
-            server.Update();
-
-            Assert.NotNull(connectedClientId);
-            Assert.True(connectedClientId > 0);
+            await client.ConnectAsync("127.0.0.1", port, cts.Token);
         }
-        finally
+        catch (TimeoutException)
         {
-            server.Dispose();
-            client.Dispose();
+            Assert.Skip("UDP networking not available in this environment");
+            return;
         }
+        catch (OperationCanceledException)
+        {
+            Assert.Skip("UDP networking not available in this environment");
+            return;
+        }
+
+        await Task.Delay(100);
+        server.Update();
+
+        Assert.NotNull(connectedClientId);
+        Assert.True(connectedClientId > 0);
     }
 
     [Fact]

--- a/tests/KeenEyes.Parallelism.Tests/ParallelProfilerTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/ParallelProfilerTests.cs
@@ -158,7 +158,7 @@ public class ParallelProfilerTests
     {
         var (world, scheduler) = CreateScheduler();
         using var _ = world;
-        var profiler = new ParallelProfiler(scheduler);
+        using var profiler = new ParallelProfiler(scheduler);
 
         profiler.Start();
         profiler.Dispose();
@@ -216,8 +216,8 @@ public class ParallelProfilerTests
 
         var metrics = profiler.GetMetrics();
 
-        Assert.True(metrics.SystemStats.ContainsKey(typeof(MovementSystem)));
-        Assert.Equal(1, metrics.SystemStats[typeof(MovementSystem)].ExecutionCount);
+        Assert.True(metrics.SystemStats.TryGetValue(typeof(MovementSystem), out var movementStats));
+        Assert.Equal(1, movementStats.ExecutionCount);
     }
 
     [Fact]
@@ -523,7 +523,7 @@ public class ParallelProfilerTests
     {
         var (world, scheduler) = CreateScheduler();
         using var _ = world;
-        var profiler = new ParallelProfiler(scheduler);
+        using var profiler = new ParallelProfiler(scheduler);
 
         profiler.Dispose();
         profiler.Dispose(); // Should not throw

--- a/tests/KeenEyes.Parallelism.Tests/ParallelQueryExtensionsTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/ParallelQueryExtensionsTests.cs
@@ -101,8 +101,8 @@ public class ParallelQueryExtensionsTests
         for (int i = 0; i < 50; i++)
         {
             ref var pos = ref world.Get<ParallelTestPosition>(entities[i]);
-            Assert.Equal(i * 2, pos.X);
-            Assert.Equal(i * 2, pos.Y);
+            Assert.Equal(i * 2f, pos.X);
+            Assert.Equal(i * 2f, pos.Y);
         }
     }
 
@@ -214,7 +214,7 @@ public class ParallelQueryExtensionsTests
         {
             entities.Add(world.Spawn()
                 .With(new ParallelTestPosition { X = 0, Y = 0 })
-                .With(new ParallelTestVelocity { X = i, Y = i * 2 })
+                .With(new ParallelTestVelocity { X = i, Y = i * 2f })
                 .Build());
         }
 
@@ -231,7 +231,7 @@ public class ParallelQueryExtensionsTests
         {
             ref var pos = ref world.Get<ParallelTestPosition>(entities[i]);
             Assert.Equal(i, pos.X);
-            Assert.Equal(i * 2, pos.Y);
+            Assert.Equal(i * 2f, pos.Y);
         }
     }
 

--- a/tests/KeenEyes.Parallelism.Tests/ParallelSystemPluginTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/ParallelSystemPluginTests.cs
@@ -418,7 +418,7 @@ public class ParallelSystemPluginTests
             for (int i = 0; i < 10; i++)
             {
                 world.Spawn()
-                    .With(new Position { X = i * 10, Y = 0 })
+                    .With(new Position { X = i * 10f, Y = 0 })
                     .With(new Velocity { X = 1, Y = 2 })
                     .Build();
             }

--- a/tests/KeenEyes.Particles.Tests/ParticleSystemIntegrationTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleSystemIntegrationTests.cs
@@ -227,7 +227,7 @@ public class ParticleSystemIntegrationTests : IDisposable
         }
 
         // Particle should have moved
-        Assert.True(pool.PositionsX[idx] != initialX);
+        Assert.False(pool.PositionsX[idx].ApproximatelyEquals(initialX));
     }
 
     [Fact]

--- a/tests/KeenEyes.Particles.Tests/ParticlesPluginTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticlesPluginTests.cs
@@ -535,7 +535,7 @@ public class ParticlesPluginTests : IDisposable
     {
         using var w = new World();
         var config = ParticlesConfig.Default;
-        var manager = new ParticleManager(w, config);
+        using var manager = new ParticleManager(w, config);
 
         var entity = new Entity(1, 0);
         var emitter = ParticleEmitter.Burst(10, 1f);
@@ -556,7 +556,6 @@ public class ParticlesPluginTests : IDisposable
         Assert.Equal(1, manager.EmitterCount);
         Assert.Same(originalPool, manager.GetPool(entity));
 
-        manager.Dispose();
     }
 
     [Fact]
@@ -564,7 +563,7 @@ public class ParticlesPluginTests : IDisposable
     {
         using var w = new World();
         var config = ParticlesConfig.Default;
-        var manager = new ParticleManager(w, config);
+        using var manager = new ParticleManager(w, config);
 
         var entity = new Entity(999, 0);
 
@@ -573,7 +572,6 @@ public class ParticlesPluginTests : IDisposable
 
         Assert.Equal(0, manager.EmitterCount);
 
-        manager.Dispose();
     }
 
     #endregion

--- a/tests/KeenEyes.Persistence.Tests/EncryptedPersistenceApiAdditionalTests.cs
+++ b/tests/KeenEyes.Persistence.Tests/EncryptedPersistenceApiAdditionalTests.cs
@@ -64,7 +64,7 @@ public class EncryptedPersistenceApiAdditionalTests : IDisposable
         api.SaveToSlot("json_load_slot", serializer, options);
         world.Clear();
 
-        var (slotInfo, entityMap) = api.LoadFromSlot("json_load_slot", serializer);
+        var (slotInfo, _) = api.LoadFromSlot("json_load_slot", serializer);
 
         Assert.Equal(SaveFormat.Json, slotInfo.Format);
         var player = world.GetEntityByName("Player");
@@ -105,7 +105,7 @@ public class EncryptedPersistenceApiAdditionalTests : IDisposable
         await api.SaveToSlotAsync("async_json_load", serializer, options, TestContext.Current.CancellationToken);
         world.Clear();
 
-        var (info, entityMap) = await api.LoadFromSlotAsync("async_json_load", serializer, cancellationToken: TestContext.Current.CancellationToken);
+        var (info, _) = await api.LoadFromSlotAsync("async_json_load", serializer, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(SaveFormat.Json, info.Format);
         var player = world.GetEntityByName("AsyncPlayer");

--- a/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
+++ b/tests/KeenEyes.Persistence.Tests/PersistencePluginTests.cs
@@ -150,7 +150,7 @@ public class PersistencePluginTests : IDisposable
         api.SaveToSlot("slot1", serializer);
         world.Clear();
 
-        var (_, entityMap) = api.LoadFromSlot("slot1", serializer);
+        api.LoadFromSlot("slot1", serializer);
 
         Assert.Single(world.GetAllEntities());
         var player = world.GetEntityByName("Player");
@@ -192,7 +192,7 @@ public class PersistencePluginTests : IDisposable
         api.SaveToSlot("slot1", serializer);
         world.Clear();
 
-        var (_, entityMap) = api.LoadFromSlot("slot1", serializer);
+        api.LoadFromSlot("slot1", serializer);
 
         var player = world.GetEntityByName("Player");
         Assert.True(player.IsValid);
@@ -351,7 +351,7 @@ public class PersistencePluginTests : IDisposable
         await api.SaveToSlotAsync("slot1", serializer, cancellationToken: TestContext.Current.CancellationToken);
         world.Clear();
 
-        var (info, entityMap) = await api.LoadFromSlotAsync("slot1", serializer, cancellationToken: TestContext.Current.CancellationToken);
+        await api.LoadFromSlotAsync("slot1", serializer, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Single(world.GetAllEntities());
     }

--- a/tests/KeenEyes.TestBridge.Tests/Process/ProcessControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Process/ProcessControllerImplTests.cs
@@ -321,7 +321,7 @@ public class ProcessControllerImplTests : IDisposable
     public async Task Dispose_WithRunningProcesses_KillsAll()
     {
         using var testController = new ProcessControllerImpl();
-        var info = await testController.StartAsync("dotnet", "--help");
+        await testController.StartAsync("dotnet", "--help");
 
         testController.Dispose();
 
@@ -333,7 +333,7 @@ public class ProcessControllerImplTests : IDisposable
     [Fact]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
-        var testController = new ProcessControllerImpl();
+        using var testController = new ProcessControllerImpl();
 
         testController.Dispose();
         testController.Dispose(); // Should not throw

--- a/tests/KeenEyes.TestBridge.Tests/State/StateControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/State/StateControllerImplTests.cs
@@ -65,7 +65,7 @@ public class StateControllerImplTests
     public async Task GetEntityByNameAsync_ExistingEntity_ReturnsSnapshot()
     {
         using var world = new World();
-        var entity = world.Spawn()
+        world.Spawn()
             .WithName("Player")
             .Build();
         using var bridge = new InProcessBridge(world);


### PR DESCRIPTION
## Summary
- Final fix batch (7 of 7) of the CodeQL cleanup: 155 alerts across ~15 smaller test projects — 123 fixed, 32 recorded for dismissal.
- **SimpleFormatterTests verdict: false positive**, not deliberate-malformed input — the 9 `cs/invalid-string-formatting` alerts flag `{name}`-style placeholders that are `SimpleFormatter`'s own documented template DSL, which CodeQL misreads as .NET composite format strings.
- Fixes: 71 unused-local cleanups, 30 `using var` conversions (post-dispose-assertion sites preserved), shadowing renames, float literals, `TryGetValue`, one Particles float comparison correctly moved to `ApproximatelyEquals`.
- Dismissal-bound: formatter DSL false positives, best-effort-cleanup catch-alls, the AOT smoke test's deliberate exact-float asserts, one `Equals(null)` contract test.

## Test plan
- [x] 17 touched test projects all 0 failed (agent) + independently re-verified post-rebase: Parallelism 102/102 (full project — the agent's 600s hang was fleet-load contention, gone on a quiet machine), Network 312, Generators 474
- [x] AotCompatibility smoke exe: 15 PASS / 0 FAIL
- [x] Release build 0 warnings / 0 errors; format verify exit 0

## Related Issues
Security-tab cleanup — remaining tests batch (7 of 7)