### PR TITLE
fix(core): Harden MessageManager dispatch against reentrancy and cross-handler unsubscribe

### DIFF
--- a/src/KeenEyes.Core/Events/EventBus.cs
+++ b/src/KeenEyes.Core/Events/EventBus.cs
@@ -247,9 +247,10 @@ public sealed class EventBus
                 snapshot = [.. list];
             }
 
-            // Invoke in reverse order to match original behavior
-            // (allows handlers to unsubscribe during iteration)
-            for (int i = snapshot.Length - 1; i >= 0; i--)
+            // Invoke in registration order, as documented. The snapshot taken under
+            // lock lets handlers subscribe or unsubscribe during iteration without
+            // affecting the current dispatch.
+            for (int i = 0; i < snapshot.Length; i++)
             {
                 ((Action<T>)(object)snapshot[i])(evt);
             }

--- a/src/KeenEyes.Core/MessageManager.cs
+++ b/src/KeenEyes.Core/MessageManager.cs
@@ -109,10 +109,15 @@ internal sealed class MessageManager
         }
 
         var handlerList = (List<Action<T>>)handlersObj;
-        // Iterate in reverse to allow handlers to unsubscribe during iteration
-        for (int i = handlerList.Count - 1; i >= 0; i--)
+
+        // Snapshot the handler list before dispatch. This lets a handler safely
+        // unsubscribe itself or any other handler during delivery without shifting
+        // the set of handlers seen by the current dispatch (a live reverse-iteration
+        // would re-invoke a just-run handler when an earlier one is removed).
+        var snapshot = handlerList.ToArray();
+        for (int i = 0; i < snapshot.Length; i++)
         {
-            handlerList[i](message);
+            snapshot[i](message);
         }
     }
 
@@ -151,14 +156,25 @@ internal sealed class MessageManager
     /// different message types are processed is not guaranteed.
     /// </para>
     /// <para>
-    /// After processing, all message queues are cleared. If a handler throws an exception,
-    /// remaining messages in that type's queue will not be processed, but the queue will
-    /// be cleared.
+    /// After processing, the queues that existed at the start of the call are drained.
+    /// If a handler queues a message of a type that was not already present, that message
+    /// is delivered on the next <see cref="ProcessQueuedMessages"/> call rather than the
+    /// current one. If a handler throws an exception, remaining messages in that type's
+    /// queue will not be processed.
     /// </para>
     /// </remarks>
     internal void ProcessQueuedMessages()
     {
-        foreach (var kvp in messageQueues)
+        // Snapshot the queue set before dispatch. Handlers may queue a never-before-seen
+        // message type mid-dispatch, which adds a key to messageQueues via
+        // GetOrCreateMessageQueueWrapper; enumerating the live dictionary would then throw
+        // "Collection was modified". Messages for newly-added types are left in place and
+        // delivered on the next drain. Draining each wrapper (rather than a trailing
+        // clear-all pass) also avoids silently discarding messages a handler just queued.
+        var snapshot = new KeyValuePair<Type, IMessageQueueWrapper>[messageQueues.Count];
+        ((ICollection<KeyValuePair<Type, IMessageQueueWrapper>>)messageQueues).CopyTo(snapshot, 0);
+
+        foreach (var kvp in snapshot)
         {
             var messageType = kvp.Key;
             var wrapper = kvp.Value;
@@ -173,12 +189,6 @@ internal sealed class MessageManager
 
             // Process the queue using the typed wrapper (no reflection needed)
             wrapper.Process(handlersObj);
-        }
-
-        // Clear all queues after processing
-        foreach (var wrapper in messageQueues.Values)
-        {
-            wrapper.Clear();
         }
     }
 
@@ -211,14 +221,17 @@ internal sealed class MessageManager
 
         var handlerList = (List<Action<T>>)handlersObj;
 
+        // Snapshot the handler list before dispatch so a handler can safely unsubscribe
+        // itself or another handler without perturbing the current dispatch.
+        var snapshot = handlerList.ToArray();
+
         while (typedWrapper.Queue.Count > 0)
         {
             var message = typedWrapper.Queue.Dequeue();
 
-            // Dispatch to handlers in reverse order for safe unsubscription
-            for (int i = handlerList.Count - 1; i >= 0; i--)
+            for (int i = 0; i < snapshot.Length; i++)
             {
-                handlerList[i](message);
+                snapshot[i](message);
             }
         }
     }
@@ -365,14 +378,17 @@ internal sealed class MessageManager
         {
             var handlerList = (List<Action<T>>)handlersObj;
 
+            // Snapshot the handler list before dispatch so a handler can safely unsubscribe
+            // itself or another handler without perturbing the current dispatch.
+            var snapshot = handlerList.ToArray();
+
             while (Queue.Count > 0)
             {
                 var message = Queue.Dequeue();
 
-                // Dispatch to handlers in reverse order for safe unsubscription
-                for (int i = handlerList.Count - 1; i >= 0; i--)
+                for (int i = 0; i < snapshot.Length; i++)
                 {
-                    handlerList[i](message);
+                    snapshot[i](message);
                 }
             }
         }

