### PR TITLE
fix(physics): Correct sleep thresholds, gravity, interpolation, collision-end, shape/body counts

### DIFF
--- a/src/KeenEyes.Physics/Components/RigidBody.cs
+++ b/src/KeenEyes.Physics/Components/RigidBody.cs
@@ -59,7 +59,13 @@ public readonly struct ActivityDescription(float sleepThreshold = 0.01f, byte mi
     /// <summary>
     /// Settings for bodies that should never sleep (always active).
     /// </summary>
-    public static ActivityDescription NeverSleep => new(float.MaxValue, byte.MaxValue);
+    /// <remarks>
+    /// BepuPhysics treats a negative <see cref="SleepThreshold"/> as "never a sleep candidate",
+    /// so the body cannot go to sleep without an explicit user action. A large positive threshold
+    /// (such as <see cref="float.MaxValue"/>) has the opposite effect: every velocity falls below
+    /// it, so the body sleeps as soon as it becomes a candidate.
+    /// </remarks>
+    public static ActivityDescription NeverSleep => new(-1f);
 }
 
 /// <summary>

--- a/src/KeenEyes.Physics/Core/CollisionEventManager.cs
+++ b/src/KeenEyes.Physics/Core/CollisionEventManager.cs
@@ -77,7 +77,7 @@ internal struct CollisionData
 /// This implementation is designed for zero allocations in hot paths (RecordCollision, PublishEvents).
 /// </para>
 /// </remarks>
-internal sealed class CollisionEventManager(IWorld world)
+internal sealed class CollisionEventManager(IWorld world, Func<Entity, bool>? isEntityAsleep = null)
 {
     // Current frame's collision data (collected during narrow phase)
     // Using regular Dictionary + lock since we need to update existing values atomically
@@ -92,6 +92,15 @@ internal sealed class CollisionEventManager(IWorld world)
 
     // Reusable list for entity removal (avoids allocation during RemoveEntity)
     private readonly List<CollisionPairKey> removalBuffer = [with(16)];
+
+    // Reusable list for resting pairs whose bodies fell asleep. The narrow phase stops
+    // reporting contacts for a sleeping island, so these pairs must be persisted rather
+    // than treated as ended (avoids spurious CollisionEndedEvent for still-touching bodies).
+    private readonly List<CollisionPairKey> sleepingRestingPairs = [with(16)];
+
+    // Predicate that reports whether an entity's body is currently asleep. Null when no
+    // simulation is attached (e.g. isolated unit tests), in which case nothing is asleep.
+    private readonly Func<Entity, bool>? isEntityAsleep = isEntityAsleep;
 
     /// <summary>
     /// Records a collision from the narrow phase callback.
@@ -198,10 +207,22 @@ internal sealed class CollisionEventManager(IWorld world)
         }
 
         // Find collisions that ended (were in previous frame but not current)
+        sleepingRestingPairs.Clear();
         foreach (var key in previousFramePairs)
         {
             if (!currentFrameCollisions.ContainsKey(key))
             {
+                // A pair can disappear from the narrow phase either because the bodies truly
+                // separated or because their island went to sleep while still touching. Only
+                // the former is a genuine "ended". For the latter, persist the resting contact
+                // so no spurious CollisionEndedEvent fires and a real separation after waking
+                // is still detected.
+                if (IsPairSleeping(key))
+                {
+                    sleepingRestingPairs.Add(key);
+                    continue;
+                }
+
                 // Collision ended
                 pairTriggerStatus.TryGetValue(key, out bool wasTrigger);
 
@@ -221,8 +242,27 @@ internal sealed class CollisionEventManager(IWorld world)
             previousFramePairs.Add(key);
         }
 
+        // Retain resting pairs whose bodies are asleep so they are re-evaluated once the
+        // bodies wake up (their trigger status is intentionally left in pairTriggerStatus).
+        foreach (var key in sleepingRestingPairs)
+        {
+            previousFramePairs.Add(key);
+        }
+
         // Clear current frame for next step
         currentFrameCollisions.Clear();
+    }
+
+    private bool IsPairSleeping(CollisionPairKey key)
+    {
+        if (isEntityAsleep is null)
+        {
+            return false;
+        }
+
+        // If either body is asleep the pair will not be re-reported by the narrow phase,
+        // so the contact should be treated as resting rather than ended.
+        return isEntityAsleep(key.EntityA) || isEntityAsleep(key.EntityB);
     }
 
     /// <summary>

