### PR TITLE
test(editor): Isolate EditorSettings global state so editor tests are parallel-safe

### DIFF
--- a/editor/KeenEyes.Editor/Settings/EditorSettings.cs
+++ b/editor/KeenEyes.Editor/Settings/EditorSettings.cs
@@ -588,6 +588,27 @@ public static class EditorSettings
     }
 
     /// <summary>
+    /// Resets all process-global settings state for test isolation.
+    /// </summary>
+    /// <remarks>
+    /// Clears the in-memory settings back to their defaults, forgets the current settings
+    /// file path, marks settings as not loaded (so subsequent mutations are not persisted to
+    /// disk), and detaches every <see cref="SettingChanged"/> subscriber. Because
+    /// <see cref="EditorSettings"/> is a process-global static, concurrently- or
+    /// sequentially-executing editor tests can otherwise observe each other's writes and
+    /// leaked event subscriptions; calling this in test setup/teardown makes that bleed
+    /// impossible. Unlike <see cref="ResetToDefaults"/>, this never writes to disk and never
+    /// raises <see cref="SettingChanged"/>.
+    /// </remarks>
+    internal static void ResetForTesting()
+    {
+        CopySettings(new SettingsData(), _data);
+        _settingsPath = null;
+        _isLoaded = false;
+        SettingChanged = null;
+    }
+
+    /// <summary>
     /// Resets settings for a specific category to their defaults.
     /// </summary>
     /// <param name="category">The category to reset.</param>

