### PR TITLE
fix(generators): Make bundle/serializer/replicated codegen compile for all component shapes

### DIFF
--- a/editor/KeenEyes.Generators/BundleGenerator.cs
+++ b/editor/KeenEyes.Generators/BundleGenerator.cs
@@ -181,7 +181,9 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (field.IsStatic || field.IsConst)
+            // Skip compiler-generated fields (e.g. auto-property backing fields),
+            // whose names like <Foo>k__BackingField are not valid C# identifiers.
+            if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }
@@ -332,7 +334,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
 
         foreach (var member in typeSymbol.GetMembers())
         {
-            if (member is not IFieldSymbol field || field.IsStatic || field.IsConst)
+            if (member is not IFieldSymbol field || field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }
@@ -639,7 +641,26 @@ public sealed class BundleGenerator : IIncrementalGenerator
     /// </summary>
     private static void GenerateFieldAddition(StringBuilder sb, ComponentFieldInfo field, string bundleVar, string worldVar, string entityVar, string indent = "        ")
     {
-        if (field.IsOptional && field.IsNullable)
+        if (field.IsBundle)
+        {
+            // Nested bundles are not components; recurse into the generated
+            // Add{BundleName}(World, Entity, bundle) overload for that bundle type.
+            var nestedBundleName = GetSimpleTypeName(field.IsNullable && field.UnderlyingType is not null
+                ? field.UnderlyingType
+                : field.Type);
+            if (field.IsOptional && field.IsNullable)
+            {
+                sb.AppendLine($"{indent}if ({bundleVar}.{field.Name}.HasValue)");
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    {worldVar}.Add{nestedBundleName}({entityVar}, {bundleVar}.{field.Name}.Value);");
+                sb.AppendLine($"{indent}}}");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}{worldVar}.Add{nestedBundleName}({entityVar}, {bundleVar}.{field.Name});");
+            }
+        }
+        else if (field.IsOptional && field.IsNullable)
         {
             sb.AppendLine($"{indent}if ({bundleVar}.{field.Name}.HasValue)");
             sb.AppendLine($"{indent}{{");
@@ -650,6 +671,23 @@ public sealed class BundleGenerator : IIncrementalGenerator
         {
             sb.AppendLine($"{indent}{worldVar}.Add({entityVar}, {bundleVar}.{field.Name});");
         }
+    }
+
+    /// <summary>
+    /// Returns the underlying non-nullable component/bundle type for a field, stripping
+    /// any nullable (<c>T?</c>) wrapper. Used on the ref/Get side where <c>world.Get&lt;T&gt;</c>
+    /// requires a non-nullable <c>struct, IComponent</c> type argument.
+    /// </summary>
+    private static string GetComponentType(ComponentFieldInfo field)
+        => field.IsNullable && field.UnderlyingType is not null ? field.UnderlyingType : field.Type;
+
+    /// <summary>
+    /// Extracts the simple (unqualified) type name from a fully-qualified type string.
+    /// </summary>
+    private static string GetSimpleTypeName(string typeName)
+    {
+        var lastDot = typeName.LastIndexOf('.');
+        return lastDot >= 0 ? typeName.Substring(lastDot + 1) : typeName;
     }
 
     private static string GenerateEntityBuilderExtensions(ImmutableArray<BundleInfo?> bundles)
@@ -791,11 +829,12 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine($"public ref struct {info.Name}Ref");
         sb.AppendLine("{");
 
-        // Generate ref fields for each component
+        // Generate ref fields for each component (nullable wrappers stripped: a ref
+        // targets the live component storage, which holds the non-nullable value).
         foreach (var field in info.Fields)
         {
             sb.AppendLine($"    /// <summary>Reference to the {field.Name} component.</summary>");
-            sb.AppendLine($"    public ref {field.Type} {field.Name};");
+            sb.AppendLine($"    public ref {GetComponentType(field)} {field.Name};");
             sb.AppendLine();
         }
 
@@ -810,7 +849,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
         }
 
         var constructorParams = string.Join(", ", info.Fields.Select(f =>
-            $"ref {f.Type} {StringHelpers.ToCamelCase(f.Name)}"));
+            $"ref {GetComponentType(f)} {StringHelpers.ToCamelCase(f.Name)}"));
 
         sb.AppendLine($"    public {info.Name}Ref({constructorParams})");
         sb.AppendLine("    {");
@@ -883,7 +922,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
             sb.AppendLine($"    {{");
             sb.AppendLine($"        return new {info.FullName}Ref(");
 
-            var refParams = info.Fields.Select(f => $"            ref world.Get<{f.Type}>(entity)");
+            var refParams = info.Fields.Select(f => $"            ref world.Get<{GetComponentType(f)}>(entity)");
             sb.AppendLine(string.Join(",\r\n", refParams));
 
             sb.AppendLine($"        );");
@@ -905,10 +944,17 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine();
         sb.AppendLine("namespace KeenEyes;");
         sb.AppendLine();
-        sb.AppendLine("public sealed partial class World");
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Generated query-starter extension methods for bundles.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("public static partial class WorldBundleExtensions");
         sb.AppendLine("{");
 
-        // Generate Query<TBundle>() methods for 1-4 bundle parameters
+        // Generate a Query{BundleName}() extension per bundle. A single generic
+        // Query<TBundle>() cannot dispatch to a per-bundle component set, and emitting
+        // it into a consumer-side World partial does not compile (the defining partial
+        // and archetypeManager live only in KeenEyes.Core). Named extension methods on
+        // World avoid both problems and never collide across multiple bundles.
         foreach (var info in bundles)
         {
             if (info is null)
@@ -916,34 +962,32 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 continue;
             }
 
-            // Generate Query<TBundle>() that expands to Query<C1, C2, ...>()
+            // Use flattened component types to handle nested bundles correctly.
+            // World.Query<T1..T4>() supports at most 4 component type arguments; larger
+            // bundles must be queried via QueryBuilder.With<>() for each component.
+            if (info.FlattenedComponentTypes.Length is 0 or > 4)
+            {
+                continue;
+            }
+
+            var componentTypeParams = string.Join(", ", info.FlattenedComponentTypes);
+
             sb.AppendLine($"    /// <summary>");
             sb.AppendLine($"    /// Creates a query for entities with all components in <see cref=\"{info.FullName}\"/>.");
             sb.AppendLine($"    /// </summary>");
