### PR TITLE
fix(animation): Correct wrap modes, event timing, GPU skinning, and zero-duration transitions

### DIFF
--- a/src/KeenEyes.Animation/Components/AnimationPlayer.cs
+++ b/src/KeenEyes.Animation/Components/AnimationPlayer.cs
@@ -71,6 +71,17 @@ public partial struct AnimationPlayer
     public bool IsComplete;
 
     /// <summary>
+    /// Whether ping-pong playback is currently travelling in reverse.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Time"/> stores the reflected (displayed) time, which is not monotonic,
+    /// so the direction of travel cannot be recovered from it alone. This flag preserves
+    /// the ping-pong half-cycle across frames so the timeline sweeps fully in both directions.
+    /// </remarks>
+    [BuilderIgnore]
+    public bool PingPongReversed;
+
+    /// <summary>
     /// Creates a default animation player.
     /// </summary>
     public static AnimationPlayer Default => new()
@@ -82,7 +93,8 @@ public partial struct AnimationPlayer
         IsPlaying = false,
         WrapModeOverride = null,
         Weight = 1f,
-        IsComplete = false
+        IsComplete = false,
+        PingPongReversed = false
     };
 
     /// <summary>

--- a/src/KeenEyes.Animation/Components/SkinnedMesh.cs
+++ b/src/KeenEyes.Animation/Components/SkinnedMesh.cs
@@ -12,7 +12,7 @@ namespace KeenEyes.Animation.Components;
 /// </para>
 /// <para>
 /// The skinning system reads bone transforms from the bone entity hierarchy and computes
-/// the final bone matrices (boneWorldTransform * inverseBindMatrix) for GPU skinning.
+/// the final bone matrices (inverseBindMatrix * boneWorldTransform, row-vector order) for GPU skinning.
 /// </para>
 /// <para>
 /// Prerequisites for a skinned mesh entity:
@@ -56,7 +56,7 @@ public partial struct SkinnedMesh
     /// </para>
     /// <para>
     /// The skinning system reads world transforms from these entities
-    /// and multiplies by the inverse bind matrices to compute
+    /// and composes them with the inverse bind matrices to compute
     /// the final bone matrices for GPU upload.
     /// </para>
     /// </remarks>
@@ -68,7 +68,7 @@ public partial struct SkinnedMesh
     /// <remarks>
     /// Each inverse bind matrix transforms vertices from model space to the
     /// corresponding bone's local space. During rendering, the final skinning
-    /// matrix is computed as: boneWorldTransform * inverseBindMatrix.
+    /// matrix is computed as: inverseBindMatrix * boneWorldTransform (row-vector order).
     /// </remarks>
     public Matrix4x4[]? InverseBindMatrices;
 

--- a/src/KeenEyes.Animation/Data/AnimationClip.cs
+++ b/src/KeenEyes.Animation/Data/AnimationClip.cs
@@ -114,19 +114,10 @@ public sealed class AnimationClip
         return WrapMode switch
         {
             WrapMode.Once => Math.Clamp(time, 0f, Duration),
-            WrapMode.Loop => time % Duration,
-            WrapMode.PingPong => WrapPingPong(time),
+            WrapMode.Loop => WrapMath.Repeat(time, Duration),
+            WrapMode.PingPong => WrapMath.PingPong(time, Duration),
             WrapMode.ClampForever => Math.Max(time, 0f),
             _ => time
         };
-    }
-
-    private float WrapPingPong(float time)
-    {
-        var cycles = (int)(time / Duration);
-        var t = time % Duration;
-
-        // Odd cycles play in reverse
-        return (cycles % 2 == 1) ? Duration - t : t;
     }
 }

--- a/src/KeenEyes.Animation/Data/SpriteSheet.cs
+++ b/src/KeenEyes.Animation/Data/SpriteSheet.cs
@@ -122,17 +122,10 @@ public sealed class SpriteSheet
         return mode switch
         {
             WrapMode.Once => Math.Clamp(time, 0f, TotalDuration),
-            WrapMode.Loop => time >= 0f ? time % TotalDuration : TotalDuration + (time % TotalDuration),
-            WrapMode.PingPong => WrapPingPong(time),
+            WrapMode.Loop => WrapMath.Repeat(time, TotalDuration),
+            WrapMode.PingPong => WrapMath.PingPong(time, TotalDuration),
             WrapMode.ClampForever => Math.Max(time, 0f),
             _ => time
         };
-    }
-
-    private float WrapPingPong(float time)
-    {
-        var cycles = (int)(time / TotalDuration);
-        var t = time % TotalDuration;
-        return (cycles % 2 == 1) ? TotalDuration - t : t;
     }
 }