--- a/src/KeenEyes.Physics/Core/PhysicsWorld.cs
+++ b/src/KeenEyes.Physics/Core/PhysicsWorld.cs
@@ -23,6 +23,13 @@ namespace KeenEyes.Physics.Core;
 public readonly record struct RayHit(Entity Entity, Vector3 Position, Vector3 Normal, float Distance);
 
 /// <summary>
+/// A raw physics pose snapshot (position and rotation) captured directly from the simulation.
+/// </summary>
+/// <param name="Position">The world-space position.</param>
+/// <param name="Rotation">The world-space rotation.</param>
+internal readonly record struct InterpolationPose(Vector3 Position, Quaternion Rotation);
+
+/// <summary>
 /// Extension API for physics operations in a world.
 /// </summary>
 /// <remarks>
@@ -57,6 +64,12 @@ public sealed class PhysicsWorld : IDisposable
     private float accumulator;
     private float interpolationAlpha;
 
+    // Last two raw physics poses per dynamic body, captured straight from the simulation
+    // (never the interpolated/displayed value). Used by PhysicsSyncSystem to interpolate
+    // for rendering without feeding its own output back in as input.
+    private readonly Dictionary<Entity, InterpolationPose> interpolationPrevious = [];
+    private readonly Dictionary<Entity, InterpolationPose> interpolationCurrent = [];
+
     /// <summary>
     /// Gets the current interpolation alpha (0-1) for rendering.
     /// </summary>
@@ -73,9 +86,31 @@ public sealed class PhysicsWorld : IDisposable
     public Vector3 Gravity { get; set; }
 
     /// <summary>
-    /// Gets the number of physics bodies (dynamic + kinematic).
+    /// Gets the number of physics bodies (dynamic + kinematic), including bodies
+    /// that are currently asleep.
     /// </summary>
-    public int BodyCount => simulation.Bodies.ActiveSet.Count;
+    /// <remarks>
+    /// BepuPhysics stores bodies across multiple sets: the active set (index 0) plus
+    /// one set per sleeping island. Counting only the active set would omit any body
+    /// that has gone to sleep, so all allocated sets are summed here.
+    /// </remarks>
+    public int BodyCount
+    {
+        get
+        {
+            var total = 0;
+            var sets = simulation.Bodies.Sets;
+            for (var i = 0; i < sets.Length; i++)
+            {
+                if (sets[i].Allocated)
+                {
+                    total += sets[i].Count;
+                }
+            }
+
+            return total;
+        }
+    }
 
     /// <summary>
     /// Gets the number of static bodies.
@@ -108,7 +143,7 @@ public sealed class PhysicsWorld : IDisposable
         this.config = config;
         Gravity = config.Gravity;
         bodyLookup = new BodyLookup();
-        collisionEventManager = new CollisionEventManager(world);
+        collisionEventManager = new CollisionEventManager(world, IsBodyAsleep);
         bufferPool = new BufferPool();
         threadDispatcher = new ThreadDispatcher(Environment.ProcessorCount);
 
@@ -395,6 +430,60 @@ public sealed class PhysicsWorld : IDisposable
         return bodyLookup.HasBody(entity) || bodyLookup.HasStatic(entity);
     }
 
