### PR TITLE
fix(core): Fix delta load round-trip, chain restore, name-clear deltas, change-trigger autosave, migration paths

### DIFF
--- a/src/KeenEyes.Core/SaveManager.cs
+++ b/src/KeenEyes.Core/SaveManager.cs
@@ -541,11 +541,13 @@ internal sealed class SaveManager
         var fileData = File.ReadAllBytes(filePath);
         var (slotInfo, snapshotData) = SaveFileFormat.Read(fileData, validateChecksum);
 
-        // Check if this is a delta
+        // Check if this is a delta. CustomMetadata is IReadOnlyDictionary<string, object>,
+        // and the source-generated JSON deserializer round-trips the boxed bool as a
+        // JsonElement rather than a bool, so the stored flag must be interpreted in both
+        // forms (in-memory bool before a round-trip, JsonElement after).
         if (slotInfo.CustomMetadata is null ||
-            !slotInfo.CustomMetadata.TryGetValue("isDelta", out var isDeltatObj) ||
-            isDeltatObj is not bool isDelta ||
-            !isDelta)
+            !slotInfo.CustomMetadata.TryGetValue("isDelta", out var isDeltaObj) ||
+            !IsTrueFlag(isDeltaObj))
         {
             throw new InvalidDataException($"Save slot '{slotName}' is not a delta snapshot.");
         }
@@ -557,6 +559,17 @@ internal sealed class SaveManager
 
         return delta;
     }
+
+    /// <summary>
+    /// Interprets a custom-metadata value as a boolean flag, tolerating both a live boxed
+    /// <see cref="bool"/> and a <see cref="JsonElement"/> produced by a JSON round-trip.
+    /// </summary>
+    private static bool IsTrueFlag(object? value) => value switch
+    {
+        bool b => b,
+        JsonElement { ValueKind: JsonValueKind.True } => true,
+        _ => false
+    };
 
     #endregion
 

--- a/src/KeenEyes.Core/Serialization/AutoSaveConfig.cs
+++ b/src/KeenEyes.Core/Serialization/AutoSaveConfig.cs
@@ -36,8 +36,9 @@ public sealed record AutoSaveConfig
     /// Gets or sets the number of entity changes that trigger an auto-save.
     /// </summary>
     /// <remarks>
-    /// Set to 0 or negative to disable change-based auto-save.
-    /// Default is 1000 changes.
+    /// A "change" is an entity creation or destruction accumulated since the last auto-save;
+    /// once the running count reaches this threshold, an auto-save is performed and the count
+    /// resets. Set to 0 or negative to disable change-based auto-save. Default is 1000 changes.
     /// </remarks>
     public int ChangeThreshold { get; init; } = 1000;
 

--- a/src/KeenEyes.Core/Serialization/DeltaDiffer.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaDiffer.cs
@@ -174,17 +174,26 @@ public static class DeltaDiffer
         IComponentSerializer serializer)
     {
         string? newName = null;
+        var nameRemoved = false;
         int? newParentId = null;
         var parentRemoved = false;
         var addedComponents = new List<SerializedComponent>();
         var removedComponentTypes = new List<string>();
         var modifiedComponents = new List<SerializedComponent>();
 
-        // Check name change
+        // Check name change. A null NewName means "unchanged", so a cleared name must be
+        // signalled explicitly via NameRemoved (mirroring NewParentId / ParentRemoved).
         var currentName = world.GetName(entity);
         if (currentName != baseline.Name)
         {
-            newName = currentName; // null means name was removed
+            if (currentName is not null)
+            {
+                newName = currentName;
+            }
+            else
+            {
+                nameRemoved = true;
+            }
         }
 
         // Check parent change
@@ -252,6 +261,7 @@ public static class DeltaDiffer
         {
             EntityId = entity.Id,
             NewName = newName,
+            NameRemoved = nameRemoved,
             NewParentId = newParentId,
             ParentRemoved = parentRemoved,
             AddedComponents = addedComponents,

--- a/src/KeenEyes.Core/Serialization/DeltaRestorer.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaRestorer.cs
@@ -94,6 +94,16 @@ public static class DeltaRestorer
         // 2. Create new entities
         foreach (var created in delta.CreatedEntities)
         {
+            // Guard against re-creating an entity that already exists and is alive. Cumulative
+            // delta chains (fixed-baseline, AutoSave-style) replay the same creation records in
+            // every delta, so without this guard applying a second delta would spawn a duplicate
+            // of every entity created since the baseline. Mirrors the id-collision handling in
+            // DeltaSnapshotApplier, which treats the surviving entity as authoritative.
+            if (newEntityMap.TryGetValue(created.Id, out var existing) && world.IsAlive(existing))
+            {
+                continue;
+            }
+
             var entity = CreateEntity(world, created, serializer);
             newEntityMap[created.Id] = entity;
         }
@@ -113,7 +123,25 @@ public static class DeltaRestorer
             }
         }
 
