### PR TITLE
fix(core): Harden binary snapshot deserialization against crafted saves

### DIFF
--- a/src/KeenEyes.Abstractions/Commands/AddComponentCommand.cs
+++ b/src/KeenEyes.Abstractions/Commands/AddComponentCommand.cs
@@ -7,10 +7,8 @@ namespace KeenEyes;
 /// If the target is a placeholder entity (negative ID), it will be resolved
 /// to the real entity through the entity map during execution.
 /// </remarks>
-internal sealed class AddComponentCommand : ICommand
+internal sealed class AddComponentCommand : PlaceholderResolvingCommand
 {
-    private readonly Entity targetEntity;
-    private readonly int? placeholderId;
     private readonly Action<IWorld, Entity> addAction;
 
     /// <summary>
@@ -19,9 +17,8 @@ internal sealed class AddComponentCommand : ICommand
     /// <param name="entity">The entity to add the component to.</param>
     /// <param name="addAction">Delegate that adds the component to the world.</param>
     public AddComponentCommand(Entity entity, Action<IWorld, Entity> addAction)
+        : base(entity)
     {
-        targetEntity = entity;
-        placeholderId = null;
         this.addAction = addAction;
     }
 
@@ -31,14 +28,13 @@ internal sealed class AddComponentCommand : ICommand
     /// <param name="placeholderId">The placeholder ID of the entity.</param>
     /// <param name="addAction">Delegate that adds the component to the world.</param>
     public AddComponentCommand(int placeholderId, Action<IWorld, Entity> addAction)
+        : base(placeholderId)
     {
-        targetEntity = Entity.Null;
-        this.placeholderId = placeholderId;
         this.addAction = addAction;
     }
 
     /// <inheritdoc />
-    public void Execute(IWorld world, Dictionary<int, Entity> entityMap)
+    public override void Execute(IWorld world, Dictionary<int, Entity> entityMap)
     {
         var entity = ResolveEntity(entityMap);
         if (!entity.IsValid || !world.IsAlive(entity))
@@ -48,16 +44,5 @@ internal sealed class AddComponentCommand : ICommand
 
         // Invoke the stored delegate (no reflection)
         addAction(world, entity);
-    }
-
-    private Entity ResolveEntity(Dictionary<int, Entity> entityMap)
-    {
-        if (placeholderId.HasValue)
-        {
-            return entityMap.TryGetValue(placeholderId.Value, out var resolved)
-                ? resolved
-                : Entity.Null;
-        }
-        return targetEntity;
     }
 }

--- a/src/KeenEyes.Abstractions/Commands/DespawnCommand.cs
+++ b/src/KeenEyes.Abstractions/Commands/DespawnCommand.cs
@@ -7,19 +7,15 @@ namespace KeenEyes;
 /// If the target is a placeholder entity (negative ID), it will be resolved
 /// to the real entity through the entity map during execution.
 /// </remarks>
-internal sealed class DespawnCommand : ICommand
+internal sealed class DespawnCommand : PlaceholderResolvingCommand
 {
-    private readonly Entity targetEntity;
-    private readonly int? placeholderId;
-
     /// <summary>
     /// Creates a despawn command for an existing entity.
     /// </summary>
     /// <param name="entity">The entity to despawn.</param>
     public DespawnCommand(Entity entity)
+        : base(entity)
     {
-        targetEntity = entity;
-        placeholderId = null;
     }
 
     /// <summary>
@@ -27,29 +23,17 @@ internal sealed class DespawnCommand : ICommand
     /// </summary>
     /// <param name="placeholderId">The placeholder ID of the entity to despawn.</param>
     public DespawnCommand(int placeholderId)
+        : base(placeholderId)
     {
-        targetEntity = Entity.Null;
-        this.placeholderId = placeholderId;
     }
 
     /// <inheritdoc />
-    public void Execute(IWorld world, Dictionary<int, Entity> entityMap)
+    public override void Execute(IWorld world, Dictionary<int, Entity> entityMap)
     {
         var entity = ResolveEntity(entityMap);
         if (entity.IsValid)
         {
             world.Despawn(entity);
         }
-    }
-
-    private Entity ResolveEntity(Dictionary<int, Entity> entityMap)
-    {
-        if (placeholderId.HasValue)
-        {
-            return entityMap.TryGetValue(placeholderId.Value, out var resolved)
-                ? resolved
-                : Entity.Null;
-        }
-        return targetEntity;
     }
 }

