### PR TITLE
fix(parallelism): Fix tag-filter drop, command-buffer id collision, cross-scheduler dependency, unregister deps, batch threshold

### DIFF
--- a/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
+++ b/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
@@ -62,6 +62,9 @@ public static class ParallelQueryExtensions
         }
 
         // Collect all chunks across archetypes for parallel processing
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -70,6 +73,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, ref span1[i]);
             }
         });
@@ -101,6 +108,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -109,6 +119,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, in span1[i]);
             }
         });
@@ -147,6 +161,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -156,6 +173,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, ref span1[i], ref span2[i]);
             }
         });
@@ -190,6 +211,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -199,6 +223,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, in span1[i], in span2[i]);
             }
         });
@@ -240,6 +268,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -250,6 +281,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, ref span1[i], ref span2[i], ref span3[i]);
             }
         });
@@ -287,6 +322,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -297,6 +335,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, in span1[i], in span2[i], in span3[i]);
             }
         });
@@ -341,6 +383,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -352,6 +397,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, ref span1[i], ref span2[i], ref span3[i], ref span4[i]);
             }
         });
@@ -392,6 +441,9 @@ public static class ParallelQueryExtensions
             return;
         }
 
+        var world = query.World;
+        var description = query.Description;
+        var hasTagFilters = description.HasStringTagFilters;
         var chunks = CollectChunks(archetypes);
 
         Parallel.ForEach(chunks, chunk =>
@@ -403,6 +455,10 @@ public static class ParallelQueryExtensions
             for (int i = 0; i < chunk.Count; i++)
             {
                 var entity = chunk.GetEntity(i);
+                if (hasTagFilters && !MatchesStringTags(world, description, entity))
+                {
+                    continue;
+                }
                 action(entity, in span1[i], in span2[i], in span3[i], in span4[i]);
             }
         });
@@ -420,6 +476,29 @@ public static class ParallelQueryExtensions
             count += archetype.Count;
         }
         return count;
