### PR TITLE
fix(network): Fix prediction, delta baseline, RTT, dedup, ordered delivery, and connect paths

### DIFF
--- a/src/KeenEyes.Network.Transport.Tcp/TcpTransport.cs
+++ b/src/KeenEyes.Network.Transport.Tcp/TcpTransport.cs
@@ -39,7 +39,12 @@ public sealed class TcpTransport : INetworkTransport
     private const int MaxMessageSize = 1024 * 1024; // 1 MB max message
 
     private readonly ConcurrentDictionary<int, ClientConnection> connections = new();
-    private readonly ConcurrentQueue<PendingMessage> incomingMessages = new();
+
+    // Connection/disconnection/data events raised from the background accept and receive
+    // loops are enqueued here and dispatched in order on the game-loop thread during
+    // Update(), so consumers never mutate World/plugin state off the loop (see #1098).
+    // Events raised from explicit game-loop calls (e.g. Disconnect) fire synchronously.
+    private readonly ConcurrentQueue<TransportEvent> events = new();
     private readonly Lock stateLock = new();
 
     private TcpListener? listener;
@@ -153,7 +158,8 @@ public sealed class TcpTransport : INetworkTransport
                 // Start receiving for this client
                 _ = ReceiveFromClientAsync(connection, cancellationToken);
 
-                ClientConnected?.Invoke(connectionId);
+                // Runs on the background accept loop: defer to Update() (see #1098).
+                events.Enqueue(new TransportEvent { Kind = TransportEventKind.Connected, ConnectionId = connectionId });
             }
             catch (OperationCanceledException)
             {
@@ -201,8 +207,9 @@ public sealed class TcpTransport : INetworkTransport
                 Interlocked.Add(ref bytesReceived, HeaderSize + messageLength);
                 Interlocked.Increment(ref packetsReceived);
 
-                incomingMessages.Enqueue(new PendingMessage
+                events.Enqueue(new TransportEvent
                 {
+                    Kind = TransportEventKind.Data,
                     ConnectionId = connection.Id,
                     Data = messageBuffer
                 });
@@ -218,16 +225,27 @@ public sealed class TcpTransport : INetworkTransport
         }
         finally
         {
-            HandleClientDisconnection(connection.Id);
+            // Runs on the background receive loop: defer the event to Update() (see #1098).
+            HandleClientDisconnection(connection.Id, deferEvent: true);
         }
     }
 
-    private void HandleClientDisconnection(int connectionId)
+    private void HandleClientDisconnection(int connectionId, bool deferEvent = false)
     {
         if (connections.TryRemove(connectionId, out var connection))
         {
             connection.Dispose();
-            ClientDisconnected?.Invoke(connectionId);
+
+            if (deferEvent)
+            {
+                // Background-thread origin: hand off to the game loop.
+                events.Enqueue(new TransportEvent { Kind = TransportEventKind.Disconnected, ConnectionId = connectionId });
+            }
+            else
+            {
+                // Called from an explicit game-loop operation (Disconnect/Send): safe to fire directly.
+                ClientDisconnected?.Invoke(connectionId);
+            }
         }
     }
 
@@ -308,8 +326,9 @@ public sealed class TcpTransport : INetworkTransport
                 Interlocked.Add(ref bytesReceived, HeaderSize + messageLength);
                 Interlocked.Increment(ref packetsReceived);
 
-                incomingMessages.Enqueue(new PendingMessage
+                events.Enqueue(new TransportEvent
                 {
+                    Kind = TransportEventKind.Data,
                     ConnectionId = 0, // Server is always ID 0 for clients
                     Data = messageBuffer
                 });
@@ -492,9 +511,23 @@ public sealed class TcpTransport : INetworkTransport
     {
         ThrowIfDisposed();
 
-        while (incomingMessages.TryDequeue(out var message))
+        // Drain connection/disconnection/data events in arrival order on the game loop.
+        while (events.TryDequeue(out var evt))
         {
-            DataReceived?.Invoke(message.ConnectionId, message.Data);
+            switch (evt.Kind)
+            {
+                case TransportEventKind.Connected:
+                    ClientConnected?.Invoke(evt.ConnectionId);
+                    break;
+
+                case TransportEventKind.Disconnected:
+                    ClientDisconnected?.Invoke(evt.ConnectionId);
+                    break;
+
+                case TransportEventKind.Data:
+                    DataReceived?.Invoke(evt.ConnectionId, evt.Data!);
+                    break;
+            }
         }
     }
 
@@ -586,9 +619,17 @@ public sealed class TcpTransport : INetworkTransport
         }
     }
 
-    private sealed class PendingMessage
+    private enum TransportEventKind : byte
     {
+        Connected,
+        Disconnected,
+        Data,
+    }
+
+    private sealed class TransportEvent
+    {
+        public required TransportEventKind Kind { get; init; }
         public required int ConnectionId { get; init; }
-        public required byte[] Data { get; init; }
+        public byte[]? Data { get; init; }
     }
 }

--- a/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
+++ b/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
@@ -57,7 +57,12 @@ public sealed class UdpTransport : INetworkTransport
     private const byte PacketKeepalive = 5;
 
     private readonly ConcurrentDictionary<int, UdpConnection> connections = new();
-    private readonly ConcurrentQueue<PendingMessage> incomingMessages = new();
+
+    // Connection, disconnection, and data events are all enqueued here from the
+    // background receive loop and drained in order on the game-loop thread during
+    // Update(). Firing ClientConnected/ClientDisconnected directly from the receive
+    // thread would let consumers mutate World/plugin state off the loop (see #1098).
+    private readonly ConcurrentQueue<TransportEvent> events = new();
     private readonly Lock stateLock = new();
 
     private UdpClient? socket;