--- a/src/KeenEyes.Abstractions/Commands/PlaceholderResolvingCommand.cs
+++ b/src/KeenEyes.Abstractions/Commands/PlaceholderResolvingCommand.cs
@@ -1,0 +1,57 @@
+namespace KeenEyes;
+
+/// <summary>
+/// Base class for commands that target an entity which may be a placeholder
+/// created earlier in the same command buffer.
+/// </summary>
+/// <remarks>
+/// Stores either a real entity handle or a placeholder ID (negative value) and
+/// resolves the actual target through the entity map at execution time.
+/// </remarks>
+internal abstract class PlaceholderResolvingCommand : ICommand
+{
+    private readonly Entity targetEntity;
+    private readonly int? placeholderId;
+
+    /// <summary>
+    /// Initializes the command to target an existing entity.
+    /// </summary>
+    /// <param name="entity">The entity the command operates on.</param>
+    protected PlaceholderResolvingCommand(Entity entity)
+    {
+        targetEntity = entity;
+        placeholderId = null;
+    }
+
+    /// <summary>
+    /// Initializes the command to target a placeholder entity.
+    /// </summary>
+    /// <param name="placeholderId">The placeholder ID of the entity the command operates on.</param>
+    protected PlaceholderResolvingCommand(int placeholderId)
+    {
+        targetEntity = Entity.Null;
+        this.placeholderId = placeholderId;
+    }
+
+    /// <inheritdoc />
+    public abstract void Execute(IWorld world, Dictionary<int, Entity> entityMap);
+
+    /// <summary>
+    /// Resolves the target entity, mapping a placeholder ID to the real entity if needed.
+    /// </summary>
+    /// <param name="entityMap">The placeholder-to-real entity map.</param>
+    /// <returns>
+    /// The resolved entity, or <see cref="Entity.Null"/> if the placeholder has no mapping.
+    /// </returns>
+    protected Entity ResolveEntity(Dictionary<int, Entity> entityMap)
+    {
+        if (placeholderId.HasValue)
+        {
+            return entityMap.TryGetValue(placeholderId.Value, out var resolved)
+                ? resolved
+                : Entity.Null;
+        }
+
+        return targetEntity;
+    }
+}

--- a/src/KeenEyes.Abstractions/Commands/RemoveComponentCommand.cs
+++ b/src/KeenEyes.Abstractions/Commands/RemoveComponentCommand.cs
@@ -7,10 +7,8 @@ namespace KeenEyes;
 /// If the target is a placeholder entity (negative ID), it will be resolved
 /// to the real entity through the entity map during execution.
 /// </remarks>
-internal sealed class RemoveComponentCommand : ICommand
+internal sealed class RemoveComponentCommand : PlaceholderResolvingCommand
 {
-    private readonly Entity targetEntity;
-    private readonly int? placeholderId;
     private readonly Action<IWorld, Entity> removeAction;
 
     /// <summary>
@@ -19,9 +17,8 @@ internal sealed class RemoveComponentCommand : ICommand
     /// <param name="entity">The entity to remove the component from.</param>
     /// <param name="removeAction">Delegate that removes the component from the world.</param>
     public RemoveComponentCommand(Entity entity, Action<IWorld, Entity> removeAction)
+        : base(entity)
     {
-        targetEntity = entity;
-        placeholderId = null;
         this.removeAction = removeAction;
     }
 
@@ -31,14 +28,13 @@ internal sealed class RemoveComponentCommand : ICommand
     /// <param name="placeholderId">The placeholder ID of the entity.</param>
     /// <param name="removeAction">Delegate that removes the component from the world.</param>
     public RemoveComponentCommand(int placeholderId, Action<IWorld, Entity> removeAction)
+        : base(placeholderId)
     {
-        targetEntity = Entity.Null;
-        this.placeholderId = placeholderId;
         this.removeAction = removeAction;
     }
 
     /// <inheritdoc />
-    public void Execute(IWorld world, Dictionary<int, Entity> entityMap)
+    public override void Execute(IWorld world, Dictionary<int, Entity> entityMap)
     {
         var entity = ResolveEntity(entityMap);
         if (!entity.IsValid || !world.IsAlive(entity))
@@ -48,16 +44,5 @@ internal sealed class RemoveComponentCommand : ICommand
 
         // Invoke the stored delegate (no reflection)
         removeAction(world, entity);
-    }
-
-    private Entity ResolveEntity(Dictionary<int, Entity> entityMap)
-    {
-        if (placeholderId.HasValue)
-        {
-            return entityMap.TryGetValue(placeholderId.Value, out var resolved)
-                ? resolved
-                : Entity.Null;
-        }
-        return targetEntity;
     }
 }