-        // 4. Apply modifications to existing entities
+        // 4. Clear removed names up front, before any name assignments in step 5. This lets a
+        //    name freed by one entity be reused by another within the same delta (for example,
+        //    entity A drops "Boss" and entity B is renamed to "Boss"), which would otherwise
+        //    throw because the old owner still holds the name when the new owner claims it.
+        foreach (var modification in delta.ModifiedEntities)
+        {
+            if (!modification.NameRemoved)
+            {
+                continue;
+            }
+
+            if (newEntityMap.TryGetValue(modification.EntityId, out var namedEntity) &&
+                world.IsAlive(namedEntity))
+            {
+                world.SetName(namedEntity, null);
+            }
+        }
+
+        // 5. Apply modifications to existing entities
         foreach (var modification in delta.ModifiedEntities)
         {
             if (!newEntityMap.TryGetValue(modification.EntityId, out var entity))
@@ -129,7 +157,7 @@ public static class DeltaRestorer
             ApplyEntityDelta(world, entity, modification, serializer, newEntityMap);
         }
 
-        // 5. Update singletons
+        // 6. Update singletons
         foreach (var singleton in delta.ModifiedSingletons)
         {
             var type = serializer.GetType(singleton.TypeName);
@@ -145,7 +173,7 @@ public static class DeltaRestorer
             }
         }
 
