### PR TITLE
fix(ui): Fix held-key repeat, topmost-modal escape, and mid-drag click swallow

### DIFF
--- a/src/KeenEyes.UI.Abstractions/Components/UIModal.cs
+++ b/src/KeenEyes.UI.Abstractions/Components/UIModal.cs
@@ -48,6 +48,13 @@ public struct UIModal(string title, bool closeOnBackdropClick = true, bool close
     /// Reference to the content container entity.
     /// </summary>
     public Entity ContentContainer = Entity.Null;
+
+    /// <summary>
+    /// Monotonic open-order stamp identifying how recently the modal was opened.
+    /// Higher values were opened later and are therefore considered closer to the
+    /// top of the modal stack. Used to dismiss the topmost modal on Escape.
+    /// </summary>
+    public long OpenOrder = 0;
 }
 
 /// <summary>

--- a/src/KeenEyes.UI/Systems/UIFocusSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIFocusSystem.cs
@@ -27,6 +27,8 @@ public sealed class UIFocusSystem : SystemBase
     private IInputContext? inputContext;
     private bool tabWasDown;
     private bool escapeWasDown;
+    private bool enterWasDown;
+    private bool spaceWasDown;
 
     /// <inheritdoc />
     public override void Update(float deltaTime)
@@ -65,31 +67,35 @@ public sealed class UIFocusSystem : SystemBase
         }
         escapeWasDown = escapeIsDown;
 
-        // Handle Enter/Space on focused element
-        if (ui.HasFocus)
+        // Handle Enter/Space on the focused element. These are edge-triggered:
+        // holding the key down must fire Submit/Click exactly once per press, not
+        // every frame the key remains held (see #1193). Previous-frame state is
+        // tracked unconditionally so the edge is detected regardless of focus.
+        bool enterIsDown = keyboard.IsKeyDown(Key.Enter) || keyboard.IsKeyDown(Key.KeypadEnter);
+        bool spaceIsDown = keyboard.IsKeyDown(Key.Space);
+        bool enterPressed = enterIsDown && !enterWasDown;
+        bool spacePressed = spaceIsDown && !spaceWasDown;
+        enterWasDown = enterIsDown;
+        spaceWasDown = spaceIsDown;
+
+        if (ui.HasFocus && (enterPressed || spacePressed))
         {
             var focused = ui.FocusedEntity;
             if (World.IsAlive(focused) && World.Has<UIInteractable>(focused))
             {
-                bool enterPressed = keyboard.IsKeyDown(Key.Enter) || keyboard.IsKeyDown(Key.KeypadEnter);
-                bool spacePressed = keyboard.IsKeyDown(Key.Space);
+                ref var interactable = ref World.Get<UIInteractable>(focused);
 
-                if (enterPressed || spacePressed)
+                if (enterPressed)
                 {
-                    ref var interactable = ref World.Get<UIInteractable>(focused);
+                    interactable.PendingEvents |= UIEventType.Submit;
+                    World.Send(new UISubmitEvent(focused));
+                }
 
-                    if (enterPressed)
-                    {
-                        interactable.PendingEvents |= UIEventType.Submit;
-                        World.Send(new UISubmitEvent(focused));
-                    }
-
-                    if (spacePressed && interactable.CanClick)
-                    {
-                        interactable.PendingEvents |= UIEventType.Click;
-                        var rect = World.Get<UIRect>(focused);
-                        World.Send(new UIClickEvent(focused, rect.ComputedBounds.Center, MouseButton.Left));
-                    }
+                if (spacePressed && interactable.CanClick)
+                {
+                    interactable.PendingEvents |= UIEventType.Click;
+                    var rect = World.Get<UIRect>(focused);
+                    World.Send(new UIClickEvent(focused, rect.ComputedBounds.Center, MouseButton.Left));
                 }
             }
         }

--- a/src/KeenEyes.UI/Systems/UIInputSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIInputSystem.cs
@@ -187,7 +187,6 @@ public sealed class UIInputSystem : SystemBase
                     // End drag
                     interactable.State &= ~UIInteractionState.Dragging;
                     interactable.PendingEvents |= UIEventType.DragEnd;
-                    isDragging = false;
 
                     World.Send(new UIDragEndEvent(pressedEntity, mousePos));
                 }
@@ -208,7 +207,12 @@ public sealed class UIInputSystem : SystemBase
                 }
             }
 
+            // Reset drag/press state unconditionally. If the pressed entity died
+            // mid-drag, the block above is skipped, but the drag flag must still be
+            // cleared or it leaks into the next press and swallows the next click by
+            // routing the release down the DragEnd path instead of Click (see #1196).
             pressedEntity = Entity.Null;
+            isDragging = false;
         }
     }
 

--- a/src/KeenEyes.UI/Systems/UIModalSystem.cs
+++ b/src/KeenEyes.UI/Systems/UIModalSystem.cs
@@ -27,6 +27,7 @@ public sealed class UIModalSystem : SystemBase
     private EventSubscription? clickSubscription;
     private IInputContext? inputContext;
     private bool escapeWasDown;