@@ -176,10 +181,15 @@ public sealed class UdpTransport : INetworkTransport
         try
         {
             socket = new UdpClient();
-            serverEndpoint = new IPEndPoint(IPAddress.Parse(address), port);
 
-            // For DNS names, resolve first
-            if (!IPAddress.TryParse(address, out _))
+            // Only parse literal IPs directly; hostnames must resolve via DNS first.
+            // Parsing a hostname (e.g. "localhost") with IPAddress.Parse throws
+            // FormatException, which previously made the DNS branch unreachable.
+            if (IPAddress.TryParse(address, out var literalAddress))
+            {
+                serverEndpoint = new IPEndPoint(literalAddress, port);
+            }
+            else
             {
                 var addresses = await Dns.GetHostAddressesAsync(address, cancellationToken);
                 if (addresses.Length == 0)
@@ -312,7 +322,8 @@ public sealed class UdpTransport : INetworkTransport
                     Interlocked.Add(ref bytesSent, ackPacket.Length);
                     Interlocked.Increment(ref packetsSent);
 
-                    ClientConnected?.Invoke(connectionId);
+                    // Defer to Update() so the consumer handles it on the game loop.
+                    events.Enqueue(new TransportEvent { Kind = TransportEventKind.Connected, ConnectionId = connectionId });
                 }
 
                 break;
@@ -338,7 +349,7 @@ public sealed class UdpTransport : INetworkTransport
                 if (connection is not null)
                 {
                     connection.LastReceiveTime = DateTime.UtcNow;
-                    ProcessAckPacket(connection, ack);
+                    ProcessAckPacket(connection, ack, flags);
                 }
 
                 break;
@@ -383,7 +394,7 @@ public sealed class UdpTransport : INetworkTransport
                 if (serverConnection is not null)
                 {
                     serverConnection.LastReceiveTime = DateTime.UtcNow;
-                    ProcessAckPacket(serverConnection, ack);
+                    ProcessAckPacket(serverConnection, ack, flags);
                 }
 
                 break;
@@ -425,26 +436,33 @@ public sealed class UdpTransport : INetworkTransport
 
             case DeliveryMode.ReliableUnordered:
                 // Send ack
-                SendAck(connection, sequence);
+                SendAck(connection, sequence, DeliveryMode.ReliableUnordered);
 
                 // Deliver if not duplicate
                 if (!connection.ReceivedSequences.Contains(sequence))
                 {
                     connection.ReceivedSequences.Add(sequence);
-                    CleanupOldSequences(connection);
+                    if (IsSequenceNewer(sequence, connection.HighestReceivedUnorderedSequence))
+                    {
+                        connection.HighestReceivedUnorderedSequence = sequence;
+                    }
+
+                    CleanupUnorderedSequences(connection);
                     EnqueueMessage(connection.Id, payload);
                 }
 
                 break;
 
             case DeliveryMode.ReliableOrdered:
-                // Send ack
-                SendAck(connection, sequence);
+                // Send ack (tagged as ordered so the sender clears the right pending map).
+                SendAck(connection, sequence, DeliveryMode.ReliableOrdered);
 
-                // Buffer and deliver in order
-                if (!connection.ReceivedSequences.Contains(sequence))
+                // ReliableOrdered uses a dedicated sequence space (see #1096): non-ordered
+                // packets no longer consume sequence numbers the ordered receiver waits on,
+                // so a non-ordered send between two ordered sends can never stall delivery.
+                if (!connection.OrderedReceivedSequences.Contains(sequence))
                 {
-                    connection.ReceivedSequences.Add(sequence);
+                    connection.OrderedReceivedSequences.Add(sequence);
                     connection.OrderedBuffer[sequence] = payload.ToArray();
                     DeliverOrderedMessages(connection);
                 }
@@ -462,14 +480,23 @@ public sealed class UdpTransport : INetworkTransport
             connection.NextExpectedSequence++;
         }
 
-        CleanupOldSequences(connection);
+        CleanupOrderedSequences(connection);
     }
 
-    private static void CleanupOldSequences(UdpConnection connection)
+    private static void CleanupUnorderedSequences(UdpConnection connection)
     {
-        // Remove sequences that are too old
-        var minSequence = (ushort)(connection.NextExpectedSequence - SequenceWindowSize);
+        // Remove reliable-unordered dedup entries that are too old relative to the
+        // highest received unordered sequence.
+        var minSequence = (ushort)(connection.HighestReceivedUnorderedSequence - SequenceWindowSize);
         connection.ReceivedSequences.RemoveWhere(s => !IsSequenceNewer(s, minSequence));
+    }
+
+    private static void CleanupOrderedSequences(UdpConnection connection)
+    {
+        // Remove ordered dedup entries that fall outside the sliding window behind the
+        // next expected ordered sequence.
+        var minSequence = (ushort)(connection.NextExpectedSequence - SequenceWindowSize);
+        connection.OrderedReceivedSequences.RemoveWhere(s => !IsSequenceNewer(s, minSequence));
     }
 
     private static bool IsSequenceNewer(ushort a, ushort b)
@@ -478,9 +505,16 @@ public sealed class UdpTransport : INetworkTransport
         return (short)(a - b) > 0;
     }
 
-    private static void ProcessAckPacket(UdpConnection connection, ushort ack)
+    private static void ProcessAckPacket(UdpConnection connection, ushort ack, ushort flags)
     {
-        if (connection.PendingReliable.TryRemove(ack, out var pending))
+        // ReliableOrdered and ReliableUnordered have independent sequence spaces, so the
+        // ack carries its delivery mode (in the flags field) to pick the right pending map.
+        var mode = (DeliveryMode)(flags & 0x03);
+        var pendingMap = mode == DeliveryMode.ReliableOrdered
+            ? connection.PendingReliableOrdered
+            : connection.PendingReliable;
+
+        if (pendingMap.TryRemove(ack, out var pending))
         {
             // Calculate RTT from this ack
             var rtt = (float)(DateTime.UtcNow - pending.SendTime).TotalMilliseconds;
@@ -488,12 +522,13 @@ public sealed class UdpTransport : INetworkTransport
         }
     }
 