-        // 6. Remove deleted singletons
+        // 7. Remove deleted singletons
         foreach (var removedType in delta.RemovedSingletonTypes)
         {
             var type = serializer.GetType(removedType);
@@ -216,7 +244,8 @@ public static class DeltaRestorer
         IComponentSerializer serializer,
         Dictionary<int, Entity> entityMap)
     {
-        // Apply name change
+        // Apply name change. Name clears are handled in a dedicated earlier pass (see
+        // ApplyDelta) so a freed name is available before any entity here claims it.
         if (delta.NewName is not null)
         {
             world.SetName(entity, delta.NewName);

--- a/src/KeenEyes.Core/Serialization/DeltaSnapshot.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaSnapshot.cs
@@ -115,9 +115,23 @@ public sealed record EntityDelta
     public required int EntityId { get; init; }
 
     /// <summary>
-    /// Gets whether the entity's name changed.
+    /// Gets the new name assigned to the entity, or <c>null</c> when the name is unchanged.
     /// </summary>
+    /// <remarks>
+    /// A <c>null</c> value means "no change"; to represent clearing an entity's name, use
+    /// <see cref="NameRemoved"/>. This mirrors how <see cref="NewParentId"/> and
+    /// <see cref="ParentRemoved"/> distinguish "reparent" from "orphan".
+    /// </remarks>
     public string? NewName { get; init; }
+
+    /// <summary>
+    /// Gets whether the entity's name was explicitly cleared (removed).
+    /// </summary>
+    /// <remarks>
+    /// Distinct from a <c>null</c> <see cref="NewName"/>, which means the name is unchanged.
+    /// When <c>true</c>, the entity's name is removed during restoration.
+    /// </remarks>
+    public bool NameRemoved { get; init; }
 
     /// <summary>
     /// Gets whether the entity's parent changed.
@@ -150,6 +164,7 @@ public sealed record EntityDelta
     [JsonIgnore]
     public bool IsEmpty =>
         NewName is null &&
+        !NameRemoved &&
         NewParentId is null &&
         !ParentRemoved &&
         AddedComponents.Count == 0 &&

--- a/src/KeenEyes.Core/Serialization/DeltaSnapshotApplier.cs
+++ b/src/KeenEyes.Core/Serialization/DeltaSnapshotApplier.cs
@@ -126,7 +126,7 @@ public static class DeltaSnapshotApplier
     /// </summary>
     private static SerializedEntity ApplyEntityDelta(SerializedEntity entity, EntityDelta delta)
     {
-        var name = delta.NewName ?? entity.Name;
+        var name = delta.NameRemoved ? null : (delta.NewName ?? entity.Name);
 
         int? parentId = entity.ParentId;
         if (delta.ParentRemoved)

--- a/src/KeenEyes.Core/Serialization/MigrationGraph.cs
+++ b/src/KeenEyes.Core/Serialization/MigrationGraph.cs
@@ -257,30 +257,86 @@ public sealed class MigrationGraph(string componentTypeName, int currentVersion 
 
     private bool ComputeHasPath(int from, int to)
     {
-        // For linear chains (v → v+1 → v+2), use simple iteration
-        for (var v = from; v < to; v++)
+        // Breadth-first search over the actual edge set so that non-adjacent edges
+        // (e.g. a direct v1 → v3 migration) are honored, not just consecutive v → v+1 steps.
+        var visited = new HashSet<int> { from };
+        var queue = new Queue<int>();
+        queue.Enqueue(from);
+
+        while (queue.Count > 0)
         {
-            if (!adjacencyList.TryGetValue(v, out var targets) || !targets.Contains(v + 1))
+            var current = queue.Dequeue();
+            if (!adjacencyList.TryGetValue(current, out var targets))
             {
-                return false;
+                continue;
+            }
+
+            foreach (var next in targets)
+            {
+                if (next == to)
+                {
+                    return true;
+                }
+
+                if (visited.Add(next))
+                {
+                    queue.Enqueue(next);
+                }
             }
         }
-        return true;
+
+        return false;
     }
 
     private IReadOnlyList<MigrationStep> ComputeMigrationChain(int from, int to)
     {
-        // For linear chains, build the step list directly
-        var chain = new List<MigrationStep>();
-        for (var v = from; v < to; v++)
+        // Breadth-first search yields the fewest-hop path across the edge set, then the
+        // predecessor map is walked back to build the ordered migration steps. Returns an
+        // empty chain when no path exists.
+        var predecessors = new Dictionary<int, int>();
+        var visited = new HashSet<int> { from };
+        var queue = new Queue<int>();
+        queue.Enqueue(from);
+        var found = false;
+
+        while (queue.Count > 0 && !found)
         {
-            if (!adjacencyList.TryGetValue(v, out var targets) || !targets.Contains(v + 1))
+            var current = queue.Dequeue();
+            if (!adjacencyList.TryGetValue(current, out var targets))
             {
-                // Gap found - return empty chain
-                return [];
+                continue;
             }
-            chain.Add(new MigrationStep(v, v + 1));
+
+            foreach (var next in targets)
+            {
+                if (!visited.Add(next))
+                {
+                    continue;
+                }
+
+                predecessors[next] = current;
+                if (next == to)
+                {
+                    found = true;
+                    break;
+                }
+
+                queue.Enqueue(next);
+            }
         }
+
+        if (!found)
+        {
+            return [];
+        }
+
+        var chain = new List<MigrationStep>();
+        for (var node = to; node != from; node = predecessors[node])
+        {
+            chain.Add(new MigrationStep(predecessors[node], node));
+        }
+
+        chain.Reverse();
         return chain;
     }
 

--- a/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
+++ b/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
@@ -42,9 +42,12 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     private AutoSaveConfig config;
 
     private float timeSinceLastSave;
+    private int changesSinceLastSave;
     private int currentDeltaSequence;
     private WorldSnapshot? baselineSnapshot;
     private bool isInitialized;
+    private EventSubscription? entityCreatedSubscription;
+    private EventSubscription? entityDestroyedSubscription;
 
     /// <summary>
     /// Creates a new auto-save system with the specified serializer.
@@ -77,6 +80,15 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     public float TimeSinceLastSave => timeSinceLastSave;
 
     /// <summary>
+    /// Gets the number of tracked entity changes (creations and destructions) since the last save.
+    /// </summary>
+    /// <remarks>
+    /// This is the value compared against <see cref="AutoSaveConfig.ChangeThreshold"/> to drive
+    /// the change-based auto-save trigger. It resets to zero after each successful save.
+    /// </remarks>
+    public int ChangesSinceLastSave => changesSinceLastSave;
+
+    /// <summary>
     /// Gets the current delta sequence number (0 if no saves have occurred).
     /// </summary>
     public int CurrentDeltaSequence => currentDeltaSequence;
@@ -100,6 +112,12 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     protected override void OnInitialize()
     {
         isInitialized = true;
+
+        // Subscribe to entity lifecycle events to drive the change-based trigger. Entity
+        // creations and destructions since the last save are counted and compared against
+        // AutoSaveConfig.ChangeThreshold in Update.
+        entityCreatedSubscription = World.OnEntityCreated((_, _) => changesSinceLastSave++);
+        entityDestroyedSubscription = World.OnEntityDestroyed(_ => changesSinceLastSave++);
 
         // Try to load existing baseline if it exists
         if (World is ISaveLoadCapability saveLoad && saveLoad.SaveSlotExists(config.BaselineSlotName))
@@ -146,6 +164,12 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
             shouldSave = true;
         }
 
+        // Change-based trigger
+        if (config.ChangeThreshold > 0 && changesSinceLastSave >= config.ChangeThreshold)
+        {
+            shouldSave = true;
+        }
+
         if (shouldSave)
         {
             PerformAutoSave(saveLoad);
@@ -186,6 +210,7 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     public void Reset()
     {
         timeSinceLastSave = 0;
+        changesSinceLastSave = 0;
         currentDeltaSequence = 0;
         baselineSnapshot = null;
     }
@@ -214,8 +239,9 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
                 info = SaveBaseline(saveLoad);
             }
 
-            // Reset timer
+            // Reset trigger accumulators
             timeSinceLastSave = 0;
+            changesSinceLastSave = 0;
 
             // Clear dirty flags if configured
             if (config.ClearDirtyFlagsAfterSave)
@@ -308,5 +334,19 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
             }
         }
         return highest;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            entityCreatedSubscription?.Dispose();
+            entityDestroyedSubscription?.Dispose();
+            entityCreatedSubscription = null;
+            entityDestroyedSubscription = null;
+        }
+
+        base.Dispose(disposing);
     }
 }