+    private long nextOpenOrder = 1;
 
     /// <inheritdoc />
     protected override void OnInitialize()
@@ -76,16 +77,27 @@ public sealed class UIModalSystem : SystemBase
 
     private void HandleEscapeKey()
     {
-        // Find the topmost open modal that allows Escape to close
+        // Find the topmost open modal that allows Escape to close. "Topmost" is the
+        // most recently opened modal (highest OpenOrder), not the first one found in
+        // query order, which would otherwise dismiss an arbitrary background modal
+        // while a dialog stacked above it stays open (see #1195).
+        Entity topmost = Entity.Null;
+        long topmostOrder = long.MinValue;
+
         foreach (var entity in World.Query<UIModal>())
         {
             ref readonly var modal = ref World.Get<UIModal>(entity);
 
-            if (modal.IsOpen && modal.CloseOnEscape)
+            if (modal.IsOpen && modal.CloseOnEscape && modal.OpenOrder > topmostOrder)
             {
-                CloseModal(entity, ModalResult.Cancel);
-                break; // Only close the topmost modal
+                topmostOrder = modal.OpenOrder;
+                topmost = entity;
             }
+        }
+
+        if (topmost.IsValid)
+        {
+            CloseModal(topmost, ModalResult.Cancel);
         }
     }
 
@@ -181,6 +193,9 @@ public sealed class UIModalSystem : SystemBase
         var backdrop = modalComponent.Backdrop;
 
         modalComponent.IsOpen = true;
+
+        // Stamp the open-order so Escape can identify the topmost (most recent) modal.
+        modalComponent.OpenOrder = nextOpenOrder++;
 
         // Show the modal
         if (World.Has<UIElement>(modal))

--- a/tests/KeenEyes.UI.Tests/UIFocusSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIFocusSystemTests.cs
@@ -294,6 +294,83 @@ public class UIFocusSystemTests
     }
 
     [Fact]
+    public void EnterKey_HeldDownAcrossFrames_FiresSubmitOnce()
+    {
+        // Regression for #1193: Enter/Space must be edge-triggered. Holding Enter
+        // across multiple Updates must fire exactly one UISubmitEvent, not one per frame.
+        using var world = CreateWorldWithInput(out var input, out var uiContext);
+        var system = new UIFocusSystem();
+        world.AddSystem(system);
+
+        var canvas = uiContext.CreateCanvas();
+        var button = CreateButton(world, canvas, 0);
+
+        int submitCount = 0;
+        world.Subscribe<UISubmitEvent>(_ => submitCount++);
+
+        uiContext.RequestFocus(button);
+
+        // Press Enter and hold it across two frames.
+        input.PressKey(Key.Enter);
+        system.Update(0);
+        system.Update(0);
+
+        Assert.Equal(1, submitCount);
+    }
+
+    [Fact]
+    public void SpaceKey_HeldDownAcrossFrames_FiresClickOnce()
+    {
+        // Regression for #1193: holding Space must fire exactly one UIClickEvent.
+        using var world = CreateWorldWithInput(out var input, out var uiContext);
+        var system = new UIFocusSystem();
+        world.AddSystem(system);
+
+        var canvas = uiContext.CreateCanvas();
+        var button = CreateButton(world, canvas, 0);
+
+        int clickCount = 0;
+        world.Subscribe<UIClickEvent>(_ => clickCount++);
+
+        uiContext.RequestFocus(button);
+
+        // Press Space and hold it across two frames.
+        input.PressKey(Key.Space);
+        system.Update(0);
+        system.Update(0);
+
+        Assert.Equal(1, clickCount);
+    }
+
+    [Fact]
+    public void EnterKey_ReleasedAndPressedAgain_FiresSubmitEachPress()
+    {
+        // Edge-triggering must still allow a fresh Submit on each distinct press.
+        using var world = CreateWorldWithInput(out var input, out var uiContext);
+        var system = new UIFocusSystem();
+        world.AddSystem(system);
+
+        var canvas = uiContext.CreateCanvas();
+        var button = CreateButton(world, canvas, 0);
+
+        int submitCount = 0;
+        world.Subscribe<UISubmitEvent>(_ => submitCount++);
+
+        uiContext.RequestFocus(button);
+
+        input.PressKey(Key.Enter);
+        system.Update(0);
+
+        input.ReleaseKey(Key.Enter);
+        system.Update(0);
+
+        input.PressKey(Key.Enter);
+        system.Update(0);
+
+        Assert.Equal(2, submitCount);
+    }
+
+    [Fact]
     public void KeypadEnter_OnFocusedElement_FiresSubmitEvent()
     {
         using var world = CreateWorldWithInput(out var input, out var uiContext);

--- a/tests/KeenEyes.UI.Tests/UIInputSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIInputSystemTests.cs
@@ -557,6 +557,49 @@ public class UIInputSystemTests
     }
 
     [Fact]
