### PR TITLE
fix(core): Fix multi-chunk archetype storage corruption (#1092)

### DIFF
--- a/src/KeenEyes.Core/Archetypes/Archetype.cs
+++ b/src/KeenEyes.Core/Archetypes/Archetype.cs
@@ -95,16 +95,40 @@ public sealed class Archetype : IDisposable
     /// </summary>
     /// <param name="entity">The entity to add.</param>
     /// <returns>The index of the entity in this archetype (global index across all chunks).</returns>
+    /// <remarks>
+    /// The returned global index is <b>sparse</b>: once any non-last chunk holds fewer than
+    /// <see cref="ArchetypeChunk.DefaultCapacity"/> entities (for example after a swap-back
+    /// removal), a gap exists between chunks. The value must not be treated as a dense position
+    /// or a stable handle. Resolve component data through the entity-keyed accessors
+    /// (<see cref="GetByEntity{T}"/> and friends) instead.
+    /// </remarks>
     internal int AddEntity(Entity entity)
     {
-        var chunk = GetOrCreateChunkWithSpace();
-        var chunkIndex = chunks.IndexOf(chunk);
-        var indexInChunk = chunk.AddEntity(entity);
+        var chunk = AddEntityReturningChunk(entity, out var chunkIndex);
+        return (chunkIndex * ArchetypeChunk.DefaultCapacity) + chunk.GetEntityIndex(entity);
+    }
 
-        entityLocations[entity.Id] = (chunkIndex, indexInChunk);
+    /// <summary>
+    /// Adds an entity to this archetype and returns the chunk it was placed in.
+    /// </summary>
+    /// <param name="entity">The entity to add.</param>
+    /// <param name="chunkIndex">The index of the chunk the entity was placed in.</param>
+    /// <returns>The chunk the entity was placed in.</returns>
+    /// <remarks>
+    /// Component data for the entity must be written to the returned chunk at the entity's slot
+    /// so the entity and its components stay co-located. Writing components to a different chunk
+    /// (such as the last chunk) corrupts storage once a non-last chunk has a hole from a prior
+    /// swap-back removal.
+    /// </remarks>
+    internal ArchetypeChunk AddEntityReturningChunk(Entity entity, out int chunkIndex)
+    {
+        var chunk = GetOrCreateChunkWithSpace(out chunkIndex);
+        chunk.AddEntity(entity);
+
+        entityLocations[entity.Id] = (chunkIndex, chunk.GetEntityIndex(entity));
         totalCount++;
 
-        return (chunkIndex * ArchetypeChunk.DefaultCapacity) + indexInChunk;
+        return chunk;
     }
 
     /// <summary>
@@ -112,6 +136,12 @@ public sealed class Archetype : IDisposable
     /// </summary>
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="component">The component value.</param>
+    /// <remarks>
+    /// This writes to the last chunk and is only correct when the most recently added entity
+    /// was placed there. Production callers that add an entity with
+    /// <see cref="AddEntityReturningChunk"/> must write components to the returned chunk
+    /// directly to keep the entity and its components co-located.
+    /// </remarks>
     internal void AddComponent<T>(in T component) where T : struct, IComponent
     {
         if (chunks.Count == 0)
@@ -127,6 +157,12 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Adds a component value from a boxed object.
     /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <param name="value">The boxed component value.</param>
+    /// <remarks>
+    /// This writes to the last chunk. See <see cref="AddComponent{T}"/> for the co-location
+    /// constraint that production callers must observe.
+    /// </remarks>
     internal void AddComponentBoxed(Type type, object value)
     {
         if (chunks.Count == 0)
@@ -193,6 +229,11 @@ public sealed class Archetype : IDisposable
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="globalIndex">The global index of the entity within this archetype.</param>
     /// <returns>A reference to the component data.</returns>
+    /// <remarks>
+    /// The global index is <b>sparse</b> across chunk boundaries once a non-last chunk has a
+    /// hole. Prefer <see cref="GetByEntity{T}"/> for entity-addressed access; this overload is
+    /// intended for chunk-local test and diagnostic use where the index is known to be dense.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref T Get<T>(int globalIndex) where T : struct, IComponent
     {
@@ -214,11 +255,65 @@ public sealed class Archetype : IDisposable
     }
 
     /// <summary>
+    /// Gets a readonly reference to a component for an entity.
+    /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="entity">The entity to get the component for.</param>
+    /// <returns>A readonly reference to the component data.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref readonly T GetReadonlyByEntity<T>(Entity entity) where T : struct, IComponent
+    {
+        var (chunkIndex, indexInChunk) = entityLocations[entity.Id];
+        return ref chunks[chunkIndex].GetReadonly<T>(indexInChunk);
+    }
+
+    /// <summary>
+    /// Sets a component value for an entity.
+    /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="entity">The entity to set the component for.</param>
+    /// <param name="component">The component value to set.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void SetByEntity<T>(Entity entity, in T component) where T : struct, IComponent
+    {
+        var (chunkIndex, indexInChunk) = entityLocations[entity.Id];
+        chunks[chunkIndex].Set(indexInChunk, in component);
+    }
+
+    /// <summary>
+    /// Gets the boxed component value for an entity.
+    /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <param name="entity">The entity to get the component for.</param>
+    /// <returns>The boxed component value.</returns>
+    internal object GetBoxedByEntity(Type type, Entity entity)
+    {
+        var (chunkIndex, indexInChunk) = entityLocations[entity.Id];
+        return chunks[chunkIndex].GetBoxed(type, indexInChunk);
+    }
+
+    /// <summary>
+    /// Sets a component value for an entity from a boxed object.
+    /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <param name="entity">The entity to set the component for.</param>
+    /// <param name="value">The boxed component value.</param>
+    internal void SetBoxedByEntity(Type type, Entity entity, object value)
+    {
+        var (chunkIndex, indexInChunk) = entityLocations[entity.Id];
+        chunks[chunkIndex].SetBoxed(type, indexInChunk, value);
+    }
+
+    /// <summary>
     /// Gets a readonly reference to a component.
     /// </summary>
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="globalIndex">The global index of the entity within this archetype.</param>
     /// <returns>A readonly reference to the component data.</returns>
+    /// <remarks>
+    /// The global index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>.
+    /// Prefer <see cref="GetReadonlyByEntity{T}"/> for entity-addressed access.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref readonly T GetReadonly<T>(int globalIndex) where T : struct, IComponent
     {
@@ -232,6 +327,10 @@ public sealed class Archetype : IDisposable
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="globalIndex">The global index of the entity within this archetype.</param>
     /// <param name="component">The component value to set.</param>
+    /// <remarks>
+    /// The global index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>.
+    /// Prefer <see cref="SetByEntity{T}"/> for entity-addressed access.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Set<T>(int globalIndex, in T component) where T : struct, IComponent
     {
@@ -240,8 +339,12 @@ public sealed class Archetype : IDisposable
     }
 
     /// <summary>
-    /// Sets a component value from a boxed object.
+    /// Sets a component value from a boxed object at the specified global index.
     /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <param name="globalIndex">The global index of the entity within this archetype.</param>
+    /// <param name="value">The boxed component value.</param>
+    /// <remarks>The global index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>.</remarks>
     internal void SetBoxed(Type type, int globalIndex, object value)
     {
         var (chunkIndex, indexInChunk) = GetChunkLocation(globalIndex);
@@ -251,6 +354,10 @@ public sealed class Archetype : IDisposable
     /// <summary>
     /// Gets the boxed component value at the specified global index.
     /// </summary>
+    /// <param name="type">The component type.</param>
+    /// <param name="globalIndex">The global index of the entity within this archetype.</param>
+    /// <returns>The boxed component value.</returns>
+    /// <remarks>The global index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>.</remarks>
     internal object GetBoxed(Type type, int globalIndex)
     {
         var (chunkIndex, indexInChunk) = GetChunkLocation(globalIndex);
@@ -368,6 +475,10 @@ public sealed class Archetype : IDisposable
     /// </summary>
     /// <param name="entity">The entity to locate.</param>
     /// <returns>The global index of the entity, or -1 if the entity is not found in this archetype.</returns>
+    /// <remarks>
+    /// The returned index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>. It
+    /// is derived on demand from the authoritative per-entity location map.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetEntityIndex(Entity entity)
     {
@@ -394,6 +505,11 @@ public sealed class Archetype : IDisposable
     /// </summary>
     /// <param name="globalIndex">The global index within this archetype.</param>
     /// <returns>The entity at the specified index.</returns>
+    /// <remarks>
+    /// The global index is sparse across chunk boundaries; see <see cref="Get{T}(int)"/>. To
+    /// iterate live entities, walk <see cref="Chunks"/> using each chunk's
+    /// <see cref="ArchetypeChunk.Count"/> instead of a dense global range.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Entity GetEntity(int globalIndex)
     {
@@ -402,15 +518,19 @@ public sealed class Archetype : IDisposable
     }
 
     /// <summary>
-    /// Copies all shared components from one entity to another archetype.
+    /// Copies all shared components for an entity into a specific destination chunk.
     /// </summary>
-    internal void CopySharedComponentsTo(int globalIndex, Archetype destination)
+    /// <param name="entity">The source entity whose components are copied.</param>
+    /// <param name="destinationChunk">The destination chunk the entity was placed in.</param>
+    /// <remarks>
+    /// The destination chunk must be the chunk the entity was added to in the destination
+    /// archetype (see <see cref="AddEntityReturningChunk"/>) so components land at the entity's
+    /// slot rather than an unrelated chunk.
+    /// </remarks>
+    internal void CopySharedComponentsToChunk(Entity entity, ArchetypeChunk destinationChunk)
     {
-        var (chunkIndex, indexInChunk) = GetChunkLocation(globalIndex);
-        var sourceChunk = chunks[chunkIndex];
-        var destChunk = destination.chunks[^1]; // Destination's last chunk
-
-        sourceChunk.CopyComponentsTo(indexInChunk, destChunk);
+        var (chunkIndex, indexInChunk) = entityLocations[entity.Id];
+        chunks[chunkIndex].CopyComponentsTo(indexInChunk, destinationChunk);
     }
 
     /// <inheritdoc />
@@ -447,14 +567,16 @@ public sealed class Archetype : IDisposable
         return (chunkIndex, indexInChunk);
     }
 
-    private ArchetypeChunk GetOrCreateChunkWithSpace()
+    private ArchetypeChunk GetOrCreateChunkWithSpace(out int chunkIndex)
     {
-        // Find a chunk with space
-        foreach (var chunk in chunks)
+        // Find the first chunk with space. Refilling holes in earlier chunks is intentional:
+        // it keeps storage compact and avoids fragmentation across chunks.
+        for (var i = 0; i < chunks.Count; i++)
         {
-            if (!chunk.IsFull)
+            if (!chunks[i].IsFull)
             {
-                return chunk;
+                chunkIndex = i;
+                return chunks[i];
             }
         }
 
@@ -470,6 +592,7 @@ public sealed class Archetype : IDisposable
         }
 
         chunks.Add(newChunk);
+        chunkIndex = chunks.Count - 1;
         return newChunk;
     }
 

--- a/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
@@ -27,7 +27,7 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
 {
     private readonly Lock syncRoot = new();
     private readonly Dictionary<ArchetypeId, Archetype> archetypes = [];
-    private readonly Dictionary<int, (Archetype Archetype, int Index)> entityLocations = [];
+    private readonly Dictionary<int, Archetype> entityLocations = [];
     private readonly List<Archetype> archetypeList = [];
     private readonly ChunkPool chunkPool = chunkPool ?? new ChunkPool();
 
@@ -206,18 +206,19 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
             {
                 var archetype = GetOrCreateArchetypeNoLock(GetTypesSpan(componentArray, componentCount));
 
-                // Add entity to archetype
-                var index = archetype.AddEntity(entity);
+                // Add entity to archetype and write its components into the SAME chunk so the
+                // entity and its component data stay co-located (see issue #1092).
+                var chunk = archetype.AddEntityReturningChunk(entity, out _);
 
-                // Add all component values
+                // Add all component values to the entity's chunk
                 for (int i = 0; i < componentCount; i++)
                 {
                     var (info, data) = componentArray[i];
-                    archetype.AddComponentBoxed(info.Type, data);
+                    chunk.AddComponentBoxed(info.Type, data);
                 }
 
-                // Track entity location
-                entityLocations[entity.Id] = (archetype, index);
+                // Track entity location (archetype is the single source of truth for the slot)
+                entityLocations[entity.Id] = archetype;
             }
         }
         finally
@@ -243,22 +244,15 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var archetype))
             {
                 return false;
             }
 
-            var (archetype, _) = location;
-
-            // Remove from archetype (swap-back)
-            var swappedEntity = archetype.RemoveEntity(entity);
-
-            // Update swapped entity's index if one was swapped
-            if (swappedEntity.HasValue)
-            {
-                var swappedIndex = archetype.GetEntityIndex(swappedEntity.Value);
-                entityLocations[swappedEntity.Value.Id] = (archetype, swappedIndex);
-            }
+            // Remove from archetype (swap-back). The archetype owns per-entity slot bookkeeping,
+            // including any swap or chunk-removal shifts, so the manager stores only the archetype
+            // and never a cached index to reconcile (see issue #1092).
+            archetype.RemoveEntity(entity);
 
             entityLocations.Remove(entity.Id);
             return true;
@@ -275,12 +269,10 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var currentArchetype))
             {
                 throw new InvalidOperationException($"Entity {entity} is not tracked by this archetype manager.");
             }
-
-            var (currentArchetype, currentIndex) = location;
 
             // Check if already has the component
             if (currentArchetype.Has<T>())
@@ -293,11 +285,9 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
             var newId = currentArchetype.Id.With<T>();
             var newArchetype = GetOrCreateArchetypeNoLock(newId);
 
-            // Migrate entity
-            MigrateEntity(entity, currentArchetype, currentIndex, newArchetype);
-
-            // Add the new component
-            newArchetype.AddComponent(in component);
+            // Migrate entity, then write the new component into the entity's destination chunk
+            var destChunk = MigrateEntity(entity, currentArchetype, newArchetype);
+            destChunk.AddComponent(in component);
         }
     }
 