+    /// <summary>
+    /// Gets the last two raw physics poses recorded for a dynamic body, used for rendering
+    /// interpolation.
+    /// </summary>
+    /// <param name="entity">The entity whose poses to retrieve.</param>
+    /// <param name="previousPosition">The position captured one physics step before the current one.</param>
+    /// <param name="previousRotation">The rotation captured one physics step before the current one.</param>
+    /// <param name="currentPosition">The most recent raw physics position.</param>
+    /// <param name="currentRotation">The most recent raw physics rotation.</param>
+    /// <returns>True if pose data exists for the entity; false otherwise.</returns>
+    internal bool TryGetInterpolationPoses(
+        Entity entity,
+        out Vector3 previousPosition,
+        out Quaternion previousRotation,
+        out Vector3 currentPosition,
+        out Quaternion currentRotation)
+    {
+        if (interpolationCurrent.TryGetValue(entity, out var current))
+        {
+            currentPosition = current.Position;
+            currentRotation = current.Rotation;
+
+            if (interpolationPrevious.TryGetValue(entity, out var previous))
+            {
+                previousPosition = previous.Position;
+                previousRotation = previous.Rotation;
+            }
+            else
+            {
+                previousPosition = current.Position;
+                previousRotation = current.Rotation;
+            }
+
+            return true;
+        }
+
+        previousPosition = default;
+        previousRotation = Quaternion.Identity;
+        currentPosition = default;
+        currentRotation = Quaternion.Identity;
+        return false;
+    }
+
+    private bool IsBodyAsleep(Entity entity)
+    {
+        // Only dynamic/kinematic bodies can sleep; statics and unknown entities are never asleep.
+        if (bodyLookup.TryGetBody(entity, out var handle))
+        {
+            return !simulation.Bodies.GetBodyReference(handle).Awake;
+        }
+
+        return false;
+    }
+
     #endregion
 
     #region Configuration
@@ -403,9 +492,19 @@ public sealed class PhysicsWorld : IDisposable
     /// Sets the gravity vector for the simulation.
     /// </summary>
     /// <param name="newGravity">The new gravity vector.</param>
+    /// <remarks>
+    /// The pose integrator callbacks receive a copy of the gravity vector at simulation
+    /// creation, so updating <see cref="Gravity"/> alone would not affect the running
+    /// simulation. This method also writes the new value into the live integrator callbacks.
+    /// </remarks>
     public void SetGravity(Vector3 newGravity)
     {
         Gravity = newGravity;
+
+        // Propagate into the live pose integrator callbacks. The callbacks struct is stored
+        // by value on the concrete PoseIntegrator, so mutating the field there changes the
+        // gravity used by subsequent timesteps.
+        ((PoseIntegrator<PoseIntegratorCallbacks>)simulation.PoseIntegrator).Callbacks.Gravity = newGravity;
     }
 
     /// <summary>
@@ -446,9 +545,19 @@ public sealed class PhysicsWorld : IDisposable
             steps++;
         }
 
-        // Calculate interpolation alpha for rendering
+        // When the loop exits on the MaxStepsPerFrame cap, the accumulator can still hold
+        // more than a full timestep. Drain the excess so it neither grows unbounded (spiral
+        // of death) nor produces an interpolation alpha above 1. On a normal exit the loop
+        // already leaves the accumulator below one timestep, so this is a no-op.
+        if (accumulator > config.FixedTimestep)
+        {
+            accumulator = config.FixedTimestep;
+        }
+
+        // Calculate interpolation alpha for rendering, clamped to the [0, 1] range expected
+        // by Lerp/Slerp consumers.
         interpolationAlpha = config.EnableInterpolation
-            ? accumulator / config.FixedTimestep
+            ? Math.Clamp(accumulator / config.FixedTimestep, 0f, 1f)
             : 1f;
 
         return steps;