+    public void Release_AfterPressedEntityDiesMidDrag_DoesNotSwallowNextClick()
+    {
+        // Regression for #1196: if the dragged entity dies mid-drag, the release
+        // cleanup block is skipped, so isDragging must still be reset. Otherwise the
+        // leaked drag flag routes the next release down the DragEnd path and swallows
+        // the following click.
+        using var world = CreateWorldWithInput(out var input, out var uiContext, out var layoutSystem);
+        var system = new UIInputSystem();
+        world.AddSystem(system);
+
+        var canvas = uiContext.CreateCanvas();
+        var draggable = CreateDraggable(world, canvas, 100, 100, 200, 100);
+        var button = CreateButton(world, canvas, 100, 300, 200, 100);
+        layoutSystem.Update(0);
+
+        // Press the draggable and move far enough to begin dragging.
+        input.SetMousePosition(150, 150);
+        input.SetMouseButton(MouseButton.Left, true);
+        system.Update(0);
+        input.SetMousePosition(160, 150);
+        system.Update(0);
+        Assert.True(world.Get<UIInteractable>(draggable).IsDragging);
+
+        // The dragged entity dies mid-drag, then the button is released.
+        world.Despawn(draggable);
+        input.SetMouseButton(MouseButton.Left, false);
+        system.Update(0);
+
+        // Now a plain click on the button must fire a UIClickEvent.
+        UIClickEvent? receivedEvent = null;
+        world.Subscribe<UIClickEvent>(e => receivedEvent = e);
+
+        input.SetMousePosition(150, 350); // Inside button
+        input.SetMouseButton(MouseButton.Left, true);
+        system.Update(0);
+        input.SetMouseButton(MouseButton.Left, false);
+        system.Update(0);
+
+        Assert.NotNull(receivedEvent);
+        Assert.Equal(button, receivedEvent.Value.Element);
+    }
+
+    [Fact]
     public void Hover_OnNonInteractableElement_DoesNotSetHovered()
     {
         using var world = CreateWorldWithInput(out var input, out var uiContext, out var layoutSystem);

--- a/tests/KeenEyes.UI.Tests/UIModalSystemTests.cs
+++ b/tests/KeenEyes.UI.Tests/UIModalSystemTests.cs
@@ -548,6 +548,44 @@ public class UIModalSystemTests
     }
 
     [Fact]
+    public void Modal_EscapeKey_ClosesTopmostModalNotFirstOpened()
+    {
+        // Regression for #1195: with two stacked modals, Escape must close the
+        // topmost (most recently opened) modal, not an arbitrary creation-order-first one.
+        using var world = new World();
+        var mockInput = new MockInputContext();
+        world.SetExtension<IInputContext>(mockInput);
+
+        var modalSystem = new UIModalSystem();
+        world.AddSystem(modalSystem);
+
+        // Settings modal is created and opened first (background).
+        var settings = world.Spawn()
+            .With(new UIElement { Visible = false })
+            .With(new UIModal("Settings", closeOnEscape: true) { IsOpen = false })
+            .Build();
+
+        // Confirm modal is created and opened second (on top).
+        var confirm = world.Spawn()
+            .With(new UIElement { Visible = false })
+            .With(new UIModal("Confirm", closeOnEscape: true) { IsOpen = false })
+            .Build();
+
+        modalSystem.OpenModal(settings);
+        modalSystem.OpenModal(confirm);
+
+        // Initialize escape state (not pressed), then press escape.
+        mockInput.MockKeyboard.SetKeyUp(Key.Escape);
+        modalSystem.Update(0);
+        mockInput.MockKeyboard.SetKeyDown(Key.Escape);
+        modalSystem.Update(0);
+
+        // Topmost (confirm) closes; the background (settings) stays open.
+        Assert.False(world.Get<UIModal>(confirm).IsOpen);
+        Assert.True(world.Get<UIModal>(settings).IsOpen);
+    }
+
+    [Fact]
     public void Modal_EscapeKey_FiresCancelResult()
     {
         using var world = new World();


### PR DESCRIPTION
## Summary
Fixes the UI review cluster from the deep-functional-review epic (#1093).

- **#1193** — `UIFocusSystem` edge-triggers Enter/Space (previous-frame state tracked unconditionally), so Submit/Click fire once per press instead of every frame while held.
- **#1195** — `UIModal` gains a monotonic `OpenOrder`; Escape now closes the topmost (most-recently-opened) `CloseOnEscape` modal instead of the first-opened.
- **#1196** — `UIInputSystem` clears `isDragging` unconditionally on release, so a pressed entity dying mid-drag no longer leaks drag state and swallows the next click.

## Test plan
- [x] New tests in UIFocusSystem/UIInputSystem/UIModalSystem; fail-on-old/pass-on-new proven per issue via source revert
- [x] UI.Tests 1999; full suite 14,565 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1193
Closes #1195
Closes #1196