-            sb.AppendLine($"    /// <typeparam name=\"T\">The bundle type.</typeparam>");
+            sb.AppendLine($"    /// <param name=\"world\">The world to query.</param>");
+            sb.AppendLine($"    /// <returns>A query builder for entities with all bundle components.</returns>");
             sb.AppendLine($"    /// <example>");
             sb.AppendLine($"    /// <code>");
-            sb.AppendLine($"    /// foreach (var entity in world.Query&lt;{info.Name}&gt;())");
+            sb.AppendLine($"    /// foreach (var entity in world.Query{info.Name}())");
             sb.AppendLine($"    /// {{");
             sb.AppendLine($"    ///     // Process entities with all bundle components");
             sb.AppendLine($"    /// }}");
             sb.AppendLine($"    /// </code>");
             sb.AppendLine($"    /// </example>");
-
-            // Use flattened component types to handle nested bundles correctly
-            var componentTypeParams = string.Join(", ", info.FlattenedComponentTypes);
-
-            // QueryBuilder is now non-generic; bundles with more than 4 components are still limited
-            // by the World.Query<T1..T4>() overloads
-            if (info.FlattenedComponentTypes.Length > 4)
-            {
-                // Skip bundles with more than 4 components (not supported by current World.Query<>)
-                continue;
-            }
-
-            sb.AppendLine($"    public QueryBuilder Query<T>() where T : struct, global::KeenEyes.IBundle");
+            sb.AppendLine($"    public static global::KeenEyes.QueryBuilder Query{info.Name}(this global::KeenEyes.World world)");
             sb.AppendLine($"    {{");
-            sb.AppendLine($"        return Query<{componentTypeParams}>();");
+            sb.AppendLine($"        return world.Query<{componentTypeParams}>();");
             sb.AppendLine($"    }}");
             sb.AppendLine();
         }
@@ -1031,8 +1075,13 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 continue;
             }
 
-            // Generate Add method
+            // Generate Add method (individual component parameters)
             GenerateAddMethod(sb, info);
+            sb.AppendLine();
+
+            // Generate Add overload accepting a bundle instance (recursion target for
+            // nested bundles, and a convenience for adding an existing bundle value)
+            GenerateAddBundleInstanceMethod(sb, info);
             sb.AppendLine();
 
             // Generate Remove method
@@ -1096,6 +1145,32 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine("    }");
     }
 
+    private static void GenerateAddBundleInstanceMethod(StringBuilder sb, BundleInfo info)
+    {
+        // XML documentation
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Adds all components from an existing <see cref=\"{info.FullName}\"/> bundle value to an entity.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    /// <param name=\"world\">The world containing the entity.</param>");
+        sb.AppendLine("    /// <param name=\"entity\">The entity to add components to.</param>");
+        sb.AppendLine("    /// <param name=\"bundle\">The bundle value whose components are added.</param>");
+        sb.AppendLine("    /// <remarks>");
+        sb.AppendLine("    /// Nested bundle fields are added recursively via their own generated Add overloads.");
+        sb.AppendLine("    /// </remarks>");
+
+        // Method signature
+        sb.AppendLine($"    public static void Add{info.Name}(this global::KeenEyes.World world, global::KeenEyes.Entity entity, {info.FullName} bundle)");
+        sb.AppendLine("    {");
+
+        // Add each component (recursing into nested bundles)
+        foreach (var field in info.Fields)
+        {
+            GenerateFieldAddition(sb, field, "bundle", "world", "entity");
+        }
+
+        sb.AppendLine("    }");
+    }
+
     private static string GenerateBundleRegistry(ImmutableArray<BundleInfo?> bundles)
     {
         var sb = new StringBuilder();
@@ -1106,15 +1181,21 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine("namespace KeenEyes;");
         sb.AppendLine();
         sb.AppendLine("/// <summary>");
-        sb.AppendLine("/// Registry of all known bundle types for archetype pre-allocation.");
+        sb.AppendLine("/// Generated helper for pre-allocating archetypes for all bundles in this assembly.");
         sb.AppendLine("/// </summary>");
-        sb.AppendLine("internal static class BundleRegistry");
+        sb.AppendLine("public static partial class WorldBundleExtensions");
         sb.AppendLine("{");
         sb.AppendLine("    /// <summary>");
-        sb.AppendLine("    /// Gets all known bundle component type arrays.");
-        sb.AppendLine("    /// Used by World initialization to pre-allocate archetypes.");
+        sb.AppendLine("    /// Pre-allocates archetypes for every bundle type defined in this assembly.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    public static global::System.Collections.Generic.IReadOnlyList<global::System.Type[]> KnownBundles { get; } = new global::System.Type[][]");
+        sb.AppendLine("    /// <param name=\"world\">The world to pre-allocate archetypes in.</param>");
+        sb.AppendLine("    /// <remarks>");
+        sb.AppendLine("    /// Bundles are defined by consumer assemblies, so pre-allocation cannot run");
+        sb.AppendLine("    /// automatically inside <see cref=\"World\"/> (whose internals live in KeenEyes.Core).");
+        sb.AppendLine("    /// Call this once after creating a world to reduce archetype transitions when");
+        sb.AppendLine("    /// spawning many bundle entities. Uses the AOT-safe static <see cref=\"IBundle.ComponentTypes\"/>.");
+        sb.AppendLine("    /// </remarks>");
+        sb.AppendLine("    public static void PreallocateBundleArchetypes(this global::KeenEyes.World world)");
         sb.AppendLine("    {");
 
         foreach (var info in bundles)
@@ -1124,27 +1205,7 @@ public sealed class BundleGenerator : IIncrementalGenerator
                 continue;
             }
 
-            sb.AppendLine($"        {info.FullName}.ComponentTypes,");
-        }
-
-        sb.AppendLine("    };");
-        sb.AppendLine("}");
-        sb.AppendLine();
-        sb.AppendLine("/// <summary>");
-        sb.AppendLine("/// Partial World implementation for bundle archetype pre-allocation.");
-        sb.AppendLine("/// </summary>");
-        sb.AppendLine("public sealed partial class World");
-        sb.AppendLine("{");
-        sb.AppendLine("    partial void PreallocateBundleArchetypes()");
-        sb.AppendLine("    {");
-
-        if (bundles.Length > 0)
-        {
-            sb.AppendLine("        // Pre-allocate archetypes for all known bundles");
-            sb.AppendLine("        foreach (var componentTypes in BundleRegistry.KnownBundles)");
-            sb.AppendLine("        {");
-            sb.AppendLine("            archetypeManager.PreallocateArchetype(componentTypes);");
-            sb.AppendLine("        }");
+            sb.AppendLine($"        world.PreallocateArchetypeFor<{info.FullName}>();");
         }
 
         sb.AppendLine("    }");

