### PR TITLE
fix(spatial): Query loose/bounded partitioners by actual bounds, not strict node bounds or center

### DIFF
--- a/src/KeenEyes.Spatial/Partitioning/OctreePartitioner.cs
+++ b/src/KeenEyes.Spatial/Partitioning/OctreePartitioner.cs
@@ -36,6 +36,10 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
     // Track entity positions for redistribution during subdivision
     private readonly Dictionary<Entity, Vector3> entityPositions = [];
 
+    // Track each entity's world-space AABB so bounded queries can test against the
+    // entity's footprint rather than only its center point.
+    private readonly Dictionary<Entity, (Vector3 Min, Vector3 Max)> entityBounds = [];
+
     // Pool for child node arrays (8 elements for octree)
     private readonly ArrayPool<OctreeNode>? nodePool;
 
@@ -66,6 +70,12 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
     /// <inheritdoc/>
     public int EntityCount => entityCount;
 
+    // The looseness factor to expand node bounds by during query traversal.
+    // Entities are stored in a node while they remain within its loose bounds,
+    // so traversal must prune against those same loose bounds (a factor of 1.0
+    // leaves node bounds unchanged for tight octrees).
+    private float QueryLoosenessFactor => config.UseLooseBounds ? config.LoosenessFactor : 1.0f;
+
     /// <inheritdoc/>
     public void Update(Entity entity, Vector3 position)
     {
@@ -89,6 +99,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         node.Entities.Remove(entity);
         entityNodes.Remove(entity);
         entityPositions.Remove(entity);
+        entityBounds.Remove(entity);
         entityCount--;
     }
 
@@ -100,7 +111,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         var max = center + radiusVec;
 
         var results = new HashSet<Entity>();
-        root.QueryBounds(min, max, results, entityPositions);
+        root.QueryBounds(min, max, results, entityBounds, QueryLoosenessFactor);
         return MaybeSortResults(results);
     }
 
@@ -108,7 +119,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
     public IEnumerable<Entity> QueryBounds(Vector3 min, Vector3 max)
     {
         var results = new HashSet<Entity>();
-        root.QueryBounds(min, max, results, entityPositions);
+        root.QueryBounds(min, max, results, entityBounds, QueryLoosenessFactor);
         return MaybeSortResults(results);
     }
 
@@ -139,7 +150,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
 
         int count = 0;
         bool overflow = false;
-        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityPositions);
+        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityBounds, QueryLoosenessFactor);
 
         if (config.DeterministicMode && count > 0)
         {
@@ -154,7 +165,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
     {
         int count = 0;
         bool overflow = false;
-        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityPositions);
+        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityBounds, QueryLoosenessFactor);
 
         if (config.DeterministicMode && count > 0)
         {
@@ -247,6 +258,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         root.Clear(nodePool);
         entityNodes.Clear();
         entityPositions.Clear();
+        entityBounds.Clear();
         entityCount = 0;
     }
 
