### PR TITLE
fix(assets): Fix dependency refcount, cancellation stuck/poisoned entries, inverted reload debounce

### DIFF
--- a/src/KeenEyes.Assets/Caching/AssetCache.cs
+++ b/src/KeenEyes.Assets/Caching/AssetCache.cs
@@ -49,7 +49,10 @@ internal sealed class AssetCache(CachePolicy policy, long maxSizeBytes)
     {
         if (entriesByPath.TryGetValue(path, out var existing))
         {
-            existing.AddRef();
+            // Cache hit: reference the entry AND its dependencies. Release recurses into
+            // dependencies, so acquisition must be symmetric or a shared dependency can be
+            // released below zero and disposed while a parent still holds it (issue #1190).
+            AddRefWithDependencies(existing);
             Interlocked.Increment(ref cacheHits);
             wasCreated = false;
             return existing;
@@ -70,7 +73,7 @@ internal sealed class AssetCache(CachePolicy policy, long maxSizeBytes)
         // Another thread added it first
         wasCreated = false;
         var actualEntry = entriesByPath[path];
-        actualEntry.AddRef();
+        AddRefWithDependencies(actualEntry);
         Interlocked.Increment(ref cacheHits);
         return actualEntry;
     }
@@ -104,12 +107,28 @@ internal sealed class AssetCache(CachePolicy policy, long maxSizeBytes)
     {
         if (entriesById.TryGetValue(id, out var entry))
         {
-            entry.AddRef();
+            AddRefWithDependencies(entry);
+        }
+    }
 
-            // Also add refs to dependencies
-            foreach (var depId in entry.Dependencies)
+    /// <summary>
+    /// Increments the reference count of an entry and, recursively, all of its dependencies.
+    /// </summary>
+    /// <param name="entry">The entry to reference.</param>
+    /// <remarks>
+    /// This is the symmetric counterpart to <see cref="Release"/>, which recursively releases
+    /// dependencies. Both cache-hit acquisition and explicit acquisition go through here so a
+    /// dependency's reference count always matches the number of parents holding it.
+    /// </remarks>
+    private void AddRefWithDependencies(AssetEntry entry)
+    {
+        entry.AddRef();
+
+        foreach (var depId in entry.Dependencies)
+        {
+            if (entriesById.TryGetValue(depId, out var dependency))
             {
-                AddRef(depId);
+                AddRefWithDependencies(dependency);
             }
         }
     }

--- a/src/KeenEyes.Assets/Core/AssetManager.cs
+++ b/src/KeenEyes.Assets/Core/AssetManager.cs
@@ -154,6 +154,13 @@ public sealed class AssetManager : IDisposable
         {
             await LoadAssetAsync<T>(entry, path, cancellationToken);
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is not a terminal failure: evict the entry so a later load with a
+            // fresh token starts over instead of rethrowing the stale cancellation (issue #1192).
+            cache.Evict(entry.Id);
+            throw;
+        }
         catch (Exception ex)
         {
             entry.State = AssetState.Failed;
@@ -256,7 +263,20 @@ public sealed class AssetManager : IDisposable
             throw AssetLoadException.FileNotFound(path, assetType);
         }
 
-        await loadSemaphore.WaitAsync(cancellationToken);
+        // The semaphore wait must be inside a try that handles cancellation: a cancelled token
+        // throws here before the load body runs, and previously left the entry stuck in Loading
+        // forever, hanging every later load of the same path (issue #1191). It has its own try so
+        // a wait that never acquires the semaphore does not reach the release in the finally below.
+        try
+        {
+            await loadSemaphore.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            cache.Evict(entry.Id);
+            throw;
+        }
+
         try
         {
             await using var stream = File.OpenRead(fullPath);
@@ -270,7 +290,9 @@ public sealed class AssetManager : IDisposable
         }
         catch (OperationCanceledException)
         {
-            entry.State = AssetState.Failed;
+            // Cancellation is not a terminal failure: evict so a later load starts over instead
+            // of leaving a stuck/poisoned entry (issues #1191, #1192).
+            cache.Evict(entry.Id);
             throw;
         }
         catch (Exception ex)

--- a/src/KeenEyes.Assets/HotReload/ReloadManager.cs
+++ b/src/KeenEyes.Assets/HotReload/ReloadManager.cs
@@ -128,8 +128,10 @@ public sealed class ReloadManager : IDisposable
             return;
         }
 
-        // Debounce: track the change time
-        pendingReloads[relativePath] = DateTime.UtcNow;
+        // Trailing debounce: stamp this change and wait out the quiet period. A newer change to
+        // the same path overwrites the stamp, so only the most-recent change should reload.
+        var changeTime = DateTime.UtcNow;
+        pendingReloads[relativePath] = changeTime;
 
         try
         {
@@ -140,10 +142,14 @@ public sealed class ReloadManager : IDisposable
             return;
         }
 