--- a/src/KeenEyes.Abstractions/Commands/SetComponentCommand.cs
+++ b/src/KeenEyes.Abstractions/Commands/SetComponentCommand.cs
@@ -7,10 +7,8 @@ namespace KeenEyes;
 /// If the target is a placeholder entity (negative ID), it will be resolved
 /// to the real entity through the entity map during execution.
 /// </remarks>
-internal sealed class SetComponentCommand : ICommand
+internal sealed class SetComponentCommand : PlaceholderResolvingCommand
 {
-    private readonly Entity targetEntity;
-    private readonly int? placeholderId;
     private readonly Action<IWorld, Entity> setAction;
 
     /// <summary>
@@ -19,9 +17,8 @@ internal sealed class SetComponentCommand : ICommand
     /// <param name="entity">The entity to set the component on.</param>
     /// <param name="setAction">Delegate that sets the component on the world.</param>
     public SetComponentCommand(Entity entity, Action<IWorld, Entity> setAction)
+        : base(entity)
     {
-        targetEntity = entity;
-        placeholderId = null;
         this.setAction = setAction;
     }
 
@@ -31,14 +28,13 @@ internal sealed class SetComponentCommand : ICommand
     /// <param name="placeholderId">The placeholder ID of the entity.</param>
     /// <param name="setAction">Delegate that sets the component on the world.</param>
     public SetComponentCommand(int placeholderId, Action<IWorld, Entity> setAction)
+        : base(placeholderId)
     {
-        targetEntity = Entity.Null;
-        this.placeholderId = placeholderId;
         this.setAction = setAction;
     }
 
     /// <inheritdoc />
-    public void Execute(IWorld world, Dictionary<int, Entity> entityMap)
+    public override void Execute(IWorld world, Dictionary<int, Entity> entityMap)
     {
         var entity = ResolveEntity(entityMap);
         if (!entity.IsValid || !world.IsAlive(entity))
@@ -48,16 +44,5 @@ internal sealed class SetComponentCommand : ICommand
 
         // Invoke the stored delegate (no reflection)
         setAction(world, entity);
-    }
-
-    private Entity ResolveEntity(Dictionary<int, Entity> entityMap)
-    {
-        if (placeholderId.HasValue)
-        {
-            return entityMap.TryGetValue(placeholderId.Value, out var resolved)
-                ? resolved
-                : Entity.Null;
-        }
-        return targetEntity;
     }
 }

--- a/src/KeenEyes.Core/EntityNamingManager.cs
+++ b/src/KeenEyes.Core/EntityNamingManager.cs
@@ -14,8 +14,11 @@ namespace KeenEyes;
 /// need human-readable identifiers.
 /// </para>
 /// <para>
-/// This class is thread-safe: all naming operations can be called concurrently
-/// from multiple threads.
+/// Each operation on this class acquires an internal lock, so individual calls are safe
+/// from multiple threads, and name uniqueness is checked and enforced atomically within
+/// <see cref="RegisterName"/> and <see cref="SetName"/>. Sequences of separate calls are
+/// not atomic as a whole; per the threading model documented on <see cref="World"/>,
+/// world operations are expected to run on a single thread.
 /// </para>
 /// </remarks>
 internal sealed class EntityNamingManager
@@ -29,13 +32,15 @@ internal sealed class EntityNamingManager
     private readonly Dictionary<string, int> namesToEntityIds = [];
 
     /// <summary>
