### PR TITLE
fix: Gate PBR sample in slnx and annotate TryGetExtension/TryGetCapability

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -31,6 +31,7 @@
     <Project Path="samples/KeenEyes.Sample.Showcase/KeenEyes.Sample.Showcase.csproj" />
     <Project Path="samples/KeenEyes.Sample.Simulation/KeenEyes.Sample.Simulation.csproj" />
     <Project Path="samples/KeenEyes.Sample.StringTags/KeenEyes.Sample.StringTags.csproj" />
+    <Project Path="samples/KeenEyes.Sample.PBR/KeenEyes.Sample.PBR.csproj" />
     <Project Path="samples/KeenEyes.Sample.UI/KeenEyes.Sample.UI.csproj" />
     <Project Path="samples/KeenEyes.Sample.Voxel/KeenEyes.Sample.Voxel.csproj" />
     <Project Path="samples/KeenEyes.Sample/KeenEyes.Sample.csproj" />

--- a/samples/KeenEyes.Sample.PBR/Program.cs
+++ b/samples/KeenEyes.Sample.PBR/Program.cs
@@ -100,7 +100,7 @@ try
             {
                 if (args.Key == Key.Escape)
                 {
-                    Environment.Exit(0);
+                    System.Environment.Exit(0);
                 }
             };
 

--- a/samples/KeenEyes.Sample.PBR/Systems.cs
+++ b/samples/KeenEyes.Sample.PBR/Systems.cs
@@ -103,7 +103,7 @@ public class CameraZoomSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        if (World.TryGetExtension<IInputContext>(out var ctx) && ctx is not null)
+        if (World.TryGetExtension<IInputContext>(out var ctx))
         {
             input = ctx;
             scrollHandler = args =>

--- a/samples/KeenEyes.Sample.PBR/packages.lock.json
+++ b/samples/KeenEyes.Sample.PBR/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.17.0.131074, )",
-        "resolved": "10.17.0.131074",
-        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "Cyotek.Drawing.BitmapFont": {
         "type": "Transitive",
@@ -15,15 +15,15 @@
       },
       "FontStashSharp.Base": {
         "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "t2PT+/Sat9WPLm4AVYU1Aa/PrOgNQ4npSUGDHTYufXzLUHxrN3+BaRhAU0DZXkJNfuGCS5iKaQNopNXe9ES24g=="
+        "resolved": "1.2.3",
+        "contentHash": "kw8ovakGHz8jCah+H5M7qI8aOvtESF0jQRpcpubXUMsSid86dRO6DoDPlh+Tk/XAW5a3XgzGDgsHfeZTfZTr+Q=="
       },
       "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
         "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "OoXoGkxNMhyQeYR/wjeN6Bs8Guea7FisKXLcVJdeNtSYT+5iKxIh4ETi9x9OIk7GEQtNbE0yVhG3rb8RS04Kmg==",
+        "resolved": "1.2.3",
+        "contentHash": "xjzgWeiaODbW7DR/kI05V7C3CVtDvtB+4TrgX4EKNpRGzxb42vsvXKWrXORQWU2LCLnPPqdBNNSgtRujnpK2ww==",
         "dependencies": {
-          "FontStashSharp.Base": "1.2.2",
+          "FontStashSharp.Base": "1.2.3",
           "StbTrueTypeSharp": "1.26.12"
         }
       },
@@ -34,60 +34,60 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "NSmDw3K0ozNDgShSIpsZcbFIzBX4w28nDag+TfaQujkXGazBm+lid5onlWoCBy4VsLxqnnKjEBbGSJVWJMf43g=="
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
       },
       "Silk.NET.Core": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "XbDilPmvsQIrvxZkeVCNNX3LyRtA3hN6UykAiyZjlu/JkYh68U3WQummpP+j7jsxlX8s/pOrrU3vbN8LnMl0VA==",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