@@ -311,12 +301,10 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var currentArchetype))
             {
                 throw new InvalidOperationException($"Entity {entity} is not tracked by this archetype manager.");
             }
-
-            var (currentArchetype, currentIndex) = location;
 
             // Check if already has the component
             if (currentArchetype.Has(componentType))
@@ -329,11 +317,9 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
             var newId = currentArchetype.Id.With(componentType);
             var newArchetype = GetOrCreateArchetypeNoLock(newId);
 
-            // Migrate entity
-            MigrateEntity(entity, currentArchetype, currentIndex, newArchetype);
-
-            // Add the new component
-            newArchetype.AddComponentBoxed(componentType, value);
+            // Migrate entity, then write the new component into the entity's destination chunk
+            var destChunk = MigrateEntity(entity, currentArchetype, newArchetype);
+            destChunk.AddComponentBoxed(componentType, value);
         }
     }
 
@@ -347,19 +333,17 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var currentArchetype))
             {
                 return false;
             }
-
-            var (currentArchetype, currentIndex) = location;
 
             // Get or create target archetype
             var newId = currentArchetype.Id.Without<T>();
             var newArchetype = GetOrCreateArchetypeNoLock(newId);
 
             // Migrate entity (copies shared components, excludes removed one)
-            MigrateEntity(entity, currentArchetype, currentIndex, newArchetype);
+            MigrateEntity(entity, currentArchetype, newArchetype);
 
             return true;
         }