--- a/src/KeenEyes.Animation/Data/WrapMath.cs
+++ b/src/KeenEyes.Animation/Data/WrapMath.cs
@@ -1,0 +1,48 @@
+namespace KeenEyes.Animation.Data;
+
+/// <summary>
+/// Sign-safe time-wrapping helpers shared by the animation wrap modes.
+/// </summary>
+/// <remarks>
+/// C#'s <c>%</c> operator preserves the sign of the dividend, so a naive
+/// <c>time % duration</c> leaves negative (reverse-playback) times negative and never
+/// folds them into the <c>[0, duration)</c> range. These helpers use a positive-modulo
+/// formula so both forward and reverse times wrap correctly.
+/// </remarks>
+internal static class WrapMath
+{
+    /// <summary>
+    /// Wraps <paramref name="time"/> into the half-open range <c>[0, length)</c>,
+    /// handling negative times correctly.
+    /// </summary>
+    /// <param name="time">The (possibly negative or unbounded) time.</param>
+    /// <param name="length">The positive length to wrap within.</param>
+    /// <returns>The wrapped time in <c>[0, length)</c>, or 0 when length is not positive.</returns>
+    public static float Repeat(float time, float length)
+    {
+        if (length <= 0f)
+        {
+            return 0f;
+        }
+
+        return ((time % length) + length) % length;
+    }
+
+    /// <summary>
+    /// Folds a monotonic <paramref name="time"/> into a triangle (ping-pong) wave over
+    /// <c>[0, length]</c>, reflecting at each boundary.
+    /// </summary>
+    /// <param name="time">The (possibly negative or unbounded) monotonic time.</param>
+    /// <param name="length">The positive half-period (clip duration) to reflect within.</param>
+    /// <returns>The reflected time in <c>[0, length]</c>, or 0 when length is not positive.</returns>
+    public static float PingPong(float time, float length)
+    {
+        if (length <= 0f)
+        {
+            return 0f;
+        }
+
+        var folded = Repeat(time, length * 2f);
+        return folded <= length ? folded : (length * 2f) - folded;
+    }
+}

--- a/src/KeenEyes.Animation/Rendering/BoneMatrixBuffer.cs
+++ b/src/KeenEyes.Animation/Rendering/BoneMatrixBuffer.cs
@@ -25,7 +25,7 @@ namespace KeenEyes.Animation.Rendering;
 /// for (int i = 0; i &lt; skeleton.BoneCount; i++)
 /// {
 ///     var worldTransform = GetBoneWorldTransform(i);
-///     var finalMatrix = worldTransform * skeleton.InverseBindMatrices[i];
+///     var finalMatrix = skeleton.InverseBindMatrices[i] * worldTransform;
 ///     buffer.SetBoneMatrix(i, finalMatrix, frameGeneration);
 /// }
 ///
@@ -89,7 +89,7 @@ public sealed class BoneMatrixBuffer : IDisposable
     /// Sets the matrix for a specific bone.
     /// </summary>
     /// <param name="boneIndex">The bone index.</param>
-    /// <param name="matrix">The bone's final skinning matrix (world * inverseBindMatrix).</param>
+    /// <param name="matrix">The bone's final skinning matrix (inverseBindMatrix * world, row-vector order).</param>
     /// <param name="generation">The generation counter for change tracking.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when boneIndex is out of range.</exception>
     public void SetBoneMatrix(int boneIndex, Matrix4x4 matrix, ulong generation)

--- a/src/KeenEyes.Animation/Systems/AnimationEventSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimationEventSystem.cs
@@ -45,9 +45,17 @@ public sealed class AnimationEventSystem : SystemBase
 
         foreach (var entity in World.Query<AnimationPlayer>())
         {
-            ref readonly var player = ref World.Get<AnimationPlayer>(entity);
+            ref var player = ref World.Get<AnimationPlayer>(entity);
 
-            if (!player.IsPlaying || player.ClipId < 0)
+            if (player.ClipId < 0)
+            {
+                continue;
+            }
+
+            // Process while playing, and also on the frame playback completes: the player
+            // system (which runs first) clears IsPlaying on the completion frame, so gating
+            // solely on IsPlaying would drop the final advanced range's events.
+            if (!player.IsPlaying && !player.IsComplete)
             {
                 continue;
             }
@@ -70,6 +78,14 @@ public sealed class AnimationEventSystem : SystemBase
                     evt.Parameter,
                     evt.Time,
                     player.ClipId));
+            }
+
+            // A completed, stopped player is no longer advanced by AnimationPlayerSystem,
+            // so its [PreviousTime, Time] window would repeat forever. Collapse it once the
+            // final events have been dispatched to prevent re-firing on subsequent frames.
+            if (player.IsComplete && !player.IsPlaying)
+            {
+                player.PreviousTime = player.Time;
             }
         }
     }

--- a/src/KeenEyes.Animation/Systems/AnimationPlayerSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimationPlayerSystem.cs
@@ -52,8 +52,8 @@ public sealed class AnimationPlayerSystem : SystemBase
             // Save previous time for event detection
             player.PreviousTime = player.Time;
 