--- a/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
+++ b/tests/KeenEyes.Core.Tests/AutoSaveSystemTests.cs
@@ -201,6 +201,59 @@ public class AutoSaveSystemTests : IDisposable
         Assert.True(system.TimeSinceLastSave < 1f); // Timer reset
     }
 
+    [Fact]
+    public void Update_AfterChangeThresholdReached_TriggersSave()
+    {
+        using var world = new World { SaveDirectory = testSaveDirectory };
+
+        // Time trigger disabled; only the change threshold can drive a save.
+        var config = new AutoSaveConfig { AutoSaveIntervalSeconds = 0f, ChangeThreshold = 2 };
+        var system = new AutoSaveSystem<TestComponentSerializer>(serializer, config);
+        world.AddSystem(system);
+
+        // Two entity creations meet the threshold of 2.
+        world.Spawn().With(new SerializablePosition()).Build();
+        world.Spawn().With(new SerializablePosition()).Build();
+
+        world.Update(0.001f);
+
+        Assert.True(world.SaveSlotExists(config.BaselineSlotName));
+    }
+
+    [Fact]
+    public void Update_BelowChangeThreshold_DoesNotSave()
+    {
+        using var world = new World { SaveDirectory = testSaveDirectory };
+
+        var config = new AutoSaveConfig { AutoSaveIntervalSeconds = 0f, ChangeThreshold = 5 };
+        var system = new AutoSaveSystem<TestComponentSerializer>(serializer, config);
+        world.AddSystem(system);
+
+        // Only two changes; threshold is five.
+        world.Spawn().With(new SerializablePosition()).Build();
+        world.Spawn().With(new SerializablePosition()).Build();
+
+        world.Update(0.001f);
+
+        Assert.False(world.SaveSlotExists(config.BaselineSlotName));
+    }
+
+    [Fact]
+    public void Update_AfterChangeTriggeredSave_ResetsChangeCount()
+    {
+        using var world = new World { SaveDirectory = testSaveDirectory };
+
+        var config = new AutoSaveConfig { AutoSaveIntervalSeconds = 0f, ChangeThreshold = 2 };
+        var system = new AutoSaveSystem<TestComponentSerializer>(serializer, config);
+        world.AddSystem(system);
+
+        world.Spawn().With(new SerializablePosition()).Build();
+        world.Spawn().With(new SerializablePosition()).Build();
+        world.Update(0.001f);
+
+        Assert.Equal(0, system.ChangesSinceLastSave);
+    }
+
     #endregion
 
     #region Manual Save Tests

