### PR TITLE
fix(navigation): Correct DotRecast poly refs, area types, obstacle wiring, and agent/grid pathing

### DIFF
--- a/src/KeenEyes.Navigation.Abstractions/INavigationMesh.cs
+++ b/src/KeenEyes.Navigation.Abstractions/INavigationMesh.cs
@@ -103,5 +103,5 @@ public interface INavigationMesh
     /// </summary>
     /// <param name="polygonId">The polygon identifier.</param>
     /// <returns>The vertices of the polygon, or an empty span if invalid.</returns>
-    ReadOnlySpan<Vector3> GetPolygonVertices(uint polygonId);
+    ReadOnlySpan<Vector3> GetPolygonVertices(long polygonId);
 }

--- a/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
+++ b/src/KeenEyes.Navigation.Abstractions/NavPoint.cs
@@ -25,7 +25,7 @@ namespace KeenEyes.Navigation.Abstractions;
 public readonly record struct NavPoint(
     Vector3 Position,
     NavAreaType AreaType = NavAreaType.Walkable,
-    uint PolygonId = 0,
+    long PolygonId = 0,
     NavPointProperties Properties = NavPointProperties.None)
 {
     /// <summary>

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastMeshBuilder.cs
@@ -286,9 +286,19 @@ public sealed class DotRecastMeshBuilder
         var navMesh = new DtNavMesh();
         navMesh.Init(navMeshParams, config.MaxVertsPerPoly);
 
-        foreach (var meshData in tiles)
+        for (int i = 0; i < tiles.Count; i++)
         {
-            navMesh.AddTile(meshData, 0, 0, out _);
+            // Surface AddTile failures instead of silently dropping tiles. The
+            // navmesh caps tile capacity at maxTiles (1 << 14 = 16384), so a world
+            // with more non-empty tiles than that would otherwise lose geometry
+            // with no diagnostic.
+            var addStatus = navMesh.AddTile(tiles[i], 0, 0, out _);
+            if (addStatus.Failed())
+            {
+                throw new InvalidOperationException(
+                    $"Failed to add navmesh tile {i} of {tiles.Count} (status: {addStatus.Value}). " +
+                    "The tile count may exceed the navmesh capacity of 16384 tiles.");
+            }
         }
 
         return new NavMeshData(navMesh, config.ToAgentSettings());
@@ -559,14 +569,29 @@ public sealed class DotRecastMeshBuilder
     /// <summary>
     /// Assigns a walkable polygon flag to every non-null-area polygon so the default
     /// Detour query filter (which requires at least one include flag bit set) can
-    /// traverse them.
+    /// traverse them, and remaps Recast's default walkable area sentinel to a valid
+    /// <see cref="NavAreaType"/>.
     /// </summary>
+    /// <remarks>
+    /// Recast voxelizes walkable spans with <see cref="RcRecast.RC_WALKABLE_AREA"/>
+    /// (63), which is required during region building but falls outside the 0-31
+    /// <see cref="NavAreaType"/> range. Left as-is, area-cost lookups (which index a
+    /// 32-entry table) can never target ground polygons, so
+    /// <c>SetAreaCost(NavAreaType.Walkable, ...)</c> would have no effect. Remapping
+    /// the sentinel to <see cref="NavAreaType.Walkable"/> here keeps custom
+    /// per-triangle areas intact while making default ground terrain cost-adjustable.
+    /// </remarks>
     private static void MarkWalkablePolys(RcPolyMesh mesh)
     {
         for (int i = 0; i < mesh.npolys; i++)
         {
             if (mesh.areas[i] != RcRecast.RC_NULL_AREA)
             {
+                if (mesh.areas[i] == RcRecast.RC_WALKABLE_AREA)
+                {
+                    mesh.areas[i] = (int)NavAreaType.Walkable;
+                }
+
                 mesh.flags[i] = 1;
             }
         }

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastNavigationPlugin.cs
@@ -212,8 +212,10 @@ public sealed class DotRecastNavigationPlugin : IWorldPlugin
             ? new DotRecastProvider(prebuiltMesh, config)
             : new DotRecastProvider(config);
 
-        // Create obstacle manager for dynamic carving
+        // Create obstacle manager for dynamic carving and connect it to the
+        // provider so manager-added obstacles exclude polygons during queries.
         obstacleManager = new NavMeshObstacleManager();
+        provider.SetObstacleManager(obstacleManager);
 
         // Register the provider as both the concrete type and the interface
         context.SetExtension(provider);

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
@@ -33,6 +33,7 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
     private NavMeshData? activeMesh;
     private NavMeshQueryPool? queryPool;
     private DotRecastCrowdManager? crowdManager;
+    private NavMeshObstacleManager? obstacleManager;
     private bool disposed;
 
     /// <summary>
@@ -128,6 +129,21 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
         crowdManager?.SetNavMesh(navMeshData);
     }
 
+    /// <summary>
+    /// Attaches an obstacle manager whose obstacles are consulted during query
+    /// filter construction so that polygons covered by dynamic obstacles are
+    /// excluded from pathfinding.
+    /// </summary>
+    /// <param name="manager">
+    /// The obstacle manager to consult, or <see langword="null"/> to stop
+    /// consulting any obstacle manager.
+    /// </param>
+    public void SetObstacleManager(NavMeshObstacleManager? manager)
+    {
+        ThrowIfDisposed();
+        obstacleManager = manager;
+    }
+
     #region Pathfinding
 
     /// <inheritdoc/>
@@ -204,7 +220,7 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
                 ? NavPointProperties.OffMeshConnection
                 : NavPointProperties.None;
 
-            waypoints[i] = new NavPoint(pos, (NavAreaType)area, (uint)pt.refs, properties);
+            waypoints[i] = new NavPoint(pos, (NavAreaType)area, pt.refs, properties);
 
             if (i > 0)
             {
@@ -586,10 +602,50 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
     private IDtQueryFilter CreateFilter(NavAreaMask areaMask)
     {
         // DtQueryDefaultFilter constructor takes include flags, exclude flags, and area costs array
-        return new DtQueryDefaultFilter((int)areaMask, 0, areaCosts);
+        var baseFilter = new DtQueryDefaultFilter((int)areaMask, 0, areaCosts);
+
+        // Consult the obstacle manager (if attached) so polygons covered by
+        // dynamic obstacles are excluded from queries that use this filter.
+        if (obstacleManager != null && activeMesh != null && obstacleManager.ObstacleCount > 0)
+        {
+            var excluded = new List<long>();
+            obstacleManager.GetExcludedPolygons(activeMesh.InternalNavMesh, excluded);
+            if (excluded.Count > 0)
+            {
+                return new ObstacleExclusionFilter(baseFilter, excluded);
+            }
+        }
+
+        return baseFilter;
     }
 
     private static Vector3 ToVector3(RcVec3f v) => new(v.X, v.Y, v.Z);
 
     private static RcVec3f ToRcVec3f(Vector3 v) => new(v.X, v.Y, v.Z);
+
+    /// <summary>
+    /// Query filter that excludes a fixed set of polygon references (those
+    /// covered by dynamic obstacles) on top of a wrapped base filter.
+    /// </summary>
+    private sealed class ObstacleExclusionFilter(IDtQueryFilter inner, IEnumerable<long> excluded) : IDtQueryFilter
+    {
+        private readonly HashSet<long> excluded = [.. excluded];
+
+        public bool PassFilter(long refs, DtMeshTile tile, DtPoly poly)
+            => !excluded.Contains(refs) && inner.PassFilter(refs, tile, poly);
+
+        public float GetCost(
+            RcVec3f pa,
+            RcVec3f pb,
+            long prevRef,
+            DtMeshTile prevTile,
+            DtPoly prevPoly,
+            long curRef,
+            DtMeshTile curTile,
+            DtPoly curPoly,
+            long nextRef,
+            DtMeshTile nextTile,
+            DtPoly nextPoly)
+            => inner.GetCost(pa, pb, prevRef, prevTile, prevPoly, curRef, curTile, curPoly, nextRef, nextTile, nextPoly);
+    }
 }

--- a/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
+++ b/src/KeenEyes.Navigation.DotRecast/NavMeshData.cs
@@ -127,7 +127,7 @@ public sealed class NavMeshData : INavigationMesh
         }
 
         navMesh.GetPolyArea(nearestRef, out var area);