-            // Advance time
-            player.Time += deltaTime * player.Speed * clip.Speed;
+            // Signed timeline step for this frame
+            var step = deltaTime * player.Speed * clip.Speed;
 
             // Get wrap mode
             var wrapMode = player.WrapModeOverride ?? clip.WrapMode;
@@ -65,22 +65,36 @@ public sealed class AnimationPlayerSystem : SystemBase
                 player.IsComplete = true;
                 player.IsPlaying = false;
             }
-            else if (wrapMode == WrapMode.Once && player.Time >= clip.Duration)
+            else if (wrapMode == WrapMode.PingPong)
             {
-                player.Time = clip.Duration;
-                player.IsComplete = true;
-                player.IsPlaying = false;
-            }
-            else if (wrapMode == WrapMode.ClampForever)
-            {
-                player.Time = Math.Max(player.Time, 0f);
-                player.IsComplete = player.Time >= clip.Duration;
+                // Ping-pong reflects the timeline, so the stored Time is not monotonic.
+                // Advance from the current reflected position using the tracked direction
+                // so the half-cycle parity survives across frames.
+                (player.Time, player.PingPongReversed) =
+                    AdvancePingPong(player.Time, player.PingPongReversed, step, clip.Duration);
+                player.IsComplete = false;
             }
             else
             {
-                // Wrap the time based on the effective wrap mode
-                player.Time = WrapTime(player.Time, clip.Duration, wrapMode);
-                player.IsComplete = false;
+                player.Time += step;
+
+                if (wrapMode == WrapMode.Once && player.Time >= clip.Duration)
+                {
+                    player.Time = clip.Duration;
+                    player.IsComplete = true;
+                    player.IsPlaying = false;
+                }
+                else if (wrapMode == WrapMode.ClampForever)
+                {
+                    player.Time = Math.Max(player.Time, 0f);
+                    player.IsComplete = player.Time >= clip.Duration;
+                }
+                else
+                {
+                    // Wrap the time based on the effective wrap mode
+                    player.Time = WrapTime(player.Time, clip.Duration, wrapMode);
+                    player.IsComplete = false;
+                }
             }
         }
     }
@@ -90,19 +104,25 @@ public sealed class AnimationPlayerSystem : SystemBase
         return wrapMode switch
         {
             WrapMode.Once => Math.Clamp(time, 0f, duration),
-            WrapMode.Loop => time % duration,
-            WrapMode.PingPong => WrapPingPong(time, duration),
+            WrapMode.Loop => WrapMath.Repeat(time, duration),
             WrapMode.ClampForever => Math.Max(time, 0f),
             _ => time
         };
     }
 
-    private static float WrapPingPong(float time, float duration)
+    /// <summary>
+    /// Advances a ping-pong timeline by a signed step, reflecting at both boundaries.
+    /// </summary>
+    /// <returns>The new reflected time and whether travel is now in reverse.</returns>
+    private static (float Time, bool Reversed) AdvancePingPong(float time, bool reversed, float step, float duration)
     {
-        var cycles = (int)(time / duration);
-        var t = time % duration;
+        var period = duration * 2f;
 
-        // Odd cycles play in reverse
-        return (cycles % 2 == 1) ? duration - t : t;
+        // Reconstruct the monotonic phase from the reflected position + direction,
+        // advance it, then fold back into a triangle wave.
+        var phase = reversed ? period - time : time;
+        var folded = WrapMath.Repeat(phase + step, period);
+
+        return folded <= duration ? (folded, false) : (period - folded, true);
     }
 }

--- a/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
+++ b/src/KeenEyes.Animation/Systems/AnimatorSystem.cs
@@ -113,7 +113,18 @@ public sealed class AnimatorSystem : SystemBase
             // Update transition
             if (animator.NextStateHash != 0)
             {
-                animator.TransitionProgress += deltaTime / animator.TransitionDuration;
+                // A zero (or negative) duration is a valid instantaneous transition.
+                // Guard the division: dt/0 is +Infinity (completes by luck) and 0/0 is NaN,
+                // which never satisfies >= 1 and poisons the animator permanently.
+                if (animator.TransitionDuration <= 0f)
+                {
+                    animator.TransitionProgress = 1f;
+                }
+                else
+                {
+                    animator.TransitionProgress += deltaTime / animator.TransitionDuration;
+                }
+
                 animator.NextStateTime += deltaTime * speed;
 
                 if (animator.TransitionProgress >= 1f)

--- a/src/KeenEyes.Animation/Systems/SkeletonPoseSystem.cs
+++ b/src/KeenEyes.Animation/Systems/SkeletonPoseSystem.cs
@@ -111,7 +111,13 @@ public sealed class SkeletonPoseSystem : SystemBase
                 manager.TryGetClip(nextState.ClipId, out nextClip);
             }
 
