### PR TITLE
fix(generators): Restore incremental caching and add missing diagnostics

### DIFF
--- a/editor/KeenEyes.Generators/AttributeUsageAnalyzer.cs
+++ b/editor/KeenEyes.Generators/AttributeUsageAnalyzer.cs
@@ -47,7 +47,7 @@ public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
 
     #endregion
 
-    #region Component Diagnostics (KEEN015-016)
+    #region Component Diagnostics (KEEN015-017)
 
     /// <summary>
     /// KEEN015: [Component] or [TagComponent] must be applied to a struct.
@@ -72,6 +72,18 @@ public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Component structs must be declared as 'partial' to allow source generators to implement the IComponent interface.");
+
+    /// <summary>
+    /// KEEN017: A type cannot have both [Component] and [TagComponent].
+    /// </summary>
+    public static readonly DiagnosticDescriptor ComponentAndTagComponentConflict = new(
+        id: "KEEN017",
+        title: "Component cannot also be a tag component",
+        messageFormat: "Type '{0}' is marked with both [Component] and [TagComponent]; use exactly one of the two attributes",
+        category: "KeenEyes.Component",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [Component] and [TagComponent] attributes are mutually exclusive. A type carrying both is processed by both generator pipelines, which silently corrupts generated metadata such as the declared component Version.");
 
     #endregion
 
@@ -110,6 +122,7 @@ public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
             SystemMustBePartial,
             ComponentMustBeStruct,
             ComponentMustBePartial,
+            ComponentAndTagComponentConflict,
             QueryMustBeStruct,
             QueryMustBePartial);
 
@@ -126,12 +139,18 @@ public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
     {
         var typeSymbol = (INamedTypeSymbol)context.Symbol;
 
+        var hasComponent = false;
+        var hasTagComponent = false;
+
         foreach (var attribute in typeSymbol.GetAttributes())
         {
             var attributeName = attribute.AttributeClass?.ToDisplayString();
 
             if (attributeName == ComponentAttribute || attributeName == TagComponentAttribute)
             {
+                hasComponent |= attributeName == ComponentAttribute;
+                hasTagComponent |= attributeName == TagComponentAttribute;
+
                 AnalyzeComponentAttribute(context, typeSymbol, attributeName);
             }
             else if (attributeName == SystemAttribute)
@@ -141,6 +160,21 @@ public sealed class AttributeUsageAnalyzer : DiagnosticAnalyzer
             else if (attributeName == QueryAttribute)
             {
                 AnalyzeQueryAttribute(context, typeSymbol);
+            }
+        }
+
+        // KEEN017: [Component] and [TagComponent] are mutually exclusive. Both providers
+        // would pick up the type and the tag branch silently overwrites the declared
+        // Version in the generated migration metadata.
+        if (hasComponent && hasTagComponent)
+        {
+            var location = typeSymbol.Locations.FirstOrDefault();
+            if (location != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ComponentAndTagComponentConflict,
+                    location,
+                    typeSymbol.Name));
             }
         }
     }

--- a/editor/KeenEyes.Generators/BundleGenerator.cs
+++ b/editor/KeenEyes.Generators/BundleGenerator.cs
@@ -46,7 +46,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 ctx.ReportDiagnostic(Diagnostic.Create(
                     diag.Descriptor,
                     diag.Location,
-                    diag.MessageArgs));
+                    diag.MessageArgs.ToArray()));
             }
 
             // Only generate code for valid bundles
@@ -157,7 +157,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
             diagnostics.Add(new DiagnosticInfo(
                 Diagnostics.BundleNestingDepthExceeded,
                 errorLocation,
-                [bundleType.Name, MaxNestingDepth]));
+                ImmutableArray.Create(bundleType.Name, MaxNestingDepth.ToString())));
             return flattenedFields;
         }
 
@@ -168,7 +168,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
             diagnostics.Add(new DiagnosticInfo(
                 Diagnostics.BundleCircularReference,
                 errorLocation,
-                [bundleType.Name, "nested"]));
+                ImmutableArray.Create(bundleType.Name, "nested")));
             return flattenedFields;
         }
 
@@ -271,7 +271,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleExceedsQueryLimit,
                     location,
-                    [typeSymbol.Name, flattenedComponentTypes.Count]));
+                    ImmutableArray.Create(typeSymbol.Name, flattenedComponentTypes.Count.ToString())));
             }
         }
 
@@ -316,7 +316,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleMustBeStruct,
                     location,
-                    [typeSymbol.Name]));
+                    ImmutableArray.Create(typeSymbol.Name)));
             }
             return false;
         }
@@ -382,7 +382,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleCircularReference,
                     location,
-                    [bundleType.Name, field.Name]));
+                    ImmutableArray.Create(bundleType.Name, field.Name)));
             }
             return null;
         }
@@ -426,7 +426,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleOptionalFieldMustBeNullable,
                     location,
-                    [field.Name, bundleType.Name]));
+                    ImmutableArray.Create(field.Name, bundleType.Name)));
             }
             return false;
         }
@@ -485,7 +485,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleFieldMustBeComponent,
                     location,
-                    [field.Name, bundleType.Name, underlyingType.ToDisplayString()]));
+                    ImmutableArray.Create(field.Name, bundleType.Name, underlyingType.ToDisplayString())));
             }
             return false;
         }
@@ -505,7 +505,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 diagnostics.Add(new DiagnosticInfo(
                     Diagnostics.BundleMustHaveFields,
                     location,
-                    [typeSymbol.Name]));
+                    ImmutableArray.Create(typeSymbol.Name)));
             }
             return false;
         }
@@ -1203,9 +1203,9 @@ public sealed class BundleGenerator : IIncrementalGenerator
         string Name,
         string Namespace,
         string FullName,