-          "Microsoft.Extensions.DependencyModel": "8.0.0"
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
         }
       },
       "Silk.NET.GLFW": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "I1u6CmwwtD+5OIHditbMBVHRQUHZWhfW3Z38mvydxwkZpAvjs5BCxyen6ecOVpbYD6I0EOjZ42M3IsaZbwiYUg==",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Core": "2.23.0",
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
       "Silk.NET.Input.Common": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "DZy30akJABBmTnn8OICik0TFEuXrkd7YCQvoq+oh50eJzXt8JgEYYa+sJYBib/Phs5WULZg/QR7fM8Gi1G3tXg==",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
         "dependencies": {
-          "Silk.NET.Windowing.Common": "2.22.0"
+          "Silk.NET.Windowing.Common": "2.23.0"
         }
       },
       "Silk.NET.Input.Glfw": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "LZPZT1e/RxnjKfkqlp2Wp8KJFP1Av/ErTCZ00EzZpFR1lhUSBgSmgJwXg6XlWoEJHyeJcsXV688zjoEe6YW0BA==",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
         "dependencies": {
-          "Silk.NET.Input.Common": "2.22.0",
-          "Silk.NET.Windowing.Glfw": "2.22.0"
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
         }
       },
       "Silk.NET.Windowing.Common": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "ynasHSQ4jGrmpn/07UagE3qVNRLzWvg+fbM8uHI0d5LF95y++Kuno42QLkP/UEruC1YovI+NRhMfGJy0gDQaZg==",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
-          "Silk.NET.Maths": "2.22.0"
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
         }
       },
       "Silk.NET.Windowing.Glfw": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "hBNxNSLvx/jdfvbU6oCsXcgLfqf9hMlEc6Mq/rllJ0eUTLloacuOZHTM8V702QGf7hOR+Mo4bTFqTqBnC0CM7g==",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
         "dependencies": {
-          "Silk.NET.GLFW": "2.22.0",
-          "Silk.NET.Windowing.Common": "2.22.0"
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
         }
       },
       "StbTrueTypeSharp": {
@@ -107,6 +107,7 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
         }
       },
@@ -119,10 +120,10 @@
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
-          "NLayer": "[1.16.0, )",
+          "NLayer": "[2.0.1, )",
           "NVorbis": "[0.10.5, )",
+          "Pfim": "[0.11.4, )",
           "SharpGLTF.Core": "[1.0.6, )",
-          "SixLabors.ImageSharp": "[3.1.12, )",
           "StbImageSharp": "[2.30.15, )"
         }
       },
@@ -162,13 +163,14 @@
       "keeneyes.graphics.silk": {
         "type": "Project",
         "dependencies": {
-          "FontStashSharp.PlatformAgnostic": "[1.5.2, )",
+          "FontStashSharp.PlatformAgnostic": "[1.5.6, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Maths": "[2.22.0, )",
-          "Silk.NET.OpenGL": "[2.22.0, )"
+          "Silk.NET.Maths": "[2.23.0, )",
+          "Silk.NET.OpenGL": "[2.23.0, )",
+          "StbImageSharp": "[2.30.15, )"
         }
       },
       "keeneyes.input": {
@@ -190,7 +192,7 @@
           "KeenEyes.Input": "[1.0.0, )",
           "KeenEyes.Input.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Input": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )"
         }
       },
       "keeneyes.platform.silk": {
@@ -198,15 +200,15 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Input": "[2.22.0, )",
-          "Silk.NET.Windowing": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
         }
       },
       "keeneyes.platform.silk.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Silk.NET.Input": "[2.22.0, )",