-            animatorCache[entity.Id] = (currentClip, animator.StateTime, nextClip, animator.NextStateTime, animator.TransitionProgress);
+            // Animator state times accumulate unbounded; wrap them through each clip's
+            // WrapMode before sampling so looping/ping-pong states do not freeze at the
+            // final keyframe (the curves clamp past their last key).
+            var currentTime = currentClip?.WrapTime(animator.StateTime) ?? animator.StateTime;
+            var nextTime = nextClip?.WrapTime(animator.NextStateTime) ?? animator.NextStateTime;
+
+            animatorCache[entity.Id] = (currentClip, currentTime, nextClip, nextTime, animator.TransitionProgress);
         }
     }
 

--- a/src/KeenEyes.Animation/Systems/SkinnedMeshBoneSystem.cs
+++ b/src/KeenEyes.Animation/Systems/SkinnedMeshBoneSystem.cs
@@ -17,7 +17,7 @@ namespace KeenEyes.Animation.Systems;
 /// <list type="number">
 ///   <item><description>Reads world transforms from bone entities</description></item>
 ///   <item><description>Gets inverse bind matrices from the SkinnedMesh component</description></item>
-///   <item><description>Computes: boneMatrix = boneWorldTransform × inverseBindMatrix</description></item>
+///   <item><description>Computes: boneMatrix = inverseBindMatrix × boneWorldTransform (row-vector order)</description></item>
 ///   <item><description>Stores results in a <see cref="BoneMatrixBuffer"/> for GPU upload</description></item>
 /// </list>
 /// <para>
