### PR TITLE
feat(mcp): Add HTTP transport to TestBridge MCP server

### DIFF
--- a/.claude/hooks/install-packages.sh
+++ b/.claude/hooks/install-packages.sh
@@ -151,6 +151,14 @@ download_pkg "DotRecast.Core" "2024.4.1"
 download_pkg "DotRecast.Detour" "2024.4.1"
 download_pkg "DotRecast.Recast" "2024.4.1"
 
+# MCP server packages (KeenEyes.Mcp.TestBridge dependencies)
+# Harvested from packages.lock.json normally; listed explicitly per the web-session maintenance rule.
+# ModelContextProtocol.AspNetCore adds the HTTP transport; it only pulls the shared
+# Microsoft.AspNetCore.App framework (not a NuGet package), so no extra transitive deps to list.
+download_pkg "ModelContextProtocol" "1.4.1"
+download_pkg "ModelContextProtocol.Core" "1.4.1"
+download_pkg "ModelContextProtocol.AspNetCore" "1.4.1"
+
 # Localization packages (ICU MessageFormat support)
 download_pkg "MessageFormat" "7.1.3"
 # MessageFormat transitive dependencies

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup Label="MCP">
     <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,6 +78,10 @@ Or with a published executable:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+**Server → game hop** (how the MCP server reaches the game):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
 | `KEENEYES_PIPE_NAME` | Named pipe name for IPC | `KeenEyes.TestBridge` |
 | `KEENEYES_HOST` | TCP host for network connections | `127.0.0.1` |
 | `KEENEYES_PORT` | TCP port for network connections | `19283` |
@@ -87,15 +91,83 @@ Or with a published executable:
 | `KEENEYES_MAX_PING_FAILURES` | Max consecutive ping failures | `3` |
 | `KEENEYES_TIMEOUT` | Connection timeout in ms | `30000` |
 
+**Client → server hop** (how an MCP client such as Claude Code reaches this server):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KEENEYES_MCP_TRANSPORT` | Client transport: `stdio` or `http` | `stdio` |
+| `KEENEYES_MCP_URL` | URL the HTTP transport binds to (only when `http`) | `http://127.0.0.1:19284/` |
+| `KEENEYES_MCP_TOKEN` | Bearer token required by the HTTP endpoint; unset = unauthenticated | *(unset)* |
+
+`KEENEYES_MCP_*` is orthogonal to the `KEENEYES_TRANSPORT`/pipe/tcp settings: the former chooses how a client reaches this server, the latter how this server reaches the game.
+
 ### Command-Line Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `--pipe <name>` | Named pipe name |
-| `--host <host>` | TCP host address |
-| `--port <port>` | TCP port number |
-| `--transport <mode>` | Transport: `pipe` or `tcp` |
+| `--pipe <name>` | Named pipe name (server → game) |
+| `--host <host>` | TCP host address (server → game) |
+| `--port <port>` | TCP port number (server → game) |
+| `--transport <mode>` | Server → game transport: `pipe` or `tcp` |
 | `--timeout <ms>` | Connection timeout in milliseconds |
+| `--mcp-transport <mode>` | Client → server transport: `stdio` or `http` |
+| `--mcp-url <url>` | URL the HTTP transport binds to (only when `http`) |
+
+## Remote TestBridge over HTTP
+
+By default the server speaks MCP over **stdio**: Claude Code launches it as a local subprocess, and the standard local `.mcp.json` entry relies on this. To let Claude Code on **one machine** drive a game running on **another**, switch the client-facing transport to **HTTP**.
+
+### Topology
+
+```
+Claude Code (host A) --HTTP/LAN--> KeenEyes.Mcp.TestBridge (host B, HTTP server)
+                                        └-- loopback named-pipe IPC --> game (host B)
+```
+
+The powerful game-control channel (input injection, world mutation, memory read) stays on **loopback** on the game's machine. Only the MCP protocol — a first-class, auth-capable transport — crosses the network. This is cleaner and safer than exposing the raw TCP IPC channel across the network.
+
+### Host B — game + MCP server
+
+Run the game with the TestBridge IPC server on a **loopback named pipe** (no game code change; this is the default), then launch the MCP server bound to host B's LAN address with a bearer token:
+
+```bash
+# Bind to host B's LAN IP (e.g. 192.168.1.50); keep the game hop on the loopback pipe.
+export KEENEYES_MCP_TRANSPORT=http
+export KEENEYES_MCP_URL=http://192.168.1.50:19284/
+export KEENEYES_MCP_TOKEN=$(openssl rand -hex 32)
+export KEENEYES_TRANSPORT=pipe
+export KEENEYES_PIPE_NAME=KeenEyes.TestBridge
+
+./KeenEyes.Mcp.TestBridge         # or: dotnet run --project tools/KeenEyes.Mcp.TestBridge
+echo "token: $KEENEYES_MCP_TOKEN"  # copy this to host A
+```
+
+### Host A — Claude Code
+
+Add an `http` entry to `.mcp.json` pointing at host B, carrying the bearer token:
+
+```json
+{
+  "mcpServers": {
+    "keeneyes-remote": {
+      "type": "http",
+      "url": "http://192.168.1.50:19284/",
+      "headers": {
+        "Authorization": "Bearer <paste KEENEYES_MCP_TOKEN here>"
+      }
+    }
+  }
+}
+```
+
+### Security
+
+An HTTP endpoint that controls a game process **must not be left open**.
+
+- **Bearer token (required in practice):** set `KEENEYES_MCP_TOKEN`. The endpoint then requires `Authorization: Bearer <token>` and returns **401** for missing or wrong tokens. If the token is unset, the server logs a prominent warning and serves **unauthenticated** — only ever acceptable on loopback.
+- **Bind narrowly:** point `KEENEYES_MCP_URL` at a specific loopback or LAN IP. **Never bind to `0.0.0.0`** or a public interface. The default (`http://127.0.0.1:19284/`) is loopback-only.
+- **Trusted networks only:** restrict with a host firewall to host A's address; treat the endpoint as you would an SSH port.
+- **Token vs mTLS:** a bearer token authenticates the client but leaves the channel in cleartext on plain HTTP — anyone who can read LAN traffic can capture the token. For hardened deployments, terminate TLS at a reverse proxy in front of the server (set `KEENEYES_MCP_URL` behind it) or use **mutual TLS (mTLS)**, which additionally authenticates the client with a certificate and encrypts the channel. mTLS is stronger but needs certificate provisioning on both hosts; the built-in bearer-token check is the minimum bar and is sufficient on a trusted LAN.
 
 ## Available Tools
 