@@ -379,8 +363,8 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            var (archetype, index) = GetEntityLocationNoLock(entity);
-            return ref archetype.Get<T>(index);
+            var archetype = GetArchetypeNoLock(entity);
+            return ref archetype.GetByEntity<T>(entity);
         }
     }
 
@@ -400,8 +384,8 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            var (archetype, index) = GetEntityLocationNoLock(entity);
-            return ref archetype.GetReadonly<T>(index);
+            var archetype = GetArchetypeNoLock(entity);
+            return ref archetype.GetReadonlyByEntity<T>(entity);
         }
     }
 
@@ -415,11 +399,11 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var archetype))
             {
                 return false;
             }
-            return location.Archetype.Has<T>();
+            return archetype.Has<T>();
         }
     }
 
@@ -433,11 +417,11 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var archetype))
             {
                 return false;
             }
-            return location.Archetype.Has(componentType);
+            return archetype.Has(componentType);
         }
     }
 
@@ -451,8 +435,8 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            var (archetype, index) = GetEntityLocationNoLock(entity);
-            archetype.Set(index, in component);
+            var archetype = GetArchetypeNoLock(entity);
+            archetype.SetByEntity(entity, in component);
         }
     }
 
@@ -466,8 +450,8 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            var (archetype, index) = GetEntityLocationNoLock(entity);
-            archetype.SetBoxed(componentType, index, value);
+            var archetype = GetArchetypeNoLock(entity);
+            archetype.SetBoxedByEntity(componentType, entity, value);
         }
     }
 