--- a/editor/KeenEyes.Generators/ComponentGenerator.cs
+++ b/editor/KeenEyes.Generators/ComponentGenerator.cs
@@ -92,7 +92,9 @@ public sealed class ComponentGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                if (field.IsStatic || field.IsConst)
+                // Skip compiler-generated fields (e.g. auto-property backing fields),
+                // whose names like <Foo>k__BackingField are not valid C# identifiers.
+                if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
                 {
                     continue;
                 }

--- a/editor/KeenEyes.Generators/MixinGenerator.cs
+++ b/editor/KeenEyes.Generators/MixinGenerator.cs
@@ -204,7 +204,7 @@ public sealed class MixinGenerator : IIncrementalGenerator
         var componentFields = new HashSet<string>(
             typeSymbol.GetMembers()
                 .OfType<IFieldSymbol>()
-                .Where(f => !f.IsStatic && !f.IsConst)
+                .Where(f => !f.IsStatic && !f.IsConst && !f.IsImplicitlyDeclared)
                 .Select(f => f.Name));
 
         var conflictingFields = allMixinFields.Where(f => componentFields.Contains(f.Name)).ToArray();
@@ -279,7 +279,9 @@ public sealed class MixinGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (field.IsStatic || field.IsConst)
+            // Skip compiler-generated fields (e.g. auto-property backing fields),
+            // whose names like <Foo>k__BackingField are not valid C# identifiers.
+            if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }

--- a/editor/KeenEyes.Generators/QueryGenerator.cs
+++ b/editor/KeenEyes.Generators/QueryGenerator.cs
@@ -77,7 +77,9 @@ public sealed class QueryGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (field.IsStatic || field.IsConst)
+            // Skip compiler-generated fields (e.g. auto-property backing fields),
+            // whose names like <Foo>k__BackingField are not valid C# identifiers.
+            if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }

--- a/editor/KeenEyes.Generators/ReplicatedGenerator.cs
+++ b/editor/KeenEyes.Generators/ReplicatedGenerator.cs
@@ -136,7 +136,9 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (field.IsStatic || field.IsConst)
+            // Skip compiler-generated fields (e.g. auto-property backing fields),
+            // whose names like <Foo>k__BackingField are not valid C# identifiers.
+            if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }
@@ -349,6 +351,16 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                 case FieldSerializationType.UInt32:
                     sb.AppendLine($"        writer.WriteUInt32({field.Name});");
                     break;
+                case FieldSerializationType.Int64:
+                    // BitWriter has no 64-bit primitive; write high then low 32 bits.
+                    sb.AppendLine($"        writer.WriteUInt32(unchecked((uint)((ulong){field.Name} >> 32)));");
+                    sb.AppendLine($"        writer.WriteUInt32(unchecked((uint)(ulong){field.Name}));");
+                    break;
+                case FieldSerializationType.UInt64:
+                    // BitWriter has no 64-bit primitive; write high then low 32 bits.
+                    sb.AppendLine($"        writer.WriteUInt32(unchecked((uint)({field.Name} >> 32)));");
+                    sb.AppendLine($"        writer.WriteUInt32(unchecked((uint){field.Name}));");
+                    break;
                 case FieldSerializationType.Float:
                     sb.AppendLine($"        writer.WriteFloat({field.Name});");
                     break;
@@ -416,6 +428,14 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                     break;
                 case FieldSerializationType.UInt32:
                     sb.AppendLine($"        {field.Name} = reader.ReadUInt32();");
+                    break;
+                case FieldSerializationType.Int64:
+                    // Read high then low 32 bits (matching the write order).
+                    sb.AppendLine($"        {field.Name} = unchecked((long)(((ulong)reader.ReadUInt32() << 32) | reader.ReadUInt32()));");
+                    break;
+                case FieldSerializationType.UInt64:
+                    // Read high then low 32 bits (matching the write order).
+                    sb.AppendLine($"        {field.Name} = ((ulong)reader.ReadUInt32() << 32) | reader.ReadUInt32();");
                     break;
                 case FieldSerializationType.Float:
                     sb.AppendLine($"        {field.Name} = reader.ReadFloat();");

--- a/editor/KeenEyes.Generators/SerializationGenerator.cs
+++ b/editor/KeenEyes.Generators/SerializationGenerator.cs
@@ -241,7 +241,9 @@ public sealed class SerializationGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (field.IsStatic || field.IsConst)
+            // Skip compiler-generated fields (e.g. auto-property backing fields),
+            // whose names like <Foo>k__BackingField are not valid C# identifiers.
+            if (field.IsStatic || field.IsConst || field.IsImplicitlyDeclared)
             {
                 continue;
             }
@@ -265,6 +267,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
                 field.Type.ToDisplayString(),
                 GetJsonTypeName(field.Type),
                 isNullable,
+                field.Type.IsValueType,
                 defaultValueLiteral));
         }
 
@@ -297,6 +300,45 @@ public sealed class SerializationGenerator : IIncrementalGenerator
             "System.Numerics.Quaternion" => "Quaternion",
             _ => "Object" // For complex types, use generic deserialization
         };