--- a/docs/testbridge.md
+++ b/docs/testbridge.md
@@ -188,6 +188,44 @@ Publish the MCP server:
 dotnet publish tools/KeenEyes.Mcp.TestBridge -c Release -o .mcp
 ```
 
+### Remote TestBridge over HTTP
+
+The MCP server speaks **stdio** by default (local subprocess, as above). To let Claude Code on one machine drive a game on another, switch the client-facing transport to **HTTP** — the game-control channel stays on loopback, and only the auth-capable MCP protocol crosses the network:
+
+```
+Claude Code (host A) --HTTP/LAN--> KeenEyes.Mcp.TestBridge (host B, HTTP server)
+                                        └-- loopback named-pipe IPC --> game (host B)
+```
+
+**Host B (game + MCP server):** keep the game's TestBridge IPC on a loopback named pipe (default; no game code change), and launch the MCP server bound to host B's LAN IP with a bearer token:
+
+```bash
+export KEENEYES_MCP_TRANSPORT=http
+export KEENEYES_MCP_URL=http://192.168.1.50:19284/   # host B's LAN IP, never 0.0.0.0
+export KEENEYES_MCP_TOKEN=$(openssl rand -hex 32)
+export KEENEYES_TRANSPORT=pipe                        # server -> game hop stays loopback
+export KEENEYES_PIPE_NAME=MyGame.TestBridge
+./KeenEyes.Mcp.TestBridge
+```
+
+**Host A (Claude Code):** add an `http` entry to `.mcp.json` carrying the token:
+
+```json
+{
+  "mcpServers": {
+    "keeneyes-remote": {
+      "type": "http",
+      "url": "http://192.168.1.50:19284/",
+      "headers": {
+        "Authorization": "Bearer <paste KEENEYES_MCP_TOKEN here>"
+      }
+    }
+  }
+}
+```
+
+**Security:** the HTTP endpoint controls a game process, so it must not be open. When `KEENEYES_MCP_TOKEN` is set, the server requires `Authorization: Bearer <token>` and returns **401** for missing/wrong tokens; when unset it serves unauthenticated and logs a prominent warning (only acceptable on loopback). Bind to a specific loopback/LAN IP (the default `http://127.0.0.1:19284/` is loopback-only), firewall it to host A, and treat it like an SSH port. A bearer token authenticates the client but leaves plain HTTP in cleartext; for hardened setups terminate TLS at a reverse proxy or use mutual TLS (mTLS), which also encrypts the channel and authenticates the client by certificate. See [docs/mcp-server.md](mcp-server.md#remote-testbridge-over-http) for the full reference.
+
 ## IPC Protocol Specification
 
 The IPC layer uses a simple request/response protocol over named pipes or TCP.

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/BearerTokenAuthenticationTests.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/BearerTokenAuthenticationTests.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using KeenEyes.Mcp.TestBridge;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace KeenEyes.Mcp.TestBridge.Tests;
+
+/// <summary>
+/// Tests for the HTTP bearer-token authentication used by the remote MCP transport.
+/// </summary>
+public sealed class BearerTokenAuthenticationTests
+{
+    private const string Token = "correct-horse-battery-staple";
+
+    #region BearerTokenValidator Tests
+
+    [Fact]
+    public void IsAuthorized_WithCorrectToken_ReturnsTrue()
+    {
+        Assert.True(BearerTokenValidator.IsAuthorized($"Bearer {Token}", Token));
+    }
+
+    [Fact]
+    public void IsAuthorized_WithMissingHeader_ReturnsFalse()
+    {
+        Assert.False(BearerTokenValidator.IsAuthorized(null, Token));
+    }
+
+    [Fact]
+    public void IsAuthorized_WithWrongToken_ReturnsFalse()
+    {
+        Assert.False(BearerTokenValidator.IsAuthorized("Bearer wrong-token", Token));
+    }
+
+    [Fact]
+    public void IsAuthorized_WithoutBearerPrefix_ReturnsFalse()
+    {
+        Assert.False(BearerTokenValidator.IsAuthorized(Token, Token));
+    }
+
+    [Fact]
+    public void IsAuthorized_WithEmptyBearerValue_ReturnsFalse()
+    {
+        Assert.False(BearerTokenValidator.IsAuthorized("Bearer ", Token));
+    }
+
+    #endregion
+
+    #region Middleware Tests
+
+    [Fact]
+    public async Task InvokeAsync_WithMissingToken_Returns401AndDoesNotCallNext()
+    {
+        var (context, nextCalled) = await RunMiddlewareAsync(authorizationHeader: null);
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.False(nextCalled());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithWrongToken_Returns401AndDoesNotCallNext()
+    {
+        var (context, nextCalled) = await RunMiddlewareAsync(authorizationHeader: "Bearer not-the-token");
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.False(nextCalled());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithCorrectToken_CallsNext()
+    {
+        var (context, nextCalled) = await RunMiddlewareAsync(authorizationHeader: $"Bearer {Token}");
+
+        Assert.True(nextCalled());
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    #endregion
+
+    private static async Task<(HttpContext Context, Func<bool> NextCalled)> RunMiddlewareAsync(string? authorizationHeader)
+    {
+        var wasCalled = false;
+        RequestDelegate next = _ =>
+        {
+            wasCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new BearerTokenAuthenticationMiddleware(next, Token);
+
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        if (authorizationHeader is not null)
+        {
+            context.Request.Headers.Authorization = authorizationHeader;
+        }
+
+        await middleware.InvokeAsync(context);
+
+        return (context, () => wasCalled);
+    }
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/ConfigurationParserTests.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/ConfigurationParserTests.cs
@@ -1,0 +1,173 @@
+using System;
+using KeenEyes.Mcp.TestBridge;
+using Xunit;
+
+namespace KeenEyes.Mcp.TestBridge.Tests;
+
+/// <summary>
+/// Tests for <see cref="ConfigurationParser"/> transport-mode selection and configuration parsing.
+/// </summary>
+/// <remarks>
+/// All tests live in a single class so xUnit runs them sequentially, keeping the process-global
+/// environment-variable mutations from racing one another.
+/// </remarks>
+public sealed class ConfigurationParserTests
+{
+    #region ParseClientTransport Tests
+
+    [Fact]
+    public void ParseClientTransport_WithNull_ReturnsStdio()
+    {
+        Assert.Equal(McpClientTransport.Stdio, ConfigurationParser.ParseClientTransport(null));
+    }
+
+    [Fact]
+    public void ParseClientTransport_WithEmpty_ReturnsStdio()
+    {
+        Assert.Equal(McpClientTransport.Stdio, ConfigurationParser.ParseClientTransport("  "));
+    }
+
+    [Theory]
+    [InlineData("http")]
+    [InlineData("HTTP")]
+    [InlineData(" Http ")]
+    public void ParseClientTransport_WithHttp_ReturnsHttp(string value)
+    {
+        Assert.Equal(McpClientTransport.Http, ConfigurationParser.ParseClientTransport(value));
+    }
+
+    [Fact]
+    public void ParseClientTransport_WithStdio_ReturnsStdio()
+    {
+        Assert.Equal(McpClientTransport.Stdio, ConfigurationParser.ParseClientTransport("stdio"));
+    }
+
+    [Fact]
+    public void ParseClientTransport_WithUnknownValue_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigurationParser.ParseClientTransport("websocket"));
+    }
+
+    #endregion
+
+    #region Parse Default Tests
+
+    [Fact]
+    public void Parse_WithNoArgsOrEnv_DefaultsToStdio()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            var config = ConfigurationParser.Parse([]);
+
+            Assert.Equal(McpClientTransport.Stdio, config.ClientTransport);
+            Assert.Equal(ConfigurationParser.DefaultHttpUrl, config.HttpUrl);
+            Assert.Null(config.AuthToken);
+        });
+    }
+
+    #endregion
+
+    #region Parse Flag Override Tests
+
+    [Fact]
+    public void Parse_WithMcpTransportFlag_SelectsHttp()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            var config = ConfigurationParser.Parse(["--mcp-transport", "http"]);
+
+            Assert.Equal(McpClientTransport.Http, config.ClientTransport);
+        });
+    }
+
+    [Fact]
+    public void Parse_WithMcpUrlFlag_OverridesDefaultUrl()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            var config = ConfigurationParser.Parse(["--mcp-transport", "http", "--mcp-url", "http://192.168.1.5:9000/"]);
+
+            Assert.Equal("http://192.168.1.5:9000/", config.HttpUrl);
+        });
+    }
+
+    #endregion
+
+    #region Parse Environment Tests
+
+    [Fact]
+    public void Parse_WithTransportEnvironmentVariable_SelectsHttp()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TRANSPORT", "http");
+
+            var config = ConfigurationParser.Parse([]);
+
+            Assert.Equal(McpClientTransport.Http, config.ClientTransport);
+        });
+    }
+
+    [Fact]
+    public void Parse_WithTokenEnvironmentVariable_PopulatesAuthToken()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TOKEN", "s3cret");
+
+            var config = ConfigurationParser.Parse([]);
+
+            Assert.Equal("s3cret", config.AuthToken);
+        });
+    }
+
+    [Fact]
+    public void Parse_WithBlankTokenEnvironmentVariable_LeavesAuthTokenNull()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TOKEN", "   ");
+
+            var config = ConfigurationParser.Parse([]);
+
+            Assert.Null(config.AuthToken);
+        });
+    }
+
+    [Fact]
+    public void Parse_FlagOverridesTransportEnvironmentVariable()
+    {
+        WithoutMcpEnvironment(() =>
+        {
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TRANSPORT", "stdio");
+
+            var config = ConfigurationParser.Parse(["--mcp-transport", "http"]);
+
+            Assert.Equal(McpClientTransport.Http, config.ClientTransport);
+        });
+    }
+
+    #endregion
+
+    private static void WithoutMcpEnvironment(Action action)
+    {
+        var transport = Environment.GetEnvironmentVariable("KEENEYES_MCP_TRANSPORT");
+        var url = Environment.GetEnvironmentVariable("KEENEYES_MCP_URL");
+        var token = Environment.GetEnvironmentVariable("KEENEYES_MCP_TOKEN");
+
+        Environment.SetEnvironmentVariable("KEENEYES_MCP_TRANSPORT", null);
+        Environment.SetEnvironmentVariable("KEENEYES_MCP_URL", null);
+        Environment.SetEnvironmentVariable("KEENEYES_MCP_TOKEN", null);
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TRANSPORT", transport);
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_URL", url);
+            Environment.SetEnvironmentVariable("KEENEYES_MCP_TOKEN", token);
+        }
+    }
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/packages.lock.json
@@ -525,7 +525,8 @@
         "dependencies": {
           "KeenEyes.TestBridge.Client": "[1.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.10, )",
-          "ModelContextProtocol": "[1.4.1, )"
+          "ModelContextProtocol": "[1.4.1, )",
+          "ModelContextProtocol.AspNetCore": "[1.4.1, )"
         }
       },
       "keeneyes.navigation": {
@@ -651,6 +652,15 @@
           "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
           "ModelContextProtocol.Core": "1.4.1"
+        }
+      },
+      "ModelContextProtocol.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "AoI+00fRxb0GAMMabMUgpV5QhNoa/F7I9oiVGHfJKtBZ4g/DEyoDdTS9Rp/m4e3MnXhhvSBeu2wTafhesdf52w==",
+        "dependencies": {
+          "ModelContextProtocol": "1.4.1"
         }
       },
       "StbImageWriteSharp": {

--- a/tools/KeenEyes.Mcp.TestBridge/BearerTokenAuthentication.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/BearerTokenAuthentication.cs
@@ -1,0 +1,61 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace KeenEyes.Mcp.TestBridge;
+
+/// <summary>
+/// Validates the <c>Authorization: Bearer &lt;token&gt;</c> header against an expected token.
+/// </summary>
+internal static class BearerTokenValidator
+{
+    private const string BearerPrefix = "Bearer ";
+
+    /// <summary>
+    /// Determines whether an <c>Authorization</c> header value carries the expected bearer token.
+    /// </summary>
+    /// <param name="authorizationHeader">The raw <c>Authorization</c> header value, or <see langword="null"/> when absent.</param>
+    /// <param name="expectedToken">The token the endpoint requires.</param>
+    /// <returns><see langword="true"/> when the header presents the exact expected token; otherwise <see langword="false"/>.</returns>
+    public static bool IsAuthorized(string? authorizationHeader, string expectedToken)
+    {
+        if (string.IsNullOrEmpty(authorizationHeader))
+        {
+            return false;
+        }
+
+        if (!authorizationHeader.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var provided = authorizationHeader[BearerPrefix.Length..].Trim();
+        return !string.IsNullOrEmpty(provided) && string.Equals(provided, expectedToken, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// ASP.NET middleware that rejects requests lacking a valid bearer token with HTTP 401.
+/// </summary>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="expectedToken">The bearer token every request must present.</param>
+internal sealed class BearerTokenAuthenticationMiddleware(RequestDelegate next, string expectedToken)
+{
+    /// <summary>
+    /// Rejects the request with 401 when the bearer token is missing or wrong; otherwise forwards it.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var header = context.Request.Headers.Authorization.ToString();
+        if (!BearerTokenValidator.IsAuthorized(header, expectedToken))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.Headers.WWWAuthenticate = "Bearer";
+            await context.Response.WriteAsync("Unauthorized: a valid bearer token is required.");
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
+++ b/tools/KeenEyes.Mcp.TestBridge/KeenEyes.Mcp.TestBridge.csproj
@@ -13,11 +13,16 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\KeenEyes.TestBridge.Client\KeenEyes.TestBridge.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Mcp.TestBridge.Tests" />
   </ItemGroup>
 
 </Project>

--- a/tools/KeenEyes.Mcp.TestBridge/McpServerServices.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/McpServerServices.cs
@@ -1,0 +1,63 @@
+using KeenEyes.Mcp.TestBridge.Connection;
+using KeenEyes.Mcp.TestBridge.Prompts;
+using KeenEyes.Mcp.TestBridge.Resources;
+using KeenEyes.Mcp.TestBridge.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KeenEyes.Mcp.TestBridge;
+
+/// <summary>
+/// Registers the MCP TestBridge services shared by every client transport.
+/// Centralising registration here guarantees the stdio and HTTP hosts expose an identical tool set.
+/// </summary>
+internal static class McpServerServices
+{
+    /// <summary>
+    /// Registers the <see cref="BridgeConnectionManager"/> singleton and the MCP server with its
+    /// full complement of tools, resources, and prompts. The caller adds the transport
+    /// (for example <c>WithStdioServerTransport()</c> or <c>WithHttpTransport()</c>) to the returned builder.
+    /// </summary>
+    /// <param name="services">The service collection to populate.</param>
+    /// <param name="config">The resolved server configuration.</param>
+    /// <returns>The MCP server builder, so the caller can attach a transport.</returns>
+    public static IMcpServerBuilder AddSharedTestBridgeServices(IServiceCollection services, McpConfiguration config)
+    {
+        // Register the connection manager as singleton
+        services.AddSingleton<BridgeConnectionManager>(sp =>
+        {
+            return new BridgeConnectionManager
+            {
+                HeartbeatInterval = TimeSpan.FromMilliseconds(config.HeartbeatInterval),
+                PingTimeout = TimeSpan.FromMilliseconds(config.HeartbeatTimeout),
+                MaxPingFailures = config.MaxPingFailures,
+                ConnectionTimeout = TimeSpan.FromMilliseconds(config.ConnectionTimeout)
+            };
+        });
+
+        // Configure MCP server with the same capabilities and tools regardless of transport.
+        return services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new()
+                {
+                    Name = "KeenEyes TestBridge",
+                    Version = "1.0.0"
+                };
+                options.Capabilities = new()
+                {
+                    Tools = new() { ListChanged = true },
+                    Resources = new() { ListChanged = true, Subscribe = true },
+                    Prompts = new() { ListChanged = true }
+                };
+            })
+            .WithTools<GameTools>()
+            .WithTools<InputTools>()
+            .WithTools<StateTools>()
+            .WithTools<CaptureTools>()
+            .WithResources<ConnectionResources>()
+            .WithResources<WorldResources>()
+            .WithResources<ExtensionResources>()
+            .WithResources<CaptureResources>()
+            .WithPrompts<WorkflowPrompts>();
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Program.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Program.cs
@@ -1,8 +1,7 @@
 using KeenEyes.Mcp.TestBridge;
 using KeenEyes.Mcp.TestBridge.Connection;
-using KeenEyes.Mcp.TestBridge.Prompts;
-using KeenEyes.Mcp.TestBridge.Resources;
-using KeenEyes.Mcp.TestBridge.Tools;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -11,158 +10,112 @@ using ModelContextProtocol.Server;
 // Parse configuration from environment variables and command line
 var config = ConfigurationParser.Parse(args);
 
-// Build and run the MCP server
-var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(args);
-
-// CRITICAL: Disable all console logging - stdout must only contain MCP JSON-RPC messages
-builder.Logging.ClearProviders();
-
-// Register the connection manager as singleton
-builder.Services.AddSingleton<BridgeConnectionManager>(sp =>
+// Select the client-facing transport (how Claude Code reaches this server).
+// The pipe/tcp settings above are orthogonal: they choose how this server reaches the GAME.
+if (config.ClientTransport == McpClientTransport.Http)
 {
-    return new BridgeConnectionManager
-    {
-        HeartbeatInterval = TimeSpan.FromMilliseconds(config.HeartbeatInterval),
-        PingTimeout = TimeSpan.FromMilliseconds(config.HeartbeatTimeout),
-        MaxPingFailures = config.MaxPingFailures,
-        ConnectionTimeout = TimeSpan.FromMilliseconds(config.ConnectionTimeout)
-    };
-});
+    await RunHttpServerAsync(config, args);
+}
+else
+{
+    await RunStdioServerAsync(config, args);
+}
 
-// Configure MCP server
-builder.Services
-    .AddMcpServer(options =>
+// Runs the default stdio transport - preserves the local-subprocess flow that .mcp.json relies on.
+static async Task RunStdioServerAsync(McpConfiguration config, string[] args)
+{
+    var builder = Host.CreateApplicationBuilder(args);
+
+    // CRITICAL: Disable all console logging - stdout must only contain MCP JSON-RPC messages
+    builder.Logging.ClearProviders();
+
+    McpServerServices.AddSharedTestBridgeServices(builder.Services, config)
+        .WithStdioServerTransport();
+
+    var app = builder.Build();
+
+    // Wire up connection state change notifications for the single long-lived stdio server.
+    var connectionManager = app.Services.GetRequiredService<BridgeConnectionManager>();
+    var mcpServer = app.Services.GetRequiredService<McpServer>();
+
+    connectionManager.ConnectionStateChanged += async () =>
     {
-        options.ServerInfo = new()
+        try
         {
-            Name = "KeenEyes TestBridge",
-            Version = "1.0.0"
-        };
-        options.Capabilities = new()
-        {
-            Tools = new() { ListChanged = true },
-            Resources = new() { ListChanged = true, Subscribe = true },
-            Prompts = new() { ListChanged = true }
-        };
-    })
-    .WithStdioServerTransport()
-    .WithTools<GameTools>()
-    .WithTools<InputTools>()
-    .WithTools<StateTools>()
-    .WithTools<CaptureTools>()
-    .WithResources<ConnectionResources>()
-    .WithResources<WorldResources>()
-    .WithResources<ExtensionResources>()
-    .WithResources<CaptureResources>()
-    .WithPrompts<WorkflowPrompts>();
-
-var app = builder.Build();
-
-// Wire up connection state change notifications
-var connectionManager = app.Services.GetRequiredService<BridgeConnectionManager>();
-var mcpServer = app.Services.GetRequiredService<McpServer>();
-
-connectionManager.ConnectionStateChanged += async () =>
-{
-    try
-    {
-        await mcpServer.SendNotificationAsync("notifications/tools/list_changed");
-        await mcpServer.SendNotificationAsync("notifications/resources/list_changed");
-    }
-    catch
-    {
-        // Ignore notification errors
-    }
-};
-
-// Handle graceful shutdown
-var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
-
-lifetime.ApplicationStopping.Register(() =>
-{
-    Console.Error.WriteLine("Shutting down MCP TestBridge Server...");
-});
-
-// Handle Ctrl+C / SIGTERM
-Console.CancelKeyPress += (_, e) =>
-{
-    e.Cancel = true;
-    lifetime.StopApplication();
-};
-
-// Log to stderr (stdout is for MCP protocol)
-Console.Error.WriteLine($"KeenEyes MCP TestBridge Server starting...");
-Console.Error.WriteLine($"Default pipe: {config.PipeName}");
-Console.Error.WriteLine($"Default transport: {config.Transport}");
-Console.Error.WriteLine($"Heartbeat interval: {config.HeartbeatInterval}ms");
-
-await app.RunAsync();
-
-// Cleanup
-await connectionManager.DisposeAsync();
-
-namespace KeenEyes.Mcp.TestBridge
-{
-    internal static class ConfigurationParser
-    {
-        public static McpConfiguration Parse(string[] args)
-        {
-            var pipeName = Environment.GetEnvironmentVariable("KEENEYES_PIPE_NAME") ?? "KeenEyes.TestBridge";
-            var tcpHost = Environment.GetEnvironmentVariable("KEENEYES_HOST") ?? "127.0.0.1";
-            var port = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_PORT"), out var p) ? p : 19283;
-            var transport = Environment.GetEnvironmentVariable("KEENEYES_TRANSPORT") ?? "pipe";
-            var heartbeatInterval = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_INTERVAL"), out var hi) ? hi : 5000;
-            var heartbeatTimeout = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_TIMEOUT"), out var ht) ? ht : 10000;
-            var maxPingFailures = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_MAX_PING_FAILURES"), out var mpf) ? mpf : 3;
-            var connectionTimeout = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_TIMEOUT"), out var ct) ? ct : 30000;
-
-            // Parse command line arguments
-            var i = 0;
-            while (i < args.Length)
-            {
-                var arg = args[i];
-                if (arg == "--pipe" && i + 1 < args.Length)
-                {
-                    pipeName = args[i + 1];
-                    i += 2;
-                }
-                else if (arg == "--host" && i + 1 < args.Length)
-                {
-                    tcpHost = args[i + 1];
-                    i += 2;
-                }
-                else if (arg == "--port" && i + 1 < args.Length)
-                {
-                    port = int.Parse(args[i + 1]);
-                    i += 2;
-                }
-                else if (arg == "--transport" && i + 1 < args.Length)
-                {
-                    transport = args[i + 1];
-                    i += 2;
-                }
-                else if (arg == "--timeout" && i + 1 < args.Length)
-                {
-                    connectionTimeout = int.Parse(args[i + 1]);
-                    i += 2;
-                }
-                else
-                {
-                    i++;
-                }
-            }
-
-            return new McpConfiguration(pipeName, tcpHost, port, transport, heartbeatInterval, heartbeatTimeout, maxPingFailures, connectionTimeout);
+            await mcpServer.SendNotificationAsync("notifications/tools/list_changed");
+            await mcpServer.SendNotificationAsync("notifications/resources/list_changed");
         }
+        catch
+        {
+            // Ignore notification errors
+        }
+    };
+
+    var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+    lifetime.ApplicationStopping.Register(() =>
+    {
+        Console.Error.WriteLine("Shutting down MCP TestBridge Server...");
+    });
+
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        lifetime.StopApplication();
+    };
+
+    // Log to stderr (stdout is for MCP protocol)
+    Console.Error.WriteLine("KeenEyes MCP TestBridge Server starting (stdio transport)...");
+    Console.Error.WriteLine($"Default pipe: {config.PipeName}");
+    Console.Error.WriteLine($"Game transport: {config.Transport}");
+    Console.Error.WriteLine($"Heartbeat interval: {config.HeartbeatInterval}ms");
+
+    await app.RunAsync();
+
+    await connectionManager.DisposeAsync();
+}
+
+// Runs the HTTP transport - lets a remote MCP client connect over the network.
+static async Task RunHttpServerAsync(McpConfiguration config, string[] args)
+{
+    var builder = WebApplication.CreateBuilder(args);
+
+    // Log to stderr so stdout stays clean and nothing leaks to a captured stdout channel.
+    builder.Logging.ClearProviders();
+    builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+    builder.WebHost.UseUrls(config.HttpUrl);
+
+    McpServerServices.AddSharedTestBridgeServices(builder.Services, config)
+        .WithHttpTransport();
+
+    var app = builder.Build();
+
+    // Security: require a bearer token when one is configured; otherwise warn loudly.
+    if (config.AuthToken is not null)
+    {
+        app.UseMiddleware<BearerTokenAuthenticationMiddleware>(config.AuthToken);
+    }
+    else
+    {
+        app.Logger.LogWarning(
+            "KEENEYES_MCP_TOKEN is not set: the HTTP MCP endpoint is UNAUTHENTICATED. " +
+            "This endpoint can control a game process - bind it to loopback or a trusted LAN address only, " +
+            "never to 0.0.0.0 or a public interface.");
     }
 
-    internal sealed record McpConfiguration(
-        string PipeName,
-        string TcpHost,
-        int Port,
-        string Transport,
-        int HeartbeatInterval,
-        int HeartbeatTimeout,
-        int MaxPingFailures,
-        int ConnectionTimeout);
+    app.MapMcp();
+
+    var connectionManager = app.Services.GetRequiredService<BridgeConnectionManager>();
+
+    app.Lifetime.ApplicationStopping.Register(() =>
+    {
+        app.Logger.LogInformation("Shutting down MCP TestBridge Server (HTTP transport)...");
+    });
+
+    app.Logger.LogInformation("KeenEyes MCP TestBridge Server starting (HTTP transport) on {Url}", config.HttpUrl);
+    app.Logger.LogInformation("Game transport: {Transport}, default pipe: {Pipe}", config.Transport, config.PipeName);
+
+    await app.RunAsync();
+
+    await connectionManager.DisposeAsync();
 }

--- a/tools/KeenEyes.Mcp.TestBridge/ServerConfiguration.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/ServerConfiguration.cs
@@ -1,0 +1,167 @@
+namespace KeenEyes.Mcp.TestBridge;
+
+/// <summary>
+/// The transport used by MCP clients (such as Claude Code) to reach this MCP server.
+/// This is orthogonal to how the server reaches the game (see <see cref="McpConfiguration.Transport"/>).
+/// </summary>
+internal enum McpClientTransport
+{
+    /// <summary>Standard input/output transport. Default; used by the local-subprocess flow.</summary>
+    Stdio,
+
+    /// <summary>Streamable HTTP transport, allowing a remote MCP client to connect over the network.</summary>
+    Http,
+}
+
+/// <summary>
+/// Fully-resolved configuration for the MCP TestBridge server.
+/// </summary>
+/// <param name="PipeName">Named pipe the server uses to reach the game (game hop).</param>
+/// <param name="TcpHost">TCP host the server uses to reach the game (game hop).</param>
+/// <param name="Port">TCP port the server uses to reach the game (game hop).</param>
+/// <param name="Transport">How the server reaches the game: <c>pipe</c> or <c>tcp</c>.</param>
+/// <param name="HeartbeatInterval">Interval, in milliseconds, between heartbeats to the game.</param>
+/// <param name="HeartbeatTimeout">Ping timeout, in milliseconds, before a heartbeat is considered failed.</param>
+/// <param name="MaxPingFailures">Consecutive ping failures tolerated before disconnecting.</param>
+/// <param name="ConnectionTimeout">Connection timeout, in milliseconds, when reaching the game.</param>
+/// <param name="ClientTransport">How MCP clients reach this server: <see cref="McpClientTransport.Stdio"/> or <see cref="McpClientTransport.Http"/>.</param>
+/// <param name="HttpUrl">URL the HTTP transport listens on (only used when <paramref name="ClientTransport"/> is HTTP).</param>
+/// <param name="AuthToken">Optional bearer token required by the HTTP endpoint; when <see langword="null"/> the endpoint is unauthenticated.</param>
+internal sealed record McpConfiguration(
+    string PipeName,
+    string TcpHost,
+    int Port,
+    string Transport,
+    int HeartbeatInterval,
+    int HeartbeatTimeout,
+    int MaxPingFailures,
+    int ConnectionTimeout,
+    McpClientTransport ClientTransport,
+    string HttpUrl,
+    string? AuthToken);
+
+/// <summary>
+/// Parses <see cref="McpConfiguration"/> from environment variables and command-line arguments.
+/// </summary>
+internal static class ConfigurationParser
+{
+    private const string LoopbackAddress = "127.0.0.1";
+    private const int DefaultHttpPort = 19284;
+
+    /// <summary>The default URL the HTTP transport binds to when none is configured. Loopback only.</summary>
+    // S5332: plain HTTP is intentional here - the default binds to loopback (127.0.0.1) only, where
+    // transport encryption adds nothing. Operators exposing the endpoint on a LAN set KEENEYES_MCP_URL
+    // (with https:// and a reverse proxy / cert) plus KEENEYES_MCP_TOKEN per the security docs.
+#pragma warning disable S5332
+    public static string DefaultHttpUrl { get; } = $"http://{LoopbackAddress}:{DefaultHttpPort}/";
+#pragma warning restore S5332
+
+    /// <summary>
+    /// Interprets a client-transport value (from env or flag) as an <see cref="McpClientTransport"/>.
+    /// </summary>
+    /// <param name="value">The raw value; <see langword="null"/> or empty selects the default (stdio).</param>
+    /// <returns>The parsed transport.</returns>
+    /// <exception cref="ArgumentException">Thrown when the value is not <c>stdio</c> or <c>http</c>.</exception>
+    public static McpClientTransport ParseClientTransport(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return McpClientTransport.Stdio;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "stdio" => McpClientTransport.Stdio,
+            "http" => McpClientTransport.Http,
+            _ => throw new ArgumentException(
+                $"Invalid MCP transport '{value}'. Expected 'stdio' or 'http'.", nameof(value)),
+        };
+    }
+
+    /// <summary>
+    /// Parses configuration from environment variables, then applies command-line overrides.
+    /// </summary>
+    /// <param name="args">The process command-line arguments.</param>
+    /// <returns>The resolved configuration.</returns>
+    public static McpConfiguration Parse(string[] args)
+    {
+        var pipeName = Environment.GetEnvironmentVariable("KEENEYES_PIPE_NAME") ?? "KeenEyes.TestBridge";
+        var tcpHost = Environment.GetEnvironmentVariable("KEENEYES_HOST") ?? "127.0.0.1";
+        var port = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_PORT"), out var p) ? p : 19283;
+        var transport = Environment.GetEnvironmentVariable("KEENEYES_TRANSPORT") ?? "pipe";
+        var heartbeatInterval = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_INTERVAL"), out var hi) ? hi : 5000;
+        var heartbeatTimeout = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_HEARTBEAT_TIMEOUT"), out var ht) ? ht : 10000;
+        var maxPingFailures = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_MAX_PING_FAILURES"), out var mpf) ? mpf : 3;
+        var connectionTimeout = int.TryParse(Environment.GetEnvironmentVariable("KEENEYES_TIMEOUT"), out var ct) ? ct : 30000;
+
+        // Client-facing MCP transport (how Claude Code reaches this server).
+        var clientTransport = Environment.GetEnvironmentVariable("KEENEYES_MCP_TRANSPORT");
+        var httpUrl = Environment.GetEnvironmentVariable("KEENEYES_MCP_URL") ?? DefaultHttpUrl;
+        var authToken = Environment.GetEnvironmentVariable("KEENEYES_MCP_TOKEN");
+
+        // Parse command line arguments
+        var i = 0;
+        while (i < args.Length)
+        {
+            var arg = args[i];
+            if (arg == "--pipe" && i + 1 < args.Length)
+            {
+                pipeName = args[i + 1];
+                i += 2;
+            }
+            else if (arg == "--host" && i + 1 < args.Length)
+            {
+                tcpHost = args[i + 1];
+                i += 2;
+            }
+            else if (arg == "--port" && i + 1 < args.Length)
+            {
+                port = int.Parse(args[i + 1]);
+                i += 2;
+            }
+            else if (arg == "--transport" && i + 1 < args.Length)
+            {
+                transport = args[i + 1];
+                i += 2;
+            }
+            else if (arg == "--timeout" && i + 1 < args.Length)
+            {
+                connectionTimeout = int.Parse(args[i + 1]);
+                i += 2;
+            }
+            else if (arg == "--mcp-transport" && i + 1 < args.Length)
+            {
+                clientTransport = args[i + 1];
+                i += 2;
+            }
+            else if (arg == "--mcp-url" && i + 1 < args.Length)
+            {
+                httpUrl = args[i + 1];
+                i += 2;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        // Treat an explicitly blank token env as unset.
+        if (string.IsNullOrWhiteSpace(authToken))
+        {
+            authToken = null;
+        }
+
+        return new McpConfiguration(
+            pipeName,
+            tcpHost,
+            port,
+            transport,
+            heartbeatInterval,
+            heartbeatTimeout,
+            maxPingFailures,
+            connectionTimeout,
+            ParseClientTransport(clientTransport),
+            httpUrl,
+            authToken);
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
+++ b/tools/KeenEyes.Mcp.TestBridge/packages.lock.json
@@ -43,6 +43,15 @@
           "ModelContextProtocol.Core": "1.4.1"
         }
       },
+      "ModelContextProtocol.AspNetCore": {
+        "type": "Direct",
+        "requested": "[1.4.1, )",
+        "resolved": "1.4.1",
+        "contentHash": "AoI+00fRxb0GAMMabMUgpV5QhNoa/F7I9oiVGHfJKtBZ4g/DEyoDdTS9Rp/m4e3MnXhhvSBeu2wTafhesdf52w==",
+        "dependencies": {
+          "ModelContextProtocol": "1.4.1"
+        }
+      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[10.29.0.143774, )",


### PR DESCRIPTION
## Summary
Closes #1095. Lets Claude Code on one machine drive a game on another by exposing the MCP TestBridge over **HTTP**, keeping the powerful game-control IPC hop on loopback on the game's machine.
- **Transport switch** (`KEENEYES_MCP_TRANSPORT` / `--mcp-transport`): `stdio` (default — the local subprocess flow is unchanged, so existing `.mcp.json` setups keep working) vs `http` (Kestrel `WebApplication` + `WithHttpTransport()` + `app.MapMcp()`).
- **Shared registration** — `McpServerServices.AddSharedTestBridgeServices` registers the identical tool/resource/prompt set + `BridgeConnectionManager` for both hosts, so they can't diverge.
- **Security (required):** `BearerTokenAuthenticationMiddleware` (registered only when `KEENEYES_MCP_TOKEN` is set) rejects missing/malformed/wrong `Authorization: Bearer` with 401 + `WWW-Authenticate`; ordinal exact-match via a pure `BearerTokenValidator`. Token unset → loud unauthenticated warning; default bind is loopback `http://127.0.0.1:19284/`, never `0.0.0.0`.
- `ModelContextProtocol.AspNetCore` 1.4.1 (matches the SDK; no new transitive NuGet deps); added to `.claude/hooks/install-packages.sh`.
- Docs: "Remote TestBridge over HTTP" in `docs/mcp-server.md` + `docs/testbridge.md` (two-host `.mcp.json`, per-hop env tables, token-vs-mTLS note).

## Test plan
- [x] 22 new tests (config/transport parsing; auth middleware missing→401, wrong→401, correct→next); MCP TestBridge project 102/0
- [x] Startup verified both ways: stdio runs+exits 0; http bound to loopback returns 401 (no/wrong token) and 400 (valid token, reaches MapMcp)
- [x] Full suite 14,445 passed / 0 failed; Release build 0 warnings/0 errors; format verify exit 0 (all independently re-verified)

## Related Issues
Closes #1095