-        ImmutableArray<ComponentFieldInfo> Fields,
-        ImmutableArray<string> FlattenedComponentTypes,
-        ImmutableArray<DiagnosticInfo> Diagnostics,
+        EquatableArray<ComponentFieldInfo> Fields,
+        EquatableArray<string> FlattenedComponentTypes,
+        EquatableArray<DiagnosticInfo> Diagnostics,
         bool IsValid)
     {
         /// <summary>
@@ -1226,7 +1226,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
     private sealed record DiagnosticInfo(
         DiagnosticDescriptor Descriptor,
         Location Location,
-        object[] MessageArgs);
+        EquatableArray<string> MessageArgs);
 }
 
 /// <summary>

--- a/editor/KeenEyes.Generators/ComponentGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentGenerator.cs
@@ -437,7 +437,7 @@ public sealed class ComponentGenerator : IIncrementalGenerator
         string Namespace,
         string FullName,
         bool IsTag,
-        ImmutableArray<FieldInfo> Fields,
+        EquatableArray<FieldInfo> Fields,
         string? ContainingTypeName,
         bool IsPublic);
 

--- a/editor/KeenEyes.Generators/ComponentValidationGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentValidationGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -95,8 +96,8 @@ public sealed class ComponentValidationGenerator : IIncrementalGenerator
             typeSymbol.Name,
             typeSymbol.ContainingNamespace.ToDisplayString(),
             typeSymbol.ToDisplayString(),
-            [.. requires],
-            [.. conflicts]);
+            requires.ToImmutableArray(),
+            conflicts.ToImmutableArray());
     }
 
     private static string GenerateValidationMetadata(ImmutableArray<ValidationInfo> components)
@@ -191,8 +192,8 @@ public sealed class ComponentValidationGenerator : IIncrementalGenerator
         string Name,
         string Namespace,
         string FullName,
-        ImmutableArray<string> RequiredComponents,
-        ImmutableArray<string> ConflictingComponents)
+        EquatableArray<string> RequiredComponents,
+        EquatableArray<string> ConflictingComponents)
     {
         public bool HasConstraints => RequiredComponents.Length > 0 || ConflictingComponents.Length > 0;
     }

--- a/editor/KeenEyes.Generators/EditorExtensionGenerator.cs
+++ b/editor/KeenEyes.Generators/EditorExtensionGenerator.cs
@@ -56,8 +56,8 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
                 {
                     ctx.ReportDiagnostic(Diagnostic.Create(
                         diag.Descriptor,
-                        diag.Location,
-                        diag.Args));
+                        diag.Location?.ToLocation() ?? Location.None,
+                        diag.Args.ToArray()));
                 }
             }
 
@@ -97,8 +97,8 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
             // Report error for null property name
             var diagnostics = ImmutableArray.Create(new DiagnosticInfo(
                 NullPropertyName,
-                context.TargetNode.GetLocation(),
-                [typeSymbol.Name]));
+                LocationInfo.From(context.TargetNode.GetLocation()),
+                ImmutableArray.Create(typeSymbol.Name)));
 
             return new ExtensionInfo(
                 typeSymbol.Name,
@@ -126,7 +126,7 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
             typeSymbol.ToDisplayString(),
             propertyName,
             isNullable,
-            ImmutableArray<DiagnosticInfo>.Empty,
+            EquatableArray<DiagnosticInfo>.Empty,
             IsValid: true);
     }
 
@@ -138,7 +138,7 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
             string.Empty,
             string.Empty,
             false,
-            ImmutableArray<DiagnosticInfo>.Empty,
+            EquatableArray<DiagnosticInfo>.Empty,
             IsValid: false);
     }
 
@@ -200,8 +200,8 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
     /// </summary>
     private sealed record DiagnosticInfo(
         DiagnosticDescriptor Descriptor,
-        Location Location,
-        object[] Args);
+        LocationInfo? Location,
+        EquatableArray<string> Args);
 
     /// <summary>
     /// Information about an editor extension class.
@@ -212,6 +212,6 @@ public sealed class EditorExtensionGenerator : IIncrementalGenerator
         string FullName,
         string PropertyName,
         bool IsNullable,
-        ImmutableArray<DiagnosticInfo> Diagnostics,
+        EquatableArray<DiagnosticInfo> Diagnostics,
         bool IsValid);
 }

--- a/editor/KeenEyes.Generators/KeenEyes.Generators.csproj
+++ b/editor/KeenEyes.Generators/KeenEyes.Generators.csproj
@@ -37,6 +37,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Generators.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/editor/KeenEyes.Generators/MixinGenerator.cs
+++ b/editor/KeenEyes.Generators/MixinGenerator.cs
@@ -67,7 +67,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
                     ctx.ReportDiagnostic(Diagnostic.Create(
                         diag.Descriptor,
                         diag.Location,
-                        diag.MessageArgs));
+                        diag.MessageArgs.ToArray()));
                 }
 
                 // Only generate code for valid mixins
@@ -123,7 +123,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
                     diagnostics.Add(new DiagnosticInfo(
                         Diagnostics.MixinMustBeStruct,
                         location,
-                        [mixinType.ToDisplayString(), typeSymbol.Name]));
+                        ImmutableArray.Create(mixinType.ToDisplayString(), typeSymbol.Name)));
                 }
                 continue;
             }
@@ -137,7 +137,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
                     diagnostics.Add(new DiagnosticInfo(
                         Diagnostics.MixinTypeNotAccessible,
                         location,
-                        [mixinType.ToDisplayString(), typeSymbol.Name]));
+                        ImmutableArray.Create(mixinType.ToDisplayString(), typeSymbol.Name)));
                 }
                 continue;
             }
@@ -195,7 +195,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
                     diagnostics.Add(new DiagnosticInfo(
                         Diagnostics.MixinFieldConflict,
                         location,
-                        [group.Key, typeSymbol.Name, sources]));
+                        ImmutableArray.Create(group.Key, typeSymbol.Name, sources)));
                 }
             }
         }
@@ -218,7 +218,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
                     diagnostics.Add(new DiagnosticInfo(
                         Diagnostics.MixinFieldConflict,
                         location,
-                        [field.Name, typeSymbol.Name, $"{field.SourceMixin} and {typeSymbol.Name}"]));
+                        ImmutableArray.Create(field.Name, typeSymbol.Name, $"{field.SourceMixin} and {typeSymbol.Name}")));
                 }
             }
         }