@@ -481,12 +465,10 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var currentArchetype))
             {
                 return false;
             }
-
-            var (currentArchetype, currentIndex) = location;
 
             if (!currentArchetype.Has(componentType))
             {
@@ -498,7 +480,7 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
             var newArchetype = GetOrCreateArchetypeNoLock(newId);
 
             // Migrate entity (copies shared components, excludes removed one)
-            MigrateEntity(entity, currentArchetype, currentIndex, newArchetype);
+            MigrateEntity(entity, currentArchetype, newArchetype);
 
             return true;
         }
@@ -528,10 +510,10 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (entityLocations.TryGetValue(entity.Id, out var location))
+            if (entityLocations.TryGetValue(entity.Id, out var found))
             {
-                archetype = location.Archetype;
-                index = location.Index;
+                archetype = found;
+                index = found.GetEntityIndex(entity);
                 return true;
             }
 
@@ -573,12 +555,12 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
     {
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var archetype))
             {
                 return [];
             }
             // Return a copy since ComponentTypes is immutable array
-            return location.Archetype.ComponentTypes;
+            return archetype.ComponentTypes;
         }
     }
 
@@ -593,16 +575,15 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         List<(Type Type, object Value)> result;
         lock (syncRoot)
         {
-            if (!entityLocations.TryGetValue(entity.Id, out var location))
+            if (!entityLocations.TryGetValue(entity.Id, out var archetype))
             {
                 return [];
             }
 
-            var (archetype, index) = location;
             result = [];
             foreach (var type in archetype.ComponentTypes)
             {
-                result.Add((type, archetype.GetBoxed(type, index)));
+                result.Add((type, archetype.GetBoxedByEntity(type, entity)));
             }
         }
         return result;