-        return new NavPoint(ToVector3(nearestPt), (NavAreaType)area, (uint)nearestRef);
+        return new NavPoint(ToVector3(nearestPt), (NavAreaType)area, nearestRef);
     }
 
     /// <inheritdoc/>
@@ -145,7 +145,7 @@ public sealed class NavMeshData : INavigationMesh
         }
 
         navMesh.GetPolyArea(randomRef, out var area);
-        return new NavPoint(ToVector3(randomPt), (NavAreaType)area, (uint)randomRef);
+        return new NavPoint(ToVector3(randomPt), (NavAreaType)area, randomRef);
     }
 
     /// <inheritdoc/>
@@ -173,7 +173,7 @@ public sealed class NavMeshData : INavigationMesh
         }
 
         navMesh.GetPolyArea(randomRef, out var area);
-        return new NavPoint(ToVector3(randomPt), (NavAreaType)area, (uint)randomRef);
+        return new NavPoint(ToVector3(randomPt), (NavAreaType)area, randomRef);
     }
 
     /// <inheritdoc/>
@@ -259,7 +259,7 @@ public sealed class NavMeshData : INavigationMesh
     }
 
     /// <inheritdoc/>
-    public ReadOnlySpan<Vector3> GetPolygonVertices(uint polygonId)
+    public ReadOnlySpan<Vector3> GetPolygonVertices(long polygonId)
     {
         navMesh.GetTileAndPolyByRef(polygonId, out var tile, out var poly);
 

--- a/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
@@ -302,9 +302,10 @@ public sealed class GridNavigationProvider : INavigationProvider
                 grid.GetAreaType(centerCoord));
         }
 