-        // Check if this is still the most recent change
-        if (!pendingReloads.TryRemove(relativePath, out _))
+        // Only reload if this is still the most-recent change. The atomic key/value remove
+        // succeeds solely when the stored stamp is still ours; if a newer change arrived during
+        // the delay, the stamp differs, this remove fails, and that newer change's waiter reloads
+        // instead. Previously the stamp was never compared and an unconditional remove let the
+        // earliest waiter win, firing after the FIRST change and dropping the last (issue #1197).
+        if (!pendingReloads.TryRemove(new KeyValuePair<string, DateTime>(relativePath, changeTime)))
         {
-            return; // Another change superseded this one
+            return; // A newer change superseded this one.
         }
 
         // Check if the asset is loaded

--- a/tests/KeenEyes.Assets.Tests/AssetsClusterFixTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetsClusterFixTests.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+
+namespace KeenEyes.Assets.Tests;
+
+/// <summary>
+/// Regression tests for the assets bug cluster: dependency reference counting on cache hits
+/// (#1190), a cancelled streaming load leaving an entry stuck in Loading (#1191), cancellation
+/// poisoning cache entries (#1192), and the inverted hot-reload debounce (#1197).
+/// </summary>
+public class AssetsClusterFixTests
+{
+    #region #1190 - Dependency refcount on cache hit
+
+    /// <summary>
+    /// An asset that owns a dependency loaded through <see cref="AssetManager.LoadDependency{T}"/>.
+    /// </summary>
+    private sealed class ParentAsset(TestAsset dependency) : IDisposable
+    {
+        public TestAsset Dependency { get; } = dependency;
+
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    /// <summary>
+    /// Loader that pulls in a child asset as a registered dependency of the parent.
+    /// </summary>
+    private sealed class ParentLoader(string dependencyPath) : IAssetLoader<ParentAsset>
+    {
+        public IReadOnlyList<string> Extensions => [".parent"];
+
+        public ParentAsset Load(Stream stream, AssetLoadContext context)
+        {
+            // The returned handle is owned by the parent's dependency tracking, not the caller.
+            var dependency = context.Manager.LoadDependency<TestAsset>(context.Path, dependencyPath);
+            return new ParentAsset(dependency.Asset!);
+        }
+
+        public Task<ParentAsset> LoadAsync(Stream stream, AssetLoadContext context, CancellationToken ct = default)
+            => Task.FromResult(Load(stream, context));
+
+        public long EstimateSize(ParentAsset asset) => 1;
+    }
+
+    [Fact]
+    public void Load_CacheHitOnParent_KeepsDependencyAliveAfterReleasingOneReference()
+    {
+        using var dir = new TestAssetDirectory();
+        dir.CreateFile("dependency.txt", "dep-content");
+        dir.CreateFile("model.parent", "parent");
+
+        using var manager = new AssetManager(new AssetsConfig
+        {
+            RootPath = dir.RootPath,
+            CachePolicy = CachePolicy.Aggressive
+        });
+        manager.RegisterLoader(new TestAssetLoader());
+        manager.RegisterLoader(new ParentLoader("dependency.txt"));
+
+        // First load creates the parent and its dependency (dependency refcount = 1).
+        var first = manager.Load<ParentAsset>("model.parent");
+        var dependency = first.Asset!.Dependency;
+        Assert.False(dependency.IsDisposed);
+
+        // Second load is a cache hit. Acquisition must reference the dependency too, mirroring
+        // the recursive release, otherwise releasing one parent handle drives the dependency's
+        // refcount to zero and disposes it while a parent still holds it.
+        var second = manager.Load<ParentAsset>("model.parent");
+
+        first.Dispose();
+
+        Assert.False(dependency.IsDisposed);
+        Assert.Equal("dep-content", dependency.Content);
+        Assert.True(second.IsLoaded);
+        Assert.Same(dependency, second.Asset!.Dependency);
+
+        second.Dispose();
+    }
+
+    #endregion
+
+    #region #1191 - Cancelled LoadByTypeAsync must not stick in Loading
+
+    [Fact]
+    public async Task LoadByTypeAsync_WhenCancelled_DoesNotLeaveEntryStuckLoadingAndAllowsRetry()
+    {
+        using var dir = new TestAssetDirectory();
+        var path = dir.CreateFile("streamed.bin", "payload");
+
+        using var manager = new AssetManager(new AssetsConfig { RootPath = dir.RootPath });
+        manager.RegisterLoader(new RawLoader());
+
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        // A pre-cancelled token throws out of the semaphore wait, before the load body runs.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => manager.LoadByTypeAsync(path, typeof(RawAsset), LoadPriority.Normal, cancelled.Token));
+
+        // Before the fix the entry stayed in Loading, so this retry would spin in
+        // WaitForLoadAsync forever. It must now complete promptly.
+        var retry = manager.LoadByTypeAsync(path, typeof(RawAsset), LoadPriority.Normal, CancellationToken.None);
+        var finished = await Task.WhenAny(retry, Task.Delay(2000));
+
+        Assert.Same(retry, finished);
+        await retry;
+        Assert.True(manager.IsLoaded(path));
+    }
+
+    #endregion
+
+    #region #1192 - Cancellation must not poison a cache entry
+
+    [Fact]
+    public async Task LoadAsync_AfterCancellation_RetriesSuccessfullyWithFreshToken()
+    {
+        using var dir = new TestAssetDirectory();
+        var path = dir.CreateFile("retry.bin", "payload");
+
+        using var manager = new AssetManager(new AssetsConfig { RootPath = dir.RootPath });
+        manager.RegisterLoader(new RawLoader());
+
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => manager.LoadAsync<RawAsset>(path, LoadPriority.Normal, cancelled.Token));
+
+        // Before the fix the cancelled entry was cached as a permanent failure holding the stale
+        // OperationCanceledException, so this retry rethrew it. It must now load cleanly.
+        using var handle = await manager.LoadAsync<RawAsset>(path);
+
+        Assert.True(handle.IsLoaded);
+        Assert.NotNull(handle.Asset);
+    }
+
+    #endregion
+
+    #region #1197 - Trailing debounce reloads only the most-recent change
+
+    [Fact]
+    public async Task ReloadManager_OverlappingChanges_ReloadsExactlyOnceForTheMostRecentChange()
+    {
+        // NOTE: This exercises the debounce decision directly by invoking TriggerReloadAsync
+        // (the FileSystemWatcher callback body) rather than mutating files, because real watcher
+        // event timing is inherently non-deterministic. Debounce is deliberately large relative
+        // to the inter-change spacing so overlapping changes coalesce; the burst still spans more
+        // than one debounce window, which is what exposed the inverted (leading) behaviour.
+        using var dir = new TestAssetDirectory();
+        var relativePath = dir.CreateFile("hot.bin", "payload");
+        var fullPath = Path.Combine(dir.RootPath, relativePath);
+
+        using var manager = new AssetManager(new AssetsConfig { RootPath = dir.RootPath });
+        manager.RegisterLoader(new RawLoader());
+
+        // Keep the asset loaded so ReloadAsync actually runs and fires the reload event.
+        using var handle = manager.Load<RawAsset>(relativePath);
+        Assert.True(handle.IsLoaded);
+
+        using var reload = new ReloadManager(dir.RootPath, manager, TimeSpan.FromMilliseconds(200));
+        reload.Stop(); // Silence the real watcher; we drive the debounce logic directly.
+
+        var reloadCount = 0;
+        reload.OnAssetReloaded += _ => Interlocked.Increment(ref reloadCount);
+
+        var trigger = typeof(ReloadManager).GetMethod(
+            "TriggerReloadAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // Fire a burst of overlapping changes (~20ms apart, ~400ms total span > 200ms debounce).
+        var pending = new List<Task>();
+        for (var i = 0; i < 20; i++)
+        {
+            pending.Add((Task)trigger.Invoke(reload, [fullPath])!);
+            await Task.Delay(20);
+        }
+
+        await Task.WhenAll(pending);
+        await Task.Delay(100); // Let any trailing reload event settle.
+
+        // Leading (buggy) debounce fired for the first change while later changes were still
+        // arriving, producing multiple reloads. True trailing debounce coalesces to exactly one.
+        Assert.Equal(1, Volatile.Read(ref reloadCount));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes the assets review cluster from the deep-functional-review epic (#1093).

- **#1190** — cache-hit `AddRef` now recurses into dependencies symmetrically with `Release`, so releasing one parent handle no longer disposes a still-referenced shared dependency.
- **#1191** — cancelled `LoadByTypeAsync` no longer leaves the entry stuck `Loading` (semaphore wait wrapped; entry evicted on cancellation).
- **#1192** — cancellation is now non-terminal: entries are evicted (not cached as `Failed`), so a retry with a fresh token starts clean instead of rethrowing a stale OCE.
- **#1197** — `ReloadManager` debounce corrected to true trailing behavior via atomic key/value `TryRemove`; the last change now wins instead of the first.

## Test plan
- [x] `AssetsClusterFixTests` — all 4 fail on old code with predicted symptoms, pass on new
- [x] #1197 uses direct trigger invocation to avoid FileSystemWatcher flakiness (documented)
- [x] Full suite 14,564 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1190
Closes #1191
Closes #1192
Closes #1197