### PR TITLE
fix(core): ExtensionManager no longer disposes caller-owned or re-set extensions

### DIFF
--- a/src/KeenEyes.Abstractions/IPluginContext.cs
+++ b/src/KeenEyes.Abstractions/IPluginContext.cs
@@ -142,12 +142,19 @@ public interface IPluginContext
     /// </summary>
     /// <typeparam name="T">The extension type.</typeparam>
     /// <param name="extension">The extension instance to store.</param>
+    /// <param name="owned">
+    /// When <c>true</c> (the default) the world takes ownership of the instance and
+    /// disposes it (if it implements <see cref="IDisposable"/>) when it is replaced,
+    /// removed, or the world is disposed. Pass <c>false</c> when registering an instance
+    /// the plugin does not own (for example a caller-supplied or shared object owned by
+    /// another plugin) so it is never disposed by the world on removal.
+    /// </param>
     /// <remarks>
     /// Extensions allow plugins to expose custom APIs to application code.
     /// For example, a physics plugin might expose a <c>PhysicsWorld</c> extension
     /// that provides raycast and collision query methods.
     /// </remarks>
-    void SetExtension<T>(T extension) where T : class;
+    void SetExtension<T>(T extension, bool owned = true) where T : class;
 
     /// <summary>
     /// Removes an extension from the world.

--- a/src/KeenEyes.Core/ExtensionManager.cs
+++ b/src/KeenEyes.Core/ExtensionManager.cs
@@ -25,25 +25,53 @@ internal sealed class ExtensionManager
     private readonly Lock syncRoot = new();
     private readonly Dictionary<Type, object> extensions = [];
 
+    // Types whose current instance is caller-owned (registered with owned: false).
+    // The manager never disposes these on replacement, removal, or clear; the
+    // registrant that created the instance is responsible for disposing it.
+    // Owned extensions are the common case, so tracking only the exceptions keeps
+    // this set small.
+    private readonly HashSet<Type> unownedExtensions = [];
+
     /// <summary>
     /// Sets or updates an extension value.
     /// </summary>
     /// <typeparam name="T">The extension type. Must be a reference type.</typeparam>
     /// <param name="extension">The extension instance to store.</param>
+    /// <param name="owned">
+    /// When <c>true</c> (the default) the manager takes ownership of the instance and
+    /// disposes it (if it implements <see cref="IDisposable"/>) when it is replaced,
+    /// removed, or the world is torn down. When <c>false</c> the caller retains ownership
+    /// and the manager never disposes it.
+    /// </param>
     /// <remarks>
-    /// If an extension of the same type already exists and implements <see cref="IDisposable"/>,
-    /// it will be disposed before being replaced.
+    /// If an owned extension of the same type already exists and implements
+    /// <see cref="IDisposable"/>, it is disposed before being replaced. Re-setting the
+    /// exact same instance never disposes it, regardless of ownership.
     /// </remarks>
-    internal void SetExtension<T>(T extension) where T : class
+    internal void SetExtension<T>(T extension, bool owned = true) where T : class
     {
         ArgumentNullException.ThrowIfNull(extension);
         lock (syncRoot)
         {
-            if (extensions.TryGetValue(typeof(T), out var existing))
+            // Only dispose the previous instance when it is a different, manager-owned
+            // object. Re-setting the same instance (or replacing a caller-owned one)
+            // must never dispose it out from under a live user.
+            if (extensions.TryGetValue(typeof(T), out var existing)
+                && !ReferenceEquals(existing, extension)
+                && !unownedExtensions.Contains(typeof(T)))
             {
                 (existing as IDisposable)?.Dispose();
             }
+
             extensions[typeof(T)] = extension;
+            if (owned)
+            {
+                unownedExtensions.Remove(typeof(T));
+            }
+            else
+            {
+                unownedExtensions.Add(typeof(T));
+            }
         }
     }
 
@@ -107,16 +135,23 @@ internal sealed class ExtensionManager
     /// <typeparam name="T">The extension type to remove.</typeparam>
     /// <returns>True if the extension was found and removed; false otherwise.</returns>
     /// <remarks>