-        // Spiral outward
+        // Spiral outward, checking the perimeter (Chebyshev ring) at each radius.
         float bestDistSq = float.MaxValue;
         GridCoordinate? best = null;
+        int? firstHitRing = null;
 
         for (int r = 1; r <= radiusCells; r++)
         {
@@ -333,10 +334,17 @@ public sealed class GridNavigationProvider : INavigationProvider
                 }
             }
 
-            // If we found something at this radius, we're done
+            // The first ring with a hit does not guarantee the nearest cell: a
+            // straight-line cell in ring r+1 (distance r+1) can be closer than a
+            // diagonal cell in ring r (distance up to r*sqrt(2)). Scan one extra
+            // ring beyond the first hit before committing to the true minimum.
             if (best.HasValue)
             {
-                break;
+                firstHitRing ??= r;
+                if (r >= firstHitRing.Value + 1)
+                {
+                    break;
+                }
             }
         }
 

--- a/src/KeenEyes.Navigation/NavigationContext.cs
+++ b/src/KeenEyes.Navigation/NavigationContext.cs
@@ -351,7 +351,7 @@ public sealed class NavigationContext : IDisposable
 
     private void RequestPathForAgent(Entity entity, Vector3 destination)
     {
-        if (provider == null || !world.Has<NavMeshAgent>(entity))
+        if (!world.Has<NavMeshAgent>(entity))
         {
             return;
         }
@@ -359,9 +359,15 @@ public sealed class NavigationContext : IDisposable
         // Cancel any existing request
         CancelRequestForAgent(entity);
 
-        // Get agent's current position from Transform3D
-        if (!world.Has<Common.Transform3D>(entity))
+        // A path request can only be enqueued when there is an active provider
+        // and a source position (Transform3D). SetDestination already marked the
+        // agent PathPending; if the request cannot be enqueued, clear that flag so
+        // the agent is not left stuck "computing" forever. NavMeshAgentSystem skips
+        // PathPending agents, so a stuck flag would silently freeze the agent.
+        if (provider == null || !world.Has<Common.Transform3D>(entity))
         {
+            ref var stuckAgent = ref world.Get<NavMeshAgent>(entity);
+            stuckAgent.PathPending = false;
             return;
         }
 

--- a/tests/KeenEyes.Navigation.Abstractions.Tests/NavPointTests.cs
+++ b/tests/KeenEyes.Navigation.Abstractions.Tests/NavPointTests.cs
@@ -16,7 +16,7 @@ public class NavPointTests
 
         Assert.Equal(position, point.Position);
         Assert.Equal(NavAreaType.Road, point.AreaType);
-        Assert.Equal(42u, point.PolygonId);
+        Assert.Equal(42L, point.PolygonId);
     }
 
     [Fact]
@@ -26,7 +26,20 @@ public class NavPointTests
         var point = new NavPoint(position);
 
         Assert.Equal(NavAreaType.Walkable, point.AreaType);