@@ -29,6 +29,11 @@ namespace KeenEyes.Animation.Systems;
 public sealed class SkinnedMeshBoneSystem : SystemBase
 {
     private readonly Dictionary<int, BoneMatrixBuffer> boneBuffers = [];
+
+    // Rebuilt each frame: maps entity id -> the live entity handle (with its current
+    // version) so bone ids stored on the SkinnedMesh component can be resolved without
+    // fabricating a Version-0 handle (which IsAlive always rejects).
+    private readonly Dictionary<int, Entity> entityLookup = [];
     private ulong currentGeneration;
 
     /// <summary>
@@ -46,6 +51,13 @@ public sealed class SkinnedMeshBoneSystem : SystemBase
     {
         // Increment generation for dirty tracking
         currentGeneration++;
+
+        // Resolve bone ids to live entity handles (with correct versions) for this frame.
+        entityLookup.Clear();
+        foreach (var entity in World.Query<Transform3D>())
+        {
+            entityLookup[entity.Id] = entity;
+        }
 
         // Track which entities we've seen this frame
         var activeEntities = new HashSet<int>();
@@ -106,9 +118,12 @@ public sealed class SkinnedMeshBoneSystem : SystemBase
             // Get world transform of the bone entity
             var boneWorldMatrix = GetBoneWorldMatrix(boneEntityId);
 
-            // Compute final bone matrix: worldTransform * inverseBindMatrix
+            // Compute final skinning matrix. System.Numerics uses the row-vector convention
+            // (v' = v * M), so a vertex is first pulled into bone space by the inverse bind
+            // matrix, then pushed to the animated pose by the bone's world matrix:
+            // finalMatrix = inverseBindMatrix * boneWorldMatrix.
             var inverseBindMatrix = skinnedMesh.InverseBindMatrices[i];
-            var finalMatrix = boneWorldMatrix * inverseBindMatrix;
+            var finalMatrix = inverseBindMatrix * boneWorldMatrix;
 
             // Store in buffer with current generation for dirty tracking
             buffer.SetBoneMatrix(i, finalMatrix, currentGeneration);
@@ -117,9 +132,14 @@ public sealed class SkinnedMeshBoneSystem : SystemBase
 
     private Matrix4x4 GetBoneWorldMatrix(int boneEntityId)
     {
-        // Try to get the entity
-        var entity = new Entity(boneEntityId, 0); // Version 0 for lookup
+        // Resolve the id to the live entity handle (correct version) for this frame.
+        return entityLookup.TryGetValue(boneEntityId, out var entity)
+            ? GetBoneWorldMatrix(entity)
+            : Matrix4x4.Identity;
+    }
 
+    private Matrix4x4 GetBoneWorldMatrix(Entity entity)
+    {
         // Check if entity is alive
         if (!World.IsAlive(entity))
         {
@@ -139,11 +159,12 @@ public sealed class SkinnedMeshBoneSystem : SystemBase
                          Matrix4x4.CreateFromQuaternion(transform.Rotation) *
                          Matrix4x4.CreateTranslation(transform.Position);
 
-        // If entity has a parent, multiply by parent's world matrix
+        // If entity has a parent, compose with the parent's world matrix. GetParent returns
+        // a live handle, so recursion keeps the correct version without an id round-trip.
         var parentEntity = World.GetParent(entity);
         if (parentEntity.IsValid)
         {
-            var parentWorld = GetBoneWorldMatrix(parentEntity.Id);
+            var parentWorld = GetBoneWorldMatrix(parentEntity);
             return localMatrix * parentWorld;
         }
 

--- a/src/KeenEyes.Animation/Systems/TweenSystem.cs
+++ b/src/KeenEyes.Animation/Systems/TweenSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using KeenEyes.Animation.Components;
+using KeenEyes.Animation.Data;
 using KeenEyes.Animation.Tweening;
 
 namespace KeenEyes.Animation.Systems;
@@ -41,7 +42,7 @@ public sealed class TweenSystem : SystemBase
 
             tween.ElapsedTime += deltaTime;
 
-            var t = ComputeProgress(ref tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
+            var t = ComputeProgress(tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
             tween.IsComplete = complete;
 
             if (complete && !tween.Loop)
@@ -67,7 +68,7 @@ public sealed class TweenSystem : SystemBase
 
             tween.ElapsedTime += deltaTime;
 
-            var t = ComputeProgress(ref tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
+            var t = ComputeProgress(tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
             tween.IsComplete = complete;
 
             if (complete && !tween.Loop)
@@ -93,7 +94,7 @@ public sealed class TweenSystem : SystemBase
 
             tween.ElapsedTime += deltaTime;
 
-            var t = ComputeProgress(ref tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
+            var t = ComputeProgress(tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
             tween.IsComplete = complete;
 
             if (complete && !tween.Loop)
@@ -119,7 +120,7 @@ public sealed class TweenSystem : SystemBase
 
             tween.ElapsedTime += deltaTime;
 
-            var t = ComputeProgress(ref tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
+            var t = ComputeProgress(tween.ElapsedTime, tween.Duration, tween.Loop, tween.PingPong, out var complete);
             tween.IsComplete = complete;
 
             if (complete && !tween.Loop)
@@ -132,7 +133,7 @@ public sealed class TweenSystem : SystemBase
         }
     }
 
-    private static float ComputeProgress(ref float elapsed, float duration, bool loop, bool pingPong, out bool complete)
+    private static float ComputeProgress(float elapsed, float duration, bool loop, bool pingPong, out bool complete)
     {
         complete = false;
 
@@ -146,25 +147,19 @@ public sealed class TweenSystem : SystemBase
         {
             if (loop)
             {
+                // Keep the accumulated time monotonic and derive the wrapped phase locally.
+                // Mutating elapsed here (elapsed %= duration) destroys cycle parity, which
+                // turned ping-pong into a forward-only sawtooth.
                 if (pingPong)
                 {
-                    // Ping-pong: calculate which cycle we're in and direction
-                    var cycles = (int)(elapsed / duration);
-                    elapsed %= duration;
-                    return (cycles % 2 == 0) ? elapsed / duration : 1f - elapsed / duration;
+                    return WrapMath.PingPong(elapsed, duration) / duration;
                 }
-                else
-                {
-                    elapsed %= duration;
-                    return elapsed / duration;
-                }
+
+                return WrapMath.Repeat(elapsed, duration) / duration;
             }
-            else
-            {
-                complete = true;
-                elapsed = duration;
-                return 1f;
-            }
+
+            complete = true;
+            return 1f;
         }
 
         return elapsed / duration;

--- a/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
+++ b/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
@@ -1813,4 +1813,228 @@ public class AnimationSystemTests : IDisposable
     }
 
     #endregion
+
+    #region Bug Cluster Regression Tests (#1116-#1121)
+
+    [Fact]
+    public void AnimationPlayerSystem_ReverseLoopingPlayback_WrapsIntoRangeInsteadOfGoingNegative()
+    {
+        // Issue #1120: C#'s signed remainder left reverse (negative) loop time negative,
+        // so playback ran unboundedly negative and froze at the clamped first keyframe.
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var manager = world.GetExtension<AnimationManager>();
+        var clip = new AnimationClip { Name = "LoopClip", Duration = 1f, WrapMode = WrapMode.Loop };
+        var clipId = manager.RegisterClip(clip);
+
+        var entity = world.Spawn()
+            .With(AnimationPlayer.ForClip(clipId) with { Time = 0.5f, Speed = -1f })
+            .Build();
+
+        var system = new AnimationPlayerSystem();
+        world.AddSystem(system);
+
+        // Raw time = 0.5 + (0.75 * -1) = -0.25 -> should wrap to 0.75, not stay -0.25.
+        system.Update(0.75f);
+
+        ref readonly var player = ref world.Get<AnimationPlayer>(entity);
+        player.Time.ApproximatelyEquals(0.75f, 0.0001f).ShouldBeTrue();
+        player.IsPlaying.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AnimationPlayerSystem_PingPongPlayback_SweepsFullyBackToStart()
+    {
+        // Issue #1118: storing the reflected time back into Time destroyed the half-cycle
+        // parity, so playback bounced near the clip end instead of sweeping back to 0.
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var manager = world.GetExtension<AnimationManager>();
+        var clip = new AnimationClip { Name = "PingPongClip", Duration = 1f, WrapMode = WrapMode.PingPong };
+        var clipId = manager.RegisterClip(clip);
+
+        var entity = world.Spawn()
+            .With(AnimationPlayer.ForClip(clipId))
+            .Build();
+
+        var system = new AnimationPlayerSystem();
+        world.AddSystem(system);
+
+        // Four 0.5s steps (raw time 2.0 = one full ping-pong period) should return to 0.
+        // The old code got stuck oscillating at 0.5<->1.0 and reported 1.0 here.
+        system.Update(0.5f);
+        system.Update(0.5f);
+        system.Update(0.5f);
+        system.Update(0.5f);
+
+        ref readonly var player = ref world.Get<AnimationPlayer>(entity);
+        player.Time.ApproximatelyEquals(0f, 0.0001f).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AnimationEventSystem_FinalFrameEventOfOnceClip_IsStillFired()
+    {
+        // Issue #1117: the player system clears IsPlaying on the completion frame before the
+        // event system runs, so the event in the final advanced range used to be dropped.
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var manager = world.GetExtension<AnimationManager>();
+        var clip = new AnimationClip { Name = "OnceClip", Duration = 1f, WrapMode = WrapMode.Once };
+        clip.Events.AddEvent(0.95f, "finale");
+        var clipId = manager.RegisterClip(clip);
+
+        world.Spawn()
+            .With(AnimationPlayer.ForClip(clipId))
+            .Build();
+
+        var playerSystem = new AnimationPlayerSystem();
+        var eventSystem = new AnimationEventSystem();
+        world.AddSystem(playerSystem);
+        world.AddSystem(eventSystem);
+
+        var receivedEvents = new List<AnimationEventTriggeredEvent>();
+        using var subscription = world.Subscribe<AnimationEventTriggeredEvent>(e => receivedEvents.Add(e));
+
+        // Advance to 0.75 (before the event), then step past the end (completes this frame).
+        playerSystem.Update(0.75f);
+        eventSystem.Update(0.75f);
+        receivedEvents.Count.ShouldBe(0);
+
+        playerSystem.Update(0.25f);
+        eventSystem.Update(0.25f);
+
+        receivedEvents.Count.ShouldBe(1);
+        receivedEvents[0].EventName.ShouldBe("finale");
+
+        // A completed, stopped clip must not re-fire the same event on later frames.
+        playerSystem.Update(0.25f);
+        eventSystem.Update(0.25f);
+        receivedEvents.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TweenSystem_LoopPingPong_PlaysReversePhaseAfterFirstCycle()
+    {
+        // Issue #1119: ComputeProgress mutated ElapsedTime by ref (elapsed %= duration),
+        // destroying cycle parity so the tween ascended every cycle (sawtooth) instead of
+        // reversing (triangle wave).
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var entity = world.Spawn()
+            .With(TweenFloat.Create(0f, 10f, 1f, EaseType.Linear) with { Loop = true, PingPong = true })
+            .Build();
+
+        var system = new TweenSystem();
+        world.AddSystem(system);
+
+        // Raw elapsed 1.25 sits in the reverse half-cycle: progress 0.75 -> value 7.5.
+        // The old ref-mutating code reported 2.5 (ascending) here.
+        system.Update(0.5f);
+        system.Update(0.5f);
+        system.Update(0.25f);
+
+        ref readonly var tween = ref world.Get<TweenFloat>(entity);
+        tween.CurrentValue.ApproximatelyEquals(7.5f, 0.001f).ShouldBeTrue();
+        tween.IsComplete.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AnimatorSystem_ZeroDurationTransitionOnZeroDeltaFrame_CompletesInsteadOfWedgingInNaN()
+    {
+        // Issue #1121: TransitionProgress += dt/0 is NaN on a dt=0 frame; NaN >= 1 is false and
+        // NaN + x stays NaN, so the animator was poisoned and never left the source state.
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var manager = world.GetExtension<AnimationManager>();
+        var clipA = new AnimationClip { Name = "ClipA", Duration = 1f };
+        var clipB = new AnimationClip { Name = "ClipB", Duration = 1f };
+        var clipAId = manager.RegisterClip(clipA);
+        var clipBId = manager.RegisterClip(clipB);
+
+        var controller = new AnimatorController { Name = "TestController" };
+        var stateA = new AnimatorState { Name = "A", ClipId = clipAId };
+        var stateB = new AnimatorState { Name = "B", ClipId = clipBId };
+        stateA.AddTransition("B", 0f); // zero-duration (instantaneous) transition
+        controller.AddState(stateA, isDefault: true);
+        controller.AddState(stateB);
+        var controllerId = manager.RegisterController(controller);
+
+        var entity = world.Spawn()
+            .With(Animator.ForController(controllerId))
+            .Build();
+
+        var system = new AnimatorSystem();
+        world.AddSystem(system);
+
+        var stateBHash = Animator.GetStateHash("B");
+
+        ref var animator = ref world.Get<Animator>(entity);
+        animator.TriggerStateHash = stateBHash;
+
+        // dt=0 frame while the zero-duration transition is armed.
+        system.Update(0f);
+        system.Update(0.1f);
+        system.Update(0.1f);
+        system.Update(0.1f);
+
+        ref readonly var after = ref world.Get<Animator>(entity);
+        float.IsNaN(after.TransitionProgress).ShouldBeFalse();
+        after.CurrentStateHash.ShouldBe(stateBHash);
+        after.NextStateHash.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SkeletonPoseSystem_LoopingAnimatorStatePastClipEnd_WrapsSampleInsteadOfFreezing()
+    {
+        // Issue #1116: Animator StateTime accumulates unbounded and the pose was sampled at the
+        // raw time; a looping clip's curve clamps past its last keyframe, freezing the pose.
+        world = new World();
+        world.InstallPlugin(new AnimationPlugin());
+
+        var manager = world.GetExtension<AnimationManager>();
+
+        var positionCurve = new Vector3Curve();
+        positionCurve.AddKeyframe(0f, Vector3.Zero);
+        positionCurve.AddKeyframe(1f, new Vector3(10f, 0f, 0f));
+        var boneTrack = new BoneTrack { BoneName = "bone1", PositionCurve = positionCurve };
+
+        var clip = new AnimationClip { Name = "LoopClip", Duration = 1f, WrapMode = WrapMode.Loop };
+        clip.AddBoneTrack(boneTrack);
+        var clipId = manager.RegisterClip(clip);
+
+        var controller = new AnimatorController { Name = "TestController" };
+        var idleState = new AnimatorState { Name = "Idle", ClipId = clipId };
+        controller.AddState(idleState, isDefault: true);
+        var controllerId = manager.RegisterController(controller);
+
+        var skeletonRoot = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(Animator.ForController(controllerId))
+            .Build();
+
+        var boneEntity = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(BoneReference.Create("bone1", skeletonRoot.Id))
+            .Build();
+
+        var animatorSystem = new AnimatorSystem();
+        var poseSystem = new SkeletonPoseSystem();
+        world.AddSystem(animatorSystem);
+        world.AddSystem(poseSystem);
+
+        // StateTime advances to 1.5s of a 1s clip; wrapped sample is at 0.5 -> X == 5,
+        // not the frozen last keyframe X == 10.
+        animatorSystem.Update(1.5f);
+        poseSystem.Update(1.5f);
+
+        ref readonly var boneTransform = ref world.Get<Transform3D>(boneEntity);
+        boneTransform.Position.X.ApproximatelyEquals(5f, 0.001f).ShouldBeTrue();
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Animation.Tests/SkinnedMeshBoneSystemTests.cs
+++ b/tests/KeenEyes.Animation.Tests/SkinnedMeshBoneSystemTests.cs
@@ -1,0 +1,124 @@
+using System.Numerics;
+using KeenEyes.Animation.Components;
+using KeenEyes.Animation.Systems;
+using KeenEyes.Common;
+
+namespace KeenEyes.Animation.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="SkinnedMeshBoneSystem"/> covering GPU-skinning bone
+/// matrix computation (issue #1115).
+/// </summary>
+public class SkinnedMeshBoneSystemTests : IDisposable
+{
+    private World? world;
+
+    public void Dispose()
+    {
+        world?.Dispose();
+    }
+
+    [Fact]
+    public void Update_BoneEntityWithWorldOffset_ResolvesLiveHandleInsteadOfIdentity()
+    {
+        world = new World();
+
+        // Bone entity translated 5 units along X.
+        var bone = world.Spawn()
+            .With(new Transform3D(new Vector3(5f, 0f, 0f), Quaternion.Identity, Vector3.One))
+            .Build();
+
+        // Skinned mesh referencing that bone with an identity inverse bind matrix.
+        var mesh = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(SkinnedMesh.Create(1, [bone.Id], [Matrix4x4.Identity]))
+            .Build();
+
+        var system = new SkinnedMeshBoneSystem();
+        world.AddSystem(system);
+
+        system.Update(1f / 60f);
+
+        var buffer = system.GetBoneMatrixBuffer(mesh.Id);
+        buffer.ShouldNotBeNull();
+
+        // Before the fix the bone handle was fabricated with Version 0, IsAlive rejected it,
+        // and the matrix stayed identity (translation == 0).
+        var boneMatrix = buffer.GetBoneMatrix(0);
+        boneMatrix.M41.ApproximatelyEquals(5f).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Update_NonCommutingTransforms_UsesRowVectorMultiplicationOrder()
+    {
+        world = new World();
+
+        // Bone animated to a rotated + translated pose (rotation makes the multiply order matter).
+        var bone = world.Spawn()
+            .With(new Transform3D(
+                new Vector3(0f, 3f, 0f),
+                Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.PI / 2f),
+                Vector3.One))
+            .Build();
+
+        // Inverse bind matrix that pulls the bind-pose vertex back to the bone origin.
+        var inverseBind = Matrix4x4.CreateTranslation(-2f, 0f, 0f);
+
+        var mesh = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(SkinnedMesh.Create(1, [bone.Id], [inverseBind]))
+            .Build();
+
+        var system = new SkinnedMeshBoneSystem();
+        world.AddSystem(system);
+
+        system.Update(1f / 60f);
+
+        var buffer = system.GetBoneMatrixBuffer(mesh.Id);
+        buffer.ShouldNotBeNull();
+
+        // A bind-pose vertex at (2,0,0) should map to the animated bone origin (0,3,0).
+        // Correct row-vector order (inverseBind * boneWorld) yields (0,3,0);
+        // the reversed order (boneWorld * inverseBind) would yield (-2,5,0).
+        var skinned = Vector3.Transform(new Vector3(2f, 0f, 0f), buffer.GetBoneMatrix(0));
+        skinned.X.ApproximatelyEquals(0f).ShouldBeTrue();
+        skinned.Y.ApproximatelyEquals(3f).ShouldBeTrue();
+        skinned.Z.ApproximatelyEquals(0f).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Update_ParentedBone_ComposesParentWorldMatrixThroughLiveHandles()
+    {
+        world = new World();
+
+        // Parent bone translated 10 along X.
+        var parentBone = world.Spawn()
+            .With(new Transform3D(new Vector3(10f, 0f, 0f), Quaternion.Identity, Vector3.One))
+            .Build();
+
+        // Child bone offset 1 along X in local space, parented to the parent bone.
+        var childBone = world.Spawn()
+            .With(new Transform3D(new Vector3(1f, 0f, 0f), Quaternion.Identity, Vector3.One))
+            .Build();
+
+        world.SetParent(childBone, parentBone);
+
+        var mesh = world.Spawn()
+            .With(Transform3D.Identity)
+            .With(SkinnedMesh.Create(1, [childBone.Id], [Matrix4x4.Identity]))
+            .Build();
+
+        var system = new SkinnedMeshBoneSystem();
+        world.AddSystem(system);
+
+        system.Update(1f / 60f);
+
+        var buffer = system.GetBoneMatrixBuffer(mesh.Id);
+        buffer.ShouldNotBeNull();
+
+        // Child world X = local 1 + parent 10 = 11. The parent recursion must resolve a live
+        // handle too; the old code round-tripped through a Version-0 id and lost it.
+        var boneMatrix = buffer.GetBoneMatrix(0);
+        boneMatrix.M41.ApproximatelyEquals(11f).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the animation review cluster from the deep-functional-review epic (#1093).

- **#1115** — `SkinnedMeshBoneSystem` builds a per-frame `id → live Entity` map instead of fabricating `new Entity(id, 0)`; parent recursion threads live handles. Folded-in follow-up: corrected skinning multiply to `inverseBind * boneWorld` (row-vector convention) + fixed contradicting doc comments.
- **#1116** — `SkeletonPoseSystem` wraps unbounded state time through each clip's `WrapTime` before sampling, so looping Animator states no longer freeze at the clip end.
- **#1117** — `AnimationEventSystem` processes the final advanced range on the completion frame, then collapses `PreviousTime` so a stopped clip never re-fires.
- **#1118** — `AnimationPlayer.PingPongReversed` stateful reflect reconstructs monotonic phase, so PingPong sweeps fully.
- **#1119** — `TweenSystem.ComputeProgress` no longer mutates `ElapsedTime`; accumulated time stays monotonic (fixes sawtooth).
- **#1120** — new sign-safe `WrapMath` helper used at all wrap sites; reverse loops wrap into range instead of running negative.
- **#1121** — `AnimatorSystem` guards `TransitionDuration <= 0` as an immediate transition before dividing (fixes NaN).

## Test plan
- [x] `AnimationSystemTests` + `SkinnedMeshBoneSystemTests`; fail-on-old/pass-on-new proven per issue via source revert
- [x] Animation tests 357; full suite 14,569 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1115
Closes #1116
Closes #1117
Closes #1118
Closes #1119
Closes #1120
Closes #1121