@@ -503,12 +612,28 @@ public sealed class PhysicsWorld : IDisposable
             if (rigidBody.BodyType == RigidBodyType.Dynamic && bodyLookup.TryGetBody(entity, out var handle))
             {
                 var bodyRef = simulation.Bodies.GetBodyReference(handle);
+                var rawPosition = bodyRef.Pose.Position;
+                var rawOrientation = bodyRef.Pose.Orientation;
+
+                // Track the last two raw physics poses for rendering interpolation. Shift the
+                // previously recorded pose into "previous" before overwriting "current" so the
+                // sync system always interpolates between two authentic simulation poses.
+                if (interpolationCurrent.TryGetValue(entity, out var lastCurrent))
+                {
+                    interpolationPrevious[entity] = lastCurrent;
+                }
+                else
+                {
+                    interpolationPrevious[entity] = new InterpolationPose(rawPosition, rawOrientation);
+                }
+
+                interpolationCurrent[entity] = new InterpolationPose(rawPosition, rawOrientation);
 
                 if (world.Has<Transform3D>(entity))
                 {
                     ref var transform = ref world.Get<Transform3D>(entity);
-                    transform.Position = bodyRef.Pose.Position;
-                    transform.Rotation = bodyRef.Pose.Orientation;
+                    transform.Position = rawPosition;
+                    transform.Rotation = rawOrientation;
                 }
 
                 if (world.Has<Velocity3D>(entity))
@@ -580,14 +705,33 @@ public sealed class PhysicsWorld : IDisposable
         // Remove from collision tracking first
         collisionEventManager.RemoveEntity(entity);
 
+        // Drop interpolation state so a recycled entity id doesn't inherit a stale pose.
+        interpolationPrevious.Remove(entity);
+        interpolationCurrent.Remove(entity);
+
         if (bodyLookup.TryGetBody(entity, out var bodyHandle))
         {
+            // Capture the shape before removing the body, then release it. Each body is
+            // created with its own shape via AddShape, so failing to remove it here would
+            // leak shape slots for the lifetime of the simulation.
+            var shape = simulation.Bodies[bodyHandle].Collidable.Shape;
             simulation.Bodies.Remove(bodyHandle);
+            if (shape.Exists)
+            {
+                simulation.Shapes.Remove(shape);
+            }
+
             bodyLookup.Unregister(entity);
         }
         else if (bodyLookup.TryGetStatic(entity, out var staticHandle))
         {
+            var shape = simulation.Statics[staticHandle].Shape;
             simulation.Statics.Remove(staticHandle);
+            if (shape.Exists)
+            {
+                simulation.Shapes.Remove(shape);
+            }
+
             bodyLookup.Unregister(entity);
         }
     }
@@ -631,6 +775,8 @@ public sealed class PhysicsWorld : IDisposable
         disposed = true;
 
         collisionEventManager.Clear();
+        interpolationPrevious.Clear();
+        interpolationCurrent.Clear();
         simulation.Dispose();
         threadDispatcher.Dispose();
         bufferPool.Clear();

--- a/src/KeenEyes.Physics/Systems/PhysicsSyncSystem.cs
+++ b/src/KeenEyes.Physics/Systems/PhysicsSyncSystem.cs
@@ -24,10 +24,6 @@ public sealed class PhysicsSyncSystem : SystemBase
 {
     private PhysicsWorld? physicsWorld;
 
-    // Previous frame state for interpolation
-    private readonly Dictionary<Entity, Vector3> previousPositions = [];
-    private readonly Dictionary<Entity, Quaternion> previousRotations = [];
-
     /// <inheritdoc/>
     protected override void OnInitialize()
     {
@@ -68,63 +64,17 @@ public sealed class PhysicsSyncSystem : SystemBase
                 continue;
             }
 
+            // Interpolate between the last two raw physics poses. Reading the raw poses from
+            // the physics world (rather than the current Transform3D) avoids feeding the
+            // previously displayed, already-interpolated value back in as input.
+            if (!pw.TryGetInterpolationPoses(entity, out var prevPos, out var prevRot, out var currentPos, out var currentRot))
+            {
+                continue;
+            }
+
             ref var transform = ref World.Get<Transform3D>(entity);
-
-            // Store current as previous for next frame
-            var currentPos = transform.Position;
-            var currentRot = transform.Rotation;
-
-            // Get previous values (or use current if first frame)
-            if (!previousPositions.TryGetValue(entity, out var prevPos))
-            {
-                prevPos = currentPos;
-            }
-
-            if (!previousRotations.TryGetValue(entity, out var prevRot))
-            {
-                prevRot = currentRot;
-            }
-
-            // Interpolate for smooth rendering
             transform.Position = Vector3.Lerp(prevPos, currentPos, alpha);
             transform.Rotation = Quaternion.Slerp(prevRot, currentRot, alpha);
-
-            // Update previous state tracking
-            previousPositions[entity] = currentPos;
-            previousRotations[entity] = currentRot;
         }