+    }
+
+    /// <summary>
+    /// Builds a map from each component's full name to a unique, identifier-safe member
+    /// name used for generated members and locals (Deserialize_X, info_X, graph_X, ...).
+    /// When two components share a simple name, a namespace-derived suffix disambiguates
+    /// them so the generated identifiers do not collide.
+    /// </summary>
+    private static Dictionary<string, string> ComputeMemberNames(ImmutableArray<SerializableComponentInfo> components)
+    {
+        var result = new Dictionary<string, string>();
+        foreach (var group in components.GroupBy(c => c.Name))
+        {
+            if (group.Count() > 1)
+            {
+                foreach (var info in group)
+                {
+                    result[info.FullName] = $"{info.Name}_{GenerateNamespaceSuffix(info.Namespace)}";
+                }
+            }
+            else
+            {
+                result[group.First().FullName] = group.First().Name;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Derives an identifier-safe suffix from a namespace by joining its parts.
+    /// </summary>
+    private static string GenerateNamespaceSuffix(string namespaceName)
+    {
+        if (!StringHelpers.IsValidNamespace(namespaceName))
+        {
+            return "Global";
+        }
+
+        return namespaceName.Replace(".", string.Empty);
     }
 
     /// <summary>
@@ -502,22 +544,29 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         sb.AppendLine("        MigrationGraphsByType = new Dictionary<Type, MigrationGraph>();");
         sb.AppendLine();
 
+        // Disambiguate generated identifiers when two components share a simple name
+        // (e.g. two 'Anchor' structs in different namespaces) - without this the
+        // Deserialize_/Serialize_/info_/migrations_/graph_ members collide (CS0111/CS0128).
+        var memberNames = ComputeMemberNames(components);
+
         foreach (var component in components)
         {
-            sb.AppendLine($"        var info_{component.Name} = new ComponentSerializationInfo(");
+            var member = memberNames[component.FullName];
+
+            sb.AppendLine($"        var info_{member} = new ComponentSerializationInfo(");
             sb.AppendLine($"            typeof({component.FullName}),");
-            sb.AppendLine($"            Deserialize_{component.Name},");
-            sb.AppendLine($"            value => Serialize_{component.Name}(({component.FullName})value),");
-            sb.AppendLine($"            DeserializeBinary_{component.Name},");
-            sb.AppendLine($"            (value, writer) => SerializeBinary_{component.Name}(({component.FullName})value, writer),");
+            sb.AppendLine($"            Deserialize_{member},");
+            sb.AppendLine($"            value => Serialize_{member}(({component.FullName})value),");
+            sb.AppendLine($"            DeserializeBinary_{member},");
+            sb.AppendLine($"            (value, writer) => SerializeBinary_{member}(({component.FullName})value, writer),");
             sb.AppendLine($"            (serialization, isTag) => (ComponentInfo)serialization.Components.Register<{component.FullName}>(isTag),");
             sb.AppendLine($"            (serialization, value) => serialization.SetSingleton(({component.FullName})value),");
             sb.AppendLine($"            static () => new {component.FullName}(),");
             sb.AppendLine($"            {component.Version});");
             sb.AppendLine();
-            sb.AppendLine($"        ComponentsByName[typeof({component.FullName}).AssemblyQualifiedName!] = info_{component.Name};");
-            sb.AppendLine($"        ComponentsByName[\"{component.FullName}\"] = info_{component.Name};");
-            sb.AppendLine($"        ComponentsByType[typeof({component.FullName})] = info_{component.Name};");
+            sb.AppendLine($"        ComponentsByName[typeof({component.FullName}).AssemblyQualifiedName!] = info_{member};");
+            sb.AppendLine($"        ComponentsByName[\"{component.FullName}\"] = info_{member};");
+            sb.AppendLine($"        ComponentsByType[typeof({component.FullName})] = info_{member};");
             sb.AppendLine();
 
             // Register migrations for this component (explicit + auto-generated)
@@ -530,7 +579,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
 
             if (needsMigrations)
             {
-                sb.AppendLine($"        var migrations_{component.Name} = new Dictionary<int, Func<JsonElement, object>>");
+                sb.AppendLine($"        var migrations_{member} = new Dictionary<int, Func<JsonElement, object>>");
                 sb.AppendLine("        {");
 
                 // Add explicit migrations
@@ -546,26 +595,38 @@ public sealed class SerializationGenerator : IIncrementalGenerator
                     {
                         if (!explicitVersions.Contains(v))
                         {
-                            sb.AppendLine($"            [{v}] = AutoMigrate_{component.Name},");
+                            sb.AppendLine($"            [{v}] = AutoMigrate_{member},");
                         }
                     }
                 }
 
                 sb.AppendLine("        };");
-                sb.AppendLine($"        MigrationsByType[typeof({component.FullName})] = migrations_{component.Name};");
-                sb.AppendLine($"        MigrationsByName[typeof({component.FullName}).AssemblyQualifiedName!] = migrations_{component.Name};");
-                sb.AppendLine($"        MigrationsByName[\"{component.FullName}\"] = migrations_{component.Name};");
+                sb.AppendLine($"        MigrationsByType[typeof({component.FullName})] = migrations_{member};");
+                sb.AppendLine($"        MigrationsByName[typeof({component.FullName}).AssemblyQualifiedName!] = migrations_{member};");
+                sb.AppendLine($"        MigrationsByName[\"{component.FullName}\"] = migrations_{member};");
                 sb.AppendLine();
 
-                // Create migration graph for diagnostics
-                sb.AppendLine($"        var graph_{component.Name} = new MigrationGraph(\"{component.FullName}\", {component.Version});");
+                // Create migration graph for diagnostics. The graph must mirror EVERY entry
+                // in the migrations dictionary - explicit AND auto-generated - or CanMigrate
+                // (which reads the dictionary) contradicts FindGaps (which reads the graph).
+                sb.AppendLine($"        var graph_{member} = new MigrationGraph(\"{component.FullName}\", {component.Version});");
                 foreach (var migration in component.Migrations.OrderBy(m => m.FromVersion))
                 {
-                    sb.AppendLine($"        graph_{component.Name}.AddEdge({migration.FromVersion}, {migration.FromVersion + 1});");
+                    sb.AppendLine($"        graph_{member}.AddEdge({migration.FromVersion}, {migration.FromVersion + 1});");
                 }
-                sb.AppendLine($"        MigrationGraphsByType[typeof({component.FullName})] = graph_{component.Name};");
-                sb.AppendLine($"        MigrationGraphsByName[typeof({component.FullName}).AssemblyQualifiedName!] = graph_{component.Name};");
-                sb.AppendLine($"        MigrationGraphsByName[\"{component.FullName}\"] = graph_{component.Name};");
+                if (hasFieldsWithDefaults)
+                {
+                    for (var v = 1; v < component.Version; v++)
+                    {
+                        if (!explicitVersions.Contains(v))
+                        {
+                            sb.AppendLine($"        graph_{member}.AddEdge({v}, {v + 1});");
+                        }
+                    }
+                }
+                sb.AppendLine($"        MigrationGraphsByType[typeof({component.FullName})] = graph_{member};");
+                sb.AppendLine($"        MigrationGraphsByName[typeof({component.FullName}).AssemblyQualifiedName!] = graph_{member};");
+                sb.AppendLine($"        MigrationGraphsByName[\"{component.FullName}\"] = graph_{member};");
                 sb.AppendLine();
             }
         }
@@ -682,7 +743,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         // Generate individual serialization/deserialization methods
         foreach (var component in components)
         {
-            GenerateComponentMethods(sb, component);
+            GenerateComponentMethods(sb, component, memberNames[component.FullName]);
         }
 
         // Shared System.Numerics JSON helpers, emitted only when a field needs them
@@ -748,10 +809,10 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         }
     }
 