+    }
+
+    private static bool MatchesStringTags(World world, QueryDescription description, Entity entity)
+    {
+        // All required tags must be present.
+        foreach (var tag in description.WithStringTags)
+        {
+            if (!world.HasTag(entity, tag))
+            {
+                return false;
+            }
+        }
+
+        // No excluded tags can be present.
+        foreach (var tag in description.WithoutStringTags)
+        {
+            if (world.HasTag(entity, tag))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static List<ArchetypeChunk> CollectChunks(IReadOnlyList<Archetype> archetypes)

--- a/src/KeenEyes.Core/Parallelism/SystemDependencyTracker.cs
+++ b/src/KeenEyes.Core/Parallelism/SystemDependencyTracker.cs
@@ -14,7 +14,10 @@ namespace KeenEyes;
 /// <list type="number">
 ///   <item>Explicit declaration via <see cref="ISystemDependencyProvider"/></item>
 ///   <item>Manual registration via <see cref="RegisterDependencies"/></item>
-///   <item>Assumed full access if not declared (conservative)</item>
+///   <item>Assumed empty (no component access) if not declared — an optimistic default.
+///   Such systems never register a conflict, so they may be batched to run concurrently
+///   with any other system. Declare dependencies explicitly for systems that touch shared
+///   component data.</item>
 /// </list>
 /// </para>
 /// </remarks>

--- a/src/KeenEyes.Parallelism/JobHandle.cs
+++ b/src/KeenEyes.Parallelism/JobHandle.cs
@@ -50,6 +50,12 @@ public readonly struct JobHandle : IEquatable<JobHandle>
     public bool IsValid => source != null;
 
     /// <summary>
+    /// Gets the scheduler that produced this handle, or null for scheduler-agnostic
+    /// handles (the completed sentinel and combined handles).
+    /// </summary>
+    internal JobScheduler? OwningScheduler => source?.Owner;
+
+    /// <summary>
     /// Gets whether the job has completed execution.
     /// </summary>
     public bool IsCompleted => source?.IsCompleted ?? true;
@@ -183,6 +189,13 @@ internal class JobCompletionSource : IDisposable
     private Exception? exception;
 
     public static JobCompletionSource CompletedSource { get; } = CreateCompleted();
+
+    /// <summary>
+    /// The scheduler that owns this completion source, or null if it is scheduler-agnostic
+    /// (the shared completed sentinel or a combined source). Used to reject cross-scheduler
+    /// job dependencies, which would otherwise hang permanently (issue #1157).
+    /// </summary>
+    public JobScheduler? Owner { get; set; }
 
     public virtual bool IsCompleted => isCompleted;
     public bool IsFaulted => isFaulted;

--- a/src/KeenEyes.Parallelism/JobScheduler.cs
+++ b/src/KeenEyes.Parallelism/JobScheduler.cs
@@ -104,9 +104,10 @@ public sealed class JobScheduler : IDisposable
     public JobHandle Schedule<T>(T job, JobHandle dependency) where T : IJob
     {
         ObjectDisposedException.ThrowIf(isDisposed, this);
+        ValidateDependency(dependency);
 
         var jobId = Interlocked.Increment(ref nextJobId);
-        var source = new JobCompletionSource();
+        var source = new JobCompletionSource { Owner = this };
         activeJobs[jobId] = source;
 
         var scheduled = new ScheduledJob(
@@ -153,6 +154,7 @@ public sealed class JobScheduler : IDisposable
     public JobHandle ScheduleParallel<T>(T job, int count, JobHandle dependency) where T : IParallelJob
     {
         ObjectDisposedException.ThrowIf(isDisposed, this);
+        ValidateDependency(dependency);
 
         if (count <= 0)
         {
@@ -160,7 +162,7 @@ public sealed class JobScheduler : IDisposable
         }
 
         var jobId = Interlocked.Increment(ref nextJobId);
-        var source = new JobCompletionSource();
+        var source = new JobCompletionSource { Owner = this };
         activeJobs[jobId] = source;
 
         var scheduled = new ScheduledJob(
@@ -209,6 +211,7 @@ public sealed class JobScheduler : IDisposable
     public JobHandle ScheduleBatch<T>(T job, int count, int batchSize, JobHandle dependency) where T : IBatchJob
     {
         ObjectDisposedException.ThrowIf(isDisposed, this);
+        ValidateDependency(dependency);
 
         if (count <= 0)
         {
@@ -222,7 +225,7 @@ public sealed class JobScheduler : IDisposable
         }
 
         var jobId = Interlocked.Increment(ref nextJobId);
-        var source = new JobCompletionSource();
+        var source = new JobCompletionSource { Owner = this };
         activeJobs[jobId] = source;
 
         var scheduled = new ScheduledJob(
@@ -371,6 +374,22 @@ public sealed class JobScheduler : IDisposable
         while (completedSources.TryTake(out var source))
         {
             source.Dispose();
+        }
+    }
+
+    private void ValidateDependency(JobHandle dependency)
+    {
+        // A dependency scheduled by a different JobScheduler will never be drained by this
+        // scheduler's queue processing (JobHandle carries no owning-scheduler drainer), so a
+        // job waiting on it would hang permanently. Reject it eagerly with a clear error
+        // instead. Scheduler-agnostic handles (the completed sentinel, combined handles) have
+        // no owner and are always allowed. See issue #1157.
+        var owner = dependency.OwningScheduler;
+        if (owner is not null && !ReferenceEquals(owner, this))
+        {
+            throw new InvalidOperationException(
+                "Cannot schedule a job with a dependency that belongs to a different JobScheduler. " +
+                "Job dependencies must be scheduled on the same JobScheduler instance.");
         }
     }
 

--- a/src/KeenEyes.Parallelism/ParallelSystemPlugin.cs
+++ b/src/KeenEyes.Parallelism/ParallelSystemPlugin.cs
@@ -60,7 +60,7 @@ public sealed class ParallelSystemPlugin(ParallelSystemOptions? options = null) 
             MaxDegreeOfParallelism = options.MaxDegreeOfParallelism
         };
 
-        scheduler = new ParallelSystemScheduler(world, parallelOptions);
+        scheduler = new ParallelSystemScheduler(world, parallelOptions, options.MinBatchSizeForParallel);
         context.SetExtension(scheduler);
     }
 

--- a/src/KeenEyes.Parallelism/ParallelSystemScheduler.cs
+++ b/src/KeenEyes.Parallelism/ParallelSystemScheduler.cs
@@ -27,7 +27,15 @@ public sealed class ParallelSystemScheduler
     private readonly ParallelSystemBatcher batcher;
     private readonly CommandBufferPool commandBufferPool;
     private readonly ParallelOptions parallelOptions;
+    private readonly int minBatchSizeForParallel;
     private readonly List<ISystem> registeredSystems = [];
+
+    // Stable, monotonically-increasing command-buffer id per registered system instance.
+    // Keyed by reference so systems that override GetHashCode()/Equals cannot collide on
+    // a single CommandBufferPool key (which would throw on Rent and break deterministic
+    // flush ordering). See issue #1155.
+    private readonly Dictionary<ISystem, int> systemIds;
+    private int nextSystemId;
     private IReadOnlyList<SystemBatch>? cachedBatches;
     private bool batchesDirty = true;
 
@@ -56,9 +64,20 @@ public sealed class ParallelSystemScheduler
     /// </summary>
     /// <param name="world">The world to schedule systems for.</param>
     /// <param name="options">Optional parallel execution options.</param>
-    internal ParallelSystemScheduler(World world, ParallelOptions? options = null)
+    /// <param name="minBatchSizeForParallel">
+    /// Batches with fewer systems than this threshold execute sequentially rather than in parallel.
+    /// </param>
+    internal ParallelSystemScheduler(World world, ParallelOptions? options = null, int minBatchSizeForParallel = 2)
     {
         this.world = world;
+        this.minBatchSizeForParallel = minBatchSizeForParallel;
+
+        // IDE0028: a collection expression cannot carry the reference-equality comparer,
+        // which is required so systems overriding GetHashCode()/Equals do not collide on a
+        // single id (issue #1155). The explicit constructor is intentional.
+#pragma warning disable IDE0028
+        systemIds = new Dictionary<ISystem, int>(ReferenceEqualityComparer.Instance);
+#pragma warning restore IDE0028
         dependencyTracker = new SystemDependencyTracker();
         batcher = new ParallelSystemBatcher(dependencyTracker);
         commandBufferPool = new CommandBufferPool();
@@ -76,6 +95,7 @@ public sealed class ParallelSystemScheduler
     public void RegisterSystem(ISystem system)
     {
         registeredSystems.Add(system);
+        AssignSystemId(system);
         dependencyTracker.RegisterSystem(system);
         batchesDirty = true;
     }
@@ -88,8 +108,17 @@ public sealed class ParallelSystemScheduler
     public void RegisterSystem(ISystem system, ComponentDependencies dependencies)
     {
         registeredSystems.Add(system);
+        AssignSystemId(system);
         dependencyTracker.RegisterDependencies(system.GetType(), dependencies);
         batchesDirty = true;
+    }
+
+    private void AssignSystemId(ISystem system)
+    {
+        if (!systemIds.ContainsKey(system))
+        {
+            systemIds[system] = ++nextSystemId;
+        }
     }
 
     /// <summary>
@@ -102,7 +131,29 @@ public sealed class ParallelSystemScheduler
         var removed = registeredSystems.Remove(system);
         if (removed)
         {
-            dependencyTracker.Unregister(system.GetType());
+            systemIds.Remove(system);
+
+            // The dependency tracker keys by Type, but multiple instances of the same
+            // system type may be registered. Only drop the type's shared dependency
+            // registration when no other live instance of that type remains; otherwise
+            // a surviving sibling would silently fall back to empty dependencies and be
+            // batched to run concurrently with conflicting systems. See issue #1158.
+            var systemType = system.GetType();
+            var hasOtherInstance = false;
+            foreach (var other in registeredSystems)
+            {
+                if (other.GetType() == systemType)
+                {
+                    hasOtherInstance = true;
+                    break;
+                }
+            }
+
+            if (!hasOtherInstance)
+            {
+                dependencyTracker.Unregister(systemType);
+            }
+
             batchesDirty = true;
         }
         return removed;
@@ -114,6 +165,8 @@ public sealed class ParallelSystemScheduler
     public void Clear()
     {
         registeredSystems.Clear();
+        systemIds.Clear();
+        nextSystemId = 0;
         dependencyTracker.Clear();
         commandBufferPool.Clear();
         cachedBatches = null;
@@ -176,23 +229,26 @@ public sealed class ParallelSystemScheduler
             return;
         }
 
-        // Collect system IDs upfront for buffer management
-        var systemIds = new List<int>(systems.Count);
+        // Collect the stable command-buffer ids for this batch upfront for buffer management.
+        var bufferIds = new List<int>(systems.Count);
         for (int i = 0; i < systems.Count; i++)
         {
-            systemIds.Add(systems[i].GetHashCode());
+            bufferIds.Add(GetSystemId(systems[i]));
         }
 
         try
         {
-            if (systems.Count == 1)
+            if (systems.Count < minBatchSizeForParallel)
             {
-                // Single system - execute sequentially
-                ExecuteSystem(systems[0], deltaTime);
+                // Below the parallel threshold - execute sequentially.
+                for (int i = 0; i < systems.Count; i++)
+                {
+                    ExecuteSystem(systems[i], deltaTime);
+                }
             }
             else
             {
-                // Multiple systems - execute in parallel
+                // At or above the threshold - execute in parallel.
                 Parallel.ForEach(systems, parallelOptions, system =>
                 {
                     ExecuteSystem(system, deltaTime);
@@ -200,18 +256,25 @@ public sealed class ParallelSystemScheduler
             }
 
             // Flush all command buffers from this batch (also returns them to pool)
-            commandBufferPool.FlushBatches(world, [systemIds]);
+            commandBufferPool.FlushBatches(world, [bufferIds]);
         }
         catch
         {
             // On exception, clear buffers without flushing to avoid partial state
             // and return them to the pool for reuse
-            foreach (var systemId in systemIds)
+            foreach (var bufferId in bufferIds)
             {
-                commandBufferPool.Return(systemId);
+                commandBufferPool.Return(bufferId);
             }
             throw;
         }
+    }
+
+    private int GetSystemId(ISystem system)
+    {
+        return systemIds.TryGetValue(system, out var id)
+            ? id
+            : throw new InvalidOperationException("System is not registered with this scheduler.");
     }
 
     private void ExecuteSystem(ISystem system, float deltaTime)
@@ -224,7 +287,7 @@ public sealed class ParallelSystemScheduler
         // Get a CommandBuffer for this system
         // Note: Buffer is NOT returned here - ExecuteBatch handles flushing and returning
         // after all systems in the batch have completed, ensuring commands are not lost.
-        var systemId = system.GetHashCode();
+        var systemId = GetSystemId(system);
         var commandBuffer = commandBufferPool.Rent(systemId);
 
         if (system is SystemBase systemBase)

--- a/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/JobSchedulerTests.cs
@@ -461,6 +461,24 @@ public class JobSchedulerTests
     }
 
     [Fact]
+    public void Schedule_WithDependencyFromDifferentScheduler_ThrowsInsteadOfHanging()
+    {
+        using var schedulerA = new JobScheduler();
+        using var schedulerB = new JobScheduler();
+
+        var foreignHandle = schedulerA.Schedule(new IncrementJob { Counter = new int[1] });
+        foreignHandle.Complete();
+
+        // A dependency owned by another scheduler is never drained by schedulerB's queue
+        // processing (a JobHandle carries no owning-scheduler drainer), so a job waiting on it
+        // would hang permanently after the retry budget is exhausted. It must be rejected
+        // eagerly with a clear error instead (issue #1157). On the old code this call returned
+        // a handle without throwing.
+        Assert.Throws<InvalidOperationException>(() =>
+            schedulerB.Schedule(new IncrementJob { Counter = new int[1] }, foreignHandle));
+    }
+
+    [Fact]
     public void Schedule_AfterDispose_ThrowsObjectDisposedException()
     {
         var scheduler = new JobScheduler();

--- a/tests/KeenEyes.Parallelism.Tests/ParallelQueryExtensionsTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/ParallelQueryExtensionsTests.cs
@@ -693,6 +693,75 @@ public class ParallelQueryExtensionsTests
         Assert.Equal(50, processedCount);
     }
 
+    [Fact]
+    public void ForEachParallel_WithStringTagFilter_AboveThreshold_OnlyProcessesTaggedEntities()
+    {
+        using var world = new World();
+        var processedCount = 0;
+
+        const int total = 200;
+        const int taggedCount = 10;
+
+        // Only the first few entities carry the "player" tag. String tags are per-entity,
+        // not archetype-matched, so the parallel chunk path must apply the filter explicitly.
+        for (int i = 0; i < total; i++)
+        {
+            var builder = world.Spawn().With(new ParallelTestPosition { X = i, Y = i });
+            if (i < taggedCount)
+            {
+                builder = builder.WithTag("player");
+            }
+
+            builder.Build();
+        }
+
+        // minEntityCount well below the population forces the parallel chunk path.
+        world.Query<ParallelTestPosition>()
+            .WithTag("player")
+            .ForEachParallel<ParallelTestPosition>(
+                (Entity e, ref ParallelTestPosition pos) =>
+                {
+                    Interlocked.Increment(ref processedCount);
+                },
+                minEntityCount: 10);
+
+        // Regression for #1154: the parallel path used to ignore WithTag and process all 200.
+        Assert.Equal(taggedCount, processedCount);
+    }
+
+    [Fact]
+    public void ForEachParallelReadOnly_WithoutStringTagFilter_AboveThreshold_ExcludesTaggedEntities()
+    {
+        using var world = new World();
+        var processedCount = 0;
+
+        const int total = 200;
+        const int taggedCount = 30;
+
+        for (int i = 0; i < total; i++)
+        {
+            var builder = world.Spawn().With(new ParallelTestPosition { X = i, Y = i });
+            if (i < taggedCount)
+            {
+                builder = builder.WithTag("frozen");
+            }
+
+            builder.Build();
+        }
+
+        world.Query<ParallelTestPosition>()
+            .WithoutTag("frozen")
+            .ForEachParallelReadOnly<ParallelTestPosition>(
+                (Entity e, in ParallelTestPosition pos) =>
+                {
+                    Interlocked.Increment(ref processedCount);
+                },
+                minEntityCount: 10);
+
+        // Regression for #1154: WithoutTag must exclude the tagged entities in the parallel path.
+        Assert.Equal(total - taggedCount, processedCount);
+    }
+
     #endregion
 
     #region Thread Safety

--- a/tests/KeenEyes.Parallelism.Tests/ParallelSystemPluginTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/ParallelSystemPluginTests.cs
@@ -106,6 +106,59 @@ public class ParallelSystemPluginTests
         }
     }
 
+    /// <summary>
+    /// A system that forces a GetHashCode() collision with every other instance while
+    /// keeping reference identity for Equals. Used to prove the command-buffer pool is
+    /// keyed by a stable per-registration id rather than GetHashCode() (issue #1155).
+    /// </summary>
+    private sealed class CollidingHashSystem : SystemBase
+    {
+        public int UpdateCount;
+
+        public override void Update(float deltaTime)
+        {
+            Interlocked.Increment(ref UpdateCount);
+        }
+
+        public override int GetHashCode() => 42;
+
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+    }
+
+    /// <summary>
+    /// Records the maximum number of systems observed executing concurrently, used to
+    /// distinguish sequential from parallel batch execution (issue #1159).
+    /// </summary>
+    private sealed class ConcurrencyProbe
+    {
+        private int current;
+        private int maxObserved;
+
+        public int MaxObserved => Volatile.Read(ref maxObserved);
+
+        public void Observe()
+        {
+            var now = Interlocked.Increment(ref current);
+
+            int observed;
+            while (now > (observed = Volatile.Read(ref maxObserved)))
+            {
+                Interlocked.CompareExchange(ref maxObserved, now, observed);
+            }
+
+            // Hold long enough for a genuinely concurrent sibling to overlap.
+            Thread.Sleep(50);
+            Interlocked.Decrement(ref current);
+        }
+    }
+
+    private sealed class ConcurrencyProbeSystem : SystemBase
+    {
+        public ConcurrencyProbe Probe { get; set; } = new();
+
+        public override void Update(float deltaTime) => Probe.Observe();
+    }
+
     #endregion
 
     #region Plugin Installation Tests
@@ -187,6 +240,33 @@ public class ParallelSystemPluginTests
     }
 
     [Fact]
+    public void RegisterSystem_WithoutDeclaredDependencies_AssumesEmptyAndBatchesConcurrently()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin());
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        // ThreadTrackingSystem does not implement ISystemDependencyProvider. Per the tracker's
+        // documented (optimistic) contract, undeclared dependencies are assumed empty, so two
+        // such systems never conflict and are batched together. This pins the behavior the
+        // class doc was corrected to describe in issue #1156.
+        var a = new ThreadTrackingSystem();
+        var b = new ThreadTrackingSystem();
+        a.Initialize(world);
+        b.Initialize(world);
+        scheduler.RegisterSystem(a);
+        scheduler.RegisterSystem(b);
+
+        var deps = scheduler.DependencyTracker.GetDependencies<ThreadTrackingSystem>();
+        Assert.Empty(deps.Reads);
+        Assert.Empty(deps.Writes);
+
+        var batches = scheduler.GetBatches();
+        Assert.Single(batches);
+        Assert.Equal(2, batches[0].Count);
+    }
+
+    [Fact]
     public void UnregisterSystem_RemovesSystem()
     {
         using var world = new World();
@@ -202,6 +282,35 @@ public class ParallelSystemPluginTests
 
         Assert.True(removed);
         Assert.Equal(0, scheduler.SystemCount);
+    }
+
+    [Fact]
+    public void UnregisterSystem_WithSurvivingSameTypeInstance_RetainsDependencies()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin());
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        // Two MovementSystem instances (read Velocity, write Position) plus a PhysicsSystem
+        // (writes Velocity). MovementSystem reads what PhysicsSystem writes, so a surviving
+        // mover must still conflict with physics after one mover is unregistered.
+        var mover1 = new MovementSystem();
+        var mover2 = new MovementSystem();
+        var physics = new PhysicsSystem();
+        mover1.Initialize(world);
+        mover2.Initialize(world);
+        physics.Initialize(world);
+        scheduler.RegisterSystem(mover1);
+        scheduler.RegisterSystem(mover2);
+        scheduler.RegisterSystem(physics);
+
+        scheduler.UnregisterSystem(mover1);
+
+        // Regression for #1158: the dependency tracker keys by Type, so unregistering one
+        // instance must not drop the type's deps while another instance is still live. If it
+        // did, mover2 would fall back to empty deps and merge with physics into one batch.
+        var batches = scheduler.GetBatches();
+        Assert.Equal(2, batches.Count);
     }
 
     [Fact]