--- a/tests/KeenEyes.Core.Tests/MigrationGraphTests.cs
+++ b/tests/KeenEyes.Core.Tests/MigrationGraphTests.cs
@@ -467,6 +467,87 @@ public class MigrationGraphTests
     }
 
     #endregion
+
+    #region Non-Adjacent Edge Tests (#1136)
+
+    [Fact]
+    public void HasPath_WithDirectNonAdjacentEdge_ReturnsTrue()
+    {
+        var graph = new MigrationGraph("TestComponent", 3);
+
+        // A single direct v1 -> v3 migration, no intermediate v2 step.
+        graph.AddEdge(1, 3);
+
+        Assert.True(graph.HasPath(1, 3));
+    }
+
+    [Fact]
+    public void GetMigrationChain_WithDirectNonAdjacentEdge_ReturnsSingleStep()
+    {
+        var graph = new MigrationGraph("TestComponent", 3);
+        graph.AddEdge(1, 3);
+
+        var chain = graph.GetMigrationChain(1, 3);
+
+        Assert.Single(chain);
+        Assert.Equal(new MigrationStep(1, 3), chain[0]);
+    }
+
+    [Fact]
+    public void HasPath_AcrossChainedNonAdjacentEdges_ReturnsTrue()
+    {
+        var graph = new MigrationGraph("TestComponent", 5);
+
+        // v1 -> v3 -> v5, skipping v2 and v4 entirely.
+        graph.AddEdge(1, 3);
+        graph.AddEdge(3, 5);
+
+        Assert.True(graph.HasPath(1, 5));
+    }
+
+    [Fact]
+    public void GetMigrationChain_AcrossChainedNonAdjacentEdges_ReturnsOrderedSteps()
+    {
+        var graph = new MigrationGraph("TestComponent", 5);
+        graph.AddEdge(1, 3);
+        graph.AddEdge(3, 5);
+
+        var chain = graph.GetMigrationChain(1, 5);
+
+        Assert.Equal(2, chain.Count);
+        Assert.Equal(new MigrationStep(1, 3), chain[0]);
+        Assert.Equal(new MigrationStep(3, 5), chain[1]);
+    }
+
+    [Fact]
+    public void GetMigrationChain_PrefersFewerHopsWhenDirectEdgeExists()
+    {
+        var graph = new MigrationGraph("TestComponent", 3);
+
+        // Both a direct edge and a two-step route from v1 to v3 exist; BFS must pick the direct one.
+        graph.AddEdge(1, 2);
+        graph.AddEdge(2, 3);
+        graph.AddEdge(1, 3);
+
+        var chain = graph.GetMigrationChain(1, 3);
+
+        Assert.Single(chain);
+        Assert.Equal(new MigrationStep(1, 3), chain[0]);
+    }
+
+    [Fact]
+    public void HasPath_WhenNoRouteExists_ReturnsFalse()
+    {
+        var graph = new MigrationGraph("TestComponent", 4);
+
+        // v1 -> v2 exists but there is no way to reach v4.
+        graph.AddEdge(1, 2);
+
+        Assert.False(graph.HasPath(1, 4));
+        Assert.Empty(graph.GetMigrationChain(1, 4));
+    }
+
+    #endregion
 }
 
 /// <summary>

