### PR TITLE
ci: Enable parallel test execution (remove --max-parallel-test-modules 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 10
-        run: dotnet test --no-build --configuration Release --verbosity normal --coverage --coverage-output-format cobertura --report-github --report-github-summary-include-passed false --max-parallel-test-modules 1
+        run: dotnet test --no-build --configuration Release --verbosity normal --coverage --coverage-output-format cobertura --report-github --report-github-summary-include-passed false
 
       - name: Generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 10
-        run: dotnet test --no-build --configuration Release --verbosity normal --max-parallel-test-modules 1
+        run: dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Pack
         run: dotnet pack --no-build --configuration Release -p:Version=${{ steps.version.outputs.VERSION }} --output ./nupkg

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,13 +384,13 @@ public static class WorldPluginExtensions
 ```bash
 dotnet restore
 dotnet build                                  # Zero warnings (TreatWarningsAsErrors)
-dotnet test --max-parallel-test-modules 1     # Full suite
+dotnet test                                   # Full suite (parallel test modules)
 dotnet format --verify-no-changes             # Check formatting (auto-fix: dotnet format)
 ```
 
 The solution file is `KeenEyes.slnx` (not `.sln`). `dotnet build`/`test` with no argument operate on it.
 
-**Important:** Always use `--max-parallel-test-modules 1` when running tests. This prevents test assemblies from running in parallel, which causes ThreadPool contention and intermittent hangs in the Parallelism, Network, and Debugging test suites.
+**Parallel test execution is enabled.** Tests run with default parallel test-module scheduling (~5× faster than serial). This previously caused intermittent CI hangs, but the root cause was a `JobHandle.CombineDependencies` deadlock (`new`-hid `Wait()` on a base-typed field — fixed in #1153), not inherent ThreadPool contention: a combined handle whose children completed after construction blocked forever, and under parallel load that hung the Parallelism module (and starved the concurrently-running Network/Debugging modules, making them appear to hang too). With that fixed, the full suite completes cleanly under `--max-parallel-test-modules 32` across repeated runs. If you ever need to rule out a concurrency interaction while debugging, `--max-parallel-test-modules 1` forces serial execution, but it is no longer required.
 
 ### Running a Single Test or Project
 
@@ -398,7 +398,7 @@ Tests use **xUnit.net v3 on Microsoft Testing Platform** (MTP), not VSTest — c
 
 ```bash
 # Run one test project (fastest inner loop)
-dotnet test tests/KeenEyes.Core.Tests --max-parallel-test-modules 1
+dotnet test tests/KeenEyes.Core.Tests
 
 # Run a single test method (glob patterns supported)
 dotnet test tests/KeenEyes.Core.Tests -- --filter-method "*Spawn_CreatesEntity*"


### PR DESCRIPTION
## ⚠️ DRAFT — blocked by #1203. Do not merge until #1203 lands, or parallel CI will go ~10% red on the editor HotReload flake.

## Summary
Removes the `--max-parallel-test-modules 1` serial workaround from `build.yml` and `release.yml`, and rewrites the CLAUDE.md guidance to match reality.

The workaround existed only to dodge intermittent CI hangs. That hang was **not** inherent ThreadPool contention — it was the `JobHandle.CombineDependencies` deadlock fixed in **#1153 / #1200** (merged): `new` hid `Wait()` behind a base-typed `source` field, so a combined handle whose child jobs completed *after* construction blocked forever. Under parallel load that hung the Parallelism module and starved the concurrently-running Network/Debugging modules — which is why all three appeared in the old note.

## Evidence (empirical A/B, `--max-parallel-test-modules 32`)
| | runs | hangs | flaky failures |
|---|---|---|---|
| main **with** #1200 | 20 | **0** | 2 (both HotReloadServiceTests — see #1203) |
| main **without** the fix | 10 | **4 (40%)** | 3 |

Hang eliminated 40% → 0%. Payoff of lifting the flag: ~8s vs ~40s suite runs (~5×), and the flag stops hiding future concurrency regressions.

## Why blocked by #1203
The 2 residual flaky failures are **not** hangs — they're `KeenEyes.Editor.Tests.HotReload.HotReloadServiceTests` clobbering each other via global `EditorSettings` static state under parallel load (intra-assembly, so `--max-parallel-test-modules` can't isolate it). #1203 fixes that test-isolation bug. Once #1203 merges, this can go green and un-draft.

## Test plan
- [x] A/B validated the hang fix (above)
- [ ] #1203 merged (unblocks)
- [ ] CI green on this PR with #1203 in

Depends on #1203. Part of the #1093 review follow-through.