@@ -251,7 +251,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
             diagnostics.Add(new DiagnosticInfo(
                 Diagnostics.MixinCircularReference,
                 errorLocation,
-                [targetType.Name, string.Join(" -> ", currentPath)]));
+                ImmutableArray.Create(targetType.Name, string.Join(" -> ", currentPath))));
             return fields;
         }
 
@@ -264,7 +264,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
             diagnostics.Add(new DiagnosticInfo(
                 Diagnostics.MixinCircularReference,
                 errorLocation,
-                [targetType.Name, string.Join(" -> ", currentPath.Append(mixinTypeName))]));
+                ImmutableArray.Create(targetType.Name, string.Join(" -> ", currentPath.Append(mixinTypeName)))));
             return fields;
         }
 
@@ -366,14 +366,14 @@ public sealed class MixinGenerator : IIncrementalGenerator
         string Name,
         string Namespace,
         string FullName,
-        ImmutableArray<MixinTypeInfo> MixinTypes,
-        ImmutableArray<DiagnosticInfo> Diagnostics,
+        EquatableArray<MixinTypeInfo> MixinTypes,
+        EquatableArray<DiagnosticInfo> Diagnostics,
         bool IsValid);
 
     private sealed record MixinTypeInfo(
         string Name,
         string FullName,
-        ImmutableArray<MixinFieldInfo> Fields);
+        EquatableArray<MixinFieldInfo> Fields);
 
     private sealed record MixinFieldInfo(
         string Name,
@@ -383,7 +383,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
     private sealed record DiagnosticInfo(
         DiagnosticDescriptor Descriptor,
         Location Location,
-        object[] MessageArgs);
+        EquatableArray<string> MessageArgs);
 }
 
 /// <summary>

--- a/editor/KeenEyes.Generators/PluginExtensionGenerator.cs
+++ b/editor/KeenEyes.Generators/PluginExtensionGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -29,6 +30,18 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
         isEnabledByDefault: true,
         description: "The [PluginExtension] attribute requires a non-null property name to generate the World extension property.");
 
+    /// <summary>
+    /// KEEN009: Duplicate PluginExtension property name.
+    /// </summary>
+    public static readonly DiagnosticDescriptor DuplicatePropertyName = new(
+        id: "KEEN009",
+        title: "Duplicate PluginExtension property name",
+        messageFormat: "The property name '{0}' is declared by [PluginExtension] on both '{1}' and '{2}'; property names must be unique, so no extension property is generated for '{2}'",
+        category: "KeenEyes.Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Each [PluginExtension] property name must be unique across the compilation. Duplicate names would generate conflicting extension members on IWorld.");
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -52,19 +65,40 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
                 {
                     ctx.ReportDiagnostic(Diagnostic.Create(
                         diag.Descriptor,
-                        diag.Location,
-                        diag.Args));
+                        diag.Location?.ToLocation() ?? Location.None,
+                        diag.Args.ToArray()));
                 }
             }
 
-            // Generate code only for valid extensions
-            var validExtensions = extensions.Where(static e => e.IsValid).ToImmutableArray();
-            if (validExtensions.Length == 0)
+            // Generate code only for valid extensions with unique property names.
+            // Duplicates would emit two same-named extension members (an opaque CS0111
+            // in generated code), so report KEEN009 and skip everything after the first.
+            var validExtensions = ImmutableArray.CreateBuilder<ExtensionInfo>();
+            var firstByPropertyName = new Dictionary<string, ExtensionInfo>();
+
+            foreach (var ext in extensions.Where(static e => e.IsValid))
+            {
+                if (firstByPropertyName.TryGetValue(ext.PropertyName, out var first))
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(
+                        DuplicatePropertyName,
+                        ext.Location?.ToLocation() ?? Location.None,
+                        ext.PropertyName,
+                        first.FullName,
+                        ext.FullName));
+                    continue;
+                }
+
+                firstByPropertyName.Add(ext.PropertyName, ext);
+                validExtensions.Add(ext);
+            }
+
+            if (validExtensions.Count == 0)
             {
                 return;
             }
 
-            var source = GenerateWorldExtensions(validExtensions);
+            var source = GenerateWorldExtensions(validExtensions.ToImmutable());
             ctx.AddSource("World.PluginExtensions.g.cs", SourceText.From(source, Encoding.UTF8));
         });
     }
@@ -86,6 +120,8 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
             return CreateInvalidExtensionInfo();
         }
 
+        var location = LocationInfo.From(context.TargetNode.GetLocation());
+
         // Get property name from constructor argument
         if (attributeData.ConstructorArguments.Length == 0 ||
             attributeData.ConstructorArguments[0].Value is not string propertyName)
@@ -93,8 +129,8 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
             // Report error for null property name
             var diagnostics = ImmutableArray.Create(new DiagnosticInfo(
                 NullPropertyName,
-                context.TargetNode.GetLocation(),
-                [typeSymbol.Name]));
+                location,
+                ImmutableArray.Create(typeSymbol.Name)));
 
             return new ExtensionInfo(
                 typeSymbol.Name,
@@ -102,6 +138,7 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
                 typeSymbol.ToDisplayString(),
                 string.Empty,
                 false,
+                location,
                 diagnostics,
                 IsValid: false);
         }
@@ -122,7 +159,8 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
             typeSymbol.ToDisplayString(),
             propertyName,
             isNullable,
-            ImmutableArray<DiagnosticInfo>.Empty,
+            location,
+            EquatableArray<DiagnosticInfo>.Empty,
             IsValid: true);
     }
 
@@ -134,7 +172,8 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
             string.Empty,
             string.Empty,
             false,
-            ImmutableArray<DiagnosticInfo>.Empty,
+            null,
+            EquatableArray<DiagnosticInfo>.Empty,
             IsValid: false);
     }
 
