### PR TITLE
fix(core): AutoSaveSystem reads its baseline without wiping the live world

### DIFF
--- a/src/KeenEyes.Core/Capabilities/ISaveLoadCapability.cs
+++ b/src/KeenEyes.Core/Capabilities/ISaveLoadCapability.cs
@@ -145,6 +145,27 @@ public interface ISaveLoadCapability : IPersistenceCapability
         where TSerializer : IComponentSerializer;
 
     /// <summary>
+    /// Reads a save slot into a detached <see cref="WorldSnapshot"/> without modifying the world.
+    /// </summary>
+    /// <typeparam name="TSerializer">
+    /// The serializer type that implements both <see cref="IComponentSerializer"/>
+    /// and <see cref="IBinaryComponentSerializer"/>.
+    /// </typeparam>
+    /// <param name="slotName">The name of the save slot to read.</param>
+    /// <param name="serializer">The component serializer.</param>
+    /// <param name="validateChecksum">Whether to validate the checksum if present.</param>
+    /// <returns>The deserialized snapshot. The current world state is left unchanged.</returns>
+    /// <remarks>
+    /// Unlike <see cref="LoadFromSlot{TSerializer}"/>, this does not clear the world or restore
+    /// any entities. It is intended for callers that need the saved state only as diff input.
+    /// </remarks>
+    WorldSnapshot ReadSnapshotFromSlot<TSerializer>(
+        string slotName,
+        TSerializer serializer,
+        bool validateChecksum = true)
+        where TSerializer : IComponentSerializer, IBinaryComponentSerializer;
+
+    /// <summary>
     /// Creates a delta snapshot by comparing the current world state to a baseline.
     /// </summary>
     /// <typeparam name="TSerializer">

--- a/src/KeenEyes.Core/SaveManager.cs
+++ b/src/KeenEyes.Core/SaveManager.cs
@@ -146,22 +146,71 @@ internal sealed class SaveManager
         var (slotInfo, snapshotData) = SaveFileFormat.Read(fileData, validateChecksum);
 
         // Deserialize snapshot
-        WorldSnapshot snapshot;
-        if (slotInfo.Format == SaveFormat.Binary)
-        {
-            snapshot = SnapshotManager.FromBinary(snapshotData, serializer);
-        }
-        else
-        {
-            var json = System.Text.Encoding.UTF8.GetString(snapshotData);
-            snapshot = SnapshotManager.FromJson(json)
-                ?? throw new InvalidDataException("Failed to deserialize JSON snapshot.");
-        }
+        var snapshot = DeserializeSnapshot(slotInfo, snapshotData, serializer);
 
         // Restore snapshot
         var entityMap = SnapshotManager.RestoreSnapshot(world, snapshot, serializer);
 
         return (slotInfo, entityMap);
+    }
+
+    /// <summary>
+    /// Reads and deserializes a save slot into a detached <see cref="WorldSnapshot"/> without
+    /// restoring it into the live world.
+    /// </summary>
+    /// <typeparam name="TSerializer">The serializer type that implements both interfaces.</typeparam>
+    /// <param name="slotName">The name of the save slot to read.</param>
+    /// <param name="serializer">The component serializer for AOT-compatible deserialization.</param>
+    /// <param name="validateChecksum">Whether to validate the checksum if present.</param>
+    /// <returns>The deserialized snapshot. The live world is left untouched.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the save slot doesn't exist.</exception>
+    /// <exception cref="InvalidDataException">Thrown when the save file is corrupted.</exception>
+    /// <remarks>
+    /// Unlike <see cref="Load{TSerializer}"/>, this does not call <c>world.Clear()</c> or
+    /// restore any entities. It is intended for callers that only need the saved state as
+    /// data (for example, a delta-diffing baseline).
+    /// </remarks>
+    internal WorldSnapshot ReadSnapshot<TSerializer>(
+        string slotName,
+        TSerializer serializer,
+        bool validateChecksum = true)
+        where TSerializer : IComponentSerializer, IBinaryComponentSerializer
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slotName);
+        ArgumentNullException.ThrowIfNull(serializer);
+
+        var filePath = GetSlotFilePath(slotName);
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"Save slot '{slotName}' not found.", filePath);
+        }
+
+        // Read save file
+        var fileData = File.ReadAllBytes(filePath);
+        var (slotInfo, snapshotData) = SaveFileFormat.Read(fileData, validateChecksum);
+
+        // Deserialize snapshot only - do not restore into the world
+        return DeserializeSnapshot(slotInfo, snapshotData, serializer);
+    }
+
+    /// <summary>
+    /// Deserializes raw snapshot bytes into a <see cref="WorldSnapshot"/> using the format
+    /// recorded in the slot info.
+    /// </summary>
+    private static WorldSnapshot DeserializeSnapshot<TSerializer>(
+        SaveSlotInfo slotInfo,
+        byte[] snapshotData,
+        TSerializer serializer)
+        where TSerializer : IComponentSerializer, IBinaryComponentSerializer
+    {
+        if (slotInfo.Format == SaveFormat.Binary)
+        {
+            return SnapshotManager.FromBinary(snapshotData, serializer);
+        }
+
+        var json = System.Text.Encoding.UTF8.GetString(snapshotData);
+        return SnapshotManager.FromJson(json)
+            ?? throw new InvalidDataException("Failed to deserialize JSON snapshot.");
     }
 
     /// <summary>
@@ -620,17 +669,7 @@ internal sealed class SaveManager
         var (slotInfo, snapshotData) = SaveFileFormat.Read(fileData, validateChecksum);
 
         // Deserialize snapshot (synchronous - CPU bound)
