### PR TITLE
fix(core): Fix Clear leaks, validator rollback, dirty-entity recycling, QueryBuilder aliasing, re-entrant Spawn

### DIFF
--- a/src/KeenEyes.Core/Entities/EntityBuilder.cs
+++ b/src/KeenEyes.Core/Entities/EntityBuilder.cs
@@ -261,18 +261,32 @@ public sealed class EntityBuilder : IEntityBuilder<EntityBuilder>
     /// <returns>The created entity.</returns>
     public Entity Build()
     {
-        var entity = world.CreateEntity(components, name);
+        // Snapshot builder state before creating the entity. Entity creation fires
+        // synchronous lifecycle callbacks (ComponentAdded / EntityCreated) that may
+        // re-enter Spawn() on this thread, which resets this pooled, thread-local
+        // builder and clears its backing lists. Copying first isolates the in-flight
+        // build from any nested Spawn/Build so its components, tags, name, and parent
+        // are not corrupted mid-construction.
+        var componentsCopy = new List<(ComponentInfo Info, object Data)>(components);
+        var tagsCopy = stringTags.Count > 0 ? new List<string>(stringTags) : null;
+        var entityName = name;
+        var parent = parentEntity;
+
+        var entity = world.CreateEntity(componentsCopy, entityName);
 
         // Apply string tags after entity creation
-        foreach (var tag in stringTags)
+        if (tagsCopy is not null)
         {
-            world.AddTag(entity, tag);
+            foreach (var tag in tagsCopy)
+            {
+                world.AddTag(entity, tag);
+            }
         }
 
         // Establish parent-child relationship if parent was specified
-        if (parentEntity.HasValue && parentEntity.Value.IsValid)
+        if (parent.HasValue && parent.Value.IsValid)
         {
-            world.SetParent(entity, parentEntity.Value);
+            world.SetParent(entity, parent.Value);
         }
 
         return entity;

--- a/src/KeenEyes.Core/Events/ChangeTracker.cs
+++ b/src/KeenEyes.Core/Events/ChangeTracker.cs
@@ -28,8 +28,11 @@ internal sealed class ChangeTracker
     private readonly Lock syncRoot = new();
     private readonly EntityPool entityPool;
 
-    // Component type -> set of dirty entity IDs
-    private readonly Dictionary<Type, HashSet<int>> dirtyEntities = [];
+    // Component type -> map of dirty entity ID to the entity version at the time it was
+    // marked. The version guards against recycled IDs: if an entity is despawned and its
+    // ID reused for a brand-new entity, the stored version no longer matches and the new
+    // entity is not mistakenly reported as dirty.
+    private readonly Dictionary<Type, Dictionary<int, int>> dirtyEntities = [];
 
     // Component types with auto-tracking enabled
     private readonly HashSet<Type> autoTrackedTypes = [];
@@ -80,13 +83,14 @@ internal sealed class ChangeTracker
     {
         lock (syncRoot)
         {
-            if (!dirtyEntities.TryGetValue(typeof(T), out var entitySet))
+            if (!dirtyEntities.TryGetValue(typeof(T), out var entityMap))
             {
-                entitySet = [];
-                dirtyEntities[typeof(T)] = entitySet;
+                entityMap = [];
+                dirtyEntities[typeof(T)] = entityMap;
             }
 
-            entitySet.Add(entity.Id);
+            // Record (or refresh) the version this entity was dirtied at.
+            entityMap[entity.Id] = entity.Version;
         }
     }
 
@@ -107,30 +111,41 @@ internal sealed class ChangeTracker
     /// </remarks>
     public IEnumerable<Entity> GetDirtyEntities<T>(Func<Entity, bool> isAlive) where T : struct, IComponent
     {
-        int[] entityIdsCopy;
+        (int Id, int Version)[] entitiesCopy;
         lock (syncRoot)
         {
-            if (!dirtyEntities.TryGetValue(typeof(T), out var entitySet))
+            if (!dirtyEntities.TryGetValue(typeof(T), out var entityMap))
             {
                 return [];
             }
-            entityIdsCopy = [.. entitySet];
+
+            entitiesCopy = new (int, int)[entityMap.Count];
+            var index = 0;
+            foreach (var pair in entityMap)
+            {
+                entitiesCopy[index++] = (pair.Key, pair.Value);
+            }
         }
 
-        return GetDirtyEntitiesCore(entityIdsCopy, isAlive);
+        return GetDirtyEntitiesCore(entitiesCopy, isAlive);
     }
 
-    private IEnumerable<Entity> GetDirtyEntitiesCore(int[] entityIds, Func<Entity, bool> isAlive)
+    private IEnumerable<Entity> GetDirtyEntitiesCore((int Id, int Version)[] entities, Func<Entity, bool> isAlive)
     {
-        foreach (var entityId in entityIds)
+        foreach (var (entityId, markedVersion) in entities)
         {
-            var version = entityPool.GetVersion(entityId);
-            if (version < 0)
+            var currentVersion = entityPool.GetVersion(entityId);
+
+            // Skip IDs that never existed, or that were despawned/recycled since being
+            // marked dirty. Comparing against the marked version ensures a recycled ID
+            // reused by a new entity (possibly during this lazy enumeration) is never
+            // reported as dirty on the new entity's behalf.
+            if (currentVersion < 0 || currentVersion != markedVersion)
             {
                 continue;
             }
 
-            var entity = new Entity(entityId, version);
+            var entity = new Entity(entityId, markedVersion);
             if (isAlive(entity))
             {
                 yield return entity;
@@ -152,9 +167,9 @@ internal sealed class ChangeTracker
     {
         lock (syncRoot)
         {
-            if (dirtyEntities.TryGetValue(typeof(T), out var entitySet))
+            if (dirtyEntities.TryGetValue(typeof(T), out var entityMap))
             {
-                entitySet.Clear();
+                entityMap.Clear();
             }
         }
     }
@@ -178,12 +193,15 @@ internal sealed class ChangeTracker
 
         lock (syncRoot)
         {
-            if (!dirtyEntities.TryGetValue(typeof(T), out var entitySet))
+            if (!dirtyEntities.TryGetValue(typeof(T), out var entityMap))
             {
                 return false;
             }
 
-            return entitySet.Contains(entity.Id);
+            // Only report dirty when the marked version matches the queried entity's
+            // version, so a recycled ID is not treated as dirty for the new entity.
+            return entityMap.TryGetValue(entity.Id, out var markedVersion)
+                && markedVersion == entity.Version;
         }
     }
 
@@ -253,12 +271,12 @@ internal sealed class ChangeTracker
     {
         lock (syncRoot)
         {
-            if (!dirtyEntities.TryGetValue(typeof(T), out var entitySet))
+            if (!dirtyEntities.TryGetValue(typeof(T), out var entityMap))
             {
                 return 0;
             }
 
-            return entitySet.Count;
+            return entityMap.Count;
         }
     }
 
@@ -273,9 +291,9 @@ internal sealed class ChangeTracker
     {
         lock (syncRoot)
         {
-            foreach (var entitySet in dirtyEntities.Values)
+            foreach (var entityMap in dirtyEntities.Values)
             {
-                entitySet.Clear();
+                entityMap.Clear();
             }
         }
     }
@@ -287,9 +305,9 @@ internal sealed class ChangeTracker
     {
         lock (syncRoot)
         {
-            foreach (var entitySet in dirtyEntities.Values)
+            foreach (var entityMap in dirtyEntities.Values)
             {
-                entitySet.Remove(entityId);
+                entityMap.Remove(entityId);
             }
         }
     }

--- a/src/KeenEyes.Core/Queries/QueryBuilder.cs
+++ b/src/KeenEyes.Core/Queries/QueryBuilder.cs
@@ -121,6 +121,27 @@ public sealed class QueryDescription
     public void AddWithoutStringTag(string tag) => withoutStringTags.Add(tag);
 
     /// <summary>
+    /// Creates a deep copy of this description with independent filter collections.
+    /// </summary>
+    /// <remarks>
+    /// Used by <see cref="QueryBuilder"/> to implement copy-on-write branching so that
+    /// adding a filter to one branch does not leak into sibling branches that share a
+    /// common base builder.
+    /// </remarks>
+    /// <returns>A new <see cref="QueryDescription"/> with the same filters as this one.</returns>
+    internal QueryDescription Clone()
+    {
+        var clone = new QueryDescription();
+        clone.read.AddRange(read);
+        clone.write.AddRange(write);
+        clone.with.AddRange(with);
+        clone.without.AddRange(without);
+        clone.withStringTags.AddRange(withStringTags);
+        clone.withoutStringTags.AddRange(withoutStringTags);
+        return clone;
+    }
+
+    /// <summary>
     /// Checks if an entity with the given components matches this query.
     /// </summary>
     /// <param name="entityComponents">The component types present on the entity.</param>
@@ -187,8 +208,11 @@ public readonly struct QueryBuilder : IQueryBuilder
     /// <returns>This builder for chaining.</returns>
     public QueryBuilder With<TWith>() where TWith : struct, IComponent
     {
-        description.AddWith<TWith>();
-        return new QueryBuilder(world, description);
+        // Copy-on-write: clone the description so branching from a shared base builder
+        // does not leak this filter into sibling queries.
+        var next = description.Clone();
+        next.AddWith<TWith>();
+        return new QueryBuilder(world, next);
     }
 
     /// <summary>Excludes entities that have this component.</summary>
@@ -196,8 +220,9 @@ public readonly struct QueryBuilder : IQueryBuilder
     /// <returns>This builder for chaining.</returns>
     public QueryBuilder Without<TWithout>() where TWithout : struct, IComponent
     {
-        description.AddWithout<TWithout>();
-        return new QueryBuilder(world, description);
+        var next = description.Clone();
+        next.AddWithout<TWithout>();
+        return new QueryBuilder(world, next);
     }
 
     /// <summary>Requires the entity to have this string tag.</summary>
@@ -208,8 +233,9 @@ public readonly struct QueryBuilder : IQueryBuilder
     public QueryBuilder WithTag(string tag)
     {
         ValidateTag(tag);
-        description.AddWithStringTag(tag);
-        return new QueryBuilder(world, description);
+        var next = description.Clone();
+        next.AddWithStringTag(tag);
+        return new QueryBuilder(world, next);
     }
 
     /// <summary>Excludes entities that have this string tag.</summary>
@@ -220,8 +246,9 @@ public readonly struct QueryBuilder : IQueryBuilder
     public QueryBuilder WithoutTag(string tag)
     {
         ValidateTag(tag);
-        description.AddWithoutStringTag(tag);
-        return new QueryBuilder(world, description);
+        var next = description.Clone();
+        next.AddWithoutStringTag(tag);
+        return new QueryBuilder(world, next);
     }
 
     /// <summary>Gets the query description.</summary>

--- a/src/KeenEyes.Core/World.Entities.cs
+++ b/src/KeenEyes.Core/World.Entities.cs
@@ -148,8 +148,20 @@ public sealed partial class World
         // Add to archetype
         archetypeManager.AddEntity(entity, components);
 
-        // Run custom validators after entity is created (they need access to entity)
-        validationManager.ValidateBuildCustom(entity, components);
+        // Run custom validators after entity is created (they need access to entity).
+        // If validation fails (or the validator itself throws), roll back everything so
+        // no half-initialized entity stays alive and no name remains permanently reserved.
+        try
+        {
+            validationManager.ValidateBuildCustom(entity, components);
+        }
+        catch
+        {
+            archetypeManager.RemoveEntity(entity);
+            entityNamingManager.UnregisterName(entity.Id);
+            entityPool.Release(entity);
+            throw;
+        }
 
         // Fire component added events for each component
         foreach (var (info, data) in components)
@@ -642,8 +654,16 @@ public sealed partial class World
         entityNamingManager.Clear();
         hierarchyManager.Clear();
         singletonManager.Clear();
-        changeTracker.Clear();
-        messageManager.Clear();
+        tagManager.Clear();
+
+        // Reset dirty-flag values but preserve auto-tracking configuration: Clear() is a
+        // state-only snapshot-restore entry point, so per-type tracking opt-ins registered
+        // by systems must survive the reset (ClearAll clears flags, Clear would wipe config).
+        changeTracker.ClearAll();
+
+        // Drop transient queued messages but keep handler subscriptions registered by
+        // systems, consistent with this method preserving event subscriptions.
+        messageManager.ClearQueuedMessages();
 
         // Invalidate query cache since all entities are gone
         queryManager.InvalidateCache();

--- a/tests/KeenEyes.Core.Tests/CoreLifecycleFixTests.cs
+++ b/tests/KeenEyes.Core.Tests/CoreLifecycleFixTests.cs
@@ -1,0 +1,229 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Regression tests for the core entity-lifecycle bug cluster: stale tags and
+/// wiped tracking config after <see cref="World.Clear"/>, validator rollback on a
+/// failed <c>Build()</c>, recycled entities leaking through
+/// <see cref="World.GetDirtyEntities{T}"/>, shared-state corruption when branching a
+/// <see cref="QueryBuilder"/>, and re-entrant <c>Spawn()</c> during <c>Build()</c>.
+/// </summary>
+public class CoreLifecycleFixTests
+{
+    /// <summary>Marker message type for the message-subscription preservation test.</summary>
+    private struct LifecycleTestMessage;
+
+    #region World.Clear() — string tags (#1107)
+
+    [Fact]
+    public void Clear_ThenSpawnRecycledId_DoesNotInheritStaleStringTags()
+    {
+        using var world = new World();
+
+        var original = world.Spawn().With(new TestPosition { X = 1, Y = 2 }).Build();
+        world.AddTag(original, "Boss");
+
+        world.Clear();
+
+        // After Clear, entity IDs restart from zero, so this entity reuses the ID that
+        // "Boss" was applied to. It must not inherit the pre-Clear tag.
+        var recycled = world.Spawn().With(new TestPosition { X = 3, Y = 4 }).Build();
+
+        Assert.Equal(original.Id, recycled.Id);
+        Assert.False(world.HasTag(recycled, "Boss"));
+        Assert.Empty(world.GetTags(recycled));
+    }
+
+    #endregion
+
+    #region World.Clear() — auto-tracking config and message subscriptions (#1110)
+
+    [Fact]
+    public void Clear_PreservesAutoTrackingConfiguration()
+    {
+        using var world = new World();
+
+        world.EnableAutoTracking<TestPosition>();
+        Assert.True(world.IsAutoTrackingEnabled<TestPosition>());
+
+        world.Clear();
+
+        // Clear is a state-only snapshot-restore entry point; the per-type tracking
+        // opt-in registered by a system must survive it.
+        Assert.True(world.IsAutoTrackingEnabled<TestPosition>());
+    }
+
+    [Fact]
+    public void Clear_PreservesMessageSubscriptions()
+    {
+        using var world = new World();
+
+        using var subscription = world.Subscribe<LifecycleTestMessage>(_ => { });
+        Assert.True(world.HasMessageSubscribers<LifecycleTestMessage>());
+
+        world.Clear();
+
+        // Handler subscriptions are wiring registered by systems, not per-entity state,
+        // so they are preserved just like event subscriptions.
+        Assert.True(world.HasMessageSubscribers<LifecycleTestMessage>());
+    }
+
+    #endregion
+
+    #region Failed custom validator during Build() (#1111)
+
+    [Fact]
+    public void Build_WithFailingCustomValidator_DoesNotLeakEntityOrName()
+    {
+        using var world = new World();
+
+        world.ValidationManager.RegisterValidator<TestHealth>(
+            (_, _, health) => health.Current >= 0);
+
+        Assert.Throws<ComponentValidationException>(() =>
+            world.Spawn("Boss")
+                .With(new TestHealth { Current = -5, Max = 10 })
+                .Build());
+
+        // The rejected build must roll back completely: no live entity, no reserved name.
+        Assert.Equal(0, world.EntityCount);
+        Assert.False(world.GetEntityByName("Boss").IsValid);
+    }
+
+    [Fact]
+    public void Build_WithFailingCustomValidator_ReleasesNameForReuse()
+    {
+        using var world = new World();
+
+        world.ValidationManager.RegisterValidator<TestHealth>(
+            (_, _, health) => health.Current >= 0);
+
+        Assert.Throws<ComponentValidationException>(() =>
+            world.Spawn("Boss")
+                .With(new TestHealth { Current = -5, Max = 10 })
+                .Build());
+
+        // Because the failed build released the name, a subsequent valid build can claim it.
+        var boss = world.Spawn("Boss")
+            .With(new TestHealth { Current = 100, Max = 100 })
+            .Build();
+
+        Assert.True(boss.IsValid);
+        Assert.Equal(boss, world.GetEntityByName("Boss"));
+    }
+
+    #endregion
+
+    #region GetDirtyEntities recycled-ID leak (#1112)
+
+    [Fact]
+    public void GetDirtyEntities_WithRecycledIdDuringEnumeration_ExcludesNewEntity()
+    {
+        using var world = new World();
+
+        var marked = world.Spawn().With(new TestPosition { X = 1, Y = 1 }).Build();
+        world.MarkDirty<TestPosition>(marked);
+
+        // Snapshot the dirty set (captures the marked ID + version) before mutating.
+        var dirty = world.GetDirtyEntities<TestPosition>();
+
+        // Despawn the marked entity and recycle its ID onto a brand-new entity that was
+        // never marked dirty. This interleaves recycling with the lazy enumeration.
+        world.Despawn(marked);
+        var recycled = world.Spawn().With(new TestPosition { X = 2, Y = 2 }).Build();
+        Assert.Equal(marked.Id, recycled.Id);
+
+        var results = dirty.ToList();
+
+        // The recycled entity was never dirtied and must not be reported.
+        Assert.DoesNotContain(recycled, results);
+        Assert.Empty(results);
+    }
+
+    #endregion
+
+    #region QueryBuilder branch aliasing (#1114)
+
+    [Fact]
+    public void QueryBuilder_BranchingSharedBase_DoesNotLeakFiltersBetweenSiblings()
+    {
+        using var world = new World();
+
+        // Entity A has all three components; entity B has only Position.
+        var entityA = world.Spawn()
+            .With(new TestPosition { X = 0, Y = 0 })
+            .With(new TestVelocity { X = 1, Y = 0 })
+            .With(new TestHealth { Current = 10, Max = 10 })
+            .Build();
+        var entityB = world.Spawn()
+            .With(new TestPosition { X = 5, Y = 5 })
+            .Build();
+
+        var baseQuery = world.Query<TestPosition>();
+        var withVelocity = baseQuery.With<TestVelocity>();
+        var withoutHealth = baseQuery.Without<TestHealth>();
+
+        // withVelocity requires Position + Velocity -> matches only A.
+        // Without copy-on-write, Without<TestHealth> would leak in and exclude A (it has
+        // Health), wrongly returning 0.
+        var withVelocityResults = withVelocity.ToList();
+        Assert.Single(withVelocityResults);
+        Assert.Equal(entityA, withVelocityResults[0]);
+
+        // withoutHealth requires Position and excludes Health -> matches only B.
+        // Without copy-on-write, With<TestVelocity> would leak in and exclude B (no
+        // Velocity), wrongly returning 0.
+        var withoutHealthResults = withoutHealth.ToList();
+        Assert.Single(withoutHealthResults);
+        Assert.Equal(entityB, withoutHealthResults[0]);
+    }
+
+    #endregion
+
+    #region Re-entrant Spawn during Build() (#1148)
+
+    [Fact]
+    public void Build_WithReentrantSpawnInLifecycleCallback_BuildsBothEntitiesCorrectly()
+    {
+        using var world = new World();
+
+        Entity nested = default;
+        var reentered = false;
+
+        // A ComponentAdded callback fires synchronously while the outer entity's
+        // component list is being enumerated. Re-entering Spawn() here previously
+        // corrupted the shared thread-local builder and threw "Collection was modified".
+        using var subscription = world.OnComponentAdded<TestPosition>((_, _) =>
+        {
+            if (!reentered)
+            {
+                reentered = true;
+                nested = world.Spawn()
+                    .With(new TestVelocity { X = 9, Y = 9 })
+                    .Build();
+            }
+        });
+
+        var outer = world.Spawn()
+            .With(new TestPosition { X = 1, Y = 2 })
+            .With(new TestHealth { Current = 100, Max = 100 })
+            .Build();
+
+        Assert.True(reentered);
+
+        // Outer entity built with all its components intact despite the nested Spawn.
+        Assert.True(outer.IsValid);
+        Assert.True(world.Has<TestPosition>(outer));
+        Assert.True(world.Has<TestHealth>(outer));
+        ref readonly var position = ref world.GetReadonly<TestPosition>(outer);
+        Assert.Equal(1f, position.X);
+        Assert.Equal(2f, position.Y);
+
+        // Nested entity built correctly and is distinct from the outer entity.
+        Assert.True(nested.IsValid);
+        Assert.NotEqual(outer.Id, nested.Id);
+        Assert.True(world.Has<TestVelocity>(nested));
+        Assert.False(world.Has<TestPosition>(nested));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes the core entity-lifecycle review cluster from the deep-functional-review epic (#1093).

- **#1107** — `World.Clear()` now clears `tagManager`; recycled IDs no longer inherit stale string tags.
- **#1110** — `Clear()` uses `ChangeTracker.ClearAll()` (preserves per-type auto-tracking config) and `MessageManager.ClearQueuedMessages()` (keeps handler subscriptions).
- **#1111** — `CreateEntity()` rolls back (archetype removal, name unregister, ID release) when a custom validator fails/throws — no leaked entity or reserved name.
- **#1112** — `ChangeTracker` stores `(id → version)` and validates version on yield / in `IsDirty`; recycled IDs reused mid-enumeration are skipped.
- **#1114** — `QueryBuilder` clones its `QueryDescription` copy-on-write, so sibling branches off a shared base builder no longer leak filters.
- **#1148** — `EntityBuilder.Build()` snapshots its state before `CreateEntity`, isolating an in-flight build from a re-entrant `Spawn()` fired by a synchronous lifecycle callback.

## Test plan
- [x] `CoreLifecycleFixTests` (8 tests) — fail-on-old/pass-on-new proven per issue via source revert
- [x] Core.Tests 2317/2317; full suite 14,568 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1107
Closes #1110
Closes #1111
Closes #1112
Closes #1114
Closes #1148