--- a/tests/KeenEyes.Core.Tests/SaveManagerAdditionalTests.cs
+++ b/tests/KeenEyes.Core.Tests/SaveManagerAdditionalTests.cs
@@ -413,4 +413,56 @@ public class SaveManagerAdditionalTests
     }
 
     #endregion
+
+    #region SaveDelta / LoadDelta Round-Trip (#1132)
+
+    [Fact]
+    public void LoadDelta_AfterSaveDelta_RoundTripsSuccessfully()
+    {
+        var saveDir = "test-saves-loaddelta-roundtrip";
+
+        try
+        {
+            Directory.CreateDirectory(saveDir);
+
+            using var world = new World();
+            world.Components.Register<SerializablePosition>();
+            world.SaveDirectory = saveDir;
+
+            var serializer = new TestComponentSerializer()
+                .WithComponent<SerializablePosition>();
+
+            var manager = new SaveManager(world, saveDir);
+
+            var delta = new DeltaSnapshot
+            {
+                BaselineSlotName = "baseline",
+                SequenceNumber = 3,
+                CreatedEntities =
+                [
+                    new SerializedEntity { Id = 1, Name = "Created", Components = [] }
+                ]
+            };
+
+            // Persist the delta, then read it back through the only load API.
+            manager.SaveDelta("delta1", delta, serializer);
+            var loaded = manager.LoadDelta("delta1");
+
+            // The engine's own delta file must be loadable: the isDelta flag round-trips as a
+            // JsonElement, so the guard must accept it rather than rejecting every delta.
+            Assert.Equal(3, loaded.SequenceNumber);
+            Assert.Equal("baseline", loaded.BaselineSlotName);
+            Assert.Single(loaded.CreatedEntities);
+            Assert.Equal(1, loaded.CreatedEntities[0].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(saveDir))
+            {
+                Directory.Delete(saveDir, true);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Core.Tests/Serialization/DeltaRestorerTests.cs
+++ b/tests/KeenEyes.Core.Tests/Serialization/DeltaRestorerTests.cs
@@ -816,4 +816,77 @@ public class DeltaRestorerTests
     }
 
     #endregion
+
+    #region Cumulative Chain Tests (#1133)
+
+    [Fact]
+    public void ApplyDelta_ReplayingSameCreationOnCumulativeChain_DoesNotDuplicateEntity()
+    {
+        using var world = new World();
+        world.Components.Register<SerializablePosition>();
+
+        // A baseline entity plus its mapping, as produced by restoring a baseline snapshot.
+        var baselineEntity = world.Spawn().With(new SerializablePosition { X = 1, Y = 2 }).Build();
+        var entityMap = new Dictionary<int, Entity> { [baselineEntity.Id] = baselineEntity };
+
+        // Cumulative (fixed-baseline) deltas replay the same creation record in every delta.
+        var delta = new DeltaSnapshot
+        {
+            BaselineSlotName = "baseline",
+            SequenceNumber = 1,
+            CreatedEntities =
+            [
+                new SerializedEntity
+                {
+                    Id = 999,
+                    Name = null,
+                    Components = []
+                }
+            ]
+        };
+
+        // Apply the same creation twice, as happens when d1 then d2 (both diffed against the
+        // same baseline) are applied in sequence.
+        var mapAfterFirst = DeltaRestorer.ApplyDelta(world, delta, serializer, entityMap);
+        DeltaRestorer.ApplyDelta(world, delta, serializer, mapAfterFirst);
+
+        // Expect exactly two entities (baseline + the single created one), not three.
+        Assert.Equal(2, world.GetAllEntities().Count());
+    }
+
+    #endregion
+
+    #region Name-Clear Delta Tests (#1134)
+
+    [Fact]
+    public void ApplyDelta_WithNameClearedAndReused_RestoresNamesWithoutThrowing()
+    {
+        // Author the change in a source world, diff it, then restore into a fresh world.
+        using var sourceWorld = new World();
+        sourceWorld.Components.Register<SerializablePosition>();
+
+        var a = sourceWorld.Spawn("Boss").With(new SerializablePosition { X = 1, Y = 1 }).Build();
+        var b = sourceWorld.Spawn("Bob").With(new SerializablePosition { X = 2, Y = 2 }).Build();
+
+        var baseline = SnapshotManager.CreateSnapshot(sourceWorld, serializer);
+
+        // Clear A's name, then hand "Boss" to B. This must be representable in a delta.
+        sourceWorld.SetName(a, null);
+        sourceWorld.SetName(b, "Boss");
+
+        var delta = DeltaDiffer.CreateDelta(sourceWorld, baseline, serializer, "baseline", 1);
+
+        // Restore the baseline into a fresh world and apply the delta.
+        using var targetWorld = new World();
+        targetWorld.Components.Register<SerializablePosition>();
+        var entityMap = SnapshotManager.RestoreSnapshot(targetWorld, baseline, serializer);
+
+        // Applying must not throw "name 'Boss' already exists".
+        DeltaRestorer.ApplyDelta(targetWorld, delta, serializer, entityMap);
+
+        Assert.Null(targetWorld.GetName(entityMap[a.Id]));
+        Assert.Equal("Boss", targetWorld.GetName(entityMap[b.Id]));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Fixes the core serialization/delta review cluster from the deep-functional-review epic (#1093).

- **#1132** — `LoadDelta` rejected its own delta files: `CustomMetadata["isDelta"]` round-trips through source-gen STJ as a `JsonElement`, not `bool`. Added an `IsTrueFlag` helper accepting both.
- **#1133** — `DeltaRestorer.ApplyDelta` now has an existing-alive-mapping collision guard (mirroring `DeltaSnapshotApplier`), so cumulative fixed-baseline chains no longer duplicate/resurrect entities.
- **#1134** — added an explicit `EntityDelta.NameRemoved` flag so name-clear is representable in deltas; a freed name can be reused within one delta without a "name already exists" crash.
- **#1135** — implemented the documented `AutoSaveConfig.ChangeThreshold` trigger via `OnEntityCreated`/`OnEntityDestroyed` counting (subscriptions disposed in `Dispose`), exposing `ChangesSinceLastSave`.
- **#1136** — `MigrationGraph.HasPath`/`GetMigrationChain` now BFS the edge set, honoring non-adjacent edges and returning the fewest-hop chain.

## Test plan
- [x] New/extended tests across SaveManager, DeltaRestorer, AutoSaveSystem, MigrationGraph; fail-on-old/pass-on-new proven per issue via source revert
- [x] Core.Tests 2321, Persistence.Tests 79; full suite 14,572 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1132
Closes #1133
Closes #1134
Closes #1135
Closes #1136