@@ -196,8 +235,8 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
     /// </summary>
     private sealed record DiagnosticInfo(
         DiagnosticDescriptor Descriptor,
-        Location Location,
-        object[] Args);
+        LocationInfo? Location,
+        EquatableArray<string> Args);
 
     /// <summary>
     /// Information about a plugin extension class.
@@ -208,6 +247,7 @@ public sealed class PluginExtensionGenerator : IIncrementalGenerator
         string FullName,
         string PropertyName,
         bool IsNullable,
-        ImmutableArray<DiagnosticInfo> Diagnostics,
+        LocationInfo? Location,
+        EquatableArray<DiagnosticInfo> Diagnostics,
         bool IsValid);
 }

--- a/editor/KeenEyes.Generators/QueryGenerator.cs
+++ b/editor/KeenEyes.Generators/QueryGenerator.cs
@@ -45,7 +45,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
                 ctx.ReportDiagnostic(Diagnostic.Create(
                     diag.Descriptor,
                     diag.Location,
-                    diag.MessageArgs));
+                    diag.MessageArgs.ToArray()));
             }
 
             // Only generate code if no errors
@@ -111,7 +111,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
                     diagnostics.Add(new QueryDiagnosticInfo(
                         QueryDiagnostics.ConflictingQueryAttributes,
                         location,
-                        [field.Name, typeSymbol.Name, "[With]", "[Without]"]));
+                        ImmutableArray.Create(field.Name, typeSymbol.Name, "[With]", "[Without]")));
                     hasErrors = true;
                 }
             }
@@ -124,7 +124,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
                     diagnostics.Add(new QueryDiagnosticInfo(
                         QueryDiagnostics.ConflictingQueryAttributes,
                         location,
-                        [field.Name, typeSymbol.Name, "[With]", "[Optional]"]));
+                        ImmutableArray.Create(field.Name, typeSymbol.Name, "[With]", "[Optional]")));
                     hasErrors = true;
                 }
             }
@@ -137,7 +137,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
                     diagnostics.Add(new QueryDiagnosticInfo(
                         QueryDiagnostics.ConflictingQueryAttributes,
                         location,
-                        [field.Name, typeSymbol.Name, "[Without]", "[Optional]"]));
+                        ImmutableArray.Create(field.Name, typeSymbol.Name, "[Without]", "[Optional]")));
                     hasErrors = true;
                 }
             }
@@ -240,8 +240,8 @@ public sealed class QueryGenerator : IIncrementalGenerator
         string Name,
         string Namespace,
         string FullName,
-        ImmutableArray<QueryFieldInfo> Fields,
-        ImmutableArray<QueryDiagnosticInfo> Diagnostics,
+        EquatableArray<QueryFieldInfo> Fields,
+        EquatableArray<QueryDiagnosticInfo> Diagnostics,
         bool IsValid);
 
     private sealed record QueryFieldInfo(
@@ -252,7 +252,7 @@ public sealed class QueryGenerator : IIncrementalGenerator
     private sealed record QueryDiagnosticInfo(
         DiagnosticDescriptor Descriptor,
         Location Location,
-        object[] MessageArgs);
+        EquatableArray<string> MessageArgs);
 }
 
 /// <summary>

--- a/editor/KeenEyes.Generators/ReplicatedGenerator.cs
+++ b/editor/KeenEyes.Generators/ReplicatedGenerator.cs
@@ -822,7 +822,7 @@ internal sealed record ReplicatedComponentInfo(
     bool GeneratePrediction,
     byte Priority,
     int Frequency,
-    ImmutableArray<ReplicatedFieldInfo> Fields,
+    EquatableArray<ReplicatedFieldInfo> Fields,
     Location? Location);
 
 internal sealed record ReplicatedFieldInfo(

--- a/editor/KeenEyes.Generators/SerializationGenerator.cs
+++ b/editor/KeenEyes.Generators/SerializationGenerator.cs
@@ -1310,9 +1310,9 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         string Name,
         string Namespace,
         string FullName,
-        ImmutableArray<SerializableFieldInfo> Fields,
+        EquatableArray<SerializableFieldInfo> Fields,
         int Version,
-        ImmutableArray<MigrationMethodInfo> Migrations);
+        EquatableArray<MigrationMethodInfo> Migrations);
 
     private sealed record SerializableFieldInfo(
         string Name,

--- a/editor/KeenEyes.Generators/SystemGenerator.cs
+++ b/editor/KeenEyes.Generators/SystemGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using KeenEyes.Generators.Utilities;
@@ -109,8 +110,8 @@ public sealed class SystemGenerator : IIncrementalGenerator
             phase,
             order,
             group,
-            runsBefore,
-            runsAfter);
+            runsBefore.ToImmutableArray(),
+            runsAfter.ToImmutableArray());
     }
 
     private static string GenerateSystemPartial(SystemInfo info)
@@ -232,17 +233,17 @@ public sealed class SystemGenerator : IIncrementalGenerator
     /// <param name="useCollectionExpression">If true, uses [] syntax; otherwise uses new Type[] { } syntax.</param>
     /// <param name="baseIndent">Base indentation for multi-line arrays (e.g., "    " for 4 spaces).</param>
     /// <returns>The generated type array literal.</returns>
-    private static string GenerateTypeArray(List<string> types, bool useCollectionExpression, string baseIndent = "    ")
+    private static string GenerateTypeArray(EquatableArray<string> types, bool useCollectionExpression, string baseIndent = "    ")
     {
-        if (types.Count == 0)
+        if (types.Length == 0)
         {
             return useCollectionExpression ? "[]" : "global::System.Array.Empty<global::System.Type>()";
         }
 
-        var typeofs = types.Select(t => $"typeof(global::{t})").ToList();
+        var typeofs = types.AsImmutableArray().Select(t => $"typeof(global::{t})").ToList();
 
         // Single-line for arrays below the threshold
-        if (types.Count < MultiLineArrayThreshold)
+        if (types.Length < MultiLineArrayThreshold)
         {
             var joined = string.Join(", ", typeofs);
             return useCollectionExpression
@@ -298,6 +299,6 @@ public sealed class SystemGenerator : IIncrementalGenerator
         SystemPhase Phase,
         int Order,
         string? Group,
-        List<string> RunsBefore,
-        List<string> RunsAfter);
+        EquatableArray<string> RunsBefore,
+        EquatableArray<string> RunsAfter);
 }