@@ -356,6 +465,81 @@ public class ParallelSystemPluginTests
         scheduler.UpdateParallel(0.016f);
 
         Assert.Equal(3, movement.UpdateCount);
+    }
+
+    [Fact]
+    public void UpdateParallel_SystemsWithCollidingHashCodes_ExecuteWithoutBufferCollision()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin());
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        // Both systems return GetHashCode() == 42 and have no declared dependencies, so they
+        // share one batch. The old scheme keyed the command-buffer pool by GetHashCode(), so
+        // the second Rent(42) threw a duplicate-key exception and the batch's commands were
+        // discarded. A stable per-registration id keeps their buffers distinct (issue #1155).
+        var a = new CollidingHashSystem();
+        var b = new CollidingHashSystem();
+        a.Initialize(world);
+        b.Initialize(world);
+        scheduler.RegisterSystem(a);
+        scheduler.RegisterSystem(b);
+
+        scheduler.UpdateParallel(0.016f);
+
+        Assert.Equal(1, a.UpdateCount);
+        Assert.Equal(1, b.UpdateCount);
+    }
+
+    [Fact]
+    public void UpdateParallel_BatchBelowMinBatchSize_ExecutesSequentially()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin(new ParallelSystemOptions
+        {
+            MinBatchSizeForParallel = 3
+        }));
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        var probe = new ConcurrencyProbe();
+        var a = new ConcurrencyProbeSystem { Probe = probe };
+        var b = new ConcurrencyProbeSystem { Probe = probe };
+        a.Initialize(world);
+        b.Initialize(world);
+        scheduler.RegisterSystem(a);
+        scheduler.RegisterSystem(b);
+
+        // Two non-conflicting systems form a single batch of 2. With the threshold at 3, that
+        // batch is below the limit and must run sequentially, so the probe never sees both at
+        // once. Before #1159 the option was ignored and the batch always ran in parallel.
+        scheduler.UpdateParallel(0.016f);
+
+        Assert.Equal(1, probe.MaxObserved);
+    }
+
+    [Fact]
+    public void UpdateParallel_BatchAtOrAboveMinBatchSize_ExecutesInParallel()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin(new ParallelSystemOptions
+        {
+            MinBatchSizeForParallel = 2
+        }));
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        var probe = new ConcurrencyProbe();
+        var a = new ConcurrencyProbeSystem { Probe = probe };
+        var b = new ConcurrencyProbeSystem { Probe = probe };
+        a.Initialize(world);
+        b.Initialize(world);
+        scheduler.RegisterSystem(a);
+        scheduler.RegisterSystem(b);
+
+        // A batch of 2 at the default threshold of 2 must run in parallel, so both systems
+        // overlap. Guards against the threshold fix over-serializing eligible batches (#1159).
+        scheduler.UpdateParallel(0.016f);
+
+        Assert.Equal(2, probe.MaxObserved);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Fixes the parallelism review cluster from the deep-functional-review epic (#1093).

- **#1154** — `ForEachParallel*` overloads now apply `WithTag`/`WithoutTag` filters in the parallel chunk path (were silently dropped above the threshold).
- **#1155** — `ParallelSystemScheduler` uses a stable monotonic per-registration id (reference-keyed) as the `CommandBufferPool` key instead of `GetHashCode()`, eliminating rent collisions and nondeterministic flush ordering.
- **#1156** — doc-only: corrected `SystemDependencyTracker` class doc to describe the actual optimistic empty-dependency default (added a behavior-lock test).
- **#1157** — cross-scheduler job dependencies are now forbidden explicitly (`InvalidOperationException` via an owner reference), replacing the 100-retry-then-hang path. Scheduler-agnostic handles (sentinel/combined) remain allowed.
- **#1158** — `UnregisterSystem` only unregisters type-keyed deps when no other live instance of that type remains.
- **#1159** — implemented the documented `MinBatchSizeForParallel` threshold in `ExecuteBatch` (default 2 preserves prior behavior).

## Test plan
- [x] New `ParallelQueryExtensionsTests` + `ParallelSystemPluginTests` + `JobSchedulerTests`; fail-on-old/pass-on-new proven per issue via source revert
- [x] Parallelism.Tests 111; full suite 14,568 tests, 0 failed; 0 warnings; format clean
- One justified `IDE0028` suppression (collection expression can't carry the load-bearing reference comparer)

## Related Issues
Closes #1154
Closes #1155
Closes #1156
Closes #1157
Closes #1158
Closes #1159