-        Assert.Equal(0u, point.PolygonId);
+        Assert.Equal(0L, point.PolygonId);
+    }
+
+    [Fact]
+    public void Constructor_PolygonIdAboveUInt32Range_PreservesFullValue()
+    {
+        // Regression for #1169: DotRecast packs salt/tile bits above bit 32, so
+        // PolygonId must be a 64-bit value. A ref that only differs from its
+        // uint-truncated form in the high bits must round-trip intact.
+        long polyRef = (1L << 40) | 49L;
+        var point = new NavPoint(new Vector3(1f, 2f, 3f), NavAreaType.Walkable, polyRef);
+
+        Assert.Equal(polyRef, point.PolygonId);
+        Assert.NotEqual((long)(uint)polyRef, point.PolygonId);
     }
 
     [Fact]

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
@@ -467,9 +467,9 @@ public class DotRecastProviderTests : IDisposable
     public void FindPath_AfterRemovingManagerObstacle_ReturnsToStraightCorridor()
     {
         // Removing the obstacle from the manager must stop excluding its polygons.
-        var navMesh = TestHelper.BuildTestNavMesh();
+        var testNavMesh = TestHelper.BuildTestNavMesh();
         using var world = new World();
-        world.InstallPlugin(new DotRecastNavigationPlugin(navMesh, TestHelper.CreateTestConfig()));
+        world.InstallPlugin(new DotRecastNavigationPlugin(testNavMesh, TestHelper.CreateTestConfig()));
 
         var pathProvider = world.GetExtension<DotRecastProvider>();
         var obstacles = world.GetExtension<NavMeshObstacleManager>();

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
@@ -437,9 +437,9 @@ public class DotRecastProviderTests : IDisposable
         // but the provider never consulted it, so obstacles added through it had zero
         // effect on pathfinding. With the wiring in place, an obstacle straddling the
         // straight corridor must push the path around the excluded polygons.
-        var navMesh = TestHelper.BuildTestNavMesh();
+        var testNavMesh = TestHelper.BuildTestNavMesh();
         using var world = new World();
-        world.InstallPlugin(new DotRecastNavigationPlugin(navMesh, TestHelper.CreateTestConfig()));
+        world.InstallPlugin(new DotRecastNavigationPlugin(testNavMesh, TestHelper.CreateTestConfig()));
 
         var pathProvider = world.GetExtension<DotRecastProvider>();
         var obstacles = world.GetExtension<NavMeshObstacleManager>();

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
@@ -427,4 +427,79 @@ public class DotRecastProviderTests : IDisposable
     }
 
     #endregion
+
+    #region Obstacle Manager Regression Tests
+
+    [Fact]
+    public void FindPath_WithObstacleAddedViaPluginManager_DetoursAroundExcludedPolygons()
+    {
+        // Regression for #1168: the plugin created and exposed a NavMeshObstacleManager,
+        // but the provider never consulted it, so obstacles added through it had zero
+        // effect on pathfinding. With the wiring in place, an obstacle straddling the
+        // straight corridor must push the path around the excluded polygons.
+        var navMesh = TestHelper.BuildTestNavMesh();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(navMesh, TestHelper.CreateTestConfig()));
+
+        var pathProvider = world.GetExtension<DotRecastProvider>();
+        var obstacles = world.GetExtension<NavMeshObstacleManager>();
+
+        var start = new Vector3(20f, 0f, 100f);
+        var end = new Vector3(180f, 0f, 100f);
+
+        var baseline = pathProvider.FindPath(start, end, AgentSettings.Default);
+        Assert.True(baseline.IsValid, "Baseline path across open terrain should be valid.");
+        Assert.True(
+            MaxAbsZDeviation(baseline, 100f) < 5f,
+            "Baseline path should follow the straight corridor.");
+
+        obstacles.AddBoxObstacle(new Vector3(100f, 0f, 100f), new Vector3(30f, 5f, 30f));
+
+        var detoured = pathProvider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(detoured.IsValid, "Path should still route around the obstacle.");
+        Assert.True(
+            MaxAbsZDeviation(detoured, 100f) > 5f,
+            "The manager-added obstacle must push the path off the straight corridor.");
+    }
+
+    [Fact]
+    public void FindPath_AfterRemovingManagerObstacle_ReturnsToStraightCorridor()
+    {
+        // Removing the obstacle from the manager must stop excluding its polygons.
+        var navMesh = TestHelper.BuildTestNavMesh();
+        using var world = new World();
+        world.InstallPlugin(new DotRecastNavigationPlugin(navMesh, TestHelper.CreateTestConfig()));
+
+        var pathProvider = world.GetExtension<DotRecastProvider>();
+        var obstacles = world.GetExtension<NavMeshObstacleManager>();
+
+        var start = new Vector3(20f, 0f, 100f);
+        var end = new Vector3(180f, 0f, 100f);
+
+        int obstacleId = obstacles.AddBoxObstacle(new Vector3(100f, 0f, 100f), new Vector3(30f, 5f, 30f));
+        var detoured = pathProvider.FindPath(start, end, AgentSettings.Default);
+        Assert.True(MaxAbsZDeviation(detoured, 100f) > 5f, "Precondition: obstacle should force a detour.");
+
+        obstacles.RemoveObstacle(obstacleId);
+        var cleared = pathProvider.FindPath(start, end, AgentSettings.Default);
+
+        Assert.True(cleared.IsValid);
+        Assert.True(
+            MaxAbsZDeviation(cleared, 100f) < 5f,
+            "Removing the obstacle should restore the straight corridor.");
+    }
+
+    private static float MaxAbsZDeviation(NavPath path, float baseZ)
+    {
+        float max = 0f;
+        foreach (var waypoint in path)
+        {
+            max = MathF.Max(max, MathF.Abs(waypoint.Position.Z - baseZ));
+        }
+
+        return max;
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastTiledBuildTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastTiledBuildTests.cs
@@ -39,8 +39,8 @@ public class DotRecastTiledBuildTests
     }
 
     // Counts how many distinct grid tiles the path's waypoints fall into, derived from