-    /// If the extension implements <see cref="IDisposable"/>, it will be disposed.
+    /// If the extension is manager-owned and implements <see cref="IDisposable"/>, it is
+    /// disposed. Caller-owned extensions (registered with <c>owned: false</c>) are removed
+    /// without being disposed, leaving disposal to the registrant that created them.
     /// </remarks>
     internal bool RemoveExtension<T>() where T : class
     {
         lock (syncRoot)
         {
-            if (extensions.TryGetValue(typeof(T), out var existing))
+            if (extensions.Remove(typeof(T), out var existing))
             {
-                (existing as IDisposable)?.Dispose();
-                return extensions.Remove(typeof(T));
+                // HashSet.Remove returns true when the type was caller-owned; in that
+                // case the manager must not dispose it.
+                if (!unownedExtensions.Remove(typeof(T)))
+                {
+                    (existing as IDisposable)?.Dispose();
+                }
+                return true;
             }
             return false;
         }
@@ -126,17 +161,23 @@ internal sealed class ExtensionManager
     /// Clears all extensions.
     /// </summary>
     /// <remarks>
-    /// All extensions implementing <see cref="IDisposable"/> will be disposed.
+    /// All manager-owned extensions implementing <see cref="IDisposable"/> are disposed.
+    /// Caller-owned extensions (registered with <c>owned: false</c>) are removed without
+    /// being disposed.
     /// </remarks>
     internal void Clear()
     {
         lock (syncRoot)
         {
-            foreach (var extension in extensions.Values)
+            foreach (var (type, extension) in extensions)
             {
-                (extension as IDisposable)?.Dispose();
+                if (!unownedExtensions.Contains(type))
+                {
+                    (extension as IDisposable)?.Dispose();
+                }
             }
             extensions.Clear();
+            unownedExtensions.Clear();
         }
     }
 }

--- a/src/KeenEyes.Core/Plugins/PluginContext.cs
+++ b/src/KeenEyes.Core/Plugins/PluginContext.cs
@@ -149,9 +149,9 @@ public sealed class PluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public void SetExtension<T>(T extension) where T : class
+    public void SetExtension<T>(T extension, bool owned = true) where T : class
     {
-        World.SetExtension(extension);
+        World.SetExtension(extension, owned);
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Core/World.Extensions.cs
+++ b/src/KeenEyes.Core/World.Extensions.cs
@@ -11,6 +11,13 @@ public sealed partial class World
     /// </summary>
     /// <typeparam name="T">The extension type. Must be a reference type.</typeparam>
     /// <param name="extension">The extension instance to store.</param>
+    /// <param name="owned">
+    /// When <c>true</c> (the default) this world takes ownership of the instance and
+    /// disposes it (if it implements <see cref="IDisposable"/>) when it is replaced,
+    /// removed, or the world is disposed. Pass <c>false</c> to register an instance the
+    /// caller owns (for example a shared or externally-provided object) so it is never
+    /// disposed by the world.
+    /// </param>
     /// <remarks>
     /// <para>
     /// Extensions are typically set by plugins to expose custom APIs.
@@ -34,8 +41,8 @@ public sealed partial class World
     /// <seealso cref="GetExtension{T}"/>
     /// <seealso cref="TryGetExtension{T}"/>
     /// <seealso cref="HasExtension{T}"/>
-    public void SetExtension<T>(T extension) where T : class
-        => extensionManager.SetExtension(extension);
+    public void SetExtension<T>(T extension, bool owned = true) where T : class
+        => extensionManager.SetExtension(extension, owned);
 
     /// <summary>
     /// Gets an extension by type.

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
@@ -230,7 +230,9 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         if (streamingManager != null)
         {
             context.RegisterComponent<NavMeshStreamingAnchor>();
-            context.SetExtension(streamingManager);
+            // The streaming manager is caller-owned (see constructor); the caller disposes
+            // it after uninstall, so register it as not owned to keep removal non-disposing.
+            context.SetExtension(streamingManager, owned: false);
             context.AddSystem<NavMeshStreamingSystem>(SystemPhase.Update, order: -200);
         }
 
@@ -239,7 +241,9 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
         if (tileCache != null && carveConfig != null)
         {
             context.RegisterComponent<NavMeshObstacle>();
-            context.SetExtension(tileCache);
+            // The tile cache is caller-owned (see constructor); register it as not owned so
+            // removal on uninstall does not dispose it out from under the caller.
+            context.SetExtension(tileCache, owned: false);
             context.AddSystem(new ObstacleCarveSystem(tileCache, carveConfig), SystemPhase.Update, order: -200);
         }
     }

--- a/src/KeenEyes.Navigation/NavigationPlugin.cs
+++ b/src/KeenEyes.Navigation/NavigationPlugin.cs
@@ -53,6 +53,7 @@ public sealed class NavigationPlugin : IWorldPlugin
     private readonly NavigationConfig config;
     private NavigationContext? navigationContext;
     private INavigationProvider? provider;