@@ -275,11 +287,13 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
     /// </summary>
     private void UpdateInternal(Entity entity, Vector3 position, (Vector3 min, Vector3 max)? bounds)
     {
-        // bounds reserved for future bounded entity support
-        _ = bounds;
-
         // Store entity position for potential redistribution during subdivision
         entityPositions[entity] = position;
+
+        // Store the entity's world-space AABB. Point entities (no bounds) get a
+        // degenerate box collapsed onto their position so queries can treat every
+        // entity uniformly as bounds instead of a bare center point.
+        entityBounds[entity] = bounds ?? (position, position);
 
         // Check if entity is already indexed and still fits in its current node
         if (entityNodes.TryGetValue(entity, out var oldNode))
@@ -425,100 +439,27 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         /// <summary>
         /// Queries all entities within the given bounds, recursively traversing children.
         /// </summary>
-        public void QueryBounds(Vector3 min, Vector3 max, HashSet<Entity> results, Dictionary<Entity, Vector3> entityPositions)
+        public void QueryBounds(Vector3 min, Vector3 max, HashSet<Entity> results, Dictionary<Entity, (Vector3 Min, Vector3 Max)> entityBounds, float loosenessFactor)
         {
-            // Check if this node intersects the query bounds
-            if (!Intersects(min, max))
+            // Check if this node (expanded by the looseness factor) intersects the
+            // query bounds. Entities are stored while within loose bounds, so pruning
+            // must honour those same loose bounds to avoid false negatives.
+            if (!Intersects(min, max, loosenessFactor))
             {
                 return;
             }
 
-            // Add entities from this node that are actually within bounds
-            // Use SIMD for bulk filtering when there are enough entities (threshold: 16)
-            var count = Entities.Count;
-            if (count >= 16 && count <= 128)
+            // Add entities from this node whose footprint (AABB) overlaps the query
+            // box. Testing the stored bounds rather than the center point keeps large
+            // entities visible when the query box lies inside their footprint.
+            foreach (var entity in Entities)
             {
-                // Stack allocation for small-medium arrays (zero heap allocation)
-                Span<Entity> entitySpan = stackalloc Entity[count];
-                Span<Vector3> positionSpan = stackalloc Vector3[count];
-
-                // Copy entities to span
-                int idx = 0;
-                foreach (var entity in Entities)
+                if (entityBounds.TryGetValue(entity, out var b) &&
+                    b.Max.X >= min.X && b.Min.X <= max.X &&
+                    b.Max.Y >= min.Y && b.Min.Y <= max.Y &&
+                    b.Max.Z >= min.Z && b.Min.Z <= max.Z)
                 {
-                    entitySpan[idx++] = entity;
-                }
-
-                // Extract positions
-                for (int i = 0; i < count; i++)
-                {
-                    if (entityPositions.TryGetValue(entitySpan[i], out var pos))
-                    {
-                        positionSpan[i] = pos;
-                    }
-                }
-
-                // SIMD-accelerated AABB filtering (zero-allocation with stackalloc)
-                Span<int> indices = stackalloc int[count];
-                int matchCount = SimdHelpers.FilterByAABBSIMD(positionSpan, min, max, indices);
-
-                // Add filtered entities
-                for (int i = 0; i < matchCount; i++)
-                {
-                    results.Add(entitySpan[indices[i]]);
-                }
-            }
-            else if (count > 128)
-            {
-                // ArrayPool for large arrays (reusable, zero allocation amortized)
-                var rentedEntities = ArrayPool<Entity>.Shared.Rent(count);
-                var rentedPositions = ArrayPool<Vector3>.Shared.Rent(count);
-                var rentedIndices = ArrayPool<int>.Shared.Rent(count);
-
-                try
-                {
-                    Entities.CopyTo(rentedEntities, 0);
-                    var entitySpan = rentedEntities.AsSpan(0, count);
-                    var positionSpan = rentedPositions.AsSpan(0, count);
-                    var indicesSpan = rentedIndices.AsSpan(0, count);
-
-                    // Extract positions
-                    for (int i = 0; i < count; i++)
-                    {
-                        if (entityPositions.TryGetValue(entitySpan[i], out var pos))
-                        {
-                            positionSpan[i] = pos;
-                        }
-                    }
-
-                    // SIMD-accelerated AABB filtering (zero-allocation with pooled arrays)
-                    int matchCount = SimdHelpers.FilterByAABBSIMD(positionSpan, min, max, indicesSpan);
-
-                    // Add filtered entities
-                    for (int i = 0; i < matchCount; i++)
-                    {
-                        results.Add(entitySpan[indicesSpan[i]]);
-                    }
-                }
-                finally
-                {
-                    ArrayPool<Entity>.Shared.Return(rentedEntities);
-                    ArrayPool<Vector3>.Shared.Return(rentedPositions);
-                    ArrayPool<int>.Shared.Return(rentedIndices);
-                }
-            }
-            else
-            {
-                // Scalar path for small entity counts (< 16)
-                foreach (var entity in Entities)
-                {
-                    if (entityPositions.TryGetValue(entity, out var pos) &&
-                        pos.X >= min.X && pos.X <= max.X &&
-                        pos.Y >= min.Y && pos.Y <= max.Y &&
-                        pos.Z >= min.Z && pos.Z <= max.Z)
-                    {
-                        results.Add(entity);
-                    }
+                    results.Add(entity);
                 }
             }
 
@@ -528,7 +469,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
                 // Only iterate over the first 8 children (pooled arrays may be larger)
                 for (int i = 0; i < 8; i++)
                 {
-                    Children![i].QueryBounds(min, max, results, entityPositions);
+                    Children![i].QueryBounds(min, max, results, entityBounds, loosenessFactor);
                 }
             }
         }
