### PR TITLE
chore(samples): Fix null-safety teaching patterns from nightly review

### DIFF
--- a/samples/KeenEyes.Sample.PBR/Systems.cs
+++ b/samples/KeenEyes.Sample.PBR/Systems.cs
@@ -103,14 +103,14 @@ public class CameraZoomSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        if (World.TryGetExtension<IInputContext>(out var ctx))
+        if (World.TryGetExtension<IInputContext>(out var ctx) && ctx is not null)
         {
             input = ctx;
             scrollHandler = args =>
             {
                 accumulatedScroll += args.DeltaY;
             };
-            ctx!.Mouse.OnScroll += scrollHandler;
+            ctx.Mouse.OnScroll += scrollHandler;
         }
     }
 

--- a/samples/KeenEyes.Sample.SchemaMigration/Program.cs
+++ b/samples/KeenEyes.Sample.SchemaMigration/Program.cs
@@ -106,7 +106,12 @@ if (!File.Exists(v2SavePath))
 
 Console.WriteLine($"  Loading: {v2SavePath}");
 var v2Json = File.ReadAllText(v2SavePath);
-var v2Snapshot = SnapshotManager.FromJson(v2Json)!;
+var v2Snapshot = SnapshotManager.FromJson(v2Json);
+if (v2Snapshot == null)
+{
+    Console.WriteLine("  ERROR: Failed to parse v2 snapshot");
+    return;
+}
 
 // Show what versions are in the save
 Console.WriteLine("\n  Component versions in save file:");

--- a/samples/KeenEyes.Sample/Systems.cs
+++ b/samples/KeenEyes.Sample/Systems.cs
@@ -210,9 +210,9 @@ public class DebugStatsSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Access the extension set by our plugin
-        if (World.TryGetExtension<DebugStats>(out var stats))
+        if (World.TryGetExtension<DebugStats>(out var stats) && stats is not null)
         {
-            stats!.EntitiesProcessed = World.EntityCount;
+            stats.EntitiesProcessed = World.EntityCount;
             Console.WriteLine($"  DebugStatsSystem: {stats.EntitiesProcessed} entities");
         }
     }


### PR DESCRIPTION
## Summary
- Findings 3 and 9 from the nightly review (#1082), with honest verdicts on both deviations:
- **Finding 3 fixed as specified**: SchemaMigration's `FromJson(v2Json)!` now mirrors the file's own correct v1 null-guard pattern.
- **Finding 9 fixed differently — the review's premise was wrong**: `IWorld.TryGetExtension` does *not* carry `[MaybeNullWhen(false)]` (only the concrete `World`/`ExtensionManager` overloads do), so dropping the `!` alone is CS8602. The `!` (the actual smell) is removed and replaced with an explicit `is not null` guard matching production usage. The missing interface annotation is filed separately as the real root cause.
- **Finding 4 rejected as invalid**: `required` on `[System]`-attributed types breaks the source generator's `world.AddSystem<T>()`/`new()` constraint (CS9040, verified) — the `= null!` init pattern is the intentional framework idiom for injected system dependencies. Reverted; noted on #1082.

## Test plan
- [x] Full Release build 0 warnings / 0 errors (independently re-verified); format verify exit 0

## Related Issues
Nightly review #1082 (findings 3, 9; finding 4 rejected with reasons)