--- a/tests/KeenEyes.Core.Tests/MessagingTests.cs
+++ b/tests/KeenEyes.Core.Tests/MessagingTests.cs
@@ -825,6 +825,94 @@ public class MessagingTests
 
     #endregion
 
+    #region Reentrancy And Unsubscribe-During-Dispatch Tests
+
+    [Fact]
+    public void ProcessQueuedMessages_HandlerQueuesNewMessageType_DoesNotThrowAndDeliversOnNextDrain()
+    {
+        // Regression for #1108: a handler that queues a never-before-seen message type
+        // mid-dispatch adds a key to the queue dictionary. Enumerating the live dictionary
+        // would throw "Collection was modified"; the new type must be delivered on the
+        // next drain instead.
+        using var world = new World();
+
+        var deathHandled = 0;
+        var lootHandled = 0;
+
+        using var deathSub = world.Subscribe<DeathMessage>(_ =>
+        {
+            deathHandled++;
+
+            // Queue a message type that has never been queued before this point.
+            world.QueueMessage(new LootMessage(EntityId: 7));
+        });
+
+        using var lootSub = world.Subscribe<LootMessage>(_ => lootHandled++);
+
+        world.QueueMessage(new DeathMessage(EntityId: 7));
+
+        // First drain: must not throw, delivers the death message, defers the loot message.
+        world.ProcessQueuedMessages();
+
+        Assert.Equal(1, deathHandled);
+        Assert.Equal(0, lootHandled);
+        Assert.Equal(1, world.GetQueuedMessageCount<LootMessage>());
+
+        // Second drain: the deferred loot message is delivered now.
+        world.ProcessQueuedMessages();
+
+        Assert.Equal(1, deathHandled);
+        Assert.Equal(1, lootHandled);
+        Assert.Equal(0, world.GetQueuedMessageCount<LootMessage>());
+    }
+
+    [Fact]
+    public void Send_HandlerUnsubscribesEarlierHandler_EachHandlerRunsExactlyOnce()
+    {
+        // Regression for #1109: reverse-iterating the live handler list re-invokes the
+        // just-run handler when it removes an earlier-indexed handler. Snapshotting before
+        // dispatch guarantees each handler runs exactly once.
+        using var world = new World();
+
+        var firstHandlerCount = 0;
+        var secondHandlerCount = 0;
+
+        // Subscribe the first (earlier-indexed) handler.
+        var firstSubscription = world.Subscribe<DamageMessage>(_ => firstHandlerCount++);
+
+        // The second handler disposes the first (earlier) handler during dispatch.
+        using var secondSubscription = world.Subscribe<DamageMessage>(_ =>
+        {
+            secondHandlerCount++;
+            firstSubscription.Dispose();
+        });
+
+        world.Send(new DamageMessage(1, 10));
+
+        Assert.Equal(1, firstHandlerCount);
+        Assert.Equal(1, secondHandlerCount);
+    }
+
+    [Fact]
+    public void Send_WithMultipleSubscribers_DeliversInRegistrationOrder()
+    {
+        // Regression for #1113: dispatch must honor the documented "registration order"
+        // contract rather than invoking handlers in reverse.
+        using var world = new World();
+
+        var invocationOrder = new List<int>();
+
+        using var first = world.Subscribe<DamageMessage>(_ => invocationOrder.Add(1));
+        using var second = world.Subscribe<DamageMessage>(_ => invocationOrder.Add(2));
+        using var third = world.Subscribe<DamageMessage>(_ => invocationOrder.Add(3));
+
+        world.Send(new DamageMessage(1, 10));
+
+        Assert.Equal([1, 2, 3], invocationOrder);
+    }
+
+    #endregion
+
     #region Test Message Types
 
     private readonly record struct DamageMessage(int TargetId, int Amount);
@@ -832,6 +920,10 @@ public class MessagingTests
     private readonly record struct CollisionMessage(Entity Entity1, Entity Entity2, float PenetrationDepth);
 
     private readonly record struct SpawnMessage(int EntityId);
+
+    private readonly record struct DeathMessage(int EntityId);
+
+    private readonly record struct LootMessage(int EntityId);
 
     private readonly record struct RecordStructMessage(string Name, int Value);
 


### PR DESCRIPTION
Fixes three related dispatch bugs (shared root: dispatching over live collections during synchronous handler invocation).
- **#1108 (high):** ProcessQueuedMessages snapshots the queue set before dispatch (no more `Collection was modified` crash when a handler queues a new message type); newly-queued types deliver on the next drain; removed the trailing clear-all that could silently drop them.
- **#1109 (medium):** Send / ProcessQueuedMessages<T> / MessageQueueWrapper.Process snapshot the handler list before dispatch (no more double-invoke when a handler removes an earlier one).
- **#1113 (low):** forward (registration-order) iteration in both MessageManager and EventBus, honoring the documented contract.

3 regression tests, each proven fail-on-old/pass-on-new. Full suite 14,453 passed / 0 failed; build 0 warnings; format clean. Existing `Subscribe_CanUnsubscribeDuringMessageDelivery` stays green.

Closes #1108
Closes #1109
Closes #1113