-    private static void GenerateComponentMethods(StringBuilder sb, SerializableComponentInfo component)
+    private static void GenerateComponentMethods(StringBuilder sb, SerializableComponentInfo component, string member)
     {
         // Deserialize method
-        sb.AppendLine($"    private static object Deserialize_{component.Name}(JsonElement json)");
+        sb.AppendLine($"    private static object Deserialize_{member}(JsonElement json)");
         sb.AppendLine("    {");
         sb.AppendLine($"        var result = new {component.FullName}();");
 
@@ -769,7 +830,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // Serialize method
-        sb.AppendLine($"    private static JsonElement Serialize_{component.Name}({component.FullName} value)");
+        sb.AppendLine($"    private static JsonElement Serialize_{member}({component.FullName} value)");
         sb.AppendLine("    {");
         sb.AppendLine("        using var stream = new System.IO.MemoryStream();");
         sb.AppendLine("        using var writer = new Utf8JsonWriter(stream);");
@@ -810,13 +871,13 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // Binary deserialize method
-        sb.AppendLine($"    private static object DeserializeBinary_{component.Name}(BinaryReader reader)");
+        sb.AppendLine($"    private static object DeserializeBinary_{member}(BinaryReader reader)");
         sb.AppendLine("    {");
         sb.AppendLine($"        var result = new {component.FullName}();");
 
         foreach (var field in component.Fields)
         {
-            var binaryRead = GetBinaryReadMethod(field.JsonTypeName, field.Type, field.IsNullable);
+            var binaryRead = GetBinaryReadMethod(field.JsonTypeName, field.Type, field.IsNullable, field.IsValueType);
             sb.AppendLine($"        result.{field.Name} = {binaryRead};");
         }
 
@@ -825,7 +886,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         // Binary serialize method
-        sb.AppendLine($"    private static void SerializeBinary_{component.Name}({component.FullName} value, BinaryWriter writer)");
+        sb.AppendLine($"    private static void SerializeBinary_{member}({component.FullName} value, BinaryWriter writer)");
         sb.AppendLine("    {");
 
         foreach (var field in component.Fields)
@@ -841,19 +902,20 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         var fieldsWithDefaults = component.Fields.Where(f => f.HasDefaultValue).ToList();
         if (fieldsWithDefaults.Count > 0 && component.Version > 1)
         {
-            GenerateAutoMigrationMethod(sb, component);
+            GenerateAutoMigrationMethod(sb, component, member);
         }
     }
 
     private static void GenerateAutoMigrationMethod(
         StringBuilder sb,
-        SerializableComponentInfo component)
+        SerializableComponentInfo component,
+        string member)
     {
         sb.AppendLine("    /// <summary>");
         sb.AppendLine($"    /// Auto-generated migration for {component.Name}.");
         sb.AppendLine("    /// Reads existing fields from JSON and applies default values for new fields.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine($"    private static object AutoMigrate_{component.Name}(JsonElement json)");
+        sb.AppendLine($"    private static object AutoMigrate_{member}(JsonElement json)");
         sb.AppendLine("    {");
         sb.AppendLine($"        var result = new {component.FullName}();");
 
@@ -894,8 +956,12 @@ public sealed class SerializationGenerator : IIncrementalGenerator
     {
         if (field.JsonTypeName == "Object")
         {
-            // Complex type - use generic deserialization
-            if (field.IsNullable)
+            // Complex type - use generic deserialization.
+            // The '??' null-coalescing throw is only valid (and meaningful) for reference
+            // types. For non-nullable value types (enum, struct, char, Vector2, ...),
+            // JsonSerializer.Deserialize<T> returns a non-nullable T, so '??' would be a
+            // CS0019 compile error; deserialize directly instead.
+            if (field.IsNullable || field.IsValueType)
             {
                 sb.AppendLine($"            result.{field.Name} = JsonSerializer.Deserialize<{field.Type}>({camelFieldName}Elem.GetRawText());");
             }
@@ -1267,7 +1333,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         sb.AppendLine();
     }
 
-    private static string GetBinaryReadMethod(string jsonTypeName, string type, bool isNullable)
+    private static string GetBinaryReadMethod(string jsonTypeName, string type, bool isNullable, bool isValueType)
     {
         return jsonTypeName switch
         {
@@ -1286,7 +1352,10 @@ public sealed class SerializationGenerator : IIncrementalGenerator
             "String" => "reader.ReadString()", // BinaryReader.ReadString() never returns null
             "Vector3" => "new System.Numerics.Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())",
             "Quaternion" => "new System.Numerics.Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())",
-            _ => isNullable
+            // Complex/Object types. The '??' throw is only valid for reference types;
+            // for non-nullable value types JsonSerializer.Deserialize<T> returns T and
+            // '??' would be a CS0019 compile error, so deserialize directly.
+            _ => isNullable || isValueType
                 ? $"JsonSerializer.Deserialize<{type}>(reader.ReadString())"
                 : $"JsonSerializer.Deserialize<{type}>(reader.ReadString()) ?? throw new InvalidDataException(\"Non-nullable field was null in binary data\")"
         };
@@ -1298,8 +1367,11 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         {
             "Int32" or "Int64" or "Int16" or "Byte" or
             "UInt32" or "UInt64" or "UInt16" or "SByte" or
-            "Single" or "Double" or "Decimal" or "Boolean" or "String"
+            "Single" or "Double" or "Decimal" or "Boolean"
                 => $"writer.Write({valueExpr});",
+            // BinaryWriter.Write(string) throws ArgumentNullException on null; a default
+            // struct leaves string fields null, so coalesce to empty (matches the JSON path).
+            "String" => $"writer.Write({valueExpr} ?? string.Empty);",
             "Vector3" => $"writer.Write({valueExpr}.X); writer.Write({valueExpr}.Y); writer.Write({valueExpr}.Z);",
             "Quaternion" => $"writer.Write({valueExpr}.X); writer.Write({valueExpr}.Y); writer.Write({valueExpr}.Z); writer.Write({valueExpr}.W);",
             _ => $"writer.Write(JsonSerializer.Serialize({valueExpr}));" // Complex types as JSON
@@ -1319,6 +1391,7 @@ public sealed class SerializationGenerator : IIncrementalGenerator
         string Type,
         string JsonTypeName,
         bool IsNullable,
+        bool IsValueType,
         string? DefaultValueLiteral = null)
     {
         /// <summary>

--- a/tests/KeenEyes.Generators.Tests/BundleQueryGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/BundleQueryGeneratorTests.cs
@@ -157,9 +157,10 @@ public class BundleQueryGeneratorTests
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
-        // Verify Query<T>() method returns non-generic QueryBuilder
+        // Verify per-bundle QueryTransformBundle() extension on World (not a consumer-side
+        // World partial, which would not compile and would collide across bundles).
         Assert.Contains(generatedTrees, t =>
-            t.Contains("public QueryBuilder Query<T>()"));
+            t.Contains("public static global::KeenEyes.QueryBuilder QueryTransformBundle(this global::KeenEyes.World world)"));
     }
 
     [Fact]
@@ -312,9 +313,9 @@ public class BundleQueryGeneratorTests
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
-        // Verify Query<T>() returns non-generic QueryBuilder
+        // Verify per-bundle query-starter extension for a single-component bundle
         Assert.Contains(generatedTrees, t =>
-            t.Contains("public QueryBuilder Query<T>()"));
+            t.Contains("public static global::KeenEyes.QueryBuilder QuerySingleBundle(this global::KeenEyes.World world)"));
     }
 
     [Fact]
@@ -358,9 +359,9 @@ public class BundleQueryGeneratorTests
 
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
-        // Verify Query<T>() returns non-generic QueryBuilder
+        // Verify per-bundle query-starter extension for a three-component bundle
         Assert.Contains(generatedTrees, t =>
-            t.Contains("public QueryBuilder Query<T>()"));
+            t.Contains("public static global::KeenEyes.QueryBuilder QueryTransformBundle(this global::KeenEyes.World world)"));
     }
 
     [Fact]