-    // the navmesh tile grid (origin + tile footprint). This does not rely on the
-    // waypoint polygon refs, which the provider stores as a lossy uint cast.
+    // the navmesh tile grid (origin + tile footprint) rather than the waypoint polygon
+    // refs, so the count is independent of how refs are encoded.
     private static int CountDistinctTilesAlongPath(NavMeshData mesh, NavPath path)
     {
         ref readonly var navParams = ref mesh.InternalNavMesh.GetParams();

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshDataTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/NavMeshDataTests.cs
@@ -254,6 +254,55 @@ public class NavMeshDataTests
 
     #endregion
 
+    #region Poly Ref And Area Regression Tests
+
+    [Fact]
+    public void FindNearestPoint_ReturnedPolygonId_RoundTripsToPolygonVertices()
+    {
+        // Regression for #1169: DotRecast packs salt/tile bits above bit 32, so
+        // truncating the poly ref to uint broke GetTileAndPolyByRef's salt check
+        // and GetPolygonVertices returned 0 vertices for a valid nearest point.
+        Assert.NotNull(navMesh);
+
+        var point = navMesh.FindNearestPoint(new Vector3(100f, 0f, 100f));
+        Assert.NotNull(point);
+        Assert.NotEqual(0L, point.Value.PolygonId);
+
+        var vertices = navMesh.GetPolygonVertices(point.Value.PolygonId);
+        Assert.True(
+            vertices.Length >= 3,
+            $"Expected the nearest polygon to round-trip to >=3 vertices, got {vertices.Length}.");
+    }
+
+    [Fact]
+    public void GetAreaType_OverWalkableGround_ReturnsWalkableNotRecastSentinel()
+    {
+        // Regression for #1170: ground polys were built with Recast's RC_WALKABLE_AREA
+        // (63), which is outside the 0-31 NavAreaType range, so SetAreaCost could never
+        // influence terrain cost. Walkable ground must report NavAreaType.Walkable.
+        Assert.NotNull(navMesh);
+
+        var areaType = navMesh.GetAreaType(new Vector3(100f, 0f, 100f));
+
+        Assert.Equal(NavAreaType.Walkable, areaType);
+        Assert.NotEqual(63, (int)areaType);
+    }
+
+    [Fact]
+    public void GetPolygonSurfaces_OverWalkableGround_AllAreasInValidRange()
+    {
+        // Regression for #1170: every surface area must fall in the 0-31 range that
+        // the area-cost table can address (63 is the out-of-range Recast sentinel).
+        Assert.NotNull(navMesh);
+
+        foreach (var surface in navMesh.GetPolygonSurfaces())
+        {
+            Assert.InRange((int)surface.Area, 0, 31);
+        }
+    }
+
+    #endregion
+
     #region GetPolygonSurfaces Tests
 
     [Fact]

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
@@ -314,6 +314,27 @@ public class GridNavigationProviderTests : IDisposable
     }
 
     [Fact]