-
-        // Clean up any entities that no longer exist
-        CleanupStaleEntries();
-    }
-
-    private void CleanupStaleEntries()
-    {
-        var entitiesToRemove = new List<Entity>();
-
-        foreach (var entity in previousPositions.Keys)
-        {
-            if (!World.IsAlive(entity))
-            {
-                entitiesToRemove.Add(entity);
-            }
-        }
-
-        foreach (var entity in entitiesToRemove)
-        {
-            previousPositions.Remove(entity);
-            previousRotations.Remove(entity);
-        }
-    }
-
-    /// <inheritdoc/>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            previousPositions.Clear();
-            previousRotations.Clear();
-        }
-        base.Dispose(disposing);
     }
 }

--- a/tests/KeenEyes.Physics.Tests/ComponentTests.cs
+++ b/tests/KeenEyes.Physics.Tests/ComponentTests.cs
@@ -368,12 +368,14 @@ public class ComponentTests
     }
 
     [Fact]
-    public void ActivityDescription_NeverSleep_HasMaxValues()
+    public void ActivityDescription_NeverSleep_HasNegativeSleepThreshold()
     {
         var activity = ActivityDescription.NeverSleep;
 
-        Assert.Equal(float.MaxValue, activity.SleepThreshold);
-        Assert.Equal(byte.MaxValue, activity.MinimumTimestepsBeforeSleep);
+        // BepuPhysics treats a negative sleep threshold as "never a sleep candidate", so a
+        // never-sleep body must use a negative threshold (a large positive value would make
+        // the body sleep as soon as it becomes a candidate).
+        Assert.True(activity.SleepThreshold < 0f);
     }
 
     [Fact]