-          "Silk.NET.Windowing": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -223,27 +225,33 @@
       },
       "FontStashSharp.PlatformAgnostic": {
         "type": "CentralTransitive",
-        "requested": "[1.5.2, )",
-        "resolved": "1.5.2",
-        "contentHash": "/Srtf2DyIBBTbaZ4jpOQZnGFoEcbiXPMZnPuSft8MkMdbMYgCXPD5S123a992qTGVFKQjD9IGapd7Kyg2GD6sw==",
+        "requested": "[1.5.6, )",
+        "resolved": "1.5.6",
+        "contentHash": "aIuRgPeucC3zkCZvY8Y8E8JyrvukUX8MfKCUO31HWOg3yuYniHUA/3kjpNJE2apRGQzmreYhWFMatKv8cgGRxw==",
         "dependencies": {
           "Cyotek.Drawing.BitmapFont": "2.0.4",
-          "FontStashSharp.Base": "1.2.2",
-          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.2",
+          "FontStashSharp.Base": "1.2.3",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.3",
           "StbImageSharp": "2.30.15"
         }
       },
       "NLayer": {
         "type": "CentralTransitive",
-        "requested": "[1.16.0, )",
-        "resolved": "1.16.0",
-        "contentHash": "G/AexTjdl6cm0wYlkCkQgtpPLBc5vOWyOTIQpeC6p8V8fb7kbCYA+fEHFPJiU+KeRHH4Q1RGqTFyf9uqVALnkQ=="
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "0nhnDRx98u7zXXbPIF11QYYupOOOQ9W22eqoyQyXn/gitRXbf9zAK8YfxyqS1Ix+TSqJv8EPNSk3VkDb7fChKw=="
       },
       "NVorbis": {
         "type": "CentralTransitive",
         "requested": "[0.10.5, )",
         "resolved": "0.10.5",
         "contentHash": "o+IptCG4Avze39HrGeztC+xIp6fOOwGVAwkoa1J++4Ji1WmZ+KIKlFl5wsgxsXqBkmdpfs/vFSUproiLKYa2bw=="
+      },
+      "Pfim": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.4, )",
+        "resolved": "0.11.4",
+        "contentHash": "B3KDFyxY1NTqbeqGEaOM9uE+G71GG2TxWqVSs57e1pWYPf2vNLMIxk+x55MXdkon0iGeaekolFTlLS2CkgktYg=="
       },
       "SharpGLTF.Core": {
         "type": "CentralTransitive",
@@ -253,45 +261,39 @@
       },
       "Silk.NET.Input": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "1gqbKHrKpBv2Vk983kVpMqXL4Uj36NaUIQ2YbQosFVa3pXJE8UMGiWqKtaeoMqnzItusZ1WYgDHKge37EvNm/w==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
         "dependencies": {
-          "Silk.NET.Input.Common": "2.22.0",
-          "Silk.NET.Input.Glfw": "2.22.0"
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
         }
       },
       "Silk.NET.Maths": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "W9b5UlUGCu5Ywb5f8ZyIWJ475ucY+mT/nEiSTo3JH098VxHaZS/02bYr9f29VWBaJhh3DwMkfxQvgTyXzTrHyw=="
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
       },
       "Silk.NET.OpenGL": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "AmbtflPvaGWw7fHEHrcFTd54OTAj0bemzx4WV2ELJdW2NBPSvtyz31nhyuBVTml20+NtW4Z3yhDGUpM6uouVDQ==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "CIakUoUqiAyRPykMk54tr1M1XpbJrT/iw12T85HDQcuRCFlBa1cxbX7v3FmtznKO5eM89esfmGNCgqDaKBiWfg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
-          "Silk.NET.Maths": "2.22.0"
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
         }
       },
       "Silk.NET.Windowing": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "yKGe/8REdm+T43LdtfUpFUx9eQARwx6wTmEoJ2bANVGQPCvWYC2Qi1+haT6n63dyNIX+iJWKg4++F4TFjg0/Fw==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
         "dependencies": {
-          "Silk.NET.Windowing.Common": "2.22.0",
-          "Silk.NET.Windowing.Glfw": "2.22.0"
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
         }