--- a/editor/KeenEyes.Generators/Utilities/EquatableArray.cs
+++ b/editor/KeenEyes.Generators/Utilities/EquatableArray.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace KeenEyes.Generators.Utilities;
+
+/// <summary>
+/// An immutable array wrapper with structural equality semantics for use in
+/// incremental generator pipeline models.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+/// <remarks>
+/// <see cref="ImmutableArray{T}"/> compares by reference to the underlying array,
+/// which makes compiler-generated <c>record</c> equality always false for freshly
+/// built collections and defeats <c>IIncrementalGenerator</c> caching. This wrapper
+/// compares element-by-element so equivalent pipeline values are recognized as
+/// unchanged between runs.
+/// </remarks>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+{
+    /// <summary>An empty array instance.</summary>
+    public static readonly EquatableArray<T> Empty = new(ImmutableArray<T>.Empty);
+
+    private readonly ImmutableArray<T> array;
+
+    /// <summary>
+    /// Initializes a new instance wrapping the given immutable array.
+    /// </summary>
+    /// <param name="array">The underlying immutable array.</param>
+    public EquatableArray(ImmutableArray<T> array)
+    {
+        this.array = array;
+    }
+
+    /// <summary>Gets the number of elements in the array.</summary>
+    public int Length => array.IsDefault ? 0 : array.Length;
+
+    /// <summary>Gets the element at the specified index.</summary>
+    /// <param name="index">The zero-based index.</param>
+    public T this[int index] => AsImmutableArray()[index];
+
+    /// <summary>
+    /// Returns the underlying <see cref="ImmutableArray{T}"/>, normalizing a
+    /// default instance to an empty array.
+    /// </summary>
+    public ImmutableArray<T> AsImmutableArray() => array.IsDefault ? ImmutableArray<T>.Empty : array;
+
+    /// <summary>Copies the elements into a new mutable array.</summary>
+    public T[] ToArray()
+    {
+        var source = AsImmutableArray();
+        var result = new T[source.Length];
+        source.CopyTo(result);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(EquatableArray<T> other)
+    {
+        var self = AsImmutableArray();
+        var them = other.AsImmutableArray();
+
+        if (self.Length != them.Length)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (var i = 0; i < self.Length; i++)
+        {
+            if (!comparer.Equals(self[i], them[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var comparer = EqualityComparer<T>.Default;
+
+        unchecked
+        {
+            var hash = 17;
+            foreach (var item in AsImmutableArray())
+            {
+                hash = (hash * 31) + (item is null ? 0 : comparer.GetHashCode(item));
+            }
+
+            return hash;
+        }
+    }
+
+    /// <summary>Returns an enumerator over the array elements.</summary>
+    public ImmutableArray<T>.Enumerator GetEnumerator() => AsImmutableArray().GetEnumerator();
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)AsImmutableArray()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)AsImmutableArray()).GetEnumerator();
+
+    /// <summary>Wraps an immutable array in an <see cref="EquatableArray{T}"/>.</summary>
+    /// <param name="array">The array to wrap.</param>
+    public static implicit operator EquatableArray<T>(ImmutableArray<T> array) => new(array);
+
+    /// <summary>Unwraps the underlying <see cref="ImmutableArray{T}"/>.</summary>
+    /// <param name="array">The array to unwrap.</param>
+    public static implicit operator ImmutableArray<T>(EquatableArray<T> array) => array.AsImmutableArray();
+
+    /// <summary>Compares two arrays for structural equality.</summary>
+    public static bool operator ==(EquatableArray<T> left, EquatableArray<T> right) => left.Equals(right);
+
+    /// <summary>Compares two arrays for structural inequality.</summary>
+    public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right) => !left.Equals(right);
+}

--- a/editor/KeenEyes.Generators/Utilities/LocationInfo.cs
+++ b/editor/KeenEyes.Generators/Utilities/LocationInfo.cs
@@ -1,0 +1,38 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace KeenEyes.Generators.Utilities;
+
+/// <summary>
+/// An equatable snapshot of a <see cref="Location"/> for use in incremental
+/// generator pipeline models.
+/// </summary>
+/// <remarks>
+/// <see cref="Location"/> holds a reference to its <see cref="SyntaxTree"/>, so two
+/// locations from different parses of the same file never compare equal, which
+/// defeats incremental caching. This record captures only the file path and spans
+/// and can recreate an equivalent <see cref="Location"/> for diagnostic reporting.
+/// </remarks>
+internal sealed record LocationInfo(string FilePath, TextSpan TextSpan, LinePositionSpan LineSpan)
+{
+    /// <summary>Recreates a <see cref="Location"/> suitable for diagnostic reporting.</summary>
+    public Location ToLocation() => Location.Create(FilePath, TextSpan, LineSpan);
+
+    /// <summary>
+    /// Creates a <see cref="LocationInfo"/> from a <see cref="Location"/>, or null when
+    /// the location has no source tree.
+    /// </summary>
+    /// <param name="location">The location to capture.</param>
+    public static LocationInfo? From(Location? location)
+    {
+        if (location?.SourceTree is null)
+        {
+            return null;
+        }
+
+        return new LocationInfo(
+            location.SourceTree.FilePath,
+            location.SourceSpan,
+            location.GetLineSpan().Span);
+    }
+}