+    private bool providerExtensionRegistered;
     private EventSubscription? agentAddedSubscription;
     private EventSubscription? agentRemovedSubscription;
     private EventSubscription? crowdAgentRemovedSubscription;
@@ -104,13 +105,16 @@ public sealed class NavigationPlugin : IWorldPlugin
         context.SetExtension(navigationContext);
 
         // Ensure the INavigationProvider is accessible for direct queries.
-        // In the provider-plugin path (e.g. GridNavigationPlugin) the same instance is
-        // already registered; re-registering it would dispose it, because SetExtension
-        // disposes the extension it replaces. Only register when it is not already present.
+        // The provider is always borrowed: it is either a caller-supplied custom provider
+        // (NavigationConfig.CustomProvider) or one registered by a provider plugin such as
+        // GridNavigationPlugin. This plugin never creates the provider, so it registers it
+        // as caller-owned (owned: false) and never disposes it. In the provider-plugin path
+        // the same instance is already registered, so only register when it is absent.
         if (!context.TryGetExtension<INavigationProvider>(out var registered)
             || !ReferenceEquals(registered, provider))
         {
-            context.SetExtension(provider);
+            context.SetExtension(provider, owned: false);
+            providerExtensionRegistered = true;
         }
 
         // Register systems
@@ -140,19 +144,25 @@ public sealed class NavigationPlugin : IWorldPlugin
 
         // Remove extensions
         context.RemoveExtension<NavigationContext>();
-        context.RemoveExtension<INavigationProvider>();
+
+        // Only remove the INavigationProvider extension if this plugin registered it.
+        // When a provider plugin (e.g. GridNavigationPlugin) owns that registration, it
+        // must stay in place for as long as that plugin is installed. Because the provider
+        // is registered as caller-owned, removal here never disposes it.
+        if (providerExtensionRegistered)
+        {
+            context.RemoveExtension<INavigationProvider>();
+        }
 
         // Dispose the context
         navigationContext?.Dispose();
         navigationContext = null;
 
-        // Dispose provider only if we own it (not custom provided)
-        if (config.Strategy != NavigationStrategy.Custom)
-        {
-            provider?.Dispose();
-        }
-
+        // The provider is always borrowed (a caller-supplied custom provider or one owned
+        // by another plugin), so this plugin never disposes it — the caller or owning
+        // plugin retains that responsibility.
         provider = null;
+        providerExtensionRegistered = false;
 
         // Systems are automatically cleaned up by PluginManager
     }

--- a/src/KeenEyes.Testing/Plugins/MockPluginContext.cs
+++ b/src/KeenEyes.Testing/Plugins/MockPluginContext.cs
@@ -312,7 +312,7 @@ public sealed class MockPluginContext : IPluginContext
     }
 
     /// <inheritdoc />
-    public void SetExtension<T>(T extension) where T : class
+    public void SetExtension<T>(T extension, bool owned = true) where T : class
     {
         ArgumentNullException.ThrowIfNull(extension);
         extensions[typeof(T)] = extension;

--- a/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
+++ b/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
@@ -1,0 +1,73 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Tests for extension ownership semantics (<c>owned</c> flag on <see cref="World.SetExtension{T}"/>).
+/// </summary>
+/// <remarks>
+/// Extensions default to manager-owned (disposed on replace/remove/world teardown).
+/// Registering with <c>owned: false</c> keeps the caller responsible for disposal,
+/// which is how shared or externally-supplied instances survive plugin uninstall
+/// (see issue #1171).
+/// </remarks>
+public class ExtensionOwnershipTests
+{
+    [Fact]
+    public void RemoveExtension_WhenCallerOwned_DoesNotDisposeExtension()
+    {
+        using var world = new World();
+        var extension = new DisposableTestExtension();
+        world.SetExtension(extension, owned: false);
+
+        var removed = world.RemoveExtension<DisposableTestExtension>();
+
+        Assert.True(removed);
+        Assert.False(extension.IsDisposed);
+        Assert.Equal(0, extension.DisposeCount);
+        Assert.False(world.HasExtension<DisposableTestExtension>());
+    }
+
+    [Fact]
+    public void SetExtension_ReplacingCallerOwnedWithDifferentInstance_DoesNotDisposeOld()
+    {
+        using var world = new World();
+        var original = new DisposableTestExtension();
+        world.SetExtension(original, owned: false);
+
+        world.SetExtension(new DisposableTestExtension());
+
+        Assert.False(original.IsDisposed);
+        Assert.Equal(0, original.DisposeCount);
+    }
+
+    [Fact]
+    public void WorldDispose_WithCallerOwnedExtension_DoesNotDisposeIt()
+    {
+        var extension = new DisposableTestExtension();
+        var world = new World();
+        world.SetExtension(extension, owned: false);
+
+        world.Dispose();
+
+        Assert.False(extension.IsDisposed);
+    }
+
+    [Fact]
+    public void SetExtension_ReRegisteringCallerOwnedAsOwned_ThenRemoving_DisposesIt()
+    {
+        // Ownership follows the most recent registration: re-registering a caller-owned
+        // instance as owned makes the manager responsible for disposing it on removal.
+        using var world = new World();
+        var extension = new DisposableTestExtension();
+
+        world.SetExtension(extension, owned: false);
+        world.SetExtension(extension, owned: true); // Same instance, now owned.
+
+        // Re-setting the same instance never disposes it, regardless of ownership change.
+        Assert.False(extension.IsDisposed);
+
+        world.RemoveExtension<DisposableTestExtension>();
+
+        Assert.True(extension.IsDisposed);
+        Assert.Equal(1, extension.DisposeCount);
+    }
+}

--- a/tests/KeenEyes.Core.Tests/ExtensionTests.cs
+++ b/tests/KeenEyes.Core.Tests/ExtensionTests.cs
@@ -255,6 +255,38 @@ public class WorldExtensionTests
     }
 
     [Fact]