-      },
-      "SixLabors.ImageSharp": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.12, )",
-        "resolved": "3.1.12",
-        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "StbImageSharp": {
         "type": "CentralTransitive",

--- a/samples/KeenEyes.Sample/Systems.cs
+++ b/samples/KeenEyes.Sample/Systems.cs
@@ -210,7 +210,7 @@ public class DebugStatsSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Access the extension set by our plugin
-        if (World.TryGetExtension<DebugStats>(out var stats) && stats is not null)
+        if (World.TryGetExtension<DebugStats>(out var stats))
         {
             stats.EntitiesProcessed = World.EntityCount;
             Console.WriteLine($"  DebugStatsSystem: {stats.EntitiesProcessed} entities");

--- a/src/KeenEyes.Abstractions/IPluginContext.cs
+++ b/src/KeenEyes.Abstractions/IPluginContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace KeenEyes;
 
 /// <summary>
@@ -133,7 +135,7 @@ public interface IPluginContext
     /// <typeparam name="T">The extension type.</typeparam>
     /// <param name="extension">When this method returns, contains the extension if found.</param>
     /// <returns>True if the extension is registered; false otherwise.</returns>
-    bool TryGetExtension<T>(out T? extension) where T : class;
+    bool TryGetExtension<T>([MaybeNullWhen(false)] out T extension) where T : class;
 
     /// <summary>
     /// Sets an extension value that can be retrieved by other code.
@@ -201,7 +203,7 @@ public interface IPluginContext
     /// For required capabilities, use <see cref="GetCapability{T}"/> which throws if unavailable.
     /// </para>
     /// </remarks>
-    bool TryGetCapability<T>(out T? capability) where T : class;
+    bool TryGetCapability<T>([MaybeNullWhen(false)] out T capability) where T : class;
 
     /// <summary>
     /// Checks if a capability is available in this context.

--- a/src/KeenEyes.Abstractions/IWorld.cs
+++ b/src/KeenEyes.Abstractions/IWorld.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace KeenEyes;
 
 /// <summary>
@@ -370,7 +372,7 @@ public interface IWorld : IDisposable
     /// <typeparam name="T">The extension type.</typeparam>
     /// <param name="extension">When this method returns, contains the extension if found.</param>
     /// <returns>True if the extension is registered; false otherwise.</returns>
-    bool TryGetExtension<T>(out T? extension) where T : class;
+    bool TryGetExtension<T>([MaybeNullWhen(false)] out T extension) where T : class;
 
     /// <summary>
     /// Checks if an extension of the specified type is registered.

--- a/src/KeenEyes.Animation/Systems/AnimationEventSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimationEventSystem.cs
@@ -31,7 +31,7 @@ public sealed class AnimationEventSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/AnimationPlayerSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimationPlayerSystem.cs
@@ -23,7 +23,7 @@ public sealed class AnimationPlayerSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
@@ -25,7 +25,7 @@ public sealed class AnimatorSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/IKSolverSystem.cs
+++ b/src/KeenEyes.Animation/Systems/IKSolverSystem.cs
@@ -51,7 +51,7 @@ public sealed class IKSolverSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<IKManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/RootMotionSystem.cs
+++ b/src/KeenEyes.Animation/Systems/RootMotionSystem.cs
@@ -48,7 +48,7 @@ public sealed class RootMotionSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/SkeletonPoseSystem.cs
+++ b/src/KeenEyes.Animation/Systems/SkeletonPoseSystem.cs
@@ -30,7 +30,7 @@ public sealed class SkeletonPoseSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Animation/Systems/SpriteAnimationSystem.cs
+++ b/src/KeenEyes.Animation/Systems/SpriteAnimationSystem.cs
@@ -23,7 +23,7 @@ public sealed class SpriteAnimationSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out manager);
+        World.TryGetExtension<AnimationManager>(out manager);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Core/Plugins/PluginContext.cs
+++ b/src/KeenEyes.Core/Plugins/PluginContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace KeenEyes;
 
 /// <summary>
@@ -139,7 +141,7 @@ public sealed class PluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public bool TryGetExtension<T>(out T? extension) where T : class
+    public bool TryGetExtension<T>([MaybeNullWhen(false)] out T extension) where T : class
     {
         var result = World.TryGetExtension<T>(out var ext);
         extension = ext;
@@ -177,7 +179,7 @@ public sealed class PluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public bool TryGetCapability<T>(out T? capability) where T : class
+    public bool TryGetCapability<T>([MaybeNullWhen(false)] out T capability) where T : class
     {
         // Check if World directly implements the capability
         if (World is T worldCapability)

--- a/src/KeenEyes.Graph/Systems/GraphContextMenuSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphContextMenuSystem.cs
@@ -26,24 +26,24 @@ public sealed class GraphContextMenuSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        if (inputContext is null && !World.TryGetExtension<IInputContext>(out inputContext))
         {
             return;
         }
 
-        if (graphContext is null && !World.TryGetExtension(out graphContext))
+        if (graphContext is null && !World.TryGetExtension<GraphContext>(out graphContext))
         {
             return;
         }
 
-        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        if (portRegistry is null && !World.TryGetExtension<PortRegistry>(out portRegistry))
         {
             return;
         }
 
         if (nodeTypeRegistry is null)
         {
-            World.TryGetExtension(out nodeTypeRegistry);
+            World.TryGetExtension<NodeTypeRegistry>(out nodeTypeRegistry);
         }
 
         var keyboard = inputContext!.Keyboard;

--- a/src/KeenEyes.Graph/Systems/GraphInputSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphInputSystem.cs
@@ -80,34 +80,34 @@ public sealed class GraphInputSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        if (inputContext is null && !World.TryGetExtension<IInputContext>(out inputContext))
         {
             return;
         }
 
-        if (graphContext is null && !World.TryGetExtension(out graphContext))
+        if (graphContext is null && !World.TryGetExtension<GraphContext>(out graphContext))
         {
             return;
         }
 
-        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        if (portRegistry is null && !World.TryGetExtension<PortRegistry>(out portRegistry))
         {
             return;
         }
 
         if (nodeTypeRegistry is null)
         {
-            World.TryGetExtension(out nodeTypeRegistry);
+            World.TryGetExtension<NodeTypeRegistry>(out nodeTypeRegistry);
         }
 
-        if (portCache is null && !World.TryGetExtension(out portCache))
+        if (portCache is null && !World.TryGetExtension<PortPositionCache>(out portCache))
         {
             return;
         }
 
         if (undoManager is null)
         {
-            World.TryGetExtension(out undoManager);
+            World.TryGetExtension<IUndoRedoManager>(out undoManager);
         }
 
         var mouse = inputContext!.Mouse;

--- a/src/KeenEyes.Graph/Systems/GraphLayoutSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphLayoutSystem.cs
@@ -62,12 +62,12 @@ public sealed class GraphLayoutSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        if (portRegistry is null && !World.TryGetExtension<PortRegistry>(out portRegistry))
         {
             return;
         }
 
-        if (portCache is null && !World.TryGetExtension(out portCache))
+        if (portCache is null && !World.TryGetExtension<PortPositionCache>(out portCache))
         {
             return;
         }

--- a/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphRenderSystem.cs
@@ -81,7 +81,7 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
     public override void Update(float deltaTime)
     {
         // Get renderer
-        if (renderer is null && !World.TryGetExtension(out renderer))
+        if (renderer is null && !World.TryGetExtension<I2DRenderer>(out renderer))
         {
             return;
         }
@@ -89,11 +89,11 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
         // Text renderer is optional
         if (textRenderer is null)
         {
-            World.TryGetExtension(out textRenderer);
+            World.TryGetExtension<ITextRenderer>(out textRenderer);
         }
 
         // Get port registry
-        if (portRegistry is null && !World.TryGetExtension(out portRegistry))
+        if (portRegistry is null && !World.TryGetExtension<PortRegistry>(out portRegistry))
         {
             return;
         }
@@ -101,11 +101,11 @@ public sealed class GraphRenderSystem : SystemBase, IGraphRenderer
         // Get node type registry
         if (nodeTypeRegistry is null)
         {
-            World.TryGetExtension(out nodeTypeRegistry);
+            World.TryGetExtension<NodeTypeRegistry>(out nodeTypeRegistry);
         }
 
         // Get port position cache
-        if (portCache is null && !World.TryGetExtension(out portCache))
+        if (portCache is null && !World.TryGetExtension<PortPositionCache>(out portCache))
         {
             return;
         }

--- a/src/KeenEyes.Graph/Systems/GraphWidgetSystem.cs
+++ b/src/KeenEyes.Graph/Systems/GraphWidgetSystem.cs
@@ -32,12 +32,12 @@ public sealed class GraphWidgetSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        if (inputContext is null && !World.TryGetExtension<IInputContext>(out inputContext))
         {
             return;
         }
 
-        if (graphContext is null && !World.TryGetExtension(out graphContext))
+        if (graphContext is null && !World.TryGetExtension<GraphContext>(out graphContext))
         {
             return;
         }

--- a/src/KeenEyes.Graphics/Systems/CameraSystem.cs
+++ b/src/KeenEyes.Graphics/Systems/CameraSystem.cs
@@ -31,7 +31,7 @@ public sealed class CameraSystem : ISystem
     {
         this.world = world;
 
-        world.TryGetExtension(out graphics);
+        world.TryGetExtension<IGraphicsContext>(out graphics);
 
         if (world.TryGetExtension<ILoopProvider>(out loopProvider) && loopProvider is not null)
         {

--- a/src/KeenEyes.Localization/Systems/LocalizedAssetSystem.cs
+++ b/src/KeenEyes.Localization/Systems/LocalizedAssetSystem.cs
@@ -36,8 +36,8 @@ public sealed class LocalizedAssetSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out localization);
-        World.TryGetExtension(out resolver);
+        World.TryGetExtension<LocalizationManager>(out localization);
+        World.TryGetExtension<ILocalizedAssetResolver>(out resolver);
 
         // Subscribe to locale changes
         localeChangedSubscription = World.Subscribe<LocaleChangedEvent>(OnLocaleChanged);
@@ -49,12 +49,12 @@ public sealed class LocalizedAssetSystem : SystemBase
     /// <inheritdoc />
     public override void Update(float deltaTime)
     {
-        if (localization == null && !World.TryGetExtension(out localization))
+        if (localization == null && !World.TryGetExtension<LocalizationManager>(out localization))
         {
             return;
         }
 
-        if (resolver == null && !World.TryGetExtension(out resolver))
+        if (resolver == null && !World.TryGetExtension<ILocalizedAssetResolver>(out resolver))
         {
             return;
         }

--- a/src/KeenEyes.Localization/Systems/LocalizedTextSystem.cs
+++ b/src/KeenEyes.Localization/Systems/LocalizedTextSystem.cs
@@ -39,7 +39,7 @@ public sealed class LocalizedTextSystem : SystemBase
     /// <inheritdoc />
     protected override void OnInitialize()
     {
-        World.TryGetExtension(out localization);
+        World.TryGetExtension<LocalizationManager>(out localization);
 
         // Subscribe to locale changes
         localeChangedSubscription = World.Subscribe<LocaleChangedEvent>(OnLocaleChanged);
@@ -51,7 +51,7 @@ public sealed class LocalizedTextSystem : SystemBase
     /// <inheritdoc />
     public override void Update(float deltaTime)
     {
-        if (localization == null && !World.TryGetExtension(out localization))
+        if (localization == null && !World.TryGetExtension<LocalizationManager>(out localization))
         {
             return;
         }

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingSystem.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshStreamingSystem.cs
@@ -29,7 +29,7 @@ internal sealed class NavMeshStreamingSystem : SystemBase
     /// <inheritdoc/>
     protected override void OnInitialize()
     {
-        if (!World.TryGetExtension(out NavMeshStreamingManager? streamingManager) || streamingManager is null)
+        if (!World.TryGetExtension<NavMeshStreamingManager>(out var streamingManager) || streamingManager is null)
         {
             throw new InvalidOperationException("NavMeshStreamingSystem requires the NavMeshStreamingManager extension.");
         }

--- a/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/CrowdSteeringSystem.cs
@@ -41,7 +41,7 @@ internal sealed class CrowdSteeringSystem : SystemBase
     /// <inheritdoc/>
     protected override void OnInitialize()
     {
-        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        if (!World.TryGetExtension<NavigationContext>(out var ctx) || ctx is null)
         {
             throw new InvalidOperationException("CrowdSteeringSystem requires NavigationContext extension.");
         }

--- a/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/NavMeshAgentSystem.cs
@@ -34,7 +34,7 @@ internal sealed class NavMeshAgentSystem : SystemBase
     /// <inheritdoc/>
     protected override void OnInitialize()
     {
-        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        if (!World.TryGetExtension<NavigationContext>(out var ctx) || ctx is null)
         {
             throw new InvalidOperationException("NavMeshAgentSystem requires NavigationContext extension.");
         }

--- a/src/KeenEyes.Navigation/Systems/ObstacleUpdateSystem.cs
+++ b/src/KeenEyes.Navigation/Systems/ObstacleUpdateSystem.cs
@@ -41,7 +41,7 @@ internal sealed class ObstacleUpdateSystem : SystemBase
     /// <inheritdoc/>
     protected override void OnInitialize()
     {
-        if (!World.TryGetExtension(out NavigationContext? ctx) || ctx is null)
+        if (!World.TryGetExtension<NavigationContext>(out var ctx) || ctx is null)
         {
             throw new InvalidOperationException("ObstacleUpdateSystem requires NavigationContext extension.");
         }

--- a/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
@@ -47,7 +47,7 @@ public sealed class ParticleRenderSystem : SystemBase
         var pm = manager;
         if (pm == null)
         {
-            if (!World.TryGetExtension(out pm) || pm is null)
+            if (!World.TryGetExtension<ParticleManager>(out pm) || pm is null)
             {
                 return;
             }
@@ -57,7 +57,7 @@ public sealed class ParticleRenderSystem : SystemBase
         var r = renderer;
         if (r == null)
         {
-            if (!World.TryGetExtension(out r) || r is null)
+            if (!World.TryGetExtension<I2DRenderer>(out r) || r is null)
             {
                 return;
             }

--- a/src/KeenEyes.Particles/Systems/ParticleSpawnSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleSpawnSystem.cs
@@ -38,7 +38,7 @@ public sealed class ParticleSpawnSystem : SystemBase
         var pm = manager;
         if (pm == null)
         {
-            if (!World.TryGetExtension(out pm) || pm is null)
+            if (!World.TryGetExtension<ParticleManager>(out pm) || pm is null)
             {
                 return;
             }

--- a/src/KeenEyes.Particles/Systems/ParticleUpdateSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleUpdateSystem.cs
@@ -36,7 +36,7 @@ public sealed class ParticleUpdateSystem : SystemBase
         var pm = manager;
         if (pm == null)
         {
-            if (!World.TryGetExtension(out pm) || pm is null)
+            if (!World.TryGetExtension<ParticleManager>(out pm) || pm is null)
             {
                 return;
             }

--- a/src/KeenEyes.Physics/Systems/PhysicsStepSystem.cs
+++ b/src/KeenEyes.Physics/Systems/PhysicsStepSystem.cs
@@ -41,7 +41,7 @@ public sealed class PhysicsStepSystem : SystemBase
         var pw = physicsWorld;
         if (pw == null)
         {
-            if (!World.TryGetExtension(out pw))
+            if (!World.TryGetExtension<PhysicsWorld>(out pw))
             {
                 return;
             }

--- a/src/KeenEyes.Physics/Systems/PhysicsSyncSystem.cs
+++ b/src/KeenEyes.Physics/Systems/PhysicsSyncSystem.cs
@@ -43,7 +43,7 @@ public sealed class PhysicsSyncSystem : SystemBase
         var pw = physicsWorld;
         if (pw == null)
         {
-            if (!World.TryGetExtension(out pw))
+            if (!World.TryGetExtension<PhysicsWorld>(out pw))
             {
                 return;
             }

--- a/src/KeenEyes.Testing/Plugins/MockPluginContext.cs
+++ b/src/KeenEyes.Testing/Plugins/MockPluginContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace KeenEyes.Testing.Plugins;
 
 /// <summary>
@@ -297,7 +299,7 @@ public sealed class MockPluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public bool TryGetExtension<T>(out T? extension) where T : class
+    public bool TryGetExtension<T>([MaybeNullWhen(false)] out T extension) where T : class
     {
         if (extensions.TryGetValue(typeof(T), out var ext))
         {
@@ -343,7 +345,7 @@ public sealed class MockPluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public bool TryGetCapability<T>(out T? capability) where T : class
+    public bool TryGetCapability<T>([MaybeNullWhen(false)] out T capability) where T : class
     {
         // First check mock capabilities
         if (capabilities.TryGetValue(typeof(T), out var cap))

--- a/src/KeenEyes.UI/Systems/UIFocusSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIFocusSystem.cs
@@ -32,12 +32,12 @@ public sealed class UIFocusSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        if (inputContext is null && !World.TryGetExtension<IInputContext>(out inputContext))
         {
             return;
         }
 
-        if (uiContext is null && !World.TryGetExtension(out uiContext))
+        if (uiContext is null && !World.TryGetExtension<UIContext>(out uiContext))
         {
             return;
         }

--- a/src/KeenEyes.UI/Systems/UIInputSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIInputSystem.cs
@@ -54,12 +54,12 @@ public sealed class UIInputSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization
-        if (inputContext is null && !World.TryGetExtension(out inputContext))
+        if (inputContext is null && !World.TryGetExtension<IInputContext>(out inputContext))
         {
             return;
         }
 
-        if (uiContext is null && !World.TryGetExtension(out uiContext))
+        if (uiContext is null && !World.TryGetExtension<UIContext>(out uiContext))
         {
             return;
         }

--- a/src/KeenEyes.UI/Systems/UIModalSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIModalSystem.cs
@@ -35,7 +35,7 @@ public sealed class UIModalSystem : SystemBase
         clickSubscription = World.Subscribe<UIClickEvent>(OnClick);
 
         // Try to get input context for keyboard handling
-        World.TryGetExtension(out inputContext);
+        World.TryGetExtension<IInputContext>(out inputContext);
     }
 
     /// <inheritdoc />
@@ -56,7 +56,7 @@ public sealed class UIModalSystem : SystemBase
         // Handle Escape key for open modals
         if (inputContext == null)
         {
-            World.TryGetExtension(out inputContext);
+            World.TryGetExtension<IInputContext>(out inputContext);
             if (inputContext == null)
             {
                 return;

--- a/src/KeenEyes.UI/Systems/UIRenderSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIRenderSystem.cs
@@ -103,7 +103,7 @@ public sealed class UIRenderSystem : SystemBase
     private void TryInitializeRenderers()
     {
         // Try getting I2DRenderer directly as extension first, fall back to provider
-        if (!World.TryGetExtension(out renderer2D) &&
+        if (!World.TryGetExtension<I2DRenderer>(out renderer2D) &&
             World.TryGetExtension<I2DRendererProvider>(out var provider) &&
             provider is not null)
         {
@@ -111,7 +111,7 @@ public sealed class UIRenderSystem : SystemBase
         }
 
         // Try getting ITextRenderer directly as extension first, fall back to provider
-        if (!World.TryGetExtension(out textRenderer) &&
+        if (!World.TryGetExtension<ITextRenderer>(out textRenderer) &&
             World.TryGetExtension<ITextRendererProvider>(out var textProvider) &&
             textProvider is not null)
         {

--- a/src/KeenEyes.UI/Systems/UITextInputSystem.cs
+++ b/src/KeenEyes.UI/Systems/UITextInputSystem.cs
@@ -54,14 +54,14 @@ public sealed class UITextInputSystem : SystemBase
     public override void Update(float deltaTime)
     {
         // Lazy initialization of input context
-        if (inputContext is null && World.TryGetExtension(out inputContext))
+        if (inputContext is null && World.TryGetExtension<IInputContext>(out inputContext))
         {
             SubscribeToInput();
         }
 
         if (uiContext is null)
         {
-            World.TryGetExtension(out uiContext);
+            World.TryGetExtension<UIContext>(out uiContext);
         }
     }
 


### PR DESCRIPTION
## Summary
- **#1084**: PBR's `CS0104` fixed (`System.Environment.Exit`), project added to `KeenEyes.slnx` — it's now permanently build-gated (its stale lockfile regenerated as a consequence). The audit found one more un-gated sample, InputDebugger, which turns out to have rotted against the current `Material` API (47 errors) — deferred to a dedicated issue rather than rewritten inside this fix.
- **#1085**: `[MaybeNullWhen(false)]` added to `IWorld.TryGetExtension` and `IPluginContext.TryGetExtension`/`TryGetCapability`, plus the `PluginContext`/`MockPluginContext` implementations — standardizing on the shape the concrete `World` always had. ~50 call sites across src/ updated (explicit type args where the out-target was a nullable field; the two sample workaround guards from #1083 removed). Interface callers now get correct nullability flow analysis instead of reaching for `!`.

## Test plan
- [x] Full Release build 0 warnings / 0 errors (first gated build includes PBR)
- [x] Full suite 14,423 passed / 0 failed / 62 pre-existing skips
- [x] `dotnet format --verify-no-changes` exit 0

## Related Issues
Closes #1084, Closes #1085