@@ -621,27 +602,26 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         }
     }
 
-    // Called from within a lock - do not acquire lock here
-    private void MigrateEntity(Entity entity, Archetype source, int sourceIndex, Archetype destination)
+    // Called from within a lock - do not acquire lock here.
+    // Returns the destination chunk the entity was placed in so callers can write any
+    // newly-added component into the SAME chunk as the entity (see issue #1092).
+    private ArchetypeChunk MigrateEntity(Entity entity, Archetype source, Archetype destination)
     {
-        // Add entity to new archetype
-        var newIndex = destination.AddEntity(entity);
+        // Add entity to the new archetype, capturing the chunk it landed in
+        var destChunk = destination.AddEntityReturningChunk(entity, out _);
 
-        // Copy shared components
-        source.CopySharedComponentsTo(sourceIndex, destination);
+        // Copy shared components into the entity's actual destination chunk
+        source.CopySharedComponentsToChunk(entity, destChunk);
 
-        // Remove from old archetype
-        var swappedEntity = source.RemoveEntity(entity);
+        // Remove from old archetype. The source archetype owns its own slot bookkeeping
+        // (including swap shifts and chunk removal), so no manager-side index reconciliation
+        // is needed for the swapped entity.
+        source.RemoveEntity(entity);
 
-        // Update swapped entity's index
-        if (swappedEntity.HasValue)
-        {
-            var swappedIndex = source.GetEntityIndex(swappedEntity.Value);
-            entityLocations[swappedEntity.Value.Id] = (source, swappedIndex);
-        }
+        // Update entity location (archetype only; the archetype resolves the slot)
+        entityLocations[entity.Id] = destination;
 
-        // Update entity location
-        entityLocations[entity.Id] = (destination, newIndex);
+        return destChunk;
     }
 
     private static bool MatchesQuery(Archetype archetype, QueryDescription description)
@@ -705,14 +685,22 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         return archetype;
     }
 
-    // Lock-free version for use within locked sections
+    // Lock-free version for use within locked sections. The returned index is the archetype's
+    // sparse global index, derived on demand from the archetype's authoritative location map.
     private (Archetype Archetype, int Index) GetEntityLocationNoLock(Entity entity)
     {
-        if (!entityLocations.TryGetValue(entity.Id, out var location))
+        var archetype = GetArchetypeNoLock(entity);
+        return (archetype, archetype.GetEntityIndex(entity));
+    }
+
+    // Lock-free archetype lookup for use within locked sections.
+    private Archetype GetArchetypeNoLock(Entity entity)
+    {
+        if (!entityLocations.TryGetValue(entity.Id, out var archetype))
         {
             throw new InvalidOperationException($"Entity {entity} is not tracked by this archetype manager.");
         }
-        return location;
+        return archetype;
     }
 
     /// <summary>

--- a/src/KeenEyes.Core/Queries/QueryEnumerator.cs
+++ b/src/KeenEyes.Core/Queries/QueryEnumerator.cs
@@ -15,7 +15,8 @@ public struct QueryEnumerator : IEnumerator<Entity>
     private readonly IReadOnlyList<string> withoutStringTags;
     private readonly bool hasStringTagFilters;
     private int archetypeIndex;
-    private int entityIndex;
+    private int chunkIndex;
+    private int indexInChunk;
 
     internal QueryEnumerator(World world, QueryDescription description)
     {
@@ -25,7 +26,8 @@ public struct QueryEnumerator : IEnumerator<Entity>
         withoutStringTags = description.WithoutStringTags;
         hasStringTagFilters = description.HasStringTagFilters;
         archetypeIndex = 0;
-        entityIndex = -1;
+        chunkIndex = 0;
+        indexInChunk = -1;
     }
 
     /// <inheritdoc />
@@ -36,7 +38,11 @@ public struct QueryEnumerator : IEnumerator<Entity>
         {
             if (archetypeIndex < archetypes.Count)
             {
-                return archetypes[archetypeIndex].GetEntity(entityIndex);
+                var chunks = archetypes[archetypeIndex].Chunks;
+                if (chunkIndex < chunks.Count)
+                {
+                    return chunks[chunkIndex].GetEntity(indexInChunk);
+                }
             }
             return Entity.Null;
         }
