### PR TITLE
fix(parallelism): Fix CombineDependencies deadlock (virtual Wait/override, not new)

### DIFF
--- a/src/KeenEyes.Parallelism/JobHandle.cs
+++ b/src/KeenEyes.Parallelism/JobHandle.cs
@@ -184,7 +184,7 @@ internal class JobCompletionSource : IDisposable
 
     public static JobCompletionSource CompletedSource { get; } = CreateCompleted();
 
-    public bool IsCompleted => isCompleted;
+    public virtual bool IsCompleted => isCompleted;
     public bool IsFaulted => isFaulted;
     public Exception? Exception => exception;
 
@@ -215,7 +215,7 @@ internal class JobCompletionSource : IDisposable
         }
     }
 
-    public void Wait()
+    public virtual void Wait()
     {
         if (isCompleted || isDisposed)
         {
@@ -225,7 +225,7 @@ internal class JobCompletionSource : IDisposable
         completionEvent.Wait();
     }
 
-    public bool Wait(TimeSpan timeout)
+    public virtual bool Wait(TimeSpan timeout)
     {
         if (isCompleted || isDisposed)
         {
@@ -267,17 +267,49 @@ internal sealed class CombinedJobCompletionSource : JobCompletionSource
         }
     }
 
-    public new void Wait()
+    public override bool IsCompleted
     {
+        get
+        {
+            if (base.IsCompleted)
+            {
+                return true;
+            }
+
+            foreach (var handle in handles)
+            {
+                if (!handle.IsCompleted)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public override void Wait()
+    {
+        if (IsCompleted)
+        {
+            return;
+        }
+
         foreach (var handle in handles)
         {
             handle.Complete();
         }
+
         SetCompleted();
     }
 
-    public new bool Wait(TimeSpan timeout)
+    public override bool Wait(TimeSpan timeout)
     {
+        if (IsCompleted)
+        {
+            return true;
+        }
+
         var deadline = DateTime.UtcNow + timeout;
 
         foreach (var handle in handles)

--- a/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
@@ -354,6 +354,38 @@ public class JobSchedulerTests
     }
 
     [Fact]
+    public void JobHandle_CombineDependencies_WithSlowJobs_CompletesWithoutDeadlock()
+    {
+        // Regression test for #1153: CombinedJobCompletionSource used to hide Wait()
+        // with `new` instead of `override`. Because JobHandle.source is base-typed, the
+        // non-virtual base Wait() ran through it and never awaited the child jobs, so a
+        // combined handle whose children finished AFTER construction blocked until timeout.
+        // The jobs here are deliberately slow so they cannot finish before the combined
+        // source is constructed (defeating its early-complete fast path).
+        using var scheduler = new JobScheduler();
+
+        var handle1 = scheduler.Schedule(new SlowJob { DelayMs = 250 });
+        var handle2 = scheduler.Schedule(new SlowJob { DelayMs = 250 });
+
+        var combined = JobHandle.CombineDependencies(handle1, handle2);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var completed = combined.Wait(TimeSpan.FromSeconds(5));
+        stopwatch.Stop();
+
+        // On the old code this returned false only after the full 5s timeout.
+        Assert.True(completed);
+        Assert.True(combined.IsCompleted);
+        Assert.True(handle1.IsCompleted);
+        Assert.True(handle2.IsCompleted);
+
+        // Completion must reflect actual job time (~250ms), not the timeout ceiling.
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+            $"Combined wait took {stopwatch.ElapsedMilliseconds}ms; expected well under 2s.");
+    }
+
+    [Fact]
     public void JobHandle_CombineDependencies_EmptyArray_ReturnsCompleted()
     {
         var combined = JobHandle.CombineDependencies();


### PR DESCRIPTION
**#1153 (high):** `CombinedJobCompletionSource` hid `Wait()`/`Wait(TimeSpan)` with `new`, so calls through the base-typed `JobHandle.source` field ran the non-virtual base `Wait()` — which only signaled on the constructor's early-complete path. A combined handle whose children finished later blocked until timeout. This is the root of the intermittent Parallelism-suite hangs noted in CLAUDE.md.

Base `Wait()`/`Wait(TimeSpan)`/`IsCompleted` are now `virtual`; the combined source `override`s them to wait on all children and reflect true completion (no busy-wait; fast path preserved). Regression test proven fail-on-old (5s timeout) / pass-on-new (~570ms). Parallelism suite run 3× → 103/103 each, stable; full suite 14,451/0.

Closes #1153