@@ -567,21 +508,21 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         /// <summary>
         /// Queries all entities within the given bounds into a span (zero-allocation).
         /// </summary>
-        public void QueryBoundsSpan(Vector3 min, Vector3 max, Span<Entity> results, ref int count, ref bool overflow, Dictionary<Entity, Vector3> entityPositions)
+        public void QueryBoundsSpan(Vector3 min, Vector3 max, Span<Entity> results, ref int count, ref bool overflow, Dictionary<Entity, (Vector3 Min, Vector3 Max)> entityBounds, float loosenessFactor)
         {
-            // Check if this node intersects the query bounds
-            if (!Intersects(min, max))
+            // Check if this node (expanded by the looseness factor) intersects the query bounds
+            if (!Intersects(min, max, loosenessFactor))
             {
                 return;
             }
 
-            // Add entities from this node that are actually within bounds
+            // Add entities from this node whose footprint (AABB) overlaps the query box
             foreach (var entity in Entities)
             {
-                if (entityPositions.TryGetValue(entity, out var pos) &&
-                    pos.X >= min.X && pos.X <= max.X &&
-                    pos.Y >= min.Y && pos.Y <= max.Y &&
-                    pos.Z >= min.Z && pos.Z <= max.Z &&
+                if (entityBounds.TryGetValue(entity, out var b) &&
+                    b.Max.X >= min.X && b.Min.X <= max.X &&
+                    b.Max.Y >= min.Y && b.Min.Y <= max.Y &&
+                    b.Max.Z >= min.Z && b.Min.Z <= max.Z &&
                     !SpanContainsEntity(results, count, entity))
                 {
                     if (count < results.Length)
@@ -600,7 +541,7 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
             {
                 for (int i = 0; i < 8; i++)
                 {
-                    Children![i].QueryBoundsSpan(min, max, results, ref count, ref overflow, entityPositions);
+                    Children![i].QueryBoundsSpan(min, max, results, ref count, ref overflow, entityBounds, loosenessFactor);
                 }
             }
         }
@@ -659,13 +600,17 @@ internal sealed class OctreePartitioner : ISpatialPartitioner
         }
 
         /// <summary>
-        /// Checks if this node's bounds intersect with the given bounds.
+        /// Checks if this node's bounds, expanded by the looseness factor, intersect
+        /// with the given bounds. A factor of 1.0 tests the strict node bounds.
         /// </summary>
-        private bool Intersects(Vector3 min, Vector3 max)
+        private bool Intersects(Vector3 min, Vector3 max, float loosenessFactor)
         {
-            return !(Max.X < min.X || Min.X > max.X ||
-                    Max.Y < min.Y || Min.Y > max.Y ||
-                    Max.Z < min.Z || Min.Z > max.Z);
+            var expansion = ((Max - Min) * (loosenessFactor - 1.0f)) * 0.5f;
+            var looseMin = Min - expansion;
+            var looseMax = Max + expansion;
+            return !(looseMax.X < min.X || looseMin.X > max.X ||
+                    looseMax.Y < min.Y || looseMin.Y > max.Y ||
+                    looseMax.Z < min.Z || looseMin.Z > max.Z);
         }
 
         /// <summary>

--- a/src/KeenEyes.Spatial/Partitioning/QuadtreePartitioner.cs
+++ b/src/KeenEyes.Spatial/Partitioning/QuadtreePartitioner.cs
@@ -37,6 +37,10 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
     // Track entity positions for redistribution during subdivision
     private readonly Dictionary<Entity, Vector2> entityPositions = [];
 
+    // Track each entity's world-space AABB (X-Z plane) so bounded queries can
+    // test against the entity's footprint rather than only its center point.
+    private readonly Dictionary<Entity, (Vector2 Min, Vector2 Max)> entityBounds = [];
+
     // Pool for child node arrays (4 elements for quadtree)
     private readonly ArrayPool<QuadtreeNode>? nodePool;
 
@@ -70,6 +74,12 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
     /// <inheritdoc/>
     public int EntityCount => entityCount;
 
+    // The looseness factor to expand node bounds by during query traversal.
+    // Entities are stored in a node while they remain within its loose bounds,
+    // so traversal must prune against those same loose bounds (a factor of 1.0
+    // leaves node bounds unchanged for tight quadtrees).
+    private float QueryLoosenessFactor => config.UseLooseBounds ? config.LoosenessFactor : 1.0f;
+
     /// <inheritdoc/>
     public void Update(Entity entity, Vector3 position)
     {
@@ -97,6 +107,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         node.Entities.Remove(entity);
         entityNodes.Remove(entity);
         entityPositions.Remove(entity);
+        entityBounds.Remove(entity);
         entityCount--;
     }
 
@@ -107,7 +118,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         var max = new Vector2(center.X + radius, center.Z + radius);
 
         var results = new HashSet<Entity>();
-        root.QueryBounds(min, max, results, entityPositions);
+        root.QueryBounds(min, max, results, entityBounds, QueryLoosenessFactor);
         return MaybeSortResults(results);
     }
 
@@ -118,7 +129,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         var max2D = new Vector2(max.X, max.Z);
 
         var results = new HashSet<Entity>();
-        root.QueryBounds(min2D, max2D, results, entityPositions);
+        root.QueryBounds(min2D, max2D, results, entityBounds, QueryLoosenessFactor);
         return MaybeSortResults(results);
     }
 