-    private void SendAck(UdpConnection connection, ushort sequence)
+    private void SendAck(UdpConnection connection, ushort sequence, DeliveryMode mode)
     {
         var ackPacket = new byte[HeaderSize];
         ackPacket[0] = ProtocolVersion;
         ackPacket[1] = PacketAck;
         BitConverter.TryWriteBytes(ackPacket.AsSpan(4), sequence); // ack field
+        BitConverter.TryWriteBytes(ackPacket.AsSpan(6), (ushort)mode); // flags: which sequence space
 
         socket?.Send(ackPacket, connection.Endpoint);
         Interlocked.Add(ref bytesSent, ackPacket.Length);
@@ -502,8 +537,9 @@ public sealed class UdpTransport : INetworkTransport
 
     private void EnqueueMessage(int connectionId, ReadOnlySpan<byte> data)
     {
-        incomingMessages.Enqueue(new PendingMessage
+        events.Enqueue(new TransportEvent
         {
+            Kind = TransportEventKind.Data,
             ConnectionId = connectionId,
             Data = data.ToArray()
         });
@@ -555,7 +591,13 @@ public sealed class UdpTransport : INetworkTransport
             return;
         }
 
-        var sequence = connection.NextSendSequence++;
+        // ReliableOrdered draws from its own sequence space so that Unreliable/
+        // UnreliableSequenced sends interleaved with ordered sends do not consume
+        // sequence numbers the ordered receiver is waiting on (see #1096).
+        var sequence = mode == DeliveryMode.ReliableOrdered
+            ? connection.NextSendOrderedSequence++
+            : connection.NextSendSequence++;
+
         var packet = new byte[HeaderSize + data.Length];
         packet[0] = ProtocolVersion;
         packet[1] = PacketData;
@@ -570,8 +612,17 @@ public sealed class UdpTransport : INetworkTransport
         Interlocked.Add(ref bytesSent, packet.Length);
         Interlocked.Increment(ref packetsSent);
 
-        // Track for reliable modes
-        if (mode is DeliveryMode.ReliableUnordered or DeliveryMode.ReliableOrdered)
+        // Track for reliable modes in the pending map matching the sequence space.
+        if (mode == DeliveryMode.ReliableOrdered)
+        {
+            connection.PendingReliableOrdered[sequence] = new PendingReliablePacket
+            {
+                Data = packet,
+                SendTime = DateTime.UtcNow,
+                Attempts = 1
+            };
+        }
+        else if (mode == DeliveryMode.ReliableUnordered)
         {
             connection.PendingReliable[sequence] = new PendingReliablePacket
             {
@@ -693,7 +744,8 @@ public sealed class UdpTransport : INetworkTransport
         {
             if (connections.TryRemove(connectionId, out _))
             {
-                ClientDisconnected?.Invoke(connectionId);
+                // Defer to Update() so the consumer handles it on the game loop (see #1098).
+                events.Enqueue(new TransportEvent { Kind = TransportEventKind.Disconnected, ConnectionId = connectionId });
             }
         }
         else
@@ -712,10 +764,25 @@ public sealed class UdpTransport : INetworkTransport
 
         var now = DateTime.UtcNow;
 
-        // Process incoming messages
-        while (incomingMessages.TryDequeue(out var message))
+        // Drain connection, disconnection, and data events in the order they occurred.
+        // Dispatching here (rather than from the background receive loop) keeps consumer
+        // state mutations on the game-loop thread (see #1098).
+        while (events.TryDequeue(out var evt))
         {
-            DataReceived?.Invoke(message.ConnectionId, message.Data);
+            switch (evt.Kind)
+            {
+                case TransportEventKind.Connected:
+                    ClientConnected?.Invoke(evt.ConnectionId);
+                    break;
+
+                case TransportEventKind.Disconnected:
+                    ClientDisconnected?.Invoke(evt.ConnectionId);
+                    break;
+
+                case TransportEventKind.Data:
+                    DataReceived?.Invoke(evt.ConnectionId, evt.Data!);
+                    break;
+            }
         }
 
         // Handle reliable packet resends and timeouts
@@ -749,8 +816,23 @@ public sealed class UdpTransport : INetworkTransport
 
     private void UpdateConnection(UdpConnection connection, DateTime now)
     {
-        // Resend reliable packets
-        foreach (var kvp in connection.PendingReliable)
+        // Resend reliable packets from both sequence spaces.
+        ResendPending(connection, connection.PendingReliable, now);
+        ResendPending(connection, connection.PendingReliableOrdered, now);
+
+        // Send keepalive if needed
+        if ((now - connection.LastSendTime).TotalMilliseconds > KeepaliveIntervalMs)
+        {
+            SendKeepalive(connection);
+        }
+    }
+
+    private void ResendPending(
+        UdpConnection connection,
+        ConcurrentDictionary<ushort, PendingReliablePacket> pendingMap,
+        DateTime now)
+    {
+        foreach (var kvp in pendingMap)
         {
             var pending = kvp.Value;
             var elapsed = (now - pending.SendTime).TotalMilliseconds;
@@ -760,7 +842,7 @@ public sealed class UdpTransport : INetworkTransport
                 if (pending.Attempts >= MaxResendAttempts)
                 {
                     // Give up on this packet
-                    connection.PendingReliable.TryRemove(kvp.Key, out _);
+                    pendingMap.TryRemove(kvp.Key, out _);
                     Interlocked.Increment(ref packetsLost);
                     Interlocked.Increment(ref connection.PacketsLost);
                 }
@@ -773,12 +855,6 @@ public sealed class UdpTransport : INetworkTransport
                     Interlocked.Increment(ref packetsSent);
                 }
             }
-        }
-
-        // Send keepalive if needed
-        if ((now - connection.LastSendTime).TotalMilliseconds > KeepaliveIntervalMs)
-        {
-            SendKeepalive(connection);
         }
     }
 
@@ -888,12 +964,16 @@ public sealed class UdpTransport : INetworkTransport
         public float RoundTripTimeMs { get; set; }
 
         public ushort NextSendSequence;
+        public ushort NextSendOrderedSequence;
         public ushort LastReceivedSequence;
         public ushort NextExpectedSequence;
+        public ushort HighestReceivedUnorderedSequence;
 
         public HashSet<ushort> ReceivedSequences { get; } = [];
+        public HashSet<ushort> OrderedReceivedSequences { get; } = [];
         public Dictionary<ushort, byte[]> OrderedBuffer { get; } = [];
         public ConcurrentDictionary<ushort, PendingReliablePacket> PendingReliable { get; } = new();
+        public ConcurrentDictionary<ushort, PendingReliablePacket> PendingReliableOrdered { get; } = new();
 
         public long BytesSent;
         public long BytesReceived;
@@ -909,9 +989,17 @@ public sealed class UdpTransport : INetworkTransport
         public int Attempts { get; set; }
     }
 
-    private sealed class PendingMessage
+    private enum TransportEventKind : byte
     {
+        Connected,
+        Disconnected,
+        Data,
+    }
+
+    private sealed class TransportEvent
+    {
+        public required TransportEventKind Kind { get; init; }
         public required int ConnectionId { get; init; }
-        public required byte[] Data { get; init; }
+        public byte[]? Data { get; init; }
     }
 }

--- a/src/KeenEyes.Network/NetworkClientPlugin.cs
+++ b/src/KeenEyes.Network/NetworkClientPlugin.cs
@@ -338,7 +338,14 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
         if (networkIdManager.TryGetLocalEntity(networkId, out var entity))
         {
             networkIdManager.UnregisterNetworkId(new NetworkId { Value = networkId });
-            snapshotBuffers.Remove(entity); // Clean up snapshot buffer
+
+            // Release all per-entity buffers so they do not leak for the lifetime of the
+            // client. Previously only the snapshot buffer was cleaned up, leaving input
+            // and prediction buffers to grow unbounded across despawns (#1104).
+            snapshotBuffers.Remove(entity);
+            inputBuffers.Remove(entity);
+            predictionSystem?.UnregisterEntity(entity);
+
             context.World.Despawn(entity);
         }
     }
@@ -395,7 +402,15 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
 
             case MessageType.EntitySpawn:
                 reader.ReadEntitySpawn(out var spawnNetworkId, out var ownerId);
-                var spawnedEntity = SpawnNetworkedEntity(spawnNetworkId, ownerId);
+                // Dedupe: a fresh client can receive both a FullSnapshot and the
+                // NeedsFullSync EntitySpawn broadcast for the same network ID in one tick.
+                // Spawning unconditionally created a second ghost and orphaned the first
+                // (RegisterMapping overwrites), so reuse the existing entity if present (#1101).
+                if (!networkIdManager.TryGetLocalEntity(spawnNetworkId, out var spawnedEntity))
+                {
+                    spawnedEntity = SpawnNetworkedEntity(spawnNetworkId, ownerId);
+                }
+
                 // Read and apply initial components
                 ApplyComponentUpdates(spawnedEntity, ref reader);
                 break;
@@ -560,6 +575,15 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
 
             if (serverStates is not null)
             {
+                // Owner-authoritative components on a locally owned entity: the local
+                // client is authoritative, so its value must win even on the
+                // reconciliation path. Excluding it here mirrors the direct-apply filter
+                // in ApplyComponent, which the reconcile decode path previously bypassed (#1103).
+                if (context.World.Has<LocallyOwned>(entity) && IsOwnerAuthoritative(componentType))
+                {
+                    continue;
+                }
+
                 serverStates[componentType] = component;
             }
             else