+    public void FindNearestPoint_StraightCellInNextRing_ReturnsTrueNearestNotFirstRingHit()
+    {
+        // Regression for #1174: the search broke after the first ring containing any
+        // hit, but a straight-line cell one ring further out can be Euclidean-closer
+        // than a diagonal cell in the first-hit ring ((r+1) < r*sqrt(2) for r >= 3).
+        // Center at cell (10,10); leave only two walkable cells:
+        //   (13,13) -> diagonal in ring 3, distance sqrt(18) ~= 4.243
+        //   (14,10) -> straight  in ring 4, distance 4.0 (the true nearest)
+        provider.Grid.Fill(new GridCoordinate(0, 0), new GridCoordinate(19, 19), GridCell.Blocked);
+        provider.Grid[13, 13] = GridCell.Walkable;
+        provider.Grid[14, 10] = GridCell.Walkable;
+
+        var center = provider.Grid.ToWorldPosition(new GridCoordinate(10, 10));
+        var point = provider.FindNearestPoint(center, searchRadius: 6f);
+
+        Assert.NotNull(point);
+        var expected = provider.Grid.ToWorldPosition(new GridCoordinate(14, 10));
+        Assert.Equal(expected, point.Value.Position);
+    }
+
+    [Fact]
     public void FindNearestPoint_NoWalkableInRadius_ReturnsNull()
     {
         // Block a large area

--- a/tests/KeenEyes.Navigation.Tests/NavigationContextTests.cs
+++ b/tests/KeenEyes.Navigation.Tests/NavigationContextTests.cs
@@ -98,6 +98,25 @@ public class NavigationContextTests : IDisposable
     }
 
     [Fact]
+    public void SetDestination_WithoutTransform3D_DoesNotLeaveAgentPathPending()
+    {
+        // Regression for #1173: SetDestination marked the agent PathPending before the
+        // path request early-returned on the missing Transform3D. Because
+        // NavMeshAgentSystem skips PathPending agents, the flag stuck forever and the
+        // agent silently froze. The request must clear PathPending when it cannot be
+        // enqueued.
+        var entity = world.Spawn()
+            .With(NavMeshAgent.Create())
+            .Build();
+
+        context.SetDestination(entity, new Vector3(10, 0, 10));
+
+        ref readonly var agent = ref world.Get<NavMeshAgent>(entity);
+        agent.PathPending.ShouldBeFalse();
+        context.PendingRequestCount.ShouldBe(0);
+    }
+
+    [Fact]
     public void SetDestination_CalledTwice_CancelsPreviousRequest()
     {
         var entity = world.Spawn()


### PR DESCRIPTION
## Summary
Fixes the navigation correctness cluster from the deep review — the DotRecast path was substantially non-functional. DotRecast 2026.1.3 API names verified against the installed package.

- **#1169 (high):** widened `NavPoint.PolygonId` and `INavigationMesh.GetPolygonVertices` from `uint`→`long`; removed the truncating casts (`DotRecastProvider:207`, `NavMeshData` ×3) that stripped DotRecast's salt/tile bits, so returned `PolygonId`s now round-trip through `GetTileAndPolyByRef` (`GetPolygonVertices` returns real verts, was 0).
- **#1170 (high):** `MarkWalkablePolys` remaps the `RC_WALKABLE_AREA` (63) sentinel to `NavAreaType.Walkable` (0) after the poly mesh is built, so `GetAreaType` is correct and `SetAreaCost` affects terrain again.
- **#1168 (high):** `DotRecastProvider.CreateFilter` now consults an attached `NavMeshObstacleManager` via an `ObstacleExclusionFilter` wrapper (`SetObstacleManager` + one-line plugin `Install` wiring) — manager-added obstacles finally affect pathfinding.
- **#1172 (low):** `BuildTiled` checks `AddTile`'s `DtStatus` and throws a diagnostic on failure instead of silently dropping tiles.
- **#1173 (medium):** `RequestPathForAgent` clears `PathPending` when it can't enqueue (no provider / no `Transform3D`) instead of leaving the agent stuck forever.
- **#1174 (medium):** `GridNavigationProvider.FindNearestPoint` scans one extra ring past the first hit and returns the true nearest cell.

## Test plan
- [x] Per-issue fail-on-old/pass-on-new tests (compile-level for the #1169 API widening; behavioral for the rest)
- [x] Nav suites: DotRecast 121 (+52 pre-existing skips), Navigation 47, Grid 168, Abstractions 128 — all pass; full suite 14,465 / 0 failed; build 0 warnings; format exit 0 (independently re-verified)

## Related Issues
Closes #1168
Closes #1169
Closes #1170
Closes #1172
Closes #1173
Closes #1174

Note: touches `DotRecastNavigationPlugin.cs` `Install` (obstacle wiring), which #1209 also edits (disposal) — different regions; whichever merges second may need a trivial rebase (I'll handle it).