--- a/tests/KeenEyes.Generators.Tests/GeneratorShapeTests.cs
+++ b/tests/KeenEyes.Generators.Tests/GeneratorShapeTests.cs
@@ -1,0 +1,502 @@
+using System.Reflection;
+using System.Text.Json;
+using KeenEyes.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace KeenEyes.Generators.Tests;
+
+/// <summary>
+/// End-to-end verification that the generators emit code which actually compiles against
+/// KeenEyes.Core (and round-trips at runtime) for the component/bundle/replicated shapes
+/// that used to break only for consumers - the latent bugs in #1137-#1146.
+/// </summary>
+/// <remarks>
+/// Unlike the string-matching generator tests, these drive the generator, add the emitted
+/// trees back into a compilation that references the real runtime assemblies, and assert the
+/// result has no compile errors (and, for serialization, emit + load the assembly and invoke
+/// the generated <c>ComponentSerializer</c>).
+/// </remarks>
+public class GeneratorShapeTests
+{
+    private static readonly MetadataReference[] references = BuildReferences();
+
+    private static MetadataReference[] BuildReferences()
+    {
+        // Explicitly pull in the key runtime assemblies (their .Assembly access forces a load
+        // and is not elided), then add everything else already loaded (System.*, etc.).
+        var explicitAssemblies = new[]
+        {
+            typeof(global::KeenEyes.World).Assembly,
+            typeof(global::KeenEyes.IComponent).Assembly,
+            typeof(global::KeenEyes.Common.FloatExtensions).Assembly,
+            typeof(global::KeenEyes.Network.Serialization.BitWriter).Assembly,
+            typeof(global::KeenEyes.Network.ReplicatedAttribute).Assembly,
+            typeof(global::KeenEyes.Serialization.IComponentSerializer).Assembly,
+            // System.Text.Json is used by the generated serializer but may not yet be loaded
+            // when this static initializer runs, so pull it in explicitly.
+            typeof(System.Text.Json.JsonElement).Assembly,
+        };
+
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Concat(explicitAssemblies)
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Distinct()
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToArray();
+    }
+
+    private static (Compilation Output, IReadOnlyList<Diagnostic> GeneratorDiagnostics, IReadOnlyList<string> Sources) Run(
+        string source, params IIncrementalGenerator[] generators)
+    {
+        // Use default parse options so the source tree's language version matches the
+        // trees the generator driver produces (otherwise CSharpCompilation rejects the mix).
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var compilation = CSharpCompilation.Create(
+            "ShapeTestAssembly_" + Guid.NewGuid().ToString("N"),
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generators);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var output, out _);
+
+        var runResult = driver.GetRunResult();
+        var sources = runResult.GeneratedTrees.Select(t => t.GetText().ToString()).ToList();
+        return (output, runResult.Diagnostics.ToList(), sources);
+    }
+
+    private static void AssertNoCompileErrors(Compilation output)
+    {
+        var errors = output.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        Assert.True(
+            errors.Count == 0,
+            "Generated code failed to compile against KeenEyes.Core:\n" +
+            string.Join("\n", errors.Select(e => e.ToString())));
+    }
+
+    private static Assembly EmitAndLoad(Compilation output)
+    {
+        using var stream = new MemoryStream();
+        var result = output.Emit(stream);
+
+        Assert.True(
+            result.Success,
+            "Emit failed:\n" + string.Join(
+                "\n",
+                result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.ToString())));
+
+        return Assembly.Load(stream.ToArray());
+    }
+
+    #region #1138 - Bundle helpers must compile against Core (no consumer-side World partial)
+
+    [Fact]
+    public void BundleGenerator_SingleBundle_CompilesAgainstCore()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [Component]
+            public partial struct Rotation { public float Angle; }
+
+            [Bundle]
+            public partial struct TransformBundle
+            {
+                public Position Position;
+                public Rotation Rotation;
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new BundleGenerator());
+
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
+    public void BundleGenerator_TwoBundles_DoNotProduceDuplicateMembers()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [Component]
+            public partial struct Velocity { public float X; public float Y; }
+
+            [Component]
+            public partial struct Health { public int Current; public int Max; }
+
+            [Bundle]
+            public partial struct PhysicsBundle
+            {
+                public Position Position;
+                public Velocity Velocity;
+            }
+
+            [Bundle]
+            public partial struct HealthBundle
+            {
+                public Health Health;
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new BundleGenerator());
+
+        // Two bundles previously each emitted a colliding World.Query<T>() (CS0111) inside a
+        // consumer-side World partial that also failed with CS0759/CS0103/CS1061.
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1140 - Optional nullable bundle field compiles (no world.Get<T?>)
+
+    [Fact]
+    public void BundleGenerator_OptionalNullableField_CompilesAgainstCore()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [Component]
+            public partial struct Tint { public float R; public float G; public float B; }
+
+            [Bundle]
+            public partial struct SpriteBundle
+            {
+                public Position Position;
+
+                [Optional]
+                public Tint? Tint;
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new BundleGenerator());
+
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1142 - Nested bundle field compiles (recursive Add)
+
+    [Fact]
+    public void BundleGenerator_NestedBundle_CompilesAgainstCore()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [Component]
+            public partial struct Rotation { public float Angle; }
+
+            [Component]
+            public partial struct Health { public int Current; public int Max; }
+
+            [Bundle]
+            public partial struct TransformBundle
+            {
+                public Position Position;
+                public Rotation Rotation;
+            }
+
+            [Bundle]
+            public partial struct CharacterBundle
+            {
+                public TransformBundle Transform;
+                public Health Health;
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new BundleGenerator());
+
+        // The Add side previously emitted world.Add(entity, bundle.Transform) for the nested
+        // bundle field (CS0315). It must recurse into the nested bundle's Add overload instead.
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1141 - Auto-property components compile (no <X>k__BackingField)
+
+    [Fact]
+    public void SerializationGenerator_AutoPropertyComponent_CompilesAndOmitsBackingField()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component(Serializable = true)]
+            public partial struct Stats
+            {
+                public int Level { get; set; }
+                public float Ratio;
+            }
+            """;
+
+        var (output, _, sources) = Run(source, new ComponentGenerator(), new SerializationGenerator());
+
+        Assert.DoesNotContain(sources, s => s.Contains("k__BackingField"));
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1137 / #1139 - Complex serializable field shapes compile and round-trip
+
+    [Fact]
+    public void SerializationGenerator_ComplexFieldShapes_CompileAndRoundTrip()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            public enum Facing { North, East, South, West }
+
+            public struct Inner
+            {
+                public int A;
+                public int B;
+            }
+
+            [Component(Serializable = true)]
+            public partial struct Sample
+            {
+                public Facing Direction;              // enum -> Object
+                public System.Numerics.Vector2 Offset; // Vector2 -> Object
+                public Inner Nested;                   // nested struct -> Object
+                public char Symbol;                    // char -> Object
+                public string Label;                   // string
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new SerializationGenerator());
+
+        // #1137: non-nullable value-type Object fields must not get `?? throw` (CS0019).
+        AssertNoCompileErrors(output);
+
+        var assembly = EmitAndLoad(output);
+        var sampleType = assembly.GetType("ShapeApp.Sample")!;
+        var facingType = assembly.GetType("ShapeApp.Facing")!;
+
+        var directionField = sampleType.GetField("Direction")!;
+        var symbolField = sampleType.GetField("Symbol")!;
+        var labelField = sampleType.GetField("Label")!;
+
+        // Leave Label null to exercise #1139 (binary write must not throw on a null string).
+        object value = Activator.CreateInstance(sampleType)!;
+        directionField.SetValue(value, Enum.ToObject(facingType, 2)); // Facing.South
+        symbolField.SetValue(value, 'Z');
+
+        var serializerType = assembly.GetType("KeenEyes.Generated.ComponentSerializer")!;
+        var instance = serializerType.GetField("Instance")!.GetValue(null)!;
+        var jsonSerializer = (IComponentSerializer)instance;
+        var binarySerializer = (IBinaryComponentSerializer)instance;
+
+        // JSON round-trip
+        JsonElement? json = jsonSerializer.Serialize(sampleType, value);
+        Assert.NotNull(json);
+        object jsonBack = jsonSerializer.Deserialize("ShapeApp.Sample", json!.Value)!;
+
+        Assert.Equal(
+            Convert.ToInt32(directionField.GetValue(value)),
+            Convert.ToInt32(directionField.GetValue(jsonBack)));
+        Assert.Equal('Z', (char)symbolField.GetValue(jsonBack)!);
+        Assert.Equal(string.Empty, (string)labelField.GetValue(jsonBack)!);
+
+        // Binary round-trip - must not throw on the null Label (#1139).
+        using var memory = new MemoryStream();
+        using (var writer = new BinaryWriter(memory, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            Assert.True(binarySerializer.WriteTo(sampleType, value, writer));
+        }
+
+        memory.Position = 0;
+        object binaryBack;
+        using (var reader = new BinaryReader(memory, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            binaryBack = binarySerializer.ReadFrom("ShapeApp.Sample", reader)!;
+        }
+
+        Assert.Equal(
+            Convert.ToInt32(directionField.GetValue(value)),
+            Convert.ToInt32(directionField.GetValue(binaryBack)));
+        Assert.Equal('Z', (char)symbolField.GetValue(binaryBack)!);
+        Assert.Equal(string.Empty, (string)labelField.GetValue(binaryBack)!);
+    }
+
+    #endregion
+
+    #region #1143 - [Replicated] long/ulong fields emit no #error
+
+    [Fact]
+    public void ReplicatedGenerator_LongAndUlongFields_CompileWithoutErrorDirective()
+    {
+        var source = """
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            [Replicated]
+            public partial struct BigCounters
+            {
+                public long Signed;
+                public ulong Unsigned;
+            }
+            """;
+
+        var (output, _, sources) = Run(source, new ReplicatedGenerator());
+
+        Assert.DoesNotContain(sources, s => s.Contains("#error"));
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1144 - Same-named serializable components in different namespaces
+
+    [Fact]
+    public void SerializationGenerator_SameNameDifferentNamespaces_CompileWithoutCollision()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp.Ui
+            {
+                [Component(Serializable = true)]
+                public partial struct Anchor { public int X; }
+            }
+
+            namespace ShapeApp.Physics
+            {
+                [Component(Serializable = true)]
+                public partial struct Anchor { public int Y; }
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new SerializationGenerator());
+
+        // Both used to emit Deserialize_Anchor / info_Anchor (CS0111 / CS0128).
+        AssertNoCompileErrors(output);
+    }
+
+    #endregion
+
+    #region #1145 - Diagnostic for more than 32 replicated fields
+
+    [Fact]
+    public void ReplicatedGenerator_MoreThan32Fields_EmitsTooManyFieldsDiagnostic()
+    {
+        var fields = string.Join(
+            "\n    ",
+            Enumerable.Range(0, 33).Select(i => $"public int Field{i};"));
+
+        var source = $$"""
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            [Replicated]
+            public partial struct Wide
+            {
+                {{fields}}
+            }
+            """;
+
+        var (_, generatorDiagnostics, _) = Run(source, new ReplicatedGenerator());
+
+        Assert.Contains(generatorDiagnostics, d => d.Id == "KEEN100");
+    }
+
+    [Fact]
+    public void ReplicatedGenerator_Exactly32Fields_EmitsNoDiagnostic()
+    {
+        var fields = string.Join(
+            "\n    ",
+            Enumerable.Range(0, 32).Select(i => $"public int Field{i};"));
+
+        var source = $$"""
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            [Replicated]
+            public partial struct Exactly32
+            {
+                {{fields}}
+            }
+            """;
+
+        var (_, generatorDiagnostics, _) = Run(source, new ReplicatedGenerator());
+
+        Assert.DoesNotContain(generatorDiagnostics, d => d.Id == "KEEN100");
+    }
+
+    #endregion
+
+    #region #1146 - Auto-migration graph edges match CanMigrate
+
+    [Fact]
+    public void SerializationGenerator_AutoMigrations_GraphMatchesCanMigrate()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component(Serializable = true, Version = 3)]
+            public partial struct Settings
+            {
+                public int Volume;
+
+                [DefaultValue(50)]
+                public int Brightness;
+            }
+            """;
+
+        var (output, _, sources) = Run(source, new ComponentGenerator(), new SerializationGenerator());
+
+        // The migration graph must gain edges for the auto-generated migrations, not just
+        // explicit ones - otherwise FindGaps contradicts CanMigrate.
+        Assert.Contains(sources, s => s.Contains("AddEdge(1, 2)") && s.Contains("AddEdge(2, 3)"));
+
+        AssertNoCompileErrors(output);
+
+        var assembly = EmitAndLoad(output);
+        var serializerType = assembly.GetType("KeenEyes.Generated.ComponentSerializer")!;
+        var instance = serializerType.GetField("Instance")!.GetValue(null)!;
+        var diagnostics = (IMigrationDiagnostics)instance;
+
+        Assert.True(diagnostics.CanMigrate("ShapeApp.Settings", 1, 3));
+
+        var gaps = diagnostics.FindAllMigrationGaps();
+        Assert.False(
+            gaps.ContainsKey("ShapeApp.Settings"),
+            "Auto-migrated component should report no migration gaps.");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Generators.Tests/KeenEyes.Generators.Tests.csproj
+++ b/tests/KeenEyes.Generators.Tests/KeenEyes.Generators.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Common\KeenEyes.Common.csproj" />
     <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Network.Abstractions\KeenEyes.Network.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/KeenEyes.Generators.Tests/packages.lock.json