@@ -665,6 +689,14 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
 
             if (serverStates is not null)
             {
+                // Owner-authoritative components on a locally owned entity stay under
+                // local authority even during reconciliation (#1103); see the matching
+                // exclusion on the delta decode path and in ApplyComponent.
+                if (context.World.Has<LocallyOwned>(entity) && IsOwnerAuthoritative(componentType))
+                {
+                    continue;
+                }
+
                 serverStates[componentType] = component;
             }
             else

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -39,6 +39,7 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
         config is { StateHistoryTicks: > 0 } cfg ? new ServerStateHistory(cfg.StateHistoryTicks) : null;
 
     private IPluginContext? context;
+    private NetworkServerSendSystem? sendSystem;
     private LagCompensation? lagCompensation;
     private OwnerAuthoritativeComponentSet? ownerAuthTypes;
     private INetworkSerializer? ownerAuthTypesSource;
@@ -123,7 +124,8 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
 
         // Register systems
         context.AddSystem(new NetworkServerReceiveSystem(this), SystemPhase.EarlyUpdate);
-        context.AddSystem(new NetworkServerSendSystem(this), SystemPhase.LateUpdate);
+        sendSystem = new NetworkServerSendSystem(this);
+        context.AddSystem(sendSystem, SystemPhase.LateUpdate);
 
         // Subscribe to entity events for replication
         entityCreatedSubscription = context.World.OnEntityCreated(OnEntityCreated);
@@ -150,7 +152,29 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
         entityDestroyedSubscription?.Dispose();
 
         lagCompensation = null;
+        sendSystem = null;
         this.context = null;
+    }
+
+    /// <summary>
+    /// Copies each connected client's transport-measured round-trip time into its
+    /// <see cref="ClientState.RoundTripTimeMs"/>.
+    /// </summary>
+    /// <remarks>
+    /// The transport measures RTT (e.g. from reliable-packet acks), but that value was
+    /// never propagated to <see cref="ClientState"/>, so lag compensation always saw zero
+    /// latency (#1102). Called once per network tick by the send system.
+    /// </remarks>
+    internal void RefreshClientRoundTripTimes()
+    {
+        foreach (var state in clients.Values)
+        {
+            var rtt = transport.GetRoundTripTime(state.ClientId);
+            if (rtt >= 0f)
+            {
+                state.RoundTripTimeMs = rtt;
+            }
+        }
     }
 
     /// <summary>
@@ -630,6 +654,11 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     {
         // Drop any recorded state history for the despawned entity.
         stateHistory?.Remove(entity);
+
+        // Release the send system's per-entity delta baselines so they do not leak for
+        // the server's lifetime. Entity versions increment on despawn, so keys never
+        // collide and the dictionaries only ever grew (#1104).
+        sendSystem?.ClearEntityState(entity);
 
         // Remove from network tracking
         if (networkIdManager.TryGetNetworkId(entity, out var networkId))

--- a/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
+++ b/src/KeenEyes.Network/Systems/ClientPredictionSystem.cs
@@ -68,7 +68,10 @@ public sealed class ClientPredictionSystem(
             return;
         }
 
-        ref var predState = ref World.Get<PredictionState>(entity);
+        // Note: any ref into PredictionState must be re-fetched AFTER ApplyServerState.
+        // Applying a registered-but-absent component migrates the entity to a new
+        // archetype, invalidating earlier refs; writing through a stale ref lands in the
+        // vacated slot and is silently lost (#1097).
 
         // Check if we have a prediction for this tick
         if (!predictionBuffers.TryGetValue(entity, out var buffer))
@@ -79,9 +82,10 @@ public sealed class ClientPredictionSystem(
         var predictedStates = buffer.GetStatesForTick(serverTick);
         if (predictedStates is null)
         {
-            // No prediction for this tick, just apply server state
+            // No prediction for this tick, just apply server state.
             ApplyServerState(entity, serverStates);
-            predState.LastConfirmedTick = serverTick;
+            ref var predStateAfterApply = ref World.Get<PredictionState>(entity);
+            predStateAfterApply.LastConfirmedTick = serverTick;
             return;
         }
 
@@ -90,17 +94,23 @@ public sealed class ClientPredictionSystem(
 
         if (correctionMagnitude > 0f)
         {
-            predState.MispredictionDetected = true;
+            // Reconcile applies server state (possible migration) and sets correction
+            // fields on its own freshly fetched ref, so fetch again here for the flags.
             Reconcile(entity, serverTick, serverStates, correctionMagnitude);
+
+            ref var predState = ref World.Get<PredictionState>(entity);
+            predState.MispredictionDetected = true;
+            predState.LastConfirmedTick = serverTick;
         }
         else
         {
+            ref var predState = ref World.Get<PredictionState>(entity);
             predState.MispredictionDetected = false;
             predState.LastCorrectionMagnitude = 0f;
+            predState.LastConfirmedTick = serverTick;
         }
 
-        // Update confirmed tick and clean up old predictions
-        predState.LastConfirmedTick = serverTick;
+        // Clean up old predictions
         buffer.RemoveOlderThan(serverTick);
     }
 

--- a/src/KeenEyes.Network/Systems/NetworkClientSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkClientSendSystem.cs
@@ -19,7 +19,11 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
     private readonly byte[] sendBuffer = new byte[1024];
     private float pingTimer;
     private const float PingInterval = 1.0f; // Send ping every second
-    private uint lastSentInputTick;
+
+    // High-water mark of the newest input tick already sent, tracked per predicted
+    // entity. A single shared field skipped every predicted entity after the first one
+    // reached a given tick, so only one entity's input ever reached the server (#1100).
+    private readonly Dictionary<Entity, uint> lastSentInputTicks = [];
 
     // Owner-authoritative state tracking.
     private float ownerStateAccumulator;
@@ -77,7 +81,15 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
         foreach (var entity in World.Query<LocallyOwned, Predicted, NetworkId>())
         {
             var inputBuffer = plugin.GetInputBuffer(entity) as IInputBuffer;
-            if (inputBuffer is null || inputBuffer.NewestTick <= lastSentInputTick)
+            if (inputBuffer is null)
+            {
+                continue;
+            }
+
+            // Per-entity high-water mark: each predicted entity advances independently
+            // so that two entities recording input for the same tick both send (#1100).
+            lastSentInputTicks.TryGetValue(entity, out var lastSentInputTick);
+            if (inputBuffer.NewestTick <= lastSentInputTick)
             {
                 continue;
             }
@@ -98,7 +110,7 @@ public sealed class NetworkClientSendSystem(NetworkClientPlugin plugin) : System
                 plugin.SendToServer(writer.GetWrittenSpan(), DeliveryMode.UnreliableSequenced);
             }
 
-            lastSentInputTick = inputBuffer.NewestTick;
+            lastSentInputTicks[entity] = inputBuffer.NewestTick;
         }
     }
 