@@ -45,31 +51,46 @@ public struct QueryEnumerator : IEnumerator<Entity>
     readonly object IEnumerator.Current => Current;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Iteration walks each archetype chunk by its live <see cref="ArchetypeChunk.Count"/> and
+    /// advances chunk-by-chunk, so entities in later chunks are never skipped and holes left by
+    /// swap-back removal in earlier chunks are never yielded (see issue #1092).
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
     {
         while (archetypeIndex < archetypes.Count)
         {
-            var archetype = archetypes[archetypeIndex];
-            entityIndex++;
+            var chunks = archetypes[archetypeIndex].Chunks;
 
-            if (entityIndex < archetype.Count)
+            while (chunkIndex < chunks.Count)
             {
-                // Check string tag filters if any
-                if (hasStringTagFilters)
+                var chunk = chunks[chunkIndex];
+                indexInChunk++;
+
+                if (indexInChunk < chunk.Count)
                 {
-                    var entity = archetype.GetEntity(entityIndex);
-                    if (!MatchesStringTags(entity))
+                    // Check string tag filters if any
+                    if (hasStringTagFilters)
                     {
-                        continue; // Skip this entity, try next
+                        var entity = chunk.GetEntity(indexInChunk);
+                        if (!MatchesStringTags(entity))
+                        {
+                            continue; // Skip this entity, try next slot in this chunk
+                        }
                     }
+                    return true;
                 }
-                return true;
+
+                // Move to the next chunk in this archetype
+                chunkIndex++;
+                indexInChunk = -1;
             }
 
-            // Move to next archetype
+            // Move to the next archetype
             archetypeIndex++;
-            entityIndex = -1;
+            chunkIndex = 0;
+            indexInChunk = -1;
         }
 
         return false;
@@ -102,7 +123,8 @@ public struct QueryEnumerator : IEnumerator<Entity>
     public void Reset()
     {
         archetypeIndex = 0;
-        entityIndex = -1;
+        chunkIndex = 0;
+        indexInChunk = -1;
     }
 
     /// <inheritdoc />

--- a/tests/KeenEyes.Core.Tests/MultiChunkArchetypeCorruptionTests.cs
+++ b/tests/KeenEyes.Core.Tests/MultiChunkArchetypeCorruptionTests.cs
@@ -1,0 +1,262 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Regression tests for issue #1092: multi-chunk archetype storage corruption after a
+/// swap-back removal leaves a hole in a non-last chunk.
+/// </summary>
+/// <remarks>
+/// A single <see cref="ArchetypeChunk"/> holds up to <see cref="ArchetypeChunk.DefaultCapacity"/>
+/// entities, so every scenario spawns more than that of one archetype to force multiple chunks,
+/// then removes entities from an early chunk. Component values are set at creation time and carry
+/// a unique per-entity tag so that cross-entity corruption (not just crashes) is detectable, and
+/// so the wrong-chunk write path is exercised rather than masked by a later entity-keyed write.
+/// </remarks>
+public class MultiChunkArchetypeCorruptionTests
+{
+    private const int Capacity = ArchetypeChunk.DefaultCapacity;
+
+    private static (int ChunkIndex, int IndexInChunk) LocationOf(World world, Entity entity)
+    {
+        world.ArchetypeManager.TryGetEntityLocation(entity, out var archetype, out _);
+        return archetype!.GetEntityLocation(entity);
+    }
+
+    [Fact]
+    public void Get_AfterEarlyChunkRemovalAndReadd_ReturnsCorrectComponentData()
+    {
+        using var world = new World();
+        world.Components.Register<TestPosition>();
+
+        var expected = new Dictionary<Entity, int>();
+        var alive = new List<Entity>();
+        var tag = 0;
+
+        // Position.X is set at creation so the value flows through the component-add path and is
+        // never re-written via an entity-keyed setter that would hide a wrong-chunk write.
+        Entity Spawn()
+        {
+            tag++;
+            var entity = world.Spawn().With(new TestPosition { X = tag }).Build();
+            expected[entity] = tag;
+            alive.Add(entity);
+            return entity;
+        }
+
+        for (var i = 0; i < 200; i++)
+        {
+            Spawn();
+        }
+
+        // The archetype must span at least two chunks for this scenario to be meaningful.
+        Assert.True(LocationOf(world, alive[199]).ChunkIndex >= 1);
+
+        // Despawn entities from the first chunk (none at the final spawn slots) so swap-back
+        // leaves the chunk non-full while later chunks still hold entities.
+        foreach (var index in new[] { 3, 17, 42, 88, 120 })
+        {
+            var victim = alive[index];
+            Assert.Equal(0, LocationOf(world, victim).ChunkIndex);
+            world.Despawn(victim);
+            expected.Remove(victim);
+        }
+        alive.RemoveAll(e => !world.IsAlive(e));
+
+        // Re-add entities; these refill the early-chunk hole first, so entity and components must
+        // land in the same chunk.
+        for (var i = 0; i < 10; i++)
+        {
+            Spawn();
+        }
+
+        foreach (var entity in alive)
+        {
+            Assert.True(world.IsAlive(entity));
+            Assert.Equal(expected[entity], (int)world.Get<TestPosition>(entity).X);
+        }
+    }
+
+    [Fact]
+    public void Query_OverHoledMultiChunkArchetype_YieldsExactlyAliveEntities()
+    {
+        using var world = new World();
+        world.Components.Register<TestPosition>();
+
+        var alive = new List<Entity>();
+        var tag = 0;
+
+        Entity Spawn()
+        {
+            tag++;
+            var entity = world.Spawn().With(new TestPosition { X = tag }).Build();
+            alive.Add(entity);
+            return entity;
+        }
+
+        for (var i = 0; i < 200; i++)
+        {
+            Spawn();
+        }
+
+        // Despawn more than we re-add so a hole persists in a non-last chunk at query time.
+        foreach (var index in new[] { 5, 11, 30, 44, 61, 77, 90, 102, 110, 125 })
+        {
+            world.Despawn(alive[index]);
+        }
+        alive.RemoveAll(e => !world.IsAlive(e));
+
+        for (var i = 0; i < 3; i++)
+        {
+            Spawn();
+        }
+
+        var expected = alive.ToHashSet();
+        var yielded = new List<Entity>();
+        foreach (var entity in world.Query<TestPosition>())
+        {
+            yielded.Add(entity);
+        }
+
+        // No phantom/default entity is ever yielded, and every yielded entity is alive.
+        Assert.DoesNotContain(Entity.Null, yielded);
+        foreach (var entity in yielded)
+        {
+            Assert.True(world.IsAlive(entity));
+        }
+
+        // The yielded set equals the alive set: same count and same identities (none skipped).
+        Assert.Equal(expected.Count, yielded.Count);
+        Assert.Equal(expected, yielded.ToHashSet());
+    }
+
+    [Fact]
+    public void AddComponent_AcrossChunkBoundaryAfterRemoval_PreservesData()
+    {
+        using var world = new World();
+        world.Components.Register<TestPosition>();
+        world.Components.Register<TestVelocity>();
+
+        var positionTag = new Dictionary<Entity, int>();
+        var velocityTag = new Dictionary<Entity, int>();
+        var positionOnly = new List<Entity>();
+        var tag = 0;
+
+        for (var i = 0; i < 200; i++)
+        {
+            tag++;
+            var entity = world.Spawn().With(new TestPosition { X = tag }).Build();
+            positionTag[entity] = tag;
+            positionOnly.Add(entity);
+        }
+
+        // Migrate 150 entities into the {Position, Velocity} archetype so it spans two chunks.
+        var withVelocity = new List<Entity>();
+        void AddVelocity(Entity entity)
+        {
+            tag++;
+            world.Add(entity, new TestVelocity { X = tag });
+            velocityTag[entity] = tag;
+            withVelocity.Add(entity);
+        }
+
+        for (var i = 0; i < 150; i++)
+        {
+            AddVelocity(positionOnly[i]);
+        }
+
+        // Punch holes in the first chunk of {Position, Velocity}.
+        var despawned = new HashSet<Entity>();
+        foreach (var index in new[] { 2, 20, 55, 99 })
+        {
+            var victim = withVelocity[index];
+            Assert.Equal(0, LocationOf(world, victim).ChunkIndex);
+            world.Despawn(victim);
+            despawned.Add(victim);
+        }
+
+        // Migrate the remaining survivors in; they refill the early-chunk holes, so their entity
+        // slot lands in an early chunk while the archetype's last chunk is elsewhere.
+        for (var i = 150; i < 200; i++)
+        {
+            AddVelocity(positionOnly[i]);
+        }
+
+        foreach (var entity in withVelocity)
+        {
+            if (despawned.Contains(entity))
+            {
+                continue;
+            }
+
+            Assert.True(world.IsAlive(entity));
+            Assert.Equal(positionTag[entity], (int)world.Get<TestPosition>(entity).X);
+            Assert.Equal(velocityTag[entity], (int)world.Get<TestVelocity>(entity).X);
+        }
+    }
+
+    [Fact]
+    public void Get_AfterChunkFullyEmptiedAndRemoved_ResolvesSurvivorsInLaterChunks()
+    {
+        using var world = new World();
+        world.Components.Register<TestPosition>();
+
+        var expected = new Dictionary<Entity, int>();
+        var spawned = new List<Entity>();
+
+        for (var i = 0; i < 300; i++)
+        {
+            var entity = world.Spawn().With(new TestPosition { X = i + 1 }).Build();
+            expected[entity] = i + 1;
+            spawned.Add(entity);
+        }
+
+        // The first Capacity entities occupy chunk 0; entities at index >= 2 * Capacity occupy
+        // chunk 2. Swap-back removal only moves entities within their own chunk, so despawning
+        // the first Capacity entities drains chunk 0 exactly and removes it.
+        for (var i = 0; i < Capacity; i++)
+        {
+            world.Despawn(spawned[i]);
+        }
+
+        var survivors = spawned.GetRange(Capacity, spawned.Count - Capacity);
+
+        // A survivor originally in chunk 2 must still resolve correctly after chunk 0 is removed.
+        var deepSurvivor = spawned[(2 * Capacity) + 4];
+        Assert.True(world.IsAlive(deepSurvivor));
+        Assert.Equal(expected[deepSurvivor], (int)world.Get<TestPosition>(deepSurvivor).X);
+
+        foreach (var entity in survivors)
+        {
+            Assert.True(world.IsAlive(entity));
+            Assert.Equal(expected[entity], (int)world.Get<TestPosition>(entity).X);
+        }
+    }
+
+    [Fact]
+    public void AddComponent_AfterChunkFullyEmptiedAndRemoved_MigratesSurvivorCorrectly()
+    {
+        using var world = new World();
+        world.Components.Register<TestPosition>();
+        world.Components.Register<TestVelocity>();
+
+        var spawned = new List<Entity>();
+        for (var i = 0; i < 300; i++)
+        {
+            spawned.Add(world.Spawn().With(new TestPosition { X = i + 1 }).Build());
+        }
+
+        // Empty and remove chunk 0 of the {Position} archetype.
+        for (var i = 0; i < Capacity; i++)
+        {
+            world.Despawn(spawned[i]);
+        }
+
+        // Migrate a survivor that originally lived in chunk 2 into {Position, Velocity}.
+        var survivorIndex = (2 * Capacity) + 10;
+        var survivor = spawned[survivorIndex];
+        Assert.True(world.IsAlive(survivor));
+        world.Add(survivor, new TestVelocity { X = 7777 });
+
+        Assert.Equal(survivorIndex + 1, (int)world.Get<TestPosition>(survivor).X);
+        Assert.Equal(7777, (int)world.Get<TestVelocity>(survivor).X);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the critical data-corruption bug from the deep functional review (#1092). Root cause: the sparse `globalIndex = chunkIndex*128 + slot` was used three inconsistent ways once a **non-last chunk had a hole** (from swap-back removal) — a state the 14.5k-test suite never reached because nothing spawned >128 entities of one archetype and removed from an early chunk.

The fix makes `Archetype.entityLocations` the **single source of truth** for `(chunk, slot)`:
- **Component co-location** — `AddEntityReturningChunk` exposes the chunk `AddEntity` chose; spawn and migrate now write components into *that* chunk instead of `chunks[^1]`. `CopySharedComponentsToChunk` replaces the `chunks[^1]` footgun.
- **Manager holds only the archetype** — `ArchetypeManager.entityLocations` is now `Dictionary<int, Archetype>`; all reads/writes resolve by entity through new `GetByEntity`/`GetReadonlyByEntity`/`SetByEntity`/`GetBoxedByEntity` accessors. This **structurally eliminates** the stale-cached-index bug on chunk removal (there's no second copy to desync) and deletes the swap/removal index-reconciliation code.
- **Query iteration** — `QueryEnumerator` walks `(archetype, chunk, slot)` by each chunk's live `Count`, so tail entities are never skipped and holes are never yielded. Still a zero-allocation struct enumerator.

## Test plan
- [x] 5 new regression tests (`MultiChunkArchetypeCorruptionTests`) with identity-encoded component values covering early-chunk-hole re-add, holed-archetype query, cross-chunk add-component, and chunk-removal survivor resolution
- [x] **Fail-on-old / pass-on-new independently verified** by the reviewer: reverting the 3 src files (tests present) → 5/5 fail; fix restored → 5/5 pass
- [x] Full suite `dotnet test KeenEyes.slnx --max-parallel-test-modules 1` → 14,428 passed / 0 failed / 62 pre-existing skips (this change touches every query system, so the whole suite is the regression guard)
- [x] Release build 0 warnings / 0 errors; format verify exit 0

## Related Issues
Closes #1092