### PR TITLE
fix(audio): Correct non-looping replay, WAV validation, paused-source recycling, double master volume

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -99,6 +99,8 @@
     <Project Path="tests/KeenEyes.AotCompatibility.Tests/KeenEyes.AotCompatibility.Tests.csproj" />
     <Project Path="tests/KeenEyes.Assets.Tests/KeenEyes.Assets.Tests.csproj" />
     <Project Path="tests/KeenEyes.Audio.Abstractions.Tests/KeenEyes.Audio.Abstractions.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Audio.Silk.Tests/KeenEyes.Audio.Silk.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Audio.Tests/KeenEyes.Audio.Tests.csproj" />
     <Project Path="tests/KeenEyes.Cli.Tests/KeenEyes.Cli.Tests.csproj" />
     <Project Path="tests/KeenEyes.Common.Tests/KeenEyes.Common.Tests.csproj" />
     <Project Path="tests/KeenEyes.Core.Tests/KeenEyes.Core.Tests.csproj" />

--- a/src/KeenEyes.Audio.Silk/Backend/SourcePool.cs
+++ b/src/KeenEyes.Audio.Silk/Backend/SourcePool.cs
@@ -56,7 +56,12 @@ internal sealed class SourcePool : IDisposable
         for (int i = playingSources.Count - 1; i >= 0; i--)
         {
             uint source = playingSources[i];
-            if (device.GetSourceState(source) != AudioPlayState.Playing)
+
+            // Only recycle sources that have actually finished (Stopped). A Paused
+            // source is still active — Pause/PauseAll leaves it in the pool expecting
+            // a later Resume, so recycling it here would stop it and detach its buffer,
+            // silently killing paused one-shots on the next frame.
+            if (device.GetSourceState(source) == AudioPlayState.Stopped)
             {
                 // Reset source state
                 device.StopSource(source);

--- a/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
+++ b/src/KeenEyes.Audio.Silk/Decoders/WavDecoder.cs
@@ -48,6 +48,17 @@ internal static class WavDecoder
             var chunkId = Encoding.ASCII.GetString(data.Slice(offset, 4));
             var chunkSize = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(offset + 4, 4));
 
+            // Validate the declared chunk size against the bytes actually present.
+            // A negative size would leave the offset unadvanced and spin the loop
+            // forever; an oversized size would slice past the end of the buffer.
+            // Either indicates a malformed (or untrusted/corrupt) file.
+            int remaining = data.Length - (offset + 8);
+            if (chunkSize < 0 || chunkSize > remaining)
+            {
+                throw new AudioLoadException(
+                    $"Invalid WAV file: chunk '{chunkId}' declares {chunkSize} bytes but only {remaining} remain");
+            }
+
             if (chunkId == "fmt ")
             {
                 var formatTag = BinaryPrimitives.ReadInt16LittleEndian(data.Slice(offset + 8, 2));

--- a/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
@@ -421,9 +421,19 @@ public sealed class SilkAudioContext : IAudioContext
 
     private float ComputeEffectiveVolume(float baseVolume, AudioChannel channel)
     {
-        var masterChannelVol = channelVolumes[AudioChannel.Master];
+        // The master volume and the Master channel volume are applied globally via the
+        // listener gain (see the MasterVolume setter, SetChannelVolume and HandleWindowLoad).
+        // OpenAL's final gain is source gain x listener gain, so applying them here as well
+        // would square them. The per-source gain therefore carries only the base volume and
+        // the sound's own (non-master) channel volume. Sounds on the Master channel are driven
+        // entirely by the listener gain.
+        if (channel == AudioChannel.Master)
+        {
+            return baseVolume;
+        }
+
         var channelVol = channelVolumes.TryGetValue(channel, out var vol) ? vol : 1f;
-        return baseVolume * masterChannelVol * channelVol * masterVolume;
+        return baseVolume * channelVol;
     }
 
     #endregion

--- a/src/KeenEyes.Audio/Systems/AudioSourceSystem.cs
+++ b/src/KeenEyes.Audio/Systems/AudioSourceSystem.cs
@@ -94,15 +94,28 @@ public sealed class AudioSourceSystem : ISystem
                 // Handle state transitions
                 if (source.State == AudioPlayState.Playing && actualState == AudioPlayState.Stopped)
                 {
-                    if (!source.Loop)
+                    if (source.CurrentSound.IsValid)
                     {
-                        // Non-looping sound finished naturally
-                        source.State = AudioPlayState.Stopped;
-                        source.CurrentSound = SoundHandle.Invalid;
+                        // A tracked playback reached the end of the backend source.
+                        if (source.Loop)
+                        {
+                            // Looping sound stopped unexpectedly, restart
+                            device.PlaySource(backendId);
+                        }
+                        else
+                        {
+                            // Non-looping sound finished naturally
+                            source.State = AudioPlayState.Stopped;
+                            source.CurrentSound = SoundHandle.Invalid;
+                        }
                     }
                     else
                     {
-                        // Looping sound stopped unexpectedly, restart
+                        // State was set back to Playing after the backend source stopped
+                        // (a replay request per the AudioSource.State contract). Restart
+                        // playback from the beginning with a fresh sound handle.
+                        source.CurrentSound = new SoundHandle(nextSoundId++);
+                        device.SetSourceLooping(backendId, source.Loop);
                         device.PlaySource(backendId);
                     }
                 }

--- a/tests/KeenEyes.Audio.Silk.Tests/KeenEyes.Audio.Silk.Tests.csproj
+++ b/tests/KeenEyes.Audio.Silk.Tests/KeenEyes.Audio.Silk.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Audio.Silk\KeenEyes.Audio.Silk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Audio.Silk.Tests/WavDecoderTests.cs
+++ b/tests/KeenEyes.Audio.Silk.Tests/WavDecoderTests.cs
@@ -1,0 +1,81 @@
+using System.Buffers.Binary;
+using System.Text;
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Audio.Silk.Decoders;
+
+namespace KeenEyes.Audio.Silk.Tests;
+
+/// <summary>
+/// Tests for <see cref="WavDecoder"/> input validation and decoding.
+/// </summary>
+public sealed class WavDecoderTests
+{
+    /// <summary>
+    /// Builds a PCM WAV byte array. The declared <paramref name="declaredDataSize"/>
+    /// may deliberately differ from the number of <paramref name="data"/> bytes present
+    /// in order to exercise malformed-input handling.
+    /// </summary>
+    private static byte[] BuildWav(short channels, int sampleRate, short bitsPerSample,
+        int declaredDataSize, byte[] data)
+    {
+        var buffer = new byte[44 + data.Length];
+        var span = buffer.AsSpan();
+
+        Encoding.ASCII.GetBytes("RIFF").CopyTo(span[..4]);
+        BinaryPrimitives.WriteInt32LittleEndian(span.Slice(4, 4), 36 + data.Length);
+        Encoding.ASCII.GetBytes("WAVE").CopyTo(span.Slice(8, 4));
+
+        Encoding.ASCII.GetBytes("fmt ").CopyTo(span.Slice(12, 4));
+        BinaryPrimitives.WriteInt32LittleEndian(span.Slice(16, 4), 16);
+        BinaryPrimitives.WriteInt16LittleEndian(span.Slice(20, 2), 1); // PCM
+        BinaryPrimitives.WriteInt16LittleEndian(span.Slice(22, 2), channels);
+        BinaryPrimitives.WriteInt32LittleEndian(span.Slice(24, 4), sampleRate);
+        int byteRate = sampleRate * channels * (bitsPerSample / 8);
+        BinaryPrimitives.WriteInt32LittleEndian(span.Slice(28, 4), byteRate);
+        BinaryPrimitives.WriteInt16LittleEndian(span.Slice(32, 2), (short)(channels * (bitsPerSample / 8)));
+        BinaryPrimitives.WriteInt16LittleEndian(span.Slice(34, 2), bitsPerSample);
+
+        Encoding.ASCII.GetBytes("data").CopyTo(span.Slice(36, 4));
+        BinaryPrimitives.WriteInt32LittleEndian(span.Slice(40, 4), declaredDataSize);
+        data.CopyTo(span[44..]);
+
+        return buffer;
+    }
+
+    [Fact]
+    public void Decode_ValidPcmWav_ReturnsDecodedData()
+    {
+        var samples = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        var wav = BuildWav(channels: 1, sampleRate: 8000, bitsPerSample: 16,
+            declaredDataSize: samples.Length, data: samples);
+
+        var result = WavDecoder.Decode(wav);
+
+        Assert.Equal(AudioFormat.Mono16, result.Format);
+        Assert.Equal(1, result.Channels);
+        Assert.Equal(8000, result.SampleRate);
+        Assert.Equal(16, result.BitsPerSample);
+        Assert.Equal(samples, result.Data);
+    }
+
+    [Fact]
+    public void Decode_DataChunkLargerThanRemaining_ThrowsAudioLoadException()
+    {
+        // Declares 200000 data bytes but only supplies 4.
+        var wav = BuildWav(channels: 1, sampleRate: 8000, bitsPerSample: 16,
+            declaredDataSize: 200_000, data: new byte[] { 0x01, 0x02, 0x03, 0x04 });
+
+        Assert.Throws<AudioLoadException>(() => WavDecoder.Decode(wav));
+    }
+
+    [Fact]
+    public void Decode_NegativeChunkSize_ThrowsAudioLoadException()
+    {
+        // A negative chunk size would otherwise slice out of range (or, for a
+        // non-data chunk, spin the parse loop forever).
+        var wav = BuildWav(channels: 1, sampleRate: 8000, bitsPerSample: 16,
+            declaredDataSize: -8, data: new byte[] { 0x01, 0x02, 0x03, 0x04 });
+
+        Assert.Throws<AudioLoadException>(() => WavDecoder.Decode(wav));
+    }
+}

--- a/tests/KeenEyes.Audio.Silk.Tests/packages.lock.json
+++ b/tests/KeenEyes.Audio.Silk.Tests/packages.lock.json
@@ -1,0 +1,333 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.audio": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.audio.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Audio": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.OpenAL": "[2.23.0, )"
+        }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.OpenAL": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "O8EaDRWGOcKniZ2VxKD/xOmugzUJz747KpqGRw3cezDsz8nD66OZW217o1rT06cG76f8eYigy/yY6eRdhRqHHQ==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Audio.Tests/AudioSourceSystemTests.cs
+++ b/tests/KeenEyes.Audio.Tests/AudioSourceSystemTests.cs
@@ -1,0 +1,317 @@
+using System.Numerics;
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Audio.Tests;
+
+/// <summary>
+/// Tests for <see cref="AudioSourceSystem"/> playback state synchronization.
+/// </summary>
+public sealed class AudioSourceSystemTests : IDisposable
+{
+    private readonly World world = new();
+    private readonly FakeAudioDevice device = new();
+    private readonly AudioSourceSystem system = new();
+
+    public AudioSourceSystemTests()
+    {
+        world.SetExtension<IAudioContext>(new FakeAudioContext(device), owned: false);
+        system.Initialize(world);
+    }
+
+    public void Dispose()
+    {
+        system.Dispose();
+        world.Dispose();
+    }
+
+    private static AudioSource PlayingSource() => AudioSource.Default with
+    {
+        Clip = new AudioClipHandle(1),
+        State = AudioPlayState.Playing,
+    };
+
+    [Fact]
+    public void Update_FirstPlay_StartsBackendPlaybackOnce()
+    {
+        var entity = world.Spawn().With(PlayingSource()).Build();
+
+        system.Update(1f / 60f);
+
+        ref readonly var source = ref world.Get<AudioSource>(entity);
+        Assert.Equal(1, device.TotalPlayCount);
+        Assert.Equal(AudioPlayState.Playing, source.State);
+        Assert.True(source.CurrentSound.IsValid);
+    }
+
+    [Fact]
+    public void Update_WhenNonLoopingSoundFinishes_MarksStoppedAndClearsHandle()
+    {
+        var entity = world.Spawn().With(PlayingSource()).Build();
+        system.Update(1f / 60f);
+
+        // The backend source reaches the end of the clip.
+        device.SimulateFinished();
+        system.Update(1f / 60f);
+
+        ref readonly var source = ref world.Get<AudioSource>(entity);
+        Assert.Equal(AudioPlayState.Stopped, source.State);
+        Assert.False(source.CurrentSound.IsValid);
+        // No additional PlaySource for a finished non-looping sound.
+        Assert.Equal(1, device.TotalPlayCount);
+    }
+
+    [Fact]
+    public void Update_SettingStateToPlayingAfterFinish_RestartsPlayback()
+    {
+        var entity = world.Spawn().With(PlayingSource()).Build();
+
+        // Frame 1: initial playback.
+        system.Update(1f / 60f);
+        Assert.Equal(1, device.TotalPlayCount);
+
+        // Frame 2: the non-looping sound finishes naturally.
+        device.SimulateFinished();
+        system.Update(1f / 60f);
+        Assert.Equal(AudioPlayState.Stopped, world.Get<AudioSource>(entity).State);
+
+        // The user requests a replay per the AudioSource.State contract
+        // ("Set this to Playing to start playback.").
+        world.Get<AudioSource>(entity).State = AudioPlayState.Playing;
+
+        // Frame 3: the stopped source must be restarted.
+        system.Update(1f / 60f);
+
+        ref readonly var source = ref world.Get<AudioSource>(entity);
+        Assert.Equal(2, device.TotalPlayCount);
+        Assert.Equal(AudioPlayState.Playing, source.State);
+        Assert.True(source.CurrentSound.IsValid);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IAudioDevice"/> test double that tracks per-source
+    /// playback state and counts <see cref="PlaySource"/> invocations.
+    /// </summary>
+    private sealed class FakeAudioDevice : IAudioDevice
+    {
+        private readonly Dictionary<uint, AudioPlayState> states = [];
+        private uint nextSource = 1;
+
+        public int TotalPlayCount { get; private set; }
+
+        public bool IsInitialized => true;
+
+        public string DeviceName => "Fake";
+
+        public uint CreateSource()
+        {
+            uint id = nextSource++;
+            states[id] = AudioPlayState.Stopped;
+            return id;
+        }
+
+        public void PlaySource(uint sourceId)
+        {
+            states[sourceId] = AudioPlayState.Playing;
+            TotalPlayCount++;
+        }
+
+        public void StopSource(uint sourceId) => states[sourceId] = AudioPlayState.Stopped;
+
+        public void PauseSource(uint sourceId) => states[sourceId] = AudioPlayState.Paused;
+
+        public AudioPlayState GetSourceState(uint sourceId) =>
+            states.TryGetValue(sourceId, out var state) ? state : AudioPlayState.Stopped;
+
+        /// <summary>
+        /// Simulates every playing source reaching the end of its clip.
+        /// </summary>
+        public void SimulateFinished()
+        {
+            foreach (var id in states.Keys.ToArray())
+            {
+                if (states[id] == AudioPlayState.Playing)
+                {
+                    states[id] = AudioPlayState.Stopped;
+                }
+            }
+        }
+
+        public uint CreateBuffer() => 1;
+
+        public void DeleteBuffer(uint bufferId)
+        {
+        }
+
+        public void BufferData(uint bufferId, AudioFormat format, ReadOnlySpan<byte> data, int sampleRate)
+        {
+        }
+
+        public void DeleteSource(uint sourceId) => states.Remove(sourceId);
+
+        public void SetSourceBuffer(uint sourceId, uint bufferId)
+        {
+        }
+
+        public void SetSourceGain(uint sourceId, float gain)
+        {
+        }
+
+        public void SetListenerGain(float gain)
+        {
+        }
+
+        public void SetSourcePosition(uint sourceId, Vector3 position)
+        {
+        }
+
+        public void SetSourceVelocity(uint sourceId, Vector3 velocity)
+        {
+        }
+
+        public void SetSourcePitch(uint sourceId, float pitch)
+        {
+        }
+
+        public void SetSourceLooping(uint sourceId, bool loop)
+        {
+        }
+
+        public void SetSourceMinDistance(uint sourceId, float distance)
+        {
+        }
+
+        public void SetSourceMaxDistance(uint sourceId, float distance)
+        {
+        }
+
+        public void SetSourceRolloff(uint sourceId, float rolloff)
+        {
+        }
+
+        public void SetListenerPosition(Vector3 position)
+        {
+        }
+
+        public void SetListenerVelocity(Vector3 velocity)
+        {
+        }
+
+        public void SetListenerOrientation(Vector3 forward, Vector3 up)
+        {
+        }
+
+        public void SetDistanceModel(AudioRolloffMode mode)
+        {
+        }
+
+        public void SetSpeedOfSound(float speed)
+        {
+        }
+
+        public void SetDopplerFactor(float factor)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IAudioContext"/> test double exposing only the members
+    /// <see cref="AudioSourceSystem"/> depends on (the device and buffer lookup).
+    /// </summary>
+    private sealed class FakeAudioContext(IAudioDevice device) : IAudioContext
+    {
+        public IAudioDevice? Device => device;
+
+        public bool IsInitialized => true;
+
+        public float MasterVolume { get; set; } = 1f;
+
+        public uint GetBufferId(AudioClipHandle handle) => handle.IsValid ? 1u : 0u;
+
+        public AudioClipHandle LoadClip(string path) => AudioClipHandle.Invalid;
+
+        public AudioClipHandle CreateClip(ReadOnlySpan<byte> data, AudioFormat format, int sampleRate) =>
+            AudioClipHandle.Invalid;
+
+        public AudioClipInfo? GetClipInfo(AudioClipHandle handle) => null;
+
+        public void UnloadClip(AudioClipHandle handle)
+        {
+        }
+
+        public SoundHandle Play(AudioClipHandle clip, float volume = 1f) => SoundHandle.Invalid;
+
+        public SoundHandle Play(AudioClipHandle clip, PlaybackOptions options) => SoundHandle.Invalid;
+
+        public SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, float volume = 1f) => SoundHandle.Invalid;
+
+        public SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, PlaybackOptions options) => SoundHandle.Invalid;
+
+        public void Stop(SoundHandle sound)
+        {
+        }
+
+        public void Pause(SoundHandle sound)
+        {
+        }
+
+        public void Resume(SoundHandle sound)
+        {
+        }
+
+        public void SetVolume(SoundHandle sound, float volume)
+        {
+        }
+
+        public void SetPitch(SoundHandle sound, float pitch)
+        {
+        }
+
+        public void SetPosition(SoundHandle sound, Vector3 position)
+        {
+        }
+
+        public bool IsPlaying(SoundHandle sound) => false;
+
+        public void StopAll()
+        {
+        }
+
+        public void PauseAll()
+        {
+        }
+
+        public void ResumeAll()
+        {
+        }
+
+        public float GetChannelVolume(AudioChannel channel) => 1f;
+
+        public void SetChannelVolume(AudioChannel channel, float volume)
+        {
+        }
+
+        public void SetListenerPosition(Vector3 position)
+        {
+        }
+
+        public void SetListenerOrientation(Vector3 forward, Vector3 up)
+        {
+        }
+
+        public void SetListenerVelocity(Vector3 velocity)
+        {
+        }
+
+        public void Update()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/KeenEyes.Audio.Tests/KeenEyes.Audio.Tests.csproj
+++ b/tests/KeenEyes.Audio.Tests/KeenEyes.Audio.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Audio\KeenEyes.Audio.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Audio.Tests/packages.lock.json
+++ b/tests/KeenEyes.Audio.Tests/packages.lock.json
@@ -1,0 +1,277 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.audio": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Audio.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.audio.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.network.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testbridge.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.testing": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Network.Abstractions": "[1.0.0, )",
+          "KeenEyes.Persistence": "[1.0.0, )",
+          "KeenEyes.TestBridge.Abstractions": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the audio review cluster from the deep-functional-review epic (#1093).

- **#1185** — `AudioSourceSystem` now restarts a stopped backend source when `State` is set back to `Playing` (distinguishes replay from natural finish via `CurrentSound` validity), so non-looping sources are replayable per the `AudioSource.State` contract.
- **#1186** — `WavDecoder` validates each chunk size against remaining bytes and throws `AudioLoadException` on negative/oversized sizes, preventing the slice crash and the negative-size infinite loop on untrusted files.
- **#1188** — `SourcePool.Update` only recycles `Stopped` sources (`Paused` treated as still-active), so `Pause`/`PauseAll` no longer kills pooled one-shots.
- **#1189** — `SilkAudioContext` applies master + Master-channel volume only via listener gain; `ComputeEffectiveVolume` no longer re-multiplies, eliminating the squared master volume.

## Test plan
- [x] New `KeenEyes.Audio.Tests` (replay/finish via fake device) + `KeenEyes.Audio.Silk.Tests` (WAV validation); fail-on-old/pass-on-new proven
- [x] #1188/#1189 are OpenAL-device-bound — verified by code trace
- [x] Full suite 14,566 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1185
Closes #1186
Closes #1188
Closes #1189