@@ -149,7 +160,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
 
         int count = 0;
         bool overflow = false;
-        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityPositions);
+        root.QueryBoundsSpan(min, max, results, ref count, ref overflow, entityBounds, QueryLoosenessFactor);
 
         if (config.DeterministicMode && count > 0)
         {
@@ -167,7 +178,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
 
         int count = 0;
         bool overflow = false;
-        root.QueryBoundsSpan(min2D, max2D, results, ref count, ref overflow, entityPositions);
+        root.QueryBoundsSpan(min2D, max2D, results, ref count, ref overflow, entityBounds, QueryLoosenessFactor);
 
         if (config.DeterministicMode && count > 0)
         {
@@ -261,6 +272,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         root.Clear(nodePool);
         entityNodes.Clear();
         entityPositions.Clear();
+        entityBounds.Clear();
         entityCount = 0;
     }
 
@@ -289,11 +301,13 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
     /// </summary>
     private void UpdateInternal(Entity entity, Vector2 position, (Vector2 min, Vector2 max)? bounds)
     {
-        // bounds reserved for future bounded entity support
-        _ = bounds;
-
         // Store entity position for potential redistribution during subdivision
         entityPositions[entity] = position;
+
+        // Store the entity's world-space AABB. Point entities (no bounds) get a
+        // degenerate box collapsed onto their position so queries can treat every
+        // entity uniformly as bounds instead of a bare center point.
+        entityBounds[entity] = bounds ?? (position, position);
 
         // Check if entity is already indexed and still fits in its current node
         if (entityNodes.TryGetValue(entity, out var oldNode))
@@ -425,103 +439,26 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         /// <summary>
         /// Queries all entities within the given bounds, recursively traversing children.
         /// </summary>
-        public void QueryBounds(Vector2 min, Vector2 max, HashSet<Entity> results, Dictionary<Entity, Vector2> entityPositions)
+        public void QueryBounds(Vector2 min, Vector2 max, HashSet<Entity> results, Dictionary<Entity, (Vector2 Min, Vector2 Max)> entityBounds, float loosenessFactor)
         {
-            // Check if this node intersects the query bounds
-            if (!Intersects(min, max))
+            // Check if this node (expanded by the looseness factor) intersects the
+            // query bounds. Entities are stored while within loose bounds, so pruning
+            // must honour those same loose bounds to avoid false negatives.
+            if (!Intersects(min, max, loosenessFactor))
             {
                 return;
             }
 
-            // Add entities from this node that are actually within bounds
-            // Use SIMD for bulk filtering when there are enough entities (threshold: 16)
-            var count = Entities.Count;
-            if (count >= 16 && count <= 128)
+            // Add entities from this node whose footprint (AABB) overlaps the query
+            // box. Testing the stored bounds rather than the center point keeps large
+            // entities visible when the query box lies inside their footprint.
+            foreach (var entity in Entities)
             {
-                // Stack allocation for small-medium arrays (zero heap allocation)
-                Span<Entity> entitySpan = stackalloc Entity[count];
-                Span<Vector3> positionSpan = stackalloc Vector3[count];
-
-                // Copy entities to span
-                int idx = 0;
-                foreach (var entity in Entities)
+                if (entityBounds.TryGetValue(entity, out var b) &&
+                    b.Max.X >= min.X && b.Min.X <= max.X &&
+                    b.Max.Y >= min.Y && b.Min.Y <= max.Y)
                 {
-                    entitySpan[idx++] = entity;
-                }
-
-                // Extract positions
-                for (int i = 0; i < count; i++)
-                {
-                    if (entityPositions.TryGetValue(entitySpan[i], out var pos2D))
-                    {
-                        positionSpan[i] = new Vector3(pos2D.X, 0, pos2D.Y);
-                    }
-                }
-
-                // SIMD-accelerated AABB filtering (zero-allocation with stackalloc)
-                Span<int> indices = stackalloc int[count];
-                var min3D = new Vector3(min.X, -1000, min.Y);
-                var max3D = new Vector3(max.X, 1000, max.Y);
-                int matchCount = SimdHelpers.FilterByAABBSIMD(positionSpan, min3D, max3D, indices);
-
-                // Add filtered entities
-                for (int i = 0; i < matchCount; i++)
-                {
-                    results.Add(entitySpan[indices[i]]);
-                }
-            }
-            else if (count > 128)
-            {
-                // ArrayPool for large arrays (reusable, zero allocation amortized)
-                var rentedEntities = ArrayPool<Entity>.Shared.Rent(count);
-                var rentedPositions = ArrayPool<Vector3>.Shared.Rent(count);
-                var rentedIndices = ArrayPool<int>.Shared.Rent(count);
-
-                try
-                {
-                    Entities.CopyTo(rentedEntities, 0);
-                    var entitySpan = rentedEntities.AsSpan(0, count);
-                    var positionSpan = rentedPositions.AsSpan(0, count);
-                    var indicesSpan = rentedIndices.AsSpan(0, count);
-
-                    // Extract positions
-                    for (int i = 0; i < count; i++)
-                    {
-                        if (entityPositions.TryGetValue(entitySpan[i], out var pos2D))
-                        {
-                            positionSpan[i] = new Vector3(pos2D.X, 0, pos2D.Y);
-                        }
-                    }
-
-                    // SIMD-accelerated AABB filtering (zero-allocation with pooled arrays)
-                    var min3D = new Vector3(min.X, -1000, min.Y);
-                    var max3D = new Vector3(max.X, 1000, max.Y);
-                    int matchCount = SimdHelpers.FilterByAABBSIMD(positionSpan, min3D, max3D, indicesSpan);
-
-                    // Add filtered entities
-                    for (int i = 0; i < matchCount; i++)
-                    {
-                        results.Add(entitySpan[indicesSpan[i]]);
-                    }
-                }
-                finally
-                {
-                    ArrayPool<Entity>.Shared.Return(rentedEntities);
-                    ArrayPool<Vector3>.Shared.Return(rentedPositions);
-                    ArrayPool<int>.Shared.Return(rentedIndices);
-                }
-            }
-            else
-            {
-                // Scalar path for small entity counts (< 16)
-                foreach (var entity in Entities)
-                {
-                    if (entityPositions.TryGetValue(entity, out var pos) &&
-                        pos.X >= min.X && pos.X <= max.X &&
-                        pos.Y >= min.Y && pos.Y <= max.Y)
-                    {
-                        results.Add(entity);
-                    }
+                    results.Add(entity);
                 }
             }
 
@@ -531,7 +468,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
                 // Only iterate over the first 4 children (pooled arrays may be larger)
                 for (int i = 0; i < 4; i++)
                 {
-                    Children![i].QueryBounds(min, max, results, entityPositions);
+                    Children![i].QueryBounds(min, max, results, entityBounds, loosenessFactor);
                 }
             }
         }
@@ -579,20 +516,20 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         /// <summary>
         /// Queries all entities within the given bounds into a span (zero-allocation).
         /// </summary>
-        public void QueryBoundsSpan(Vector2 min, Vector2 max, Span<Entity> results, ref int count, ref bool overflow, Dictionary<Entity, Vector2> entityPositions)
+        public void QueryBoundsSpan(Vector2 min, Vector2 max, Span<Entity> results, ref int count, ref bool overflow, Dictionary<Entity, (Vector2 Min, Vector2 Max)> entityBounds, float loosenessFactor)
         {
-            // Check if this node intersects the query bounds
-            if (!Intersects(min, max))
+            // Check if this node (expanded by the looseness factor) intersects the query bounds
+            if (!Intersects(min, max, loosenessFactor))
             {
                 return;
             }
 
-            // Add entities from this node that are actually within bounds
+            // Add entities from this node whose footprint (AABB) overlaps the query box
             foreach (var entity in Entities)
             {
-                if (entityPositions.TryGetValue(entity, out var pos) &&
-                    pos.X >= min.X && pos.X <= max.X &&
-                    pos.Y >= min.Y && pos.Y <= max.Y &&
+                if (entityBounds.TryGetValue(entity, out var b) &&
+                    b.Max.X >= min.X && b.Min.X <= max.X &&
+                    b.Max.Y >= min.Y && b.Min.Y <= max.Y &&
                     !SpanContainsEntity(results, count, entity))
                 {
                     if (count < results.Length)
@@ -611,7 +548,7 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
             {
                 for (int i = 0; i < 4; i++)
                 {
-                    Children![i].QueryBoundsSpan(min, max, results, ref count, ref overflow, entityPositions);
+                    Children![i].QueryBoundsSpan(min, max, results, ref count, ref overflow, entityBounds, loosenessFactor);
                 }
             }
         }
@@ -677,11 +614,15 @@ internal sealed class QuadtreePartitioner : ISpatialPartitioner
         }
 
         /// <summary>
-        /// Checks if this node's bounds intersect with the given bounds.
+        /// Checks if this node's bounds, expanded by the looseness factor, intersect
+        /// with the given bounds. A factor of 1.0 tests the strict node bounds.
         /// </summary>
-        private bool Intersects(Vector2 min, Vector2 max)
+        private bool Intersects(Vector2 min, Vector2 max, float loosenessFactor)
         {
-            return !(Max.X < min.X || Min.X > max.X || Max.Y < min.Y || Min.Y > max.Y);
+            var expansion = ((Max - Min) * (loosenessFactor - 1.0f)) * 0.5f;
+            var looseMin = Min - expansion;
+            var looseMax = Max + expansion;
+            return !(looseMax.X < min.X || looseMin.X > max.X || looseMax.Y < min.Y || looseMin.Y > max.Y);
         }
 
         /// <summary>

--- a/tests/KeenEyes.Spatial.Tests/Partitioning/SpatialBoundsPartitionerTests.cs
+++ b/tests/KeenEyes.Spatial.Tests/Partitioning/SpatialBoundsPartitionerTests.cs
@@ -1,0 +1,218 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Spatial.Partitioning;
+
+namespace KeenEyes.Spatial.Tests.Partitioning;
+
+/// <summary>
+/// Regression tests for spatial partitioner bounds handling.
+/// </summary>
+/// <remarks>
+/// Covers two defects that caused false negatives in tree partitioners relative to
+/// <see cref="GridPartitioner"/>:
+/// <list type="bullet">
+/// <item>#1125 - loose quadtree/octree queries pruned traversal by strict node bounds,
+/// so an entity legitimately stored in a node via its loose bounds was missed when the
+/// query box only overlapped the loose region.</item>
+/// <item>#1129 - bounded <c>Update</c> discarded the supplied bounds and filtered queries
+/// by the stored center, so a large entity whose center is outside the query box but whose
+/// footprint overlaps it was missed on the quadtree/octree yet returned by the grid.</item>
+/// </list>
+/// </remarks>
+public class SpatialBoundsPartitionerTests
+{
+    private readonly Entity building = new(1, 0);
+
+    #region #1129 - Bounded Update Filters By Footprint, Not Center
+
+    [Fact]
+    public void QueryBounds_QuadtreeEntityFootprintOverlapsButCenterOutside_ReturnsEntity()
+    {
+        var config = new QuadtreeConfig
+        {
+            MaxDepth = 8,
+            MaxEntitiesPerNode = 8,
+            WorldMin = new Vector3(-1000, 0, -1000),
+            WorldMax = new Vector3(1000, 0, 1000)
+        };
+        using var partitioner = new QuadtreePartitioner(config);
+
+        // 40x40 building centered at the origin: footprint spans (-20,-20)..(20,20).
+        var bounds = SpatialBounds.FromCenterAndExtents(Vector3.Zero, new Vector3(20, 20, 20));
+        partitioner.Update(building, Vector3.Zero, bounds);
+
+        // Query box lies wholly inside the footprint but does not contain the center.
+        var results = partitioner.QueryBounds(
+            new Vector3(5, -100, 5),
+            new Vector3(15, 100, 15)).ToList();
+
+        Assert.Contains(building, results);
+    }
+
+    [Fact]
+    public void QueryBounds_OctreeEntityFootprintOverlapsButCenterOutside_ReturnsEntity()
+    {
+        var config = new OctreeConfig
+        {
+            MaxDepth = 6,
+            MaxEntitiesPerNode = 8,
+            WorldMin = new Vector3(-1000, -1000, -1000),
+            WorldMax = new Vector3(1000, 1000, 1000)
+        };
+        using var partitioner = new OctreePartitioner(config);
+
+        // 40x40x40 building centered at the origin: footprint spans (-20,-20,-20)..(20,20,20).
+        var bounds = SpatialBounds.FromCenterAndExtents(Vector3.Zero, new Vector3(20, 20, 20));
+        partitioner.Update(building, Vector3.Zero, bounds);
+
+        var results = partitioner.QueryBounds(
+            new Vector3(5, 5, 5),
+            new Vector3(15, 15, 15)).ToList();
+
+        Assert.Contains(building, results);
+    }
+
+    [Fact]
+    public void QueryBounds_GridEntityFootprintOverlapsButCenterOutside_ReturnsEntity()
+    {
+        // Control: the grid partitioner already returns the entity. The tree partitioners
+        // must match this behavior so switching SpatialStrategy does not change correctness.
+        var config = new GridConfig { CellSize = 10f };
+        using var partitioner = new GridPartitioner(config);
+
+        var bounds = SpatialBounds.FromCenterAndExtents(Vector3.Zero, new Vector3(20, 20, 20));
+        partitioner.Update(building, Vector3.Zero, bounds);
+
+        var results = partitioner.QueryBounds(
+            new Vector3(5, 5, 5),
+            new Vector3(15, 15, 15)).ToList();
+
+        Assert.Contains(building, results);
+    }
+
+    [Fact]
+    public void QueryBoundsSpan_QuadtreeEntityFootprintOverlapsButCenterOutside_ReturnsEntity()
+    {
+        var config = new QuadtreeConfig
+        {
+            MaxDepth = 8,
+            MaxEntitiesPerNode = 8,
+            WorldMin = new Vector3(-1000, 0, -1000),
+            WorldMax = new Vector3(1000, 0, 1000)
+        };
+        using var partitioner = new QuadtreePartitioner(config);
+
+        var bounds = SpatialBounds.FromCenterAndExtents(Vector3.Zero, new Vector3(20, 20, 20));
+        partitioner.Update(building, Vector3.Zero, bounds);
+
+        Span<Entity> buffer = stackalloc Entity[8];
+        int count = partitioner.QueryBounds(
+            new Vector3(5, -100, 5),
+            new Vector3(15, 100, 15),
+            buffer);
+
+        Assert.Equal(1, count);
+        Assert.Equal(building, buffer[0]);
+    }
+
+    [Fact]
+    public void QueryBoundsSpan_OctreeEntityFootprintOverlapsButCenterOutside_ReturnsEntity()
+    {
+        var config = new OctreeConfig
+        {
+            MaxDepth = 6,
+            MaxEntitiesPerNode = 8,
+            WorldMin = new Vector3(-1000, -1000, -1000),
+            WorldMax = new Vector3(1000, 1000, 1000)
+        };
+        using var partitioner = new OctreePartitioner(config);
+
+        var bounds = SpatialBounds.FromCenterAndExtents(Vector3.Zero, new Vector3(20, 20, 20));
+        partitioner.Update(building, Vector3.Zero, bounds);
+
+        Span<Entity> buffer = stackalloc Entity[8];
+        int count = partitioner.QueryBounds(
+            new Vector3(5, 5, 5),
+            new Vector3(15, 15, 15),
+            buffer);
+
+        Assert.Equal(1, count);
+        Assert.Equal(building, buffer[0]);
+    }
+
+    #endregion
+
+    #region #1125 - Loose Query Traversal Prunes By Loose Bounds
+
+    [Fact]
+    public void QueryBounds_LooseQuadtreeEntityInLooseRegionOfNode_ReturnsEntity()
+    {
+        // A one-level subdivided loose quadtree whose NW leaf covers (0,0)..(8,8).
+        var config = new QuadtreeConfig
+        {
+            MaxDepth = 4,
+            MaxEntitiesPerNode = 4,
+            WorldMin = new Vector3(0, 0, 0),
+            WorldMax = new Vector3(16, 0, 16),
+            UseLooseBounds = true,
+            LoosenessFactor = 2.0f
+        };
+        using var partitioner = new QuadtreePartitioner(config);
+
+        // Five entities force the root to subdivide exactly once (one per quadrant + spare).
+        var target = new Entity(1, 0);
+        partitioner.Update(target, new Vector3(4, 0, 4));   // NW leaf (0,0)..(8,8)
+        partitioner.Update(new Entity(2, 0), new Vector3(12, 0, 4));   // NE
+        partitioner.Update(new Entity(3, 0), new Vector3(4, 0, 12));   // SW
+        partitioner.Update(new Entity(4, 0), new Vector3(12, 0, 12));  // SE
+        partitioner.Update(new Entity(5, 0), new Vector3(13, 0, 5));   // NE
+
+        // Move target to (10,4): outside the NW leaf's strict bounds (x > 8) but inside its
+        // loose bounds (x in [-4,12]), so it stays stored in the NW leaf.
+        partitioner.Update(target, new Vector3(10, 0, 4));
+
+        // Query box covers the target's actual position but only overlaps the NW leaf's loose
+        // region. Strict-bounds pruning would skip the NW leaf and miss the target.
+        var results = partitioner.QueryBounds(
+            new Vector3(9, -1, 3),
+            new Vector3(11, 1, 5)).ToList();
+
+        Assert.Contains(target, results);
+    }
+
+    [Fact]
+    public void QueryBounds_LooseOctreeEntityInLooseRegionOfNode_ReturnsEntity()
+    {
+        // A one-level subdivided loose octree whose "---" octant covers (0,0,0)..(8,8,8).
+        var config = new OctreeConfig
+        {
+            MaxDepth = 4,
+            MaxEntitiesPerNode = 4,
+            WorldMin = new Vector3(0, 0, 0),
+            WorldMax = new Vector3(16, 16, 16),
+            UseLooseBounds = true,
+            LoosenessFactor = 2.0f
+        };
+        using var partitioner = new OctreePartitioner(config);
+
+        // Five entities force the root to subdivide exactly once.
+        var target = new Entity(1, 0);
+        partitioner.Update(target, new Vector3(4, 4, 4));       // octant (0,0,0)..(8,8,8)
+        partitioner.Update(new Entity(2, 0), new Vector3(12, 4, 4));
+        partitioner.Update(new Entity(3, 0), new Vector3(4, 12, 4));
+        partitioner.Update(new Entity(4, 0), new Vector3(4, 4, 12));
+        partitioner.Update(new Entity(5, 0), new Vector3(12, 12, 12));
+
+        // Move target to (10,4,4): outside the octant's strict bounds (x > 8) but inside its
+        // loose bounds (x in [-4,12]), so it stays stored in that octant.
+        partitioner.Update(target, new Vector3(10, 4, 4));
+
+        var results = partitioner.QueryBounds(
+            new Vector3(9, 3, 3),
+            new Vector3(11, 5, 5)).ToList();
+
+        Assert.Contains(target, results);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Two spatial-partitioner query-correctness bugs from the deep review:
- **#1125 (high):** loose quadtree/octree queries pruned by STRICT node bounds, missing entities legitimately stored via the looseness factor. Query traversal now prunes against loose-expanded bounds (factor 1.0 collapses to the original strict test for tight trees). Applied to quadtree + octree.
- **#1129 (high):** bounded `Update` discarded the passed `bounds` (`_ = bounds;`) and queries filtered by stored center — so a large entity whose footprint overlaps a query box but whose center is outside was missed on the quadtree/octree but returned by `GridPartitioner`, silently changing results when `SpatialStrategy` changes. Now stores each entity's AABB and tests footprint-vs-box overlap, matching Grid.

## Test plan
- [x] 7 new tests; fail-on-old proven: 6/7 fail on reverted source (both footprint-overlap + Span variants for quadtree & octree, both loose-region tests), the Grid control passes on old (demonstrating the divergence); 7/7 pass on the fix
- [x] Spatial.Tests 503/503; full suite 14,491 passed / 0 failed (independently re-verified); build 0 warnings; format exit 0

## Related Issues
Closes #1125
Closes #1129