--- a/tests/KeenEyes.Editor.Tests/Application/EditorApplicationViewportTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Application/EditorApplicationViewportTests.cs
@@ -15,14 +15,17 @@ public sealed class EditorApplicationViewportTests : IDisposable
 {
     public EditorApplicationViewportTests()
     {
-        // Reset settings to defaults before each test
-        EditorSettings.ResetToDefaults();
+        // EditorSettings is process-global static state. Reset it to defaults, forget any test
+        // settings path, and detach leaked SettingChanged subscribers so this class is isolated
+        // from other editor tests (see #1203). Unlike ResetToDefaults, ResetForTesting does not
+        // write to disk.
+        EditorSettings.ResetForTesting();
     }
 
     public void Dispose()
     {
-        // Clean up settings after tests
-        EditorSettings.ResetToDefaults();
+        // Leave no global state (or leaked SettingChanged subscriptions) behind for the next test.
+        EditorSettings.ResetForTesting();
     }
 
     #region ToggleGrid Tests

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
@@ -7,33 +7,20 @@ namespace KeenEyes.Editor.Tests.HotReload;
 
 public class HotReloadServiceTests : IDisposable
 {
-    private readonly string originalGameProjectPath;
-    private readonly bool originalHotReloadEnabled;
-    private readonly int originalDebounceMs;
-    private readonly bool originalAutoReload;
-
     public HotReloadServiceTests()
     {
-        // Save original settings
-        originalGameProjectPath = EditorSettings.GameProjectPath;
-        originalHotReloadEnabled = EditorSettings.HotReloadEnabled;
-        originalDebounceMs = EditorSettings.HotReloadDebounceMs;
-        originalAutoReload = EditorSettings.HotReloadAutoReload;
-
-        // Reset settings for tests
-        EditorSettings.GameProjectPath = string.Empty;
-        EditorSettings.HotReloadEnabled = true;
-        EditorSettings.HotReloadDebounceMs = 500;
-        EditorSettings.HotReloadAutoReload = true;
+        // EditorSettings is process-global static state that HotReloadService reads/writes and
+        // subscribes to (SettingChanged). Reset it to defaults and detach any leaked
+        // subscribers so this class starts from clean, isolated state regardless of what other
+        // editor tests ran before it (see #1203). Defaults already match the values these
+        // tests expect (empty GameProjectPath, HotReload enabled, 500ms debounce, auto-reload).
+        EditorSettings.ResetForTesting();
     }
 
     public void Dispose()
     {
-        // Restore original settings
-        EditorSettings.GameProjectPath = originalGameProjectPath;
-        EditorSettings.HotReloadEnabled = originalHotReloadEnabled;
-        EditorSettings.HotReloadDebounceMs = originalDebounceMs;
-        EditorSettings.HotReloadAutoReload = originalAutoReload;
+        // Leave no global state (or leaked SettingChanged subscriptions) behind for the next test.
+        EditorSettings.ResetForTesting();
     }
 
     #region Constructor Tests

--- a/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
+++ b/tests/KeenEyes.Editor.Tests/KeenEyes.Editor.Tests.csproj
@@ -7,6 +7,19 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
+  <!--
+    #1203: Editor tests exercise process-global EditorSettings static state (shared _data,
+    _settingsPath, and a static SettingChanged event that HotReloadService subscribes to).
+    Running test collections in parallel lets these classes clobber each other and flake under
+    load. The repo-wide tests/xunit.runner.json (copied in via Directory.Build.props) enables
+    collection parallelism and takes precedence over any [assembly: CollectionBehavior] attribute,
+    so we drop that copy for this project and ship a local xunit.runner.json that disables it.
+  -->
+  <ItemGroup>
+    <None Remove="..\xunit.runner.json" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\editor\KeenEyes.Editor.Abstractions\KeenEyes.Editor.Abstractions.csproj" />
     <ProjectReference Include="..\..\editor\KeenEyes.Editor.Common\KeenEyes.Editor.Common.csproj" />

--- a/tests/KeenEyes.Editor.Tests/Settings/EditorSettingsTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Settings/EditorSettingsTests.cs
@@ -3,8 +3,21 @@ using KeenEyes.Editor.Settings;
 namespace KeenEyes.Editor.Tests.Settings;
 
 [Collection("EditorSettings")]
-public class EditorSettingsTests
+public class EditorSettingsTests : IDisposable
 {
+    public EditorSettingsTests()
+    {
+        // EditorSettings is process-global static state; start every test from clean, isolated
+        // state and with no leaked SettingChanged subscribers (see #1203).
+        EditorSettings.ResetForTesting();
+    }
+
+    public void Dispose()
+    {
+        // Leave no global state (or leaked SettingChanged subscriptions) behind for the next test.
+        EditorSettings.ResetForTesting();
+    }
+
     #region General Settings Tests
 
     [Fact]
@@ -484,8 +497,8 @@ public class EditorSettingsTests
 
     private static void ResetSettingsForTest()
     {
-        // Force reset by loading defaults
-        EditorSettings.ResetToDefaults();
+        // Reset in-memory state without touching disk or leaking SettingChanged subscribers.
+        EditorSettings.ResetForTesting();
     }
 
     private static string GetTestSettingsPath()

--- a/tests/KeenEyes.Editor.Tests/xunit.runner.json
+++ b/tests/KeenEyes.Editor.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}


### PR DESCRIPTION
## Summary
Fixes #1203 — editor tests (`HotReloadServiceTests`, `EditorApplicationViewportTests`) flaked ~10% under parallel load because `EditorSettings` is a process-global `static` class that concurrent test collections clobbered.

**Isolation approach:** a **project-local `tests/KeenEyes.Editor.Tests/xunit.runner.json`** (`parallelizeTestCollections: false`, `maxParallelThreads: 1`) + a csproj change so the local config wins over the inherited repo-wide `tests/xunit.runner.json` (which is `true` and was silently overriding an `[assembly: CollectionBehavior(DisableTestParallelization)]` attempt). This serializes editor test collections *within* the assembly without touching cross-assembly parallelism (`--max-parallel-test-modules` still runs Editor.Tests alongside other modules).

**Plus a proper reset:** new `internal EditorSettings.ResetForTesting()` (via existing `InternalsVisibleTo`) that resets `_data`, nulls `_settingsPath`, sets `_isLoaded=false` (no disk writes), and detaches all `SettingChanged` subscribers — wired into ctor+Dispose of the three affected test classes. (The existing `ResetToDefaults()` was unsuitable — it writes to disk and leaves subscribers attached.)

## Test plan
- [x] Editor.Tests 10/10 clean run alone (now internally serial → deterministic); reviewer independently re-verified
- [x] Agent's 15× full-suite `--max-parallel-test-modules 32`: **editor tests 0 failures / 0 hangs**
- [x] Revert-to-confirm: reverting the fix reproduced `HotReloadServiceTests.Dispose_StopsWatching` failing (1/20), matching the ~10% rate
- [x] Build 0 warnings; format verify exit 0

## Note — two *other* parallel flakes surfaced (separate issues, block #1204 too)
The 15× loop also caught two pre-existing, unrelated probabilistic flakes in other assemblies (not `EditorSettings`-related): Particles `SpawnSystem_ConeShape` (random distribution boundary) and Parallelism `JobHandle_Wait_TimeoutReturnsCorrectly` (timing under contention). Filed separately; they must also be fixed before the parallel-CI change (#1204) can go green.

Closes #1203