### PR TITLE
fix(testbridge): Snapshot file round-trip preserves nested-struct and array fields

### DIFF
--- a/src/KeenEyes.TestBridge/SnapshotImpl/SnapshotControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/SnapshotImpl/SnapshotControllerImpl.cs
@@ -513,20 +513,137 @@ internal sealed class SnapshotControllerImpl(World world) : ISnapshotController
         return instance;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "TestBridge uses reflection for debugging purposes")]
     private static object? ConvertJsonElement(JsonElement element, Type targetType)
     {
-        return element.ValueKind switch
+        switch (element.ValueKind)
         {
-            JsonValueKind.Number when targetType == typeof(int) => element.GetInt32(),
-            JsonValueKind.Number when targetType == typeof(long) => element.GetInt64(),
-            JsonValueKind.Number when targetType == typeof(float) => element.GetSingle(),
-            JsonValueKind.Number when targetType == typeof(double) => element.GetDouble(),
-            JsonValueKind.Number when targetType == typeof(decimal) => element.GetDecimal(),
-            JsonValueKind.String when targetType == typeof(string) => element.GetString(),
-            JsonValueKind.String when targetType.IsEnum => Enum.Parse(targetType, element.GetString()!),
-            JsonValueKind.True or JsonValueKind.False when targetType == typeof(bool) => element.GetBoolean(),
-            _ => null
-        };
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+
+            case JsonValueKind.Number:
+                return ConvertJsonNumber(element, targetType);
+
+            case JsonValueKind.String when targetType.IsEnum:
+                return Enum.Parse(targetType, element.GetString()!);
+
+            case JsonValueKind.String:
+                return element.GetString();
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean();
+
+            case JsonValueKind.Object:
+                // Rebuild the native dictionary representation used by in-memory
+                // snapshots so nested-struct fields reach ConvertDictToStruct. Each
+                // property value stays a JsonElement and is converted per-field
+                // (recursing through ConvertFromSerializable) using its target type.
+                var dict = new Dictionary<string, object?>();
+                foreach (var property in element.EnumerateObject())
+                {
+                    dict[property.Name] = property.Value;
+                }
+                return ConvertFromSerializable(dict, targetType);
+
+            case JsonValueKind.Array:
+                return ConvertJsonArray(element, targetType);
+
+            default:
+                return null;
+        }
+    }
+
+    private static object? ConvertJsonNumber(JsonElement element, Type targetType)
+    {
+        if (targetType == typeof(int))
+        {
+            return element.GetInt32();
+        }
+
+        if (targetType == typeof(long))
+        {
+            return element.GetInt64();
+        }
+
+        if (targetType == typeof(float))
+        {
+            return element.GetSingle();
+        }
+
+        if (targetType == typeof(double))
+        {
+            return element.GetDouble();
+        }
+
+        if (targetType == typeof(decimal))
+        {
+            return element.GetDecimal();
+        }
+
+        if (targetType == typeof(byte))
+        {
+            return element.GetByte();
+        }
+
+        if (targetType == typeof(sbyte))
+        {
+            return element.GetSByte();
+        }
+
+        if (targetType == typeof(short))
+        {
+            return element.GetInt16();
+        }
+
+        if (targetType == typeof(ushort))
+        {
+            return element.GetUInt16();
+        }
+
+        if (targetType == typeof(uint))
+        {
+            return element.GetUInt32();
+        }
+
+        if (targetType == typeof(ulong))
+        {
+            return element.GetUInt64();
+        }
+
+        return null;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "TestBridge uses reflection for debugging purposes")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "TestBridge uses reflection for debugging purposes")]
+    private static object? ConvertJsonArray(JsonElement element, Type targetType)
+    {
+        if (!targetType.IsArray)
+        {
+            return null;
+        }
+
+        var elementType = targetType.GetElementType();
+        if (elementType == null)
+        {
+            return null;
+        }
+
+        var array = Array.CreateInstance(elementType, element.GetArrayLength());
+        var index = 0;
+        foreach (var item in element.EnumerateArray())
+        {
+            var converted = ConvertFromSerializable(item, elementType);
+            if (converted != null)
+            {
+                array.SetValue(converted, index);
+            }
+
+            index++;
+        }
+
+        return array;
     }
 
     private static bool IsNumericType(Type type)