+    public void SetExtension_ReSettingSameInstance_DoesNotDisposeIt()
+    {
+        // Regression test for #1149: re-setting the SAME instance must not dispose it.
+        using var world = new World();
+        var extension = new DisposableTestExtension();
+
+        world.SetExtension(extension);
+        world.SetExtension(extension); // Same instance again.
+
+        Assert.False(extension.IsDisposed);
+        Assert.Equal(0, extension.DisposeCount);
+        Assert.True(world.HasExtension<DisposableTestExtension>());
+        Assert.Same(extension, world.GetExtension<DisposableTestExtension>());
+    }
+
+    [Fact]
+    public void RemoveExtension_WhenManagerOwned_DisposesExtension()
+    {
+        // No-leak regression guard: a genuinely manager-owned extension (the default)
+        // must still be disposed on removal.
+        using var world = new World();
+        var extension = new DisposableTestExtension();
+        world.SetExtension(extension);
+
+        var removed = world.RemoveExtension<DisposableTestExtension>();
+
+        Assert.True(removed);
+        Assert.True(extension.IsDisposed);
+        Assert.Equal(1, extension.DisposeCount);
+    }
+
+    [Fact]
     public void SetExtension_ReplacingMultipleTimes_DisposesEachPrevious()
     {
         using var world = new World();

--- a/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationPluginTests.cs
@@ -130,6 +130,57 @@ public class NavigationPluginTests : IDisposable
         world.TryGetExtension<NavigationContext>(out _).ShouldBeFalse();
     }
 
+    [Fact]
+    public void Uninstall_WithCustomProvider_DoesNotDisposeCallerOwnedProvider()
+    {
+        // Regression test for #1171: a caller-supplied custom provider is owned by the
+        // caller. Uninstalling the plugin must remove the registration WITHOUT disposing
+        // the provider, which the caller still holds and may reuse.
+        world = new World();
+
+        var inner = new GridNavigationProvider(GridConfig.WithSize(100, 100, 1f));
+        var customProvider = new DisposalTrackingNavigationProvider(inner);
+
+        var config = new NavigationConfig
+        {
+            Strategy = NavigationStrategy.Custom,
+            CustomProvider = customProvider
+        };
+        world.InstallPlugin(new NavigationPlugin(config));
+
+        world.UninstallPlugin<NavigationPlugin>();
+
+        // Caller-owned: never disposed by the plugin/world.
+        customProvider.DisposeCount.ShouldBe(0);
+        // The registration this plugin added is removed.
+        world.TryGetExtension<INavigationProvider>(out _).ShouldBeFalse();
+
+        // The caller can still dispose it exactly once, itself.
+        customProvider.Dispose();
+        customProvider.DisposeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Uninstall_WithSharedProviderPlugin_LeavesProviderOwnedByOtherPluginRegistered()
+    {
+        // Regression test for #1171: when GridNavigationPlugin owns the provider and is
+        // still installed, uninstalling the consumer NavigationPlugin must not remove or
+        // dispose the shared provider.
+        world = new World();
+
+        world.InstallPlugin(new GridNavigationPlugin(GridConfig.WithSize(100, 100, 1f)));
+        world.InstallPlugin(new NavigationPlugin());
+
+        var provider = world.GetExtension<INavigationProvider>();
+
+        world.UninstallPlugin<NavigationPlugin>();
+
+        // The provider belongs to GridNavigationPlugin (still installed): its registration
+        // must survive and remain the same instance.
+        world.TryGetExtension<INavigationProvider>(out var stillRegistered).ShouldBeTrue();
+        stillRegistered.ShouldBeSameAs(provider);
+    }
+
     #endregion
 
     #region Component Registration Tests
@@ -299,4 +350,54 @@ public class NavigationPluginTests : IDisposable
     }
 
     #endregion