-        WorldSnapshot snapshot;
-        if (slotInfo.Format == SaveFormat.Binary)
-        {
-            snapshot = SnapshotManager.FromBinary(snapshotData, serializer);
-        }
-        else
-        {
-            var json = System.Text.Encoding.UTF8.GetString(snapshotData);
-            snapshot = SnapshotManager.FromJson(json)
-                ?? throw new InvalidDataException("Failed to deserialize JSON snapshot.");
-        }
+        var snapshot = DeserializeSnapshot(slotInfo, snapshotData, serializer);
 
         // Restore snapshot (synchronous - CPU bound)
         var entityMap = SnapshotManager.RestoreSnapshot(world, snapshot, serializer);

--- a/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
+++ b/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
@@ -109,9 +109,10 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
                 var info = saveLoad.GetSaveSlotInfo(config.BaselineSlotName);
                 if (info is not null)
                 {
-                    // Load the baseline snapshot for delta comparison
-                    saveLoad.LoadFromSlot(config.BaselineSlotName, serializer);
-                    baselineSnapshot = saveLoad.CreateSnapshot(serializer);
+                    // Read the baseline snapshot for delta comparison WITHOUT mutating the
+                    // live world. Using LoadFromSlot here would clear the current scene and
+                    // replace it with the baseline's entities (see issue #1131).
+                    baselineSnapshot = saveLoad.ReadSnapshotFromSlot(config.BaselineSlotName, serializer);
 
                     // Find the highest existing delta sequence
                     currentDeltaSequence = FindHighestDeltaSequence(saveLoad);

--- a/src/KeenEyes.Core/World.SaveLoad.cs
+++ b/src/KeenEyes.Core/World.SaveLoad.cs
@@ -319,6 +319,35 @@ public sealed partial class World
     }
 
     /// <summary>
+    /// Reads a save slot into a detached <see cref="WorldSnapshot"/> without modifying the world.
+    /// </summary>
+    /// <typeparam name="TSerializer">
+    /// The serializer type that implements both <see cref="IComponentSerializer"/>
+    /// and <see cref="IBinaryComponentSerializer"/>.
+    /// </typeparam>
+    /// <param name="slotName">The name of the save slot to read.</param>
+    /// <param name="serializer">The component serializer for AOT-compatible deserialization.</param>
+    /// <param name="validateChecksum">Whether to validate the checksum if present. Defaults to true.</param>
+    /// <returns>The deserialized snapshot. The current world state is left unchanged.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the save slot doesn't exist.</exception>
+    /// <exception cref="InvalidDataException">Thrown when the save file is corrupted.</exception>
+    /// <remarks>
+    /// <para>
+    /// Unlike <see cref="LoadFromSlot{TSerializer}"/>, this method does not clear the world or
+    /// restore any entities. It is intended for callers that only need the saved state as data,
+    /// such as obtaining a baseline for delta comparison.
+    /// </para>
+    /// </remarks>
+    public WorldSnapshot ReadSnapshotFromSlot<TSerializer>(
+        string slotName,
+        TSerializer serializer,
+        bool validateChecksum = true)
+        where TSerializer : IComponentSerializer, IBinaryComponentSerializer
+    {
+        return GetSaveManager().ReadSnapshot(slotName, serializer, validateChecksum);
+    }
+
+    /// <summary>
     /// Creates a delta snapshot by comparing the current world state to a baseline.
     /// </summary>
     /// <typeparam name="TSerializer">

--- a/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
+++ b/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
@@ -111,6 +111,30 @@ public class AutoSaveSystemTests : IDisposable
         Assert.Equal(60f, system.Config.AutoSaveIntervalSeconds);
     }
 
+    [Fact]
+    public void OnInitialize_WithExistingBaselineOnDisk_DoesNotWipeLiveWorld()
+    {
+        var config = new AutoSaveConfig { AutoSaveIntervalSeconds = 10f };
+
+        // Session 1: persist a baseline slot containing an "OldBaseline" entity.
+        using (var baselineWorld = new World { SaveDirectory = testSaveDirectory })
+        {
+            baselineWorld.Spawn("OldBaseline").With(new SerializablePosition { X = 1, Y = 2 }).Build();
+            baselineWorld.SaveToSlot(config.BaselineSlotName, serializer);
+        }
+
+        // Session 2: a live world with a "Player" scene attaches the auto-save system.
+        using var world = new World { SaveDirectory = testSaveDirectory };
+        world.Spawn("Player").With(new SerializablePosition { X = 10, Y = 20 }).Build();
+
+        world.AddSystem(new AutoSaveSystem<TestComponentSerializer>(serializer, config));
+
+        // Attaching auto-save must not destroy the current scene: the live "Player"
+        // entity survives and the baseline's "OldBaseline" entity is never introduced.
+        Assert.NotEqual(Entity.Null, world.GetEntityByName("Player"));
+        Assert.Equal(Entity.Null, world.GetEntityByName("OldBaseline"));
+    }
+
     #endregion
 
     #region Auto-Save Trigger Tests


### PR DESCRIPTION
**#1131 (high):** attaching AutoSave to a world with a prior `autosave_baseline` slot on disk wiped the current scene, because `OnInitialize` obtained its delta baseline via `LoadFromSlot` → `RestoreSnapshot` → `world.Clear()` (and AddSystem runs OnInitialize synchronously).

Adds a read-only `SaveManager.ReadSnapshot`/`World.ReadSnapshotFromSlot` path (pure extraction of a shared `DeserializeSnapshot` helper — genuine Load/LoadAsync behavior unchanged) and points AutoSave's baseline read at it. Regression test proven fail-on-old/pass-on-new (name-based: 'Player' survives, 'OldBaseline' never introduced). Core-only change; build 0/0, Core.Tests 2300/0, Persistence 79/0.

Closes #1131