--- a/tests/KeenEyes.TestBridge.Tests/Snapshot/SnapshotFileRoundTripTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Snapshot/SnapshotFileRoundTripTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+
+namespace KeenEyes.TestBridge.Tests.Snapshot;
+
+/// <summary>
+/// Regression tests for snapshot persistence to and from disk (issue #1176).
+/// </summary>
+public class SnapshotFileRoundTripTests
+{
+    [Fact]
+    public async Task RestoreAsync_AfterFileRoundTrip_PreservesNestedStructAndArrayFields()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"keeneyes-snapshot-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            using var world = new World();
+            world.Spawn()
+                .With(new TestComplexComponent
+                {
+                    Flat = 7,
+                    Nested = new TestNested { A = 3, B = 4 },
+                    Values = [1, 2, 3]
+                })
+                .Build();
+
+            using var bridge = new InProcessBridge(world);
+
+            var create = await bridge.Snapshot.CreateAsync("complex");
+            create.Success.ShouldBeTrue();
+
+            // Persist to disk and reload: this forces every component value
+            // through JsonSerializer, turning nested structs and arrays into
+            // JsonElement.Object / JsonElement.Array on the way back in.
+            var save = await bridge.Snapshot.SaveToFileAsync("complex", path);
+            save.Success.ShouldBeTrue();
+
+            var load = await bridge.Snapshot.LoadFromFileAsync(path, "loaded");
+            load.Success.ShouldBeTrue();
+
+            var restore = await bridge.Snapshot.RestoreAsync("loaded");
+            restore.Success.ShouldBeTrue();
+
+            var entity = world.Query<TestComplexComponent>().Single();
+            ref readonly var restored = ref world.Get<TestComplexComponent>(entity);
+
+            restored.Flat.ShouldBe(7);
+            restored.Nested.A.ShouldBe(3);
+            restored.Nested.B.ShouldBe(4);
+            restored.Values.ShouldBe([1, 2, 3]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/KeenEyes.TestBridge.Tests/TestComponents.cs
+++ b/tests/KeenEyes.TestBridge.Tests/TestComponents.cs
@@ -33,6 +33,25 @@ public struct TestHealth : IComponent
 public struct TestTag : ITagComponent;
 
 /// <summary>
+/// Nested value type used to verify struct-typed component fields survive snapshot round-trips.
+/// </summary>
+public struct TestNested
+{
+    public int A;
+    public int B;
+}
+
+/// <summary>
+/// Test component combining a flat field, a nested-struct field, and an array field.
+/// </summary>
+public struct TestComplexComponent : IComponent
+{
+    public int Flat;
+    public TestNested Nested;
+    public int[] Values;
+}
+
+/// <summary>
 /// Test system that counts updates.
 /// </summary>
 public class TestCountingSystem : SystemBase


### PR DESCRIPTION
**#1176 (high):** on snapshot file save/load, component values round-trip through `JsonSerializer` as `JsonElement`, and `ConvertJsonElement` returned null for Object/Array kinds — so struct- and array-typed fields came back zeroed/null (in-memory restore was fine).

`ConvertJsonElement` is now recursive: Object → `Dictionary<string,object?>` routed back through the existing `ConvertDictToStruct` path (correct per-field typing), Array → typed array via `Array.CreateInstance` with element-typed recursion, plus full numeric-kind coverage. AOT/trim suppressions consistent with the file's existing reflection-debug justification. Regression test (nested struct + array) proven fail-on-old/pass-on-new. Build 0/0; full suite 14,451/0.

Closes #1176