--- a/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
+++ b/src/KeenEyes.Network/Systems/NetworkServerSendSystem.cs
@@ -27,8 +27,17 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
 {
     private readonly byte[] sendBuffer = new byte[4096];
 
-    // Track last sent component values per entity for delta detection (broadcast path).
+    // ACKNOWLEDGED per-entity baseline for delta detection (broadcast path): the state
+    // the connected clients are known to have received. Deltas and change detection are
+    // computed against this, so a field stays "changed" (and keeps being re-sent) until
+    // an ack confirms it. Advancing this on every send instead let a single dropped
+    // unreliable delta desync the client permanently (#1099).
     private readonly Dictionary<Entity, Dictionary<Type, object>> lastSentState = [];
+
+    // Snapshot of the full component state sent for an entity at pendingTick, promoted
+    // into lastSentState once every client has acknowledged that tick.
+    private readonly Dictionary<Entity, Dictionary<Type, object>> pendingState = [];
+    private readonly Dictionary<Entity, uint> pendingTick = [];
 
     // Track bytes sent this tick for bandwidth limiting
     private int bytesSentThisTick;
@@ -60,6 +69,10 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             return; // Not time for a network tick yet
         }
 
+        // Pull the transport's measured RTT into each client's state so lag compensation
+        // sees real latency instead of a permanent zero (#1102).
+        plugin.RefreshClientRoundTripTimes();
+
         if (plugin.Config.InterestManager is { } interestManager)
         {
             UpdateFiltered(deltaTime, interestManager);
@@ -74,6 +87,10 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
 
     private void UpdateBroadcast(float deltaTime)
     {
+        // Promote acknowledged pending snapshots into the confirmed baseline before
+        // computing this tick's deltas, so changes stay pending until a client ack (#1099).
+        PromoteAcknowledgedBaselines();
+
         // Check for clients that need full snapshots
         foreach (var client in plugin.GetConnectedClients())
         {
@@ -247,8 +264,9 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
             SendDeltaUpdate(entity, networkId, serializer);
         }
 
-        // Update last sent state for delta tracking
-        SaveSentState(entity, serializer);
+        // Record what was sent this tick as the pending snapshot. It becomes the confirmed
+        // baseline only once the client acknowledges this tick (#1099).
+        SavePendingState(entity, serializer);
     }
 
     private void SendDeltaUpdate(Entity entity, NetworkId networkId, INetworkSerializer? serializer)
@@ -735,20 +753,18 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
         return ownerAuthTypes;
     }
 
-    private void SaveSentState(Entity entity, INetworkSerializer? serializer)
+    private void SavePendingState(Entity entity, INetworkSerializer? serializer)
     {
         if (serializer is null)
         {
             return;
         }
 
-        if (!lastSentState.TryGetValue(entity, out var entityState))
-        {
-            entityState = [];
-            lastSentState[entity] = entityState;
-        }
+        // The snapshot sent this tick is the full current state of every replicated
+        // component. Rebuild it fresh each send (rather than mutating in place) so a stale
+        // entry from an earlier tick cannot linger after a component's value changes.
+        var entityState = new Dictionary<Type, object>();
 
-        // Save current state of all replicated components
         if (World is ISnapshotCapability snapshot)
         {
             foreach (var (type, value) in snapshot.GetComponents(entity))
@@ -760,6 +776,45 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
                 }
             }
         }
+
+        pendingState[entity] = entityState;
+        pendingTick[entity] = plugin.CurrentTick;
+    }
+
+    /// <summary>
+    /// Promotes each entity's pending snapshot into the confirmed baseline once every
+    /// connected client has acknowledged the tick the snapshot was sent on.
+    /// </summary>
+    /// <remarks>
+    /// Uses the minimum <see cref="ClientState.LastAckedTick"/> across all clients: the
+    /// baseline may only advance to a state every client is known to have. With no clients
+    /// connected there is nothing to confirm, so no promotion occurs.
+    /// </remarks>
+    private void PromoteAcknowledgedBaselines()
+    {
+        var minAckedTick = uint.MaxValue;
+        var clientCount = 0;
+        foreach (var client in plugin.GetConnectedClients())
+        {
+            clientCount++;
+            if (client.LastAckedTick < minAckedTick)
+            {
+                minAckedTick = client.LastAckedTick;
+            }
+        }
+
+        if (clientCount == 0)
+        {
+            return;
+        }
+
+        foreach (var (entity, tick) in pendingTick)
+        {
+            if (tick <= minAckedTick && pendingState.TryGetValue(entity, out var snapshot))
+            {
+                lastSentState[entity] = snapshot;
+            }
+        }
     }
 
     /// <summary>