+++ b/tests/KeenEyes.Generators.Tests/packages.lock.json
@@ -420,6 +420,12 @@
           "Microsoft.CodeAnalysis.CSharp": "[5.6.0, )"
         }
       },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "CentralTransitive",
         "requested": "[5.6.0, )",


### PR DESCRIPTION
## Summary
Fixes the entire generators cluster (#1137–#1146) — latent build-time breakage for type-shapes no current consumer exercised (so CI was green). Each fix is proven by a new consumer of that shape compiled through the real generators in `GeneratorShapeTests` (516 generator tests pass, 11 shape tests).

**#1138 (fixed first — it masked #1140/#1142):** `BundleGenerator` no longer emits a consumer-side `partial class World` referencing Core-only internals (`archetypeManager`, `PreallocateBundleArchetypes`) — bundle helpers are now extension methods on `World` (`WorldBundleExtensions`), so `[Bundle]` compiles in a consumer assembly and two bundles no longer collide on `Query<T>()`.

- **#1137:** no `?? throw` on non-nullable value-type `Object` fields (enum/Vector2/nested-struct/char) → compiles + round-trips.
- **#1139:** binary string writes null-coalesce to empty (no ArgumentNullException on a default string).
- **#1140:** bundle Get/ref side strips nullability (no `world.Get<T?>`).
- **#1141 (cross-cutting):** field collection skips `IsImplicitlyDeclared` in all 6 generators → auto-property components compile (no `<X>k__BackingField`).
- **#1142:** nested-bundle fields recurse via `Add{Bundle}` instead of `world.Add(entity, bundle)`.
- **#1143:** `[Replicated] long`/`ulong` emit real Int64/UInt64 serialization instead of `#error`.
- **#1144:** generated member names disambiguated by namespace (two same-named components no longer collide).
- **#1145:** regression tests for the existing KEEN100 >32-replicated-fields diagnostic.
- **#1146:** migration graph adds edges for auto-migrations so `CanMigrate`/`FindGaps` agree.

## Test plan
- [x] `GeneratorShapeTests` compiles a consumer of every shape (enum/Vector2/nested-struct/char, `[Bundle]`, two bundles, `[Optional]` nullable, nested bundle, auto-property, `long`/`ulong` `[Replicated]`, duplicate-name, `[DefaultValue]` migration) — 0 compile errors + round-trips
- [x] Fail-on-old demonstrated per generator (revert → shape test fails)
- [x] Generators.Tests 516/0; Core.Tests 2309; Shaders integration 8/8; full suite 14,484 passed / 0 failed (independently re-verified, incl. a parallel-32 run); build 0 warnings; format exit 0
- One intentional dep: `KeenEyes.Network.Abstractions` ref added to Generators.Tests for the `[Replicated]` shape

## Related Issues
Closes #1137, #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146