### PR TITLE
test: Make ConeShape and JobHandle_Wait tests deterministic under parallel load

### DIFF
--- a/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
@@ -87,6 +87,21 @@ public class JobSchedulerTests
         }
     }
 
+    /// <summary>
+    /// A job that blocks until an externally controlled gate is opened. This makes
+    /// completion deterministic (rather than time-based), so waits against it cannot
+    /// race a sleeping job under ThreadPool contention.
+    /// </summary>
+    private readonly struct GatedJob : IJob
+    {
+        public ManualResetEventSlim Gate { get; init; }
+
+        public readonly void Execute()
+        {
+            Gate.Wait();
+        }
+    }
+
     private readonly struct ThreadTrackingJob : IJob
     {
         public ConcurrentBag<int> ThreadIds { get; init; }
@@ -326,12 +341,24 @@ public class JobSchedulerTests
     public void JobHandle_Wait_TimeoutReturnsCorrectly()
     {
         using var scheduler = new JobScheduler();
+        using var gate = new ManualResetEventSlim(false);
 
-        // Use 100ms delay - long enough to reliably test 10ms timeout, but fast enough to not slow tests
-        var handle = scheduler.Schedule(new SlowJob { DelayMs = 100 });
-        var completed = handle.Wait(TimeSpan.FromMilliseconds(10));
+        // The gated job cannot complete until we open the gate, so the outcome is
+        // deterministic and does not race a sleeping job against a short timeout.
+        // This mirrors the #1053 approach: assert the timeout *behavior*, not a tight
+        // wall-clock window that drifts under ThreadPool contention.
+        var handle = scheduler.Schedule(new GatedJob { Gate = gate });
 
-        Assert.False(completed);
+        // While the gate is closed the job genuinely cannot finish, so Wait must time
+        // out and report the job as not completed - regardless of scheduling delays.
+        var timedOut = handle.Wait(TimeSpan.FromMilliseconds(50));
+        Assert.False(timedOut);
+        Assert.False(handle.IsCompleted);
+
+        // Once the gate opens the job completes, and Wait must now report success.
+        gate.Set();
+        Assert.True(handle.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(handle.IsCompleted);
     }
 
     [Fact]

--- a/tests/KeenEyes.Particles.Tests/ParticleSpawnSystemTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleSpawnSystemTests.cs
@@ -392,16 +392,21 @@ public class ParticleSpawnSystemTests : IDisposable
     [Fact]
     public void SpawnSystem_ConeShape_SpawnsInConeDirection()
     {
-        world = new World();
+        // Seeded so the spawn distribution is reproducible run-to-run; the assertion
+        // below holds for any seed by construction, but seeding removes any dependence
+        // on wall-clock RNG state under parallel load.
+        world = new World(seed: 12345);
         world.InstallPlugin(new ParticlesPlugin());
 
         var center = Vector2.Zero;
-        // Cone pointing right
+        // Cone pointing right (+X)
         var direction = new Vector2(1f, 0f);
-        var coneAngle = MathF.PI / 4f; // 45 degrees
+        var coneAngle = MathF.PI / 4f; // 45 degree total spread => +/-22.5 degrees from the axis
+        var radius = 10f;
         var emitter = ParticleEmitter.Burst(100, 1f) with
         {
-            Shape = EmissionShape.Cone(coneAngle, 10f, direction),
+            // EmissionShape.Cone(radius, angle, direction) - argument order matters.
+            Shape = EmissionShape.Cone(radius, coneAngle, direction),
             StartSpeedMin = 50f,
             StartSpeedMax = 50f
         };
@@ -419,20 +424,22 @@ public class ParticleSpawnSystemTests : IDisposable
         var alive = FindAllAlive(pool);
         Assert.Equal(100, alive.Count);
 
-        // Most velocities should be pointing roughly rightward
-        // Note: With a 45-degree cone angle, particles spread ±22.5° from horizontal
-        // Some particles will have negative X velocity at the cone edges
-        var rightwardCount = 0;
+        // Every particle spawned from a rightward 45-degree cone must travel within
+        // +/-22.5 degrees of the +X axis. This directly verifies the cone constraint:
+        // if the spawn system ignored the cone direction/angle, particles would spread
+        // outside the half-angle and this would fail. A small epsilon absorbs the
+        // floating-point error from the trig round-trip.
+        var halfAngle = coneAngle / 2f;
+        const float epsilon = 1e-4f;
         foreach (var idx in alive)
         {
-            if (pool.VelocitiesX[idx] > 0)
-            {
-                rightwardCount++;
-            }
+            var vx = pool.VelocitiesX[idx];
+            var vy = pool.VelocitiesY[idx];
+            var angleFromAxis = MathF.Atan2(vy, vx); // axis is +X, so this is the deviation
+            Assert.True(
+                MathF.Abs(angleFromAxis) <= halfAngle + epsilon,
+                $"Particle velocity ({vx}, {vy}) deviates {angleFromAxis} rad from the cone axis, exceeding half-angle {halfAngle} rad");
         }
-        // Majority should be rightward given cone direction (allowing for random variance)
-        // With random distribution, we expect at least 25% to point rightward
-        Assert.True(rightwardCount >= 25, $"Expected >=25 rightward, got {rightwardCount}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes #1206 — the last two parallel-flaky tests blocking parallel CI (#1204). Both flaked ~1/15 only under `--max-parallel-test-modules` load, which the serial workaround hid.

**1. `ParticleSpawnSystemTests.SpawnSystem_ConeShape_SpawnsInConeDirection`** — root cause was a **swapped-argument test bug**, not just RNG: the API is `EmissionShape.Cone(radius, angle, direction)` but the test passed `angle`(≈0.785) as radius and `10f` (**10 radians ≈ 573°**) as the spread angle, so only ~37% of particles pointed rightward and the `>= 25` floor sat ~2.7σ above 24. Fixed the argument order to a real 45° cone, seeded the World (`new World(seed: 12345)`), and replaced the weak count-floor with a per-particle assertion that every particle's velocity lies within the cone half-angle — deterministic *and* stronger (catches the spawn system ignoring cone direction/angle).

**2. `JobSchedulerTests.JobHandle_Wait_TimeoutReturnsCorrectly`** — a 10ms timeout raced a 100ms sleep job; under contention the waiter was descheduled past 100ms and `Wait` saw the job already done. Replaced with a `GatedJob` whose completion is externally controlled: gate closed → `Wait(50ms)` must be false / `IsCompleted` false regardless of scheduling; gate open → `Wait(5s)` true. Behavioral assertion (mirrors #1053), still catches a real timeout-handling regression.

## Test plan
- [x] Agent: 20/20 consecutive clean full-suite runs at `--max-parallel-test-modules 32` (0 fail, 0 hang); no third flake
- [x] Reviewer independently re-ran 6× + 3× post-rebase parallel-32 — all clean
- [x] Build 0 warnings; format verify exit 0; clean 2-file diff rebased onto current main

Closes #1206