@@ -769,6 +824,8 @@ public sealed class NetworkServerSendSystem(NetworkServerPlugin plugin) : System
     public void ClearEntityState(Entity entity)
     {
         lastSentState.Remove(entity);
+        pendingState.Remove(entity);
+        pendingTick.Remove(entity);
 
         foreach (var client in plugin.GetConnectedClients())
         {

--- a/tests/KeenEyes.Network.Tests/NetworkClusterFixTests.cs
+++ b/tests/KeenEyes.Network.Tests/NetworkClusterFixTests.cs
@@ -1,0 +1,735 @@
+using System.Reflection;
+using KeenEyes.Network.Components;
+using KeenEyes.Network.Prediction;
+using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Replication;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Systems;
+using KeenEyes.Network.Transport;
+using KeenEyes.Network.Transport.Udp;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+// LocalTransport completes synchronously, so Wait() is safe.
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// Regression tests for the networking bug cluster (#1096-#1105).
+/// </summary>
+/// <remarks>
+/// Reuses the replicated component types declared by the other network test files in
+/// this namespace (<see cref="NetPosition"/>, <see cref="NetVelocity"/>,
+/// <see cref="NetInput"/>, <see cref="OwnerState"/>). Each test fails on the pre-fix
+/// source and passes on the fixed source.
+/// </remarks>
+public sealed class NetworkClusterFixTests
+{
+    private const int TickRate = 60;
+    private const float TickDelta = 0.02f; // > 1/60s, so exactly one network tick per update.
+
+    #region Serializer helpers
+
+    private static MockNetworkSerializer CreatePositionSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+        RegisterNetPosition(serializer);
+        return serializer;
+    }
+
+    private static void RegisterNetPosition(MockNetworkSerializer serializer)
+    {
+        serializer.RegisterComponentWithDelta<NetPosition>(
+            serialize: (ref BitWriter w, NetPosition p) =>
+            {
+                w.WriteFloat(p.X);
+                w.WriteFloat(p.Y);
+            },
+            deserialize: (ref BitReader r) => new NetPosition { X = r.ReadFloat(), Y = r.ReadFloat() },
+            getDirtyMask: (NetPosition current, NetPosition baseline) => current.GetDirtyMask(baseline),
+            serializeDelta: (ref BitWriter w, NetPosition current, NetPosition baseline, uint mask) =>
+                current.NetworkSerializeDelta(ref w, baseline, mask),
+            deserializeDelta: (ref BitReader r, NetPosition baseline, uint mask) =>
+            {
+                new NetPosition().NetworkDeserializeDelta(ref r, ref baseline, mask);
+                return baseline;
+            },
+            new NetworkComponentInfo
+            {
+                Type = typeof(NetPosition),
+                NetworkTypeId = 1,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = true,
+                SupportsPrediction = true,
+                SupportsDelta = true,
+            });
+    }
+
+    private static void RegisterNetVelocity(MockNetworkSerializer serializer)
+    {
+        serializer.RegisterComponentWithDelta<NetVelocity>(
+            serialize: (ref BitWriter w, NetVelocity v) => w.WriteFloat(v.VX),
+            deserialize: (ref BitReader r) => new NetVelocity { VX = r.ReadFloat() },
+            getDirtyMask: (NetVelocity current, NetVelocity baseline) => current.GetDirtyMask(baseline),
+            serializeDelta: (ref BitWriter w, NetVelocity current, NetVelocity baseline, uint mask) =>
+                current.NetworkSerializeDelta(ref w, baseline, mask),
+            deserializeDelta: (ref BitReader r, NetVelocity baseline, uint mask) =>
+            {
+                new NetVelocity().NetworkDeserializeDelta(ref r, ref baseline, mask);
+                return baseline;
+            },
+            new NetworkComponentInfo
+            {
+                Type = typeof(NetVelocity),
+                NetworkTypeId = 2,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = true,
+                SupportsDelta = true,
+            });
+    }
+
+    private static void RegisterOwnerState(MockNetworkSerializer serializer)
+    {
+        serializer.RegisterComponent<OwnerState>(
+            serialize: (ref BitWriter w, OwnerState c) => w.WriteFloat(c.Value),
+            deserialize: (ref BitReader r) => new OwnerState { Value = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(OwnerState),
+                NetworkTypeId = 3,
+                Strategy = SyncStrategy.OwnerAuthoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+    }
+
+    private sealed class NetInputSerializer : IInputSerializer<NetInput>
+    {
+        public Type InputType => typeof(NetInput);
+
+        public void Serialize(in NetInput input, ref BitWriter writer)
+        {
+            writer.WriteUInt32(input.Tick);
+            writer.WriteFloat(input.DeltaX);
+        }
+
+        public NetInput Deserialize(ref BitReader reader) =>
+            new() { Tick = reader.ReadUInt32(), DeltaX = reader.ReadFloat() };
+
+        void IInputSerializer.Serialize(object input, ref BitWriter writer) => Serialize((NetInput)input, ref writer);
+
+        object IInputSerializer.Deserialize(ref BitReader reader) => Deserialize(ref reader);
+    }
+
+    #endregion
+
+    #region UDP connect helper
+
+    private static async Task<(UdpTransport Server, UdpTransport Client, int Port)?> CreateConnectedUdpPairAsync(int timeoutMs = 2000)
+    {
+        var server = new UdpTransport();
+        var client = new UdpTransport();
+
+        try
+        {
+            await server.ListenAsync(0);
+            var port = server.LocalPort;
+
+            using var cts = new CancellationTokenSource(timeoutMs);
+            await client.ConnectAsync("127.0.0.1", port, cts.Token);
+            return (server, client, port);
+        }
+        catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+        {
+            server.Dispose();
+            client.Dispose();
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region #1096 - UDP ReliableOrdered delivery must not stall behind other delivery modes
+
+    [Fact]
+    public async Task Udp_ReliableOrdered_InterleavedWithUnreliableSequenced_BothOrderedMessagesDeliver()
+    {
+        var pair = await CreateConnectedUdpPairAsync();
+        Assert.SkipWhen(pair is null, "UDP networking not available in this environment");
+
+        using var server = pair!.Value.Server;
+        using var client = pair.Value.Client;
+
+        await Task.Delay(50);
+        server.Update();
+
+        var received = new List<byte>();
+        server.DataReceived += (_, data) =>
+        {
+            if (data.Length > 0)
+            {
+                received.Add(data[0]);
+            }
+        };
+
+        // ReliableOrdered[1], then an UnreliableSequenced[2] between the ordered sends,
+        // then ReliableOrdered[3]. Before the fix the non-ordered packet consumed the
+        // sequence number the ordered receiver was waiting on, so [3] never delivered.
+        client.Send(0, [1], DeliveryMode.ReliableOrdered);
+        client.Send(0, [2], DeliveryMode.UnreliableSequenced);
+        client.Send(0, [3], DeliveryMode.ReliableOrdered);
+
+        await Task.Delay(150);
+        server.Update();
+        server.Update();
+
+        Assert.Contains((byte)1, received);
+        Assert.Contains((byte)3, received);
+    }
+
+    #endregion
+
+    #region #1097 - Prediction must not write LastConfirmedTick through a stale ref
+
+    [Fact]
+    public void OnServerStateReceived_ServerAddsAbsentComponent_ConfirmedTickSurvivesMigration()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        var serializer = new MockNetworkSerializer();
+        RegisterNetPosition(serializer);
+        RegisterNetVelocity(serializer);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = true,
+            Serializer = serializer,
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        // Replicated components must be registered on the receiving world; NetVelocity is
+        // the registered-but-absent component the server will add (triggering migration).
+        clientWorld.Components.Register<NetPosition>();
+        clientWorld.Components.Register<NetVelocity>();
+
+        clientPlugin.UpdateTick(5);
+
+        // Locally owned predicted entity that has NetPosition but NOT NetVelocity.
+        var entity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(entity, new NetPosition { X = 10f, Y = 0f });
+
+        clientWorld.Update(0.016f); // prediction system saves a tick-5 snapshot (buffer exists)
+
+        // Server state for tick 6 (no saved prediction) carries a component the entity lacks.
+        // Applying it migrates the entity to a new archetype; before the fix the subsequent
+        // LastConfirmedTick write landed in the vacated slot and was lost.
+        var serverStates = new Dictionary<Type, object>
+        {
+            [typeof(NetVelocity)] = new NetVelocity { VX = 7f },
+        };
+        clientPlugin.PredictionSystem!.OnServerStateReceived(entity, serverTick: 6, serverStates);
+
+        Assert.True(clientWorld.Has<NetVelocity>(entity)); // migration happened
+        Assert.Equal(7f, clientWorld.Get<NetVelocity>(entity).VX, 0.001f);
+        Assert.Equal(6u, clientWorld.Get<PredictionState>(entity).LastConfirmedTick);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1098 - Connection events must fire on the game loop, not the receive thread
+
+    [Fact]
+    public async Task Udp_ClientConnected_FiresDuringUpdate_NotOnReceiveThread()
+    {
+        using var server = new UdpTransport();
+        using var client = new UdpTransport();
+
+        await server.ListenAsync(0);
+        var port = server.LocalPort;
+
+        int? eventThreadId = null;
+        server.ClientConnected += _ => eventThreadId = Environment.CurrentManagedThreadId;
+
+        using var cts = new CancellationTokenSource(2000);
+        try
+        {
+            await client.ConnectAsync("127.0.0.1", port, cts.Token);
+        }
+        catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+        {
+            Assert.Skip("UDP networking not available in this environment");
+            return;
+        }
+
+        // The server's background receive loop has processed the connect handshake by the
+        // time ConnectAsync returns (it sent the ack). Before the fix ClientConnected had
+        // already fired on that background thread; after the fix it is queued for Update().
+        await Task.Delay(100);
+        Assert.Null(eventThreadId);
+
+        var updateThreadId = Environment.CurrentManagedThreadId;
+        server.Update();
+
+        Assert.NotNull(eventThreadId);
+        Assert.Equal(updateThreadId, eventThreadId);
+    }
+
+    #endregion
+
+    #region #1099 - Delta baseline must key off the acked tick so dropped deltas retransmit
+
+    [Fact]
+    public async Task Broadcast_DroppedDelta_IsRetransmittedOnceLossClears()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreatePositionSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+        clientWorld.Components.Register<NetPosition>(); // receiving world must know the type
+
+        await server.ListenAsync(7777);
+        await clientPlugin.ConnectAsync();
+        server.Update();
+        client.Update();
+
+        // Server-owned entity starts at X = 0 and syncs to the client.
+        var serverEntity = serverWorld.Spawn().With(new NetPosition { X = 0f, Y = 0f }).Build();
+        var netId = serverPlugin.RegisterNetworkedEntity(serverEntity);
+
+        serverWorld.Update(TickDelta); // full-sync spawn
+        client.Update();
+        server.Update(); // absorb the client's ack of the spawn tick
+
+        Assert.True(clientPlugin.NetworkIds.TryGetLocalEntity(netId.Value, out var clientEntity));
+        Assert.Equal(0f, clientWorld.Get<NetPosition>(clientEntity).X, 0.001f);
+
+        // Move to X = 50 during a tick where the delta is 100% lost.
+        server.SimulatedPacketLossPercent = 100f;
+        serverWorld.Set(serverEntity, new NetPosition { X = 50f, Y = 0f });
+        serverWorld.Update(TickDelta);
+        client.Update();
+
+        // The client never received the change yet.
+        Assert.Equal(0f, clientWorld.Get<NetPosition>(clientEntity).X, 0.001f);
+
+        // Loss clears. The changed field must still be re-sent (baseline never advanced
+        // past the unacked tick), converging the client to X = 50.
+        server.SimulatedPacketLossPercent = 0f;
+        for (int i = 0; i < 5; i++)
+        {
+            serverWorld.Update(TickDelta);
+            client.Update();
+            server.Update();
+        }
+
+        Assert.Equal(50f, clientWorld.Get<NetPosition>(clientEntity).X, 0.001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1100 - Every predicted entity's input must reach the server
+
+    [Fact]
+    public async Task ClientSend_TwoPredictedEntitiesSameTick_BothInputsReachServer()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig { TickRate = TickRate });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = true,
+            InputSerializer = new NetInputSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await server.ListenAsync(7777);
+        await clientPlugin.ConnectAsync();
+        server.Update();
+        client.Update();
+
+        var inputNetIds = new HashSet<uint>();
+        server.DataReceived += (_, data) =>
+        {
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var type, out uint _);
+            if (type == MessageType.ClientInput)
+            {
+                inputNetIds.Add(reader.ReadNetworkId());
+            }
+        };
+
+        var localId = clientPlugin.LocalClientId;
+        var entity1 = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: localId);
+        var entity2 = clientPlugin.SpawnNetworkedEntity(networkId: 2, ownerId: localId);
+
+        // Both locally-owned predicted entities record input for the same tick.
+        clientPlugin.UpdateTick(5);
+        clientPlugin.RecordInput(entity1, new NetInput { DeltaX = 1f });
+        clientPlugin.RecordInput(entity2, new NetInput { DeltaX = 2f });
+
+        clientWorld.Update(0.1f); // NetworkClientSendSystem flushes input for both entities.
+        server.Update();
+
+        Assert.Contains(1u, inputNetIds);
+        Assert.Contains(2u, inputNetIds);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1101 - EntitySpawn after a snapshot must not create a duplicate ghost
+
+    [Fact]
+    public async Task ClientReceive_SnapshotThenEntitySpawnSameNetworkId_SpawnsOnlyOnce()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig { TickRate = TickRate });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var serializer = CreatePositionSerializer();
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = serializer,
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+        clientWorld.Components.Register<NetPosition>(); // receiving world must know the type
+
+        await server.ListenAsync(7777);
+        await clientPlugin.ConnectAsync();
+        server.Update();
+        client.Update();
+
+        // A fresh client can receive both a FullSnapshot and a NeedsFullSync EntitySpawn
+        // for the same network ID. Craft both for network ID 1.
+        var snapshot = new byte[256];
+        var snapshotWriter = new NetworkMessageWriter(snapshot);
+        snapshotWriter.WriteHeader(MessageType.FullSnapshot, 1);
+        snapshotWriter.WriteEntityCount(1);
+        snapshotWriter.WriteEntitySpawn(networkId: 1, ownerId: 99);
+        snapshotWriter.WriteComponentCount(1);
+        snapshotWriter.WriteComponent(serializer, typeof(NetPosition), new NetPosition { X = 1f, Y = 0f });
+        server.SendToAll(snapshotWriter.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+
+        var spawn = new byte[256];
+        var spawnWriter = new NetworkMessageWriter(spawn);
+        spawnWriter.WriteHeader(MessageType.EntitySpawn, 1);
+        spawnWriter.WriteEntitySpawn(networkId: 1, ownerId: 99);
+        spawnWriter.WriteComponentCount(1);
+        spawnWriter.WriteComponent(serializer, typeof(NetPosition), new NetPosition { X = 1f, Y = 0f });
+        server.SendToAll(spawnWriter.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+
+        server.Update();
+        client.Update();
+
+        var matching = 0;
+        foreach (var entity in clientWorld.Query<NetworkId>())
+        {
+            if (clientWorld.Get<NetworkId>(entity).Value == 1u)
+            {
+                matching++;
+            }
+        }
+
+        Assert.Equal(1, matching);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1102 - Server must populate ClientState.RoundTripTimeMs from the transport
+
+    [Fact]
+    public async Task Server_PopulatesClientRoundTripTime_FromTransport()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+
+        // LocalTransport reports RTT as SimulatedLatencyMs * 2.
+        server.SimulatedLatencyMs = 50f;
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig { TickRate = TickRate });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        await server.ListenAsync(7777);
+        await client.ConnectAsync("localhost", 7777);
+        server.Update();
+
+        var clientId = serverPlugin.GetConnectedClients().First().ClientId;
+        Assert.Equal(0f, serverPlugin.GetClientRoundTripTimeMs(clientId), 0.001f);
+
+        serverWorld.Update(TickDelta); // one network tick -> RTT is refreshed
+
+        Assert.Equal(100f, serverPlugin.GetClientRoundTripTimeMs(clientId), 0.001f);
+
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1103 - Reconciliation must respect the owner-authoritative filter
+
+    [Fact]
+    public async Task Reconcile_OwnerAuthoritativeComponent_IsNotClobberedByServerState()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        await server.ListenAsync(7777);
+
+        var serializer = new MockNetworkSerializer();
+        RegisterNetPosition(serializer);
+        RegisterOwnerState(serializer);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            TickRate = TickRate,
+            EnablePrediction = true,
+            Serializer = serializer,
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await clientPlugin.ConnectAsync();
+        client.Update();
+        clientPlugin.UpdateTick(5);
+
+        // Locally owned, predicted entity: OwnerState is client-authoritative (100),
+        // NetPosition is server-authoritative and mispredicted (client 1, server 50).
+        var entity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(entity, new OwnerState { Value = 100f });
+        clientWorld.Add(entity, new NetPosition { X = 1f, Y = 0f });
+
+        clientWorld.Update(0.016f); // save the tick-5 prediction
+
+        // Server sends authoritative state for tick 5, including a stale OwnerState (999).
+        var buffer = new byte[128];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.ComponentUpdate, 5);
+        writer.WriteNetworkId(1);
+        writer.WriteComponentCount(2);
+        writer.WriteComponent(serializer, typeof(OwnerState), new OwnerState { Value = 999f });
+        writer.WriteComponent(serializer, typeof(NetPosition), new NetPosition { X = 50f, Y = 0f });
+        server.SendToAll(writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+        server.Update();
+        client.Update(); // reconciliation
+
+        // Server-authoritative NetPosition reconciled to 50; owner-authoritative OwnerState
+        // stayed under local authority at 100 instead of being clobbered to 999.
+        Assert.Equal(50f, clientWorld.Get<NetPosition>(entity).X, 0.001f);
+        Assert.Equal(100f, clientWorld.Get<OwnerState>(entity).Value, 0.001f);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
+
+    #region #1104 - Despawn must release per-entity client buffers
+
+    [Fact]
+    public async Task DespawnNetworkedEntity_ReleasesPredictionBuffer()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var clientWorld = new World();
+
+        await server.ListenAsync(7777);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            ServerAddress = "localhost",
+            ServerPort = 7777,
+            TickRate = TickRate,
+            EnablePrediction = true,
+            Serializer = CreatePositionSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+
+        await clientPlugin.ConnectAsync();
+        client.Update();
+
+        var entity = clientPlugin.SpawnNetworkedEntity(networkId: 1, ownerId: clientPlugin.LocalClientId);
+        clientWorld.Add(entity, new NetPosition { X = 0f, Y = 0f });
+
+        clientWorld.Update(0.016f); // prediction system creates a buffer for the entity
+
+        Assert.NotNull(clientPlugin.PredictionSystem);
+        Assert.NotNull(clientPlugin.PredictionSystem!.GetPredictionBuffer(entity));
+
+        clientPlugin.DespawnNetworkedEntity(1);
+
+        // The per-entity prediction buffer must be released, not leaked for the client's life.
+        Assert.Null(clientPlugin.PredictionSystem.GetPredictionBuffer(entity));
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    [Fact]
+    public async Task EntityDestroyed_ReleasesServerSendSystemBaseline()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreatePositionSerializer(),
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+        clientWorld.Components.Register<NetPosition>(); // receiving world must know the type
+
+        await server.ListenAsync(7777);
+        await clientPlugin.ConnectAsync();
+        server.Update();
+        client.Update();
+
+        var serverEntity = serverWorld.Spawn().With(new NetPosition { X = 1f, Y = 0f }).Build();
+        serverPlugin.RegisterNetworkedEntity(serverEntity);
+
+        // Tick so the send system records a pending baseline, then let the client ack it so
+        // the confirmed baseline is populated too.
+        serverWorld.Update(TickDelta);
+        client.Update();
+        server.Update();
+        serverWorld.Update(TickDelta);
+
+        Assert.True(SendSystemTracksEntity(serverPlugin, serverEntity));
+
+        serverWorld.Despawn(serverEntity);
+
+        // OnEntityDestroyed must wire through to ClearEntityState so the baselines shrink.
+        Assert.False(SendSystemTracksEntity(serverPlugin, serverEntity));
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    private static bool SendSystemTracksEntity(NetworkServerPlugin plugin, Entity entity)
+    {
+        var sendSystemField = typeof(NetworkServerPlugin).GetField(
+            "sendSystem", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(sendSystemField);
+        var sendSystem = sendSystemField!.GetValue(plugin);
+        Assert.NotNull(sendSystem);
+
+        foreach (var fieldName in new[] { "lastSentState", "pendingState" })
+        {
+            var field = sendSystem!.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field?.GetValue(sendSystem) is System.Collections.IDictionary dict && dict.Contains(entity))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region #1105 - UDP ConnectAsync must resolve hostnames instead of throwing
+
+    [Fact]
+    public async Task Udp_ConnectAsync_Hostname_DoesNotThrowFormatException()
+    {
+        using var server = new UdpTransport();
+        await server.ListenAsync(0);
+        var port = server.LocalPort;
+
+        using var client = new UdpTransport();
+        using var cts = new CancellationTokenSource(2000);
+
+        Exception? caught = null;
+        try
+        {
+            await client.ConnectAsync("localhost", port, cts.Token);
+        }
+        catch (Exception e)
+        {
+            caught = e;
+        }
+
+        // Before the fix, IPAddress.Parse("localhost") threw FormatException before the DNS
+        // branch could run, so UDP clients could never connect by hostname. After the fix the
+        // hostname resolves via DNS; the connection itself may still fail depending on which
+        // address family localhost maps to in this environment (e.g. IPv6-only), but a
+        // FormatException must never occur.
+        Assert.False(
+            caught is FormatException,
+            $"ConnectAsync must not throw FormatException for a hostname (#1105); got: {caught}");
+
+        if (caught is null)
+        {
+            Assert.Equal(ConnectionState.Connected, client.State);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes the networking review cluster from the deep-functional-review epic (#1093).

- **#1096** — ReliableOrdered gets its own sequence space + dedup/pending/ack routing, so non-ordered packets can't stall ordered delivery.
- **#1097** — re-fetch `PredictionState` ref after `ApplyServerState` so `LastConfirmedTick` survives archetype migration.
- **#1098** — connection/disconnection events marshalled to the game loop via an ordered queue drained in `Update()`, mirroring `DataReceived`.
- **#1099** — broadcast delta baseline advances only on ack; dropped deltas retransmit.
- **#1100** — `lastSentInputTick` is now per-entity.
- **#1101** — EntitySpawn path dedupes via `TryGetLocalEntity`, matching the snapshot path.
- **#1102** — server copies transport RTT into `ClientState.RoundTripTimeMs` each tick.
- **#1103** — owner-authoritative exclusion applied on both reconciliation decode paths (full + delta).
- **#1104** — despawn cleanup wired: client releases input/prediction buffers, server clears entity state on destroy.
- **#1105** — literal IPs via `IPAddress.Parse`, hostnames resolved via DNS first (fixes `FormatException`).

## Test plan
- [x] `NetworkClusterFixTests` (11 tests); fail-on-old/pass-on-new proven per issue via source revert
- [x] Network.Tests 326, Network.Abstractions.Tests 206; full suite 14,571 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1096
Closes #1097
Closes #1098
Closes #1099
Closes #1100
Closes #1101
Closes #1102
Closes #1103
Closes #1104
Closes #1105