--- a/tests/KeenEyes.Physics.Tests/PhysicsCorrectnessTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsCorrectnessTests.cs
@@ -1,0 +1,262 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Physics.Components;
+using KeenEyes.Physics.Core;
+using KeenEyes.Physics.Events;
+
+namespace KeenEyes.Physics.Tests;
+
+/// <summary>
+/// Regression tests for the physics correctness cluster (#1122, #1123, #1124, #1126, #1127,
+/// #1128, #1130). Each test fails against the pre-fix behavior and passes once the fix is in.
+/// </summary>
+public class PhysicsCorrectnessTests : IDisposable
+{
+    private World? world;
+
+    public void Dispose()
+    {
+        world?.Dispose();
+    }
+
+    #region #1122 NeverSleep
+
+    [Fact]
+    public void NeverSleep_DynamicBodyAtRest_StaysAwakeAfterManySteps()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig { Gravity = Vector3.Zero }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var entity = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(PhysicsShape.Sphere(0.5f))
+            .With(new RigidBody(1f, ActivityDescription.NeverSleep))
+            .Build();
+
+        for (var i = 0; i < 400; i++)
+        {
+            physics.Step(1f / 60f);
+        }
+
+        // A body configured to never sleep must remain awake even at rest.
+        Assert.True(physics.IsAwake(entity));
+    }
+
+    #endregion
+
+    #region #1123 Interpolation feedback
+
+    [Fact]
+    public void PhysicsSync_ConstantVelocityUnderHighRenderRate_RendersMonotonically()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig
+        {
+            FixedTimestep = 1f / 60f,
+            Gravity = Vector3.Zero,
+            EnableInterpolation = true,
+            MaxStepsPerFrame = 8
+        }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var body = world.Spawn()
+            .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+            .With(new Velocity3D(2f, 0f, 0f))
+            .With(PhysicsShape.Sphere(0.5f))
+            .With(RigidBody.Dynamic(1f))
+            .Build();
+
+        physics.SetVelocity(body, new Vector3(2f, 0f, 0f));
+
+        // Render four times as often as physics steps. Update(float) runs the FixedUpdate
+        // step system then the LateUpdate sync system, matching a real game loop.
+        var renderDt = (1f / 60f) / 4f;
+        var samples = new List<float>();
+        for (var frame = 0; frame < 40; frame++)
+        {
+            world.Update(renderDt);
+            samples.Add(world.Get<Transform3D>(body).Position.X);
+        }
+
+        // A body moving steadily in +X must never appear to move backward on screen.
+        for (var i = 1; i < samples.Count; i++)
+        {
+            Assert.True(
+                samples[i] >= samples[i - 1] - 1e-4f,
+                $"Rendered X regressed at frame {i}: {samples[i - 1]} -> {samples[i]}");
+        }
+
+        // Sanity: it actually advanced overall (the body is really moving).
+        Assert.True(samples[^1] > samples[0]);
+    }
+
+    #endregion
+
+    #region #1124 Collision-ended on sleep
+
+    [Fact]
+    public void CollisionEnded_BoxRestingOnGround_DoesNotFireWhenBodySleeps()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig
+        {
+            Gravity = new Vector3(0f, -9.81f, 0f)
+        }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var endedEvents = new List<CollisionEndedEvent>();
+        using var subscription = world.Subscribe<CollisionEndedEvent>(e => endedEvents.Add(e));
+
+        // Static ground: 1-unit-tall box centered at y = -0.5, so its top surface is at y = 0.
+        world.Spawn()
+            .With(new Transform3D(new Vector3(0f, -0.5f, 0f), Quaternion.Identity, Vector3.One))
+            .With(PhysicsShape.Box(20f, 1f, 20f))
+            .With(RigidBody.Static())
+            .Build();
+
+        // Dynamic 1-unit box resting on the ground (half-extent 0.5, centered at y = 0.5).
+        var box = world.Spawn()
+            .With(new Transform3D(new Vector3(0f, 0.5f, 0f), Quaternion.Identity, Vector3.One))
+            .With(PhysicsShape.Box(1f, 1f, 1f))
+            .With(RigidBody.Dynamic(1f))
+            .Build();
+
+        for (var i = 0; i < 300; i++)
+        {
+            physics.Step(1f / 60f);
+        }
+
+        // Precondition: the box went to sleep while still resting (the scenario is real).
+        Assert.False(physics.IsAwake(box));
+
+        // The contact never actually separated, so no CollisionEnded should have fired.
+        Assert.Empty(endedEvents);
+    }
+
+    #endregion
+
+    #region #1126 SetGravity
+
+    [Fact]
+    public void SetGravity_ToZero_StopsBodyFromAccelerating()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig
+        {
+            Gravity = new Vector3(0f, -9.81f, 0f)
+        }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var entity = world.Spawn()
+            .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
+            .With(PhysicsShape.Sphere(0.5f))
+            .With(RigidBody.Dynamic(1f))
+            .Build();
+
+        physics.SetGravity(Vector3.Zero);
+
+        for (var i = 0; i < 30; i++)
+        {
+            physics.Step(1f / 60f);
+        }
+
+        // With gravity zeroed on the live simulation, the body must not accelerate downward.
+        var velocity = physics.GetVelocity(entity);
+        Assert.True(
+            velocity.Y.IsApproximatelyZero(),
+            $"Expected ~0 vertical velocity after zeroing gravity, got {velocity.Y}");
+    }
+
+    #endregion
+
+    #region #1127 Shape slot leak
+
+    [Fact]
+    public void RemoveBody_AfterManyCreateDespawnCycles_ReusesShapeSlots()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin());
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var maxShapeIndex = -1;
+        for (var i = 0; i < 40; i++)
+        {
+            var entity = world.Spawn()
+                .With(new Transform3D(Vector3.Zero, Quaternion.Identity, Vector3.One))
+                .With(PhysicsShape.Sphere(0.5f))
+                .With(RigidBody.Dynamic(1f))
+                .Build();
+
+            Assert.True(physics.BodyLookup.TryGetBody(entity, out var handle));
+            var shapeIndex = physics.Simulation.Bodies[handle].Collidable.Shape.Index;
+            maxShapeIndex = Math.Max(maxShapeIndex, shapeIndex);
+
+            world.Despawn(entity);
+        }
+
+        // If shapes are removed on despawn, freed slots are reused and the shape index never
+        // climbs with the cycle count. Leaked shapes make it grow toward 39.
+        Assert.True(
+            maxShapeIndex < 5,
+            $"Shape slots leaked: max shape index was {maxShapeIndex} across 40 create/despawn cycles");
+    }
+
+    #endregion
+
+    #region #1128 Interpolation alpha clamp
+
+    [Fact]
+    public void Step_PastMaxStepsPerFrameCap_ClampsInterpolationAlpha()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig
+        {
+            FixedTimestep = 1f / 60f,
+            MaxStepsPerFrame = 3,
+            EnableInterpolation = true
+        }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        // One second of delta with a 3-step cap leaves a large leftover accumulator.
+        physics.Step(1f);
+
+        Assert.InRange(physics.InterpolationAlpha, 0f, 1f);
+    }
+
+    #endregion
+
+    #region #1130 BodyCount includes sleeping bodies
+
+    [Fact]
+    public void BodyCount_WithSleepingBodies_IncludesSleepingSet()
+    {
+        world = new World();
+        world.InstallPlugin(new PhysicsPlugin(new PhysicsConfig { Gravity = Vector3.Zero }));
+        var physics = world.GetExtension<PhysicsWorld>();
+
+        var entities = new List<Entity>();
+        for (var i = 0; i < 3; i++)
+        {
+            entities.Add(world.Spawn()
+                .With(new Transform3D(new Vector3(i * 10f, 0f, 0f), Quaternion.Identity, Vector3.One))
+                .With(PhysicsShape.Sphere(0.5f))
+                .With(RigidBody.Dynamic(1f))
+                .Build());
+        }
+
+        // Let the resting bodies fall asleep.
+        for (var i = 0; i < 200; i++)
+        {
+            physics.Step(1f / 60f);
+        }
+
+        // Precondition: the bodies really did go to sleep.
+        Assert.All(entities, e => Assert.False(physics.IsAwake(e)));
+
+        // BodyCount must include sleeping bodies, not just the active set.
+        Assert.Equal(3, physics.BodyCount);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
The 7 physics correctness bugs from the deep review. Bepu 2.4.0 API verified against the installed package; the shipped fixes use casts/public API (no reflection — AOT-safe).

- **#1122 (high):** `NeverSleep` now maps to a negative sleep threshold (`new(-1f)`) — Bepu docs: a negative value guarantees no sleep; `float.MaxValue` kept the body always under threshold so it slept.
- **#1123 (high):** `SyncFromSimulation` records the last two *raw* sim poses and the sync system interpolates between those, instead of feeding the previously-displayed (already-interpolated) transform back as input.
- **#1124 (high):** collision-Ended detection skips pairs whose body is asleep (via `PhysicsWorld.IsBodyAsleep`) and persists them, so a sleeping-but-touching pair no longer fires a spurious `CollisionEndedEvent` (and a real post-wake separation still does).
- **#1126 (high):** `SetGravity` now writes the live `PoseIntegrator<PoseIntegratorCallbacks>.Callbacks.Gravity` instead of a property read only at init — gravity changes affect the running sim.
- **#1127 (medium):** `RemoveBody` removes the body's shape (`Shapes.Remove`) instead of leaking a slot per create/despawn.
- **#1128 (medium):** `Step` clamps `InterpolationAlpha` to [0,1] and drains the accumulator when the `MaxStepsPerFrame` cap is hit.
- **#1130 (medium):** `BodyCount` sums all body sets (active + sleeping islands), not just the active set.

## Test plan
- [x] 7 new `PhysicsCorrectnessTests`, each proven fail-on-old with the exact issue signatures (vy=-0.163 on SetGravity; alpha≈57 past cap; shape index →39; 0 bodies counted; spurious Ended; render regression halving; stays-asleep)
- [x] Physics.Tests 386/0; full suite 14,491 passed / 0 failed (independently re-verified); build 0 warnings; format exit 0; no reflection in shipped src

## Related Issues
Closes #1122
Closes #1123
Closes #1124
Closes #1126
Closes #1127
Closes #1128
Closes #1130