--- a/tests/KeenEyes.Generators.Tests/AttributeUsageAnalyzerTests.cs
+++ b/tests/KeenEyes.Generators.Tests/AttributeUsageAnalyzerTests.cs
@@ -1,0 +1,114 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Tests for the AttributeUsageAnalyzer diagnostic analyzer.
+/// </summary>
+public class AttributeUsageAnalyzerTests
+{
+    #region KEEN017: Component and TagComponent Conflict
+
+    [Fact]
+    public void ComponentAndTagComponent_OnSameStruct_ReportsKeen017()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component(Version = 3)]
+            [KeenEyes.TagComponent]
+            public partial struct DualAttributedComponent { public int X; }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN017");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("DualAttributedComponent", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void ComponentOnly_DoesNotReportKeen017()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component(Version = 2)]
+            public partial struct RegularComponent { public int X; }
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN017");
+    }
+
+    [Fact]
+    public void TagComponentOnly_DoesNotReportKeen017()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.TagComponent]
+            public partial struct MarkerTag;
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN017");
+    }
+
+    [Fact]
+    public void ComponentAndTagComponent_OnSeparateStructs_DoesNotReportKeen017()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component]
+            public partial struct RegularComponent { public int X; }
+
+            [KeenEyes.TagComponent]
+            public partial struct MarkerTag;
+            """;
+
+        var diagnostics = RunAnalyzer(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN017");
+    }
+
+    #endregion
+
+    private static IReadOnlyList<Diagnostic> RunAnalyzer(string source)
+    {
+        var attributesAssembly = typeof(ComponentAttribute).Assembly;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(attributesAssembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Join(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Join(runtimeDir, "netstandard.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new AttributeUsageAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var diagnostics = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+
+        return diagnostics.ToList();
+    }
+}

--- a/tests/KeenEyes.Generators.Tests/EquatableArrayTests.cs
+++ b/tests/KeenEyes.Generators.Tests/EquatableArrayTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using KeenEyes.Generators.Utilities;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Tests for the <see cref="EquatableArray{T}"/> structural equality wrapper used
+/// by incremental generator pipeline models.
+/// </summary>
+public class EquatableArrayTests
+{
+    #region Equals Tests
+
+    [Fact]
+    public void Equals_WithSameElementsInFreshArrays_ReturnsTrue()
+    {
+        // Two separately allocated arrays with identical content - this is exactly
+        // the case where ImmutableArray<T> reference equality fails.
+        EquatableArray<string> first = ImmutableArray.Create("a", "b", "c");
+        EquatableArray<string> second = ImmutableArray.Create("a", "b", "c");
+
+        Assert.True(first.Equals(second));
+        Assert.True(first == second);
+        Assert.False(first != second);
+    }
+
+    [Fact]
+    public void Equals_WithDifferentElements_ReturnsFalse()
+    {
+        EquatableArray<string> first = ImmutableArray.Create("a", "b", "c");
+        EquatableArray<string> second = ImmutableArray.Create("a", "b", "d");
+
+        Assert.False(first.Equals(second));
+        Assert.True(first != second);
+    }
+
+    [Fact]
+    public void Equals_WithDifferentLengths_ReturnsFalse()
+    {
+        EquatableArray<int> first = ImmutableArray.Create(1, 2, 3);
+        EquatableArray<int> second = ImmutableArray.Create(1, 2);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_WithDifferentOrder_ReturnsFalse()
+    {
+        EquatableArray<int> first = ImmutableArray.Create(1, 2, 3);
+        EquatableArray<int> second = ImmutableArray.Create(3, 2, 1);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_DefaultInstanceAndEmpty_ReturnsTrue()
+    {
+        var defaultInstance = default(EquatableArray<int>);
+
+        Assert.True(defaultInstance.Equals(EquatableArray<int>.Empty));
+        Assert.Equal(0, defaultInstance.Length);
+    }
+
+    [Fact]
+    public void Equals_AsObject_UsesStructuralEquality()
+    {
+        EquatableArray<string> first = ImmutableArray.Create("x");
+        object second = (EquatableArray<string>)ImmutableArray.Create("x");
+
+        Assert.True(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_InsideRecord_MakesRecordsWithFreshArraysEqual()
+    {
+        // Mirrors the pipeline-model shape: a record with an EquatableArray field
+        // built freshly on every transform must still compare equal.
+        var first = new PipelineModel("Name", ImmutableArray.Create("f1", "f2"));
+        var second = new PipelineModel("Name", ImmutableArray.Create("f1", "f2"));
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    #endregion
+
+    #region GetHashCode Tests
+
+    [Fact]
+    public void GetHashCode_WithSameElements_ReturnsSameHash()
+    {
+        EquatableArray<string> first = ImmutableArray.Create("a", "b");
+        EquatableArray<string> second = ImmutableArray.Create("a", "b");
+
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_DefaultInstanceAndEmpty_ReturnsSameHash()
+    {
+        Assert.Equal(EquatableArray<int>.Empty.GetHashCode(), default(EquatableArray<int>).GetHashCode());
+    }
+
+    #endregion
+
+    #region Conversion and Access Tests
+
+    [Fact]
+    public void ImplicitConversion_RoundTripsThroughImmutableArray()
+    {
+        var source = ImmutableArray.Create(1, 2, 3);
+        EquatableArray<int> wrapped = source;
+        ImmutableArray<int> unwrapped = wrapped;
+
+        Assert.Equal(source, unwrapped);
+        Assert.Equal(3, wrapped.Length);
+        Assert.Equal(2, wrapped[1]);
+    }
+
+    [Fact]
+    public void AsImmutableArray_OnDefaultInstance_ReturnsEmptyNotDefault()
+    {
+        var defaultInstance = default(EquatableArray<string>);
+
+        Assert.False(defaultInstance.AsImmutableArray().IsDefault);
+        Assert.True(defaultInstance.AsImmutableArray().IsEmpty);
+    }
+
+    [Fact]
+    public void ToArray_ReturnsAllElements()
+    {
+        EquatableArray<string> array = ImmutableArray.Create("a", "b");
+
+        Assert.Equal(new[] { "a", "b" }, array.ToArray());
+    }
+
+    [Fact]
+    public void GetEnumerator_EnumeratesAllElements()
+    {
+        EquatableArray<int> array = ImmutableArray.Create(1, 2, 3);
+
+        var sum = 0;
+        foreach (var item in array)
+        {
+            sum += item;
+        }
+
+        Assert.Equal(6, sum);
+    }
+
+    #endregion
+
+    private sealed record PipelineModel(string Name, EquatableArray<string> Fields);
+}

--- a/tests/KeenEyes.Generators.Tests/IncrementalCachingTests.cs
+++ b/tests/KeenEyes.Generators.Tests/IncrementalCachingTests.cs
@@ -1,0 +1,269 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Verifies that generator pipelines cache correctly: when the driver re-runs over
+/// semantically unchanged inputs (an unrelated syntax tree is added), every tracked
+/// output must be reused from cache instead of being recomputed. This guards the
+/// structural equality of the pipeline model records (EquatableArray fields) - a
+/// reference-equal-only collection field would make every output report Modified/New.
+/// </summary>
+public class IncrementalCachingTests
+{
+    [Fact]
+    public void ComponentGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [KeenEyes.TagComponent]
+            public partial struct FrozenTag;
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new ComponentGenerator(), source);
+    }
+
+    [Fact]
+    public void QueryGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component]
+            public partial struct Position { public float X; }
+
+            [KeenEyes.Query]
+            public partial struct MovingQuery { public Position Pos; }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new QueryGenerator(), source);
+    }
+
+    [Fact]
+    public void SystemGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.System(Phase = KeenEyes.SystemPhase.FixedUpdate, Order = 5)]
+            [KeenEyes.RunBefore(typeof(OtherSystem))]
+            public partial class MovementSystem { }
+
+            [KeenEyes.System]
+            public partial class OtherSystem { }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new SystemGenerator(), source);
+    }
+
+    [Fact]
+    public void BundleGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component]
+            public partial struct Position { public float X; }
+
+            [KeenEyes.Component]
+            public partial struct Velocity { public float X; }
+
+            [KeenEyes.Bundle]
+            public partial struct PlayerBundle
+            {
+                public Position Position;
+                public Velocity Velocity;
+            }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new BundleGenerator(), source);
+    }
+
+    [Fact]
+    public void MixinGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            public struct Positioned { public float X; public float Y; }
+
+            [KeenEyes.Component]
+            [KeenEyes.Mixin(typeof(Positioned))]
+            public partial struct Player { public int Health; }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new MixinGenerator(), source);
+    }
+
+    [Fact]
+    public void PluginExtensionGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.PluginExtension("Physics")]
+            public class PhysicsWorld { public int Gravity { get; set; } }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new PluginExtensionGenerator(), source);
+    }
+
+    [Fact]
+    public void EditorExtensionGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        // The EditorExtension attribute lives in KeenEyes.Editor.Abstractions, which this
+        // test project does not reference; declaring it in-source is sufficient because
+        // ForAttributeWithMetadataName matches by full metadata name.
+        var source = """
+            namespace KeenEyes.Editor.Abstractions
+            {
+                public sealed class EditorExtensionAttribute : System.Attribute
+                {
+                    public EditorExtensionAttribute(string propertyName) { }
+                    public bool Nullable { get; set; }
+                }
+            }
+
+            namespace TestApp
+            {
+                [KeenEyes.Editor.Abstractions.EditorExtension("SceneAnalyzer")]
+                public class SceneAnalyzerExtension { }
+            }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new EditorExtensionGenerator(), source);
+    }
+
+    [Fact]
+    public void ReplicatedGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        // The Replicated attribute lives in KeenEyes.Network.Abstractions, which this
+        // test project does not reference; declaring it in-source is sufficient.
+        var source = """
+            namespace KeenEyes.Network
+            {
+                public sealed class ReplicatedAttribute : System.Attribute { }
+            }
+
+            namespace TestApp
+            {
+                [KeenEyes.Network.Replicated]
+                public partial struct NetworkedPosition { public float X; public float Y; }
+            }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new ReplicatedGenerator(), source);
+    }
+
+    [Fact]
+    public void SerializationGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component(Serializable = true, Version = 2)]
+            public partial struct SavedPosition { public float X; public float Y; }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new SerializationGenerator(), source);
+    }
+
+    [Fact]
+    public void ComponentValidationGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component]
+            public partial struct Velocity { public float X; }
+
+            [KeenEyes.Component]
+            [KeenEyes.RequiresComponent(typeof(Velocity))]
+            public partial struct Position { public float X; }
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new ComponentValidationGenerator(), source);
+    }
+
+    [Fact]
+    public void ComponentMigrationMetadataGenerator_UnrelatedChange_ReusesCachedOutputs()
+    {
+        var source = """
+            namespace TestApp;
+
+            [KeenEyes.Component(Version = 4)]
+            public partial struct VersionedComponent { public float X; }
+
+            [KeenEyes.TagComponent]
+            public partial struct MarkerTag;
+            """;
+
+        AssertOutputsCachedOnUnrelatedChange(new ComponentMigrationMetadataGenerator(), source);
+    }
+
+    private static void AssertOutputsCachedOnUnrelatedChange(IIncrementalGenerator generator, string source)
+    {
+        var compilation = CreateCompilation(source);
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [generator.AsSourceGenerator()],
+            driverOptions: new GeneratorDriverOptions(
+                IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true));
+
+        // First run computes everything.
+        driver = driver.RunGenerators(compilation);
+        var firstResult = driver.GetRunResult().Results[0];
+        Assert.NotEmpty(firstResult.GeneratedSources);
+
+        // Second run over the same inputs plus one unrelated tree: the pipeline
+        // re-evaluates, but every model value is equal, so outputs must be cached.
+        var updatedCompilation = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText("// unrelated change that must not invalidate the pipeline"));
+        driver = driver.RunGenerators(updatedCompilation);
+        var secondResult = driver.GetRunResult().Results[0];
+
+        var outputReasons = secondResult.TrackedOutputSteps
+            .SelectMany(static stepsByName => stepsByName.Value)
+            .SelectMany(static step => step.Outputs)
+            .Select(static output => output.Reason)
+            .ToList();
+
+        Assert.NotEmpty(outputReasons);
+        Assert.All(outputReasons, static reason =>
+            Assert.True(
+                reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged,
+                $"Expected all outputs to be Cached/Unchanged after an unrelated change, but got {reason}. " +
+                "A pipeline model field is likely breaking record value-equality."));
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var attributesAssembly = typeof(ComponentAttribute).Assembly;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(attributesAssembly.Location),
+        };
+
+        // Add runtime assembly references
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Join(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Join(runtimeDir, "netstandard.dll")));
+
+        return CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/tests/KeenEyes.Generators.Tests/PluginExtensionGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/PluginExtensionGeneratorTests.cs
@@ -319,6 +319,61 @@ public class PluginExtensionGeneratorTests
         Assert.Contains(diagnostics, d => d.GetMessage().Contains("TestExtension"));
     }
 
+    [Fact]
+    public void PluginExtensionGenerator_WithDuplicatePropertyNames_ReportsKeen009AndSkipsDuplicate()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [PluginExtension("Physics")]
+            public class PhysicsWorld { }
+
+            [PluginExtension("Physics")]
+            public class AlternatePhysicsWorld { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        // Should report KEEN009 naming both conflicting types
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "KEEN009");
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("Physics", diagnostic.GetMessage());
+        Assert.Contains("TestApp.PhysicsWorld", diagnostic.GetMessage());
+        Assert.Contains("TestApp.AlternatePhysicsWorld", diagnostic.GetMessage());
+
+        // Only the first declaration generates a property - no CS0111 from a duplicate member
+        var generated = Assert.Single(generatedTrees);
+        Assert.Contains("global::TestApp.PhysicsWorld Physics =>", generated);
+        Assert.DoesNotContain("AlternatePhysicsWorld Physics", generated);
+    }
+
+    [Fact]
+    public void PluginExtensionGenerator_WithDistinctPropertyNames_DoesNotReportKeen009()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [PluginExtension("Physics")]
+            public class PhysicsWorld { }
+
+            [PluginExtension("Audio")]
+            public class AudioWorld { }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "KEEN009");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+        var generated = Assert.Single(generatedTrees);
+        Assert.Contains("global::TestApp.PhysicsWorld Physics =>", generated);
+        Assert.Contains("global::TestApp.AudioWorld Audio =>", generated);
+    }
+
     private static (IReadOnlyList<Diagnostic> Diagnostics, IReadOnlyList<string> GeneratedSources) RunGenerator(string source)
     {
         var attributesAssembly = typeof(PluginExtensionAttribute).Assembly;

--- a/tests/KeenEyes.Generators.Tests/SystemPhaseParityTests.cs
+++ b/tests/KeenEyes.Generators.Tests/SystemPhaseParityTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// Guards the ordinal coupling between the generator's private SystemPhase mirror enum
+/// and the public <see cref="KeenEyes.SystemPhase"/>. The generator casts the attribute's
+/// raw integer value to its private enum and embeds the resulting member name in generated
+/// code, so any reorder or rename of either enum must fail this test.
+/// </summary>
+public class SystemPhaseParityTests
+{
+    [Fact]
+    public void SystemGeneratorSystemPhase_MatchesAbstractionsSystemPhase_ByNameAndValue()
+    {
+        var generatorPhaseEnum = typeof(SystemGenerator).GetNestedType("SystemPhase", BindingFlags.NonPublic);
+
+        Assert.NotNull(generatorPhaseEnum);
+        Assert.True(generatorPhaseEnum!.IsEnum);
+
+        var expectedByName = Enum.GetValues<KeenEyes.SystemPhase>()
+            .ToDictionary(value => value.ToString(), value => (int)value);
+
+        var actualNames = Enum.GetNames(generatorPhaseEnum);
+
+        Assert.Equal(expectedByName.Count, actualNames.Length);
+
+        foreach (var name in actualNames)
+        {
+            Assert.True(
+                expectedByName.TryGetValue(name, out var expectedValue),
+                $"Generator SystemPhase member '{name}' does not exist on KeenEyes.SystemPhase.");
+
+            var actualValue = Convert.ToInt32(Enum.Parse(generatorPhaseEnum, name));
+
+            Assert.True(
+                expectedValue == actualValue,
+                $"Generator SystemPhase.{name} has value {actualValue} but KeenEyes.SystemPhase.{name} has value {expectedValue}. " +
+                "The two enums must stay in ordinal lockstep or generated code will silently target the wrong phase.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Findings 5–8 from nightly review #1082.
- **Incremental caching restored (finding 5)**: every generator pipeline record carried `ImmutableArray`/`List`/`object[]` fields whose reference equality defeated `IIncrementalGenerator` caching — every keystroke recomputed everything. New netstandard2.0-safe `EquatableArray<T>` (structural equality/hash) now backs all collection fields across **10 generators** (the finding listed 7; the sweep found 3 more). Output is byte-for-byte identical — all pre-existing emit-assertion tests pass unchanged.
- **Caching is now CI-enforced**: 11 `IncrementalCachingTests` run each generator twice with `trackIncrementalGeneratorSteps` and assert `Cached`/`Unchanged` outputs — proven non-vacuous by temporarily reverting one conversion (test correctly failed with `Modified`).
- **KEEN017** (finding 6): dual `[Component]`+`[TagComponent]` annotation is now an analyzer error instead of silently corrupting migration version metadata.
- **KEEN009** (finding 7): duplicate `[PluginExtension]` property names get a proper diagnostic naming both conflicting types instead of an opaque CS0111 in generated code (with an equatable `LocationInfo` so the diagnostic path doesn't regress caching).
- **Enum-parity test** (finding 8): the generator's private `SystemPhase` mirror is now asserted name/value-identical to `KeenEyes.SystemPhase` — a reorder fails CI instead of silently mis-phasing every generated system.

## Test plan
- [x] Generators.Tests 505 passed / 5 pre-existing skips (+31 new tests); caching tests 11/11 (independently re-verified)
- [x] Core.Tests 2322/2322 and Shaders integration 8/8 as generated-output consumers; full suite 14,475 passed / 0 failed
- [x] Build 0 warnings / 0 errors; format verify exit 0; no lockfile churn

## Related Issues
Nightly review #1082 — findings 5, 6, 7, 8