-    /// Validates that a name is available for use.
+    /// Validates name availability and registers the name for an entity in a single
+    /// atomic operation.
     /// </summary>
-    /// <param name="name">The name to validate.</param>
+    /// <param name="entityId">The entity ID to register the name for.</param>
+    /// <param name="name">The name to register. If null, no registration occurs.</param>
     /// <exception cref="ArgumentException">
     /// Thrown when the name is already assigned to another entity.
     /// </exception>
-    internal void ValidateName(string? name)
+    internal void RegisterName(int entityId, string? name)
     {
         if (name is null)
         {
@@ -49,28 +54,7 @@ internal sealed class EntityNamingManager
                 throw new ArgumentException(
                     $"An entity with the name '{name}' already exists in this world.", nameof(name));
             }
-        }
-    }
 
-    /// <summary>
-    /// Registers a name for an entity.
-    /// </summary>
-    /// <param name="entityId">The entity ID to register the name for.</param>
-    /// <param name="name">The name to register. If null, no registration occurs.</param>
-    /// <remarks>
-    /// <para>
-    /// Call <see cref="ValidateName"/> before this method to ensure the name is available.
-    /// </para>
-    /// </remarks>
-    internal void RegisterName(int entityId, string? name)
-    {
-        if (name is null)
-        {
-            return;
-        }
-
-        lock (syncRoot)
-        {
             entityNames[entityId] = name;
             namesToEntityIds[name] = entityId;
         }

--- a/src/KeenEyes.Core/Serialization/SnapshotManager.cs
+++ b/src/KeenEyes.Core/Serialization/SnapshotManager.cs
@@ -401,6 +401,16 @@ public static class SnapshotManager
     private const int MaxDataLength = 100_000_000;
 
     /// <summary>
+    /// Maximum allowed entity or singleton count in a binary snapshot header to prevent
+    /// DoS via memory exhaustion.
+    /// </summary>
+    /// <remarks>
+    /// A crafted header claiming a huge count would otherwise trigger an enormous list
+    /// allocation before any per-entity validation runs.
+    /// </remarks>
+    private const int MaxEntityCount = 1_000_000;
+
+    /// <summary>
     /// Binary format flags.
     /// </summary>
     [Flags]
@@ -757,6 +767,19 @@ public static class SnapshotManager
         var entityCount = reader.ReadInt32();
         var singletonCount = reader.ReadInt32();
 
+        // Validate counts before using them as list capacities to prevent DoS via memory exhaustion
+        if (entityCount < 0 || entityCount > MaxEntityCount)
+        {
+            throw new InvalidDataException(
+                $"Entity count {entityCount} is invalid or exceeds the maximum allowed count ({MaxEntityCount}).");
+        }
+
+        if (singletonCount < 0 || singletonCount > MaxEntityCount)
+        {
+            throw new InvalidDataException(
+                $"Singleton count {singletonCount} is invalid or exceeds the maximum allowed count ({MaxEntityCount}).");
+        }
+
         // Read timestamp
         var unixMs = reader.ReadInt64();
         var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(unixMs);
@@ -827,8 +850,9 @@ public static class SnapshotManager
                     var dataLength = reader.ReadInt32();
                     if (dataLength != 0)
                     {
-                        // Validate data length to prevent DoS via memory exhaustion
-                        var absoluteLength = Math.Abs(dataLength);
+                        // Validate data length to prevent DoS via memory exhaustion.
+                        // Widen to long before Math.Abs: Math.Abs(int.MinValue) throws OverflowException.
+                        var absoluteLength = Math.Abs((long)dataLength);
                         if (absoluteLength > MaxDataLength)
                         {
                             throw new InvalidDataException(
@@ -905,8 +929,9 @@ public static class SnapshotManager
             var dataLength = reader.ReadInt32();
             JsonElement data;
 
-            // Validate data length to prevent DoS via memory exhaustion
-            var absoluteLength = Math.Abs(dataLength);
+            // Validate data length to prevent DoS via memory exhaustion.
+            // Widen to long before Math.Abs: Math.Abs(int.MinValue) throws OverflowException.
+            var absoluteLength = Math.Abs((long)dataLength);
             if (absoluteLength > MaxDataLength)
             {
                 throw new InvalidDataException(

--- a/src/KeenEyes.Core/World.Entities.cs
+++ b/src/KeenEyes.Core/World.Entities.cs
@@ -127,20 +127,26 @@ public sealed partial class World
     /// </summary>
     internal Entity CreateEntity(List<(ComponentInfo Info, object Data)> components, string? name = null)
     {
-        // Validate name uniqueness before creating the entity
-        entityNamingManager.ValidateName(name);
-
         // Validate component constraints (dependencies and conflicts) before creating entity
         validationManager.ValidateBuild(components);
 
         // Acquire entity from pool
         var entity = entityPool.Acquire();
 
+        // Validate and register the entity name in a single atomic operation.
+        // Release the pooled entity on failure so nothing leaks.
+        try
+        {
+            entityNamingManager.RegisterName(entity.Id, name);
+        }
+        catch (ArgumentException)
+        {
+            entityPool.Release(entity);
+            throw;
+        }
+
         // Add to archetype
         archetypeManager.AddEntity(entity, components);
-
-        // Register the entity name if provided
-        entityNamingManager.RegisterName(entity.Id, name);
 
         // Run custom validators after entity is created (they need access to entity)
         validationManager.ValidateBuildCustom(entity, components);

--- a/tests/KeenEyes.Core.Tests/EntityNamingTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityNamingTests.cs
@@ -76,6 +76,23 @@ public class EntityNamingTests
     }
 
     [Fact]
+    public void Spawn_WithDuplicateName_DoesNotLeakEntity()
+    {
+        using var world = new World();
+
+        world.Spawn("Player")
+            .With(new NamingTestPosition { X = 0f, Y = 0f })
+            .Build();
+
+        Assert.Throws<ArgumentException>(() =>
+            world.Spawn("Player")
+                .With(new NamingTestPosition { X = 1f, Y = 1f })
+                .Build());
+
+        Assert.Equal(1, world.EntityCount);
+    }
+
+    [Fact]
     public void Spawn_WithEmptyName_AllowsEmptyStringAsName()
     {
         using var world = new World();

--- a/tests/KeenEyes.Core.Tests/SerializationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SerializationTests.cs
@@ -478,6 +478,105 @@ public class SerializationTests
         Assert.Contains("version", ex.Message.ToLower());
     }
 
+    /// <summary>
+    /// Builds a crafted binary snapshot payload with a valid header (no string table)
+    /// and the given entity/singleton counts, followed by optional body content.
+    /// </summary>
+    private static byte[] CreateCraftedBinarySnapshot(
+        int entityCount, int singletonCount, Action<BinaryWriter>? writeBody = null)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream))
+        {
+            writer.Write("KEEN"u8);       // Magic bytes
+            writer.Write((ushort)2);      // Binary format version
+            writer.Write((ushort)0);      // Flags: no string table, no metadata
+            writer.Write(entityCount);
+            writer.Write(singletonCount);
+            writer.Write(0L);             // Timestamp (unix ms)
+            writer.Write(1);              // Snapshot version
+            writeBody?.Invoke(writer);
+        }
+
+        return stream.ToArray();
+    }
+
+    [Fact]
+    public void FromBinary_WithComponentDataLengthIntMinValue_ThrowsInvalidDataException()
+    {
+        // A crafted component data length of int.MinValue must not surface as an
+        // unhandled OverflowException from Math.Abs.
+        var crafted = CreateCraftedBinarySnapshot(entityCount: 1, singletonCount: 0, writer =>
+        {
+            writer.Write(1);               // Entity ID
+            writer.Write(-1);              // Parent ID (none)
+            writer.Write("Crafted");       // Entity name
+            writer.Write((ushort)1);       // Component count
+            writer.Write("FakeComponent"); // Component type name (inline, no string table)
+            writer.Write(false);           // IsTag
+            writer.Write((short)1);        // Component schema version
+            writer.Write(int.MinValue);    // Component data length
+        });
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
+    [Fact]
+    public void FromBinary_WithSingletonDataLengthIntMinValue_ThrowsInvalidDataException()
+    {
+        // A crafted singleton data length of int.MinValue must not surface as an
+        // unhandled OverflowException from Math.Abs.
+        var crafted = CreateCraftedBinarySnapshot(entityCount: 0, singletonCount: 1, writer =>
+        {
+            writer.Write("FakeSingleton"); // Singleton type name (inline, no string table)
+            writer.Write(int.MinValue);    // Singleton data length
+        });
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
+    [Fact]
+    public void FromBinary_WithEntityCountIntMaxValue_ThrowsInvalidDataException()
+    {
+        // A header claiming int.MaxValue entities must be rejected before any
+        // list allocation is attempted.
+        var crafted = CreateCraftedBinarySnapshot(entityCount: int.MaxValue, singletonCount: 0);
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
+    [Fact]
+    public void FromBinary_WithNegativeEntityCount_ThrowsInvalidDataException()
+    {
+        var crafted = CreateCraftedBinarySnapshot(entityCount: -1, singletonCount: 0);
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
+    [Fact]
+    public void FromBinary_WithSingletonCountIntMaxValue_ThrowsInvalidDataException()
+    {
+        // A header claiming int.MaxValue singletons must be rejected before any
+        // list allocation is attempted.
+        var crafted = CreateCraftedBinarySnapshot(entityCount: 0, singletonCount: int.MaxValue);
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
+    [Fact]
+    public void FromBinary_WithNegativeSingletonCount_ThrowsInvalidDataException()
+    {
+        var crafted = CreateCraftedBinarySnapshot(entityCount: 0, singletonCount: -1);
+
+        Assert.Throws<InvalidDataException>(() =>
+            SnapshotManager.FromBinary(crafted, testSerializer));
+    }
+
     [Fact]
     public void ToBinary_ThrowsOnNullSnapshot()
     {

--- a/tests/KeenEyes.Spatial.Tests/SimdHelpersTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/SimdHelpersTests.cs
@@ -9,12 +9,14 @@ namespace KeenEyes.Spatial.Tests;
 public class SimdHelpersTests
 {
     [Fact]
-    public void IsHardwareAccelerated_ReturnsBoolean()
+    public void IsHardwareAccelerated_ReadMultipleTimes_ReturnsConsistentValue()
     {
-        // Simply verify the property is accessible
-        // On modern x64 hardware, this should be true
-        _ = SimdHelpers.IsHardwareAccelerated;
-        Assert.True(true); // Property accessed successfully
+        // The property reports a hardware capability, so it must be gate-free:
+        // reading it must not throw and must return the same value on every read.
+        var exception = Record.Exception(() => _ = SimdHelpers.IsHardwareAccelerated);
+        Assert.Null(exception);
+
+        Assert.Equal(SimdHelpers.IsHardwareAccelerated, SimdHelpers.IsHardwareAccelerated);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- The two HIGH findings from nightly review #1082, plus three smaller ones:
- **Crafted-save hardening (`SnapshotManager`)**: `Math.Abs((long)dataLength)` widening kills the `int.MinValue` `OverflowException` escape from the `InvalidDataException` contract; new documented `MaxEntityCount` (1M) bounds `entityCount`/`singletonCount` before any allocation, closing the OOM-DoS gap — both matching the module's existing `MaxDataLength` hardening style. 6 new crafted-binary-payload tests cover both fields at both positions.
- **Entity naming (finding 10)**: validate+register merged into one atomic locked `RegisterName`; class docs now state exactly what's guaranteed. Bonus regression fix: a duplicate-name spawn no longer leaks a pooled entity (`CreateEntity` releases on failure, with a guarding test).
- **Command dedup (finding 11)**: shared `PlaceholderResolvingCommand` base extracts the 4× duplicated fields/ctors/`ResolveEntity` (fully documented; all types internal, no structural blockers).
- **Finding 12**: the `Assert.True(true)` tautology became a consistency assertion; SIMD/scalar equivalence was already covered by the neighboring `*_MatchesScalarImplementation` tests.

## Test plan
- [x] 8 new tests; Core.Tests 2329/0, Spatial 496/0, Persistence 79/0; full suite 14,451 passed / 0 failed
- [x] Build 0 warnings / 0 errors (CS1591 tier); format verify exit 0 (independently re-verified)

## Related Issues
Nightly review #1082 — findings 1, 2, 10, 11, 12