+}
+
+/// <summary>
+/// A caller-owned <see cref="INavigationProvider"/> that delegates to an inner provider
+/// and records how many times it is disposed. Used to verify that plugin uninstall does
+/// not dispose providers the caller owns (issue #1171).
+/// </summary>
+internal sealed class DisposalTrackingNavigationProvider(INavigationProvider inner) : INavigationProvider
+{
+    public int DisposeCount { get; private set; }
+
+    public NavigationStrategy Strategy => inner.Strategy;
+
+    public bool IsReady => inner.IsReady;
+
+    public INavigationMesh? ActiveMesh => inner.ActiveMesh;
+
+    public NavPath FindPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+        => inner.FindPath(start, end, agent, areaMask);
+
+    public IPathRequest RequestPath(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask = NavAreaMask.All)
+        => inner.RequestPath(start, end, agent, areaMask);
+
+    public void CancelAllRequests() => inner.CancelAllRequests();
+
+    public bool Raycast(Vector3 start, Vector3 end, out Vector3 hitPosition)
+        => inner.Raycast(start, end, out hitPosition);
+
+    public bool Raycast(Vector3 start, Vector3 end, NavAreaMask areaMask, out Vector3 hitPosition, out NavAreaType hitAreaType)
+        => inner.Raycast(start, end, areaMask, out hitPosition, out hitAreaType);
+
+    public NavPoint? FindNearestPoint(Vector3 position, float searchRadius = 10f)
+        => inner.FindNearestPoint(position, searchRadius);
+
+    public bool IsNavigable(Vector3 position, AgentSettings agent) => inner.IsNavigable(position, agent);
+
+    public Vector3? ProjectToNavMesh(Vector3 position, float maxDistance = 5f)
+        => inner.ProjectToNavMesh(position, maxDistance);
+
+    public float GetAreaCost(NavAreaType areaType) => inner.GetAreaCost(areaType);
+
+    public void SetAreaCost(NavAreaType areaType, float cost) => inner.SetAreaCost(areaType, cost);
+
+    public void Update(float deltaTime) => inner.Update(deltaTime);
+
+    public void Dispose()
+    {
+        DisposeCount++;
+        inner.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #1149 and #1171 — one root: `ExtensionManager` disposed extensions unconditionally.
- **#1149:** `SetExtension` now guards `!ReferenceEquals(existing, extension)` — re-setting the same instance never disposes the live object.
- **#1171:** introduces lightweight **ownership tracking**. `SetExtension`/`World.SetExtension`/`IPluginContext.SetExtension` gain an additive `bool owned = true` param (no caller breaks). `owned: true` (default) preserves the existing dispose-on-replace/remove/clear behavior for manager-owned extensions — verified by an audit of all ~90 call sites (every plugin that registers an `IDisposable` already disposes it in its own Uninstall; nothing relied solely on removal-disposal). `owned: false` = caller retains ownership, never disposed by the manager. `NavigationPlugin`/`DotRecastNavigationPlugin` now register their borrowed providers/managers `owned: false` and only remove registrations they actually added.

Chose ownership tracking over "removal never disposes" because the latter would break the `World.Dispose()` teardown safety net (pinned by existing tests) and can't satisfy the "manager-owned IS still disposed" no-leak guard.

## Test plan
- [x] 4 fail-on-old/pass-on-new regression tests (same-instance re-set; caller-owned survives uninstall; shared-provider survives; manager-owned still disposed) + 4 ownership unit tests
- [x] Full suite 14,465 passed / 0 failed; Core 2309, Navigation 48 (independently re-verified); build 0 warnings; format exit 0

## Related Issues
Closes #1149
Closes #1171