### PR TITLE
fix(graphics): Fix ellipse index packing, per-batch instance capacity, and honored Begin projection

### DIFF
--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -53,6 +53,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     private uint currentTexture;
     private bool isBatching;
     private Matrix4x4 screenProjection;
+    private Matrix4x4 activeProjection;
     private Vector2 screenSize;
     private bool disposed;
 
@@ -310,6 +311,10 @@ public sealed class Silk2DRenderer : I2DRenderer
         indexCount = 0;
         currentTexture = whiteTexture;
 
+        // Remember the caller-supplied projection so Flush/FlushRoundedRects re-bind
+        // it (rather than the internal screen projection) before every draw call.
+        activeProjection = projection;
+
         device.UseProgram(shaderProgram);
         device.UniformMatrix4(projectionLocation, projection);
         device.Uniform1(textureLocation, 0);
@@ -343,7 +348,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Ensure our shader and state are active (may have been changed by other renderers)
         device.UseProgram(shaderProgram);
-        device.UniformMatrix4(projectionLocation, screenProjection);
+        device.UniformMatrix4(projectionLocation, activeProjection);
         device.Uniform1(textureLocation, 0);
         device.Enable(RenderCapability.Blend);
         device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
@@ -550,22 +555,30 @@ public sealed class Silk2DRenderer : I2DRenderer
     {
         SetTexture(whiteTexture);
 
+        var center = new Vector2(centerX, centerY);
+
         for (int i = 0; i < segments; i++)
         {
             float angle1 = MathF.PI * 2 * i / segments;
             float angle2 = MathF.PI * 2 * (i + 1) / segments;
 
-            float x1 = centerX + MathF.Cos(angle1) * radiusX;
-            float y1 = centerY + MathF.Sin(angle1) * radiusY;
-            float x2 = centerX + MathF.Cos(angle2) * radiusX;
-            float y2 = centerY + MathF.Sin(angle2) * radiusY;
+            var p1 = new Vector2(centerX + MathF.Cos(angle1) * radiusX, centerY + MathF.Sin(angle1) * radiusY);
+            var p2 = new Vector2(centerX + MathF.Cos(angle2) * radiusX, centerY + MathF.Sin(angle2) * radiusY);
 
-            EnsureCapacity(3, 3);
+            // The batch shares a single quad-patterned index buffer (v+0, v+1, v+2,
+            // v+2, v+3, v+0), so each wedge must be emitted as four vertices to stay
+            // aligned with it. Duplicating p2 as the fourth vertex makes the second
+            // triangle (p2, p2, center) degenerate, leaving exactly one visible
+            // wedge triangle (center, p1, p2) per segment. Emitting three vertices
+            // here instead would desynchronize the fan from the quad indices and
+            // corrupt the shape (see #1183).
+            EnsureCapacity(4, 6);
 
-            vertices[vertexCount++] = new Vertex2D(new Vector2(centerX, centerY), Vector2.Zero, color);
-            vertices[vertexCount++] = new Vertex2D(new Vector2(x1, y1), Vector2.Zero, color);
-            vertices[vertexCount++] = new Vertex2D(new Vector2(x2, y2), Vector2.Zero, color);
-            indexCount += 3;
+            vertices[vertexCount++] = new Vertex2D(center, Vector2.Zero, color);
+            vertices[vertexCount++] = new Vertex2D(p1, Vector2.Zero, color);
+            vertices[vertexCount++] = new Vertex2D(p2, Vector2.Zero, color);
+            vertices[vertexCount++] = new Vertex2D(p2, Vector2.Zero, color);
+            indexCount += 6;
         }
     }
 
@@ -743,7 +756,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Setup rounded rect shader
         device.UseProgram(roundedRectShaderProgram);
-        device.UniformMatrix4(roundedRectProjectionLocation, screenProjection);
+        device.UniformMatrix4(roundedRectProjectionLocation, activeProjection);
         device.Enable(RenderCapability.Blend);
         device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
 
@@ -765,7 +778,7 @@ public sealed class Silk2DRenderer : I2DRenderer
 
         // Restore regular shader for subsequent draws
         device.UseProgram(shaderProgram);
-        device.UniformMatrix4(projectionLocation, screenProjection);
+        device.UniformMatrix4(projectionLocation, activeProjection);
         device.Uniform1(textureLocation, 0);
     }
 

--- a/src/KeenEyes.Graphics.Silk/Text/FontStashRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Text/FontStashRenderer.cs
@@ -44,6 +44,7 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
     private uint currentTexture;
     private bool isBatching;
     private Matrix4x4 projection;
+    private Matrix4x4 activeProjection;
     private Vector2 screenSize;
     private bool disposed;
 
@@ -104,6 +105,10 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
         indexCount = 0;
         currentTexture = 0;
 
+        // Remember the caller-supplied projection so Flush re-binds it (rather than
+        // the internal screen projection) before every draw call.
+        activeProjection = customProjection;
+
         device.UseProgram(shaderProgram);
         device.UniformMatrix4(projectionLocation, customProjection);
         device.Uniform1(textureLocation, 0);
@@ -140,7 +145,7 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
 
         // Ensure our shader and state are active (may have been changed by other renderers)
         device.UseProgram(shaderProgram);
-        device.UniformMatrix4(projectionLocation, projection);
+        device.UniformMatrix4(projectionLocation, activeProjection);
         device.Uniform1(textureLocation, 0);
         device.Enable(RenderCapability.Blend);
         // FontStashSharp uses premultiplied alpha

--- a/src/KeenEyes.Graphics/Systems/InstanceBatchingSystem.cs
+++ b/src/KeenEyes.Graphics/Systems/InstanceBatchingSystem.cs
@@ -39,6 +39,12 @@ public sealed class PreparedBatch
     public InstanceBufferHandle InstanceBuffer { get; set; }
 
     /// <summary>
+    /// The allocated capacity (in instances) of <see cref="InstanceBuffer"/> on the GPU.
+    /// Tracked per batch so growth decisions are independent of any shared staging array.
+    /// </summary>
+    internal int Capacity { get; set; }
+
+    /// <summary>
     /// The number of instances in this batch.
     /// </summary>
     public int InstanceCount { get; set; }
@@ -189,31 +195,39 @@ public sealed class InstanceBatchingSystem : ISystem
             // Get or create prepared batch
             if (!preparedBatches.TryGetValue(key, out var prepared))
             {
-                // Create new batch with initial buffer
+                // Create new batch with a buffer sized to fit the current instances
                 int capacity = Math.Max(InitialBufferCapacity, instances.Count);
                 var buffer = graphics.CreateInstanceBuffer(capacity);
 
                 prepared = new PreparedBatch
                 {
                     Mesh = new MeshHandle(key.MeshId),
-                    InstanceBuffer = buffer
+                    InstanceBuffer = buffer,
+                    Capacity = capacity,
                 };
                 preparedBatches[key] = prepared;
             }
 
-            // Check if buffer needs to grow
-            var currentBuffer = prepared.InstanceBuffer;
-            // We need to track capacity - for now, recreate if count exceeds uploadBuffer
+            // Ensure the reusable CPU staging buffer is large enough to hold this batch.
+            // This array is shared across all batches, so it only ever grows.
             if (instances.Count > uploadBuffer.Length)
             {
-                // Grow upload buffer
-                int newCapacity = (int)(instances.Count * BufferGrowthFactor);
-                uploadBuffer = new InstanceData[newCapacity];
+                uploadBuffer = new InstanceData[(int)(instances.Count * BufferGrowthFactor)];
+            }
 
-                // Recreate GPU buffer with new capacity
+            // Grow this batch's GPU buffer when it can no longer hold the instances.
+            // Capacity is tracked per batch (not via the shared staging array) so that a
+            // batch which grows after another batch already enlarged the staging buffer
+            // still resizes its own GPU buffer (see #1184).
+            var currentBuffer = prepared.InstanceBuffer;
+            if (instances.Count > prepared.Capacity)
+            {
+                int newCapacity = (int)(instances.Count * BufferGrowthFactor);
+
                 graphics.DeleteInstanceBuffer(currentBuffer);
                 currentBuffer = graphics.CreateInstanceBuffer(newCapacity);
                 prepared.InstanceBuffer = currentBuffer;
+                prepared.Capacity = newCapacity;
             }
 
             // Copy to upload buffer

--- a/tests/KeenEyes.Graphics.Tests/InstanceBatchingSystemTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/InstanceBatchingSystemTests.cs
@@ -1,0 +1,106 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests for <see cref="InstanceBatchingSystem"/> GPU buffer capacity bookkeeping.
+/// </summary>
+public class InstanceBatchingSystemTests : IDisposable
+{
+    private World? world;
+
+    public void Dispose()
+    {
+        world?.Dispose();
+    }
+
+    private void SpawnInstances(int meshId, int batchId, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            world!.Spawn()
+                .With(new Transform3D(new Vector3(i, 0, 0), Quaternion.Identity, Vector3.One))
+                .With(new Renderable(meshId, 0))
+                .With(new InstanceBatch(batchId))
+                .Build();
+        }
+    }
+
+    /// <summary>
+    /// Regression test for #1184: a batch that grows after a different batch has already
+    /// enlarged the shared CPU staging array must still resize its own GPU buffer.
+    /// </summary>
+    /// <remarks>
+    /// With the pre-fix code, capacity was gated on the shared, only-growing
+    /// <c>uploadBuffer.Length</c>. Once a large batch inflated that array, a smaller batch
+    /// that later grew past its own GPU capacity (but stayed under the staging length) was
+    /// never resized, leaving its GPU buffer too small for the uploaded data.
+    /// </remarks>
+    [Fact]
+    public void Update_SecondBatchGrowsAfterAnotherEnlargedStaging_ResizesOwnGpuBuffer()
+    {
+        world = new World();
+        var context = new MockGraphicsContext();
+        world.SetExtension<IGraphicsContext>(context);
+
+        var system = new InstanceBatchingSystem();
+        world.AddSystem(system);
+
+        // Frame 1: a large batch (A) inflates the shared staging buffer well past the
+        // initial capacity, while a small batch (B) gets a small GPU buffer.
+        const int largeCount = 600;
+        const int smallCount = 130;
+        SpawnInstances(meshId: 1, batchId: 1, count: largeCount);
+        SpawnInstances(meshId: 1, batchId: 2, count: smallCount);
+        system.Update(1f / 60f);
+
+        // Frame 2: batch B grows past its GPU capacity but stays below the staging length
+        // that batch A already grew to.
+        const int grownCount = 500;
+        SpawnInstances(meshId: 1, batchId: 2, count: grownCount - smallCount);
+        system.Update(1f / 60f);
+
+        // Every batch's GPU buffer must be able to hold the instances it reports uploading.
+        Assert.NotEmpty(system.Batches);
+        foreach (var batch in system.Batches)
+        {
+            var bufferInfo = context.InstanceBuffers[batch.InstanceBuffer];
+            Assert.True(
+                bufferInfo.MaxInstances >= batch.InstanceCount,
+                $"GPU buffer capacity ({bufferInfo.MaxInstances}) is smaller than the batch " +
+                $"instance count ({batch.InstanceCount}).");
+        }
+
+        // And specifically, the grown batch must have kept up.
+        var grownBatch = system.Batches.Single(b => b.InstanceCount == grownCount);
+        Assert.True(context.InstanceBuffers[grownBatch.InstanceBuffer].MaxInstances >= grownCount);
+    }
+
+    /// <summary>
+    /// A single batch that grows across frames must resize its GPU buffer to fit.
+    /// </summary>
+    [Fact]
+    public void Update_SingleBatchGrows_ResizesGpuBuffer()
+    {
+        world = new World();
+        var context = new MockGraphicsContext();
+        world.SetExtension<IGraphicsContext>(context);
+
+        var system = new InstanceBatchingSystem();
+        world.AddSystem(system);
+
+        SpawnInstances(meshId: 1, batchId: 1, count: 100);
+        system.Update(1f / 60f);
+
+        SpawnInstances(meshId: 1, batchId: 1, count: 900);
+        system.Update(1f / 60f);
+
+        var batch = system.Batches.Single();
+        Assert.Equal(1000, batch.InstanceCount);
+        Assert.True(context.InstanceBuffers[batch.InstanceBuffer].MaxInstances >= 1000);
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/Silk2DRendererTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/Silk2DRendererTests.cs
@@ -1,0 +1,200 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Rendering2D;
+using KeenEyes.Graphics.Silk.Resources;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Headless tests for <see cref="Silk2DRenderer"/> geometry and projection handling.
+/// </summary>
+/// <remarks>
+/// The renderer is normally GPU-bound, but <see cref="MockGraphicsDevice"/> records every
+/// buffer upload, draw call, and uniform assignment, which lets these tests verify the
+/// vertex/index math and projection state without a real OpenGL context.
+/// </remarks>
+public class Silk2DRendererTests : IDisposable
+{
+    private const float ScreenWidth = 800f;
+    private const float ScreenHeight = 600f;
+
+    // Vertex2D layout: Position (Vector2, 8 bytes) + TexCoord (Vector2, 8 bytes) + Color (Vector4, 16 bytes).
+    private const int FloatsPerVertex = 8;
+
+    private readonly MockGraphicsDevice device = new();
+    private readonly TextureManager textureManager;
+    private readonly Silk2DRenderer renderer;
+
+    public Silk2DRendererTests()
+    {
+        textureManager = new TextureManager { Device = device };
+        renderer = new Silk2DRenderer(device, textureManager, ScreenWidth, ScreenHeight);
+    }
+
+    public void Dispose()
+    {
+        renderer.Dispose();
+        textureManager.Dispose();
+    }
+
+    #region #1183 - FillEllipse / FillCircle index packing
+
+    /// <summary>
+    /// Regression test for #1183: filled circles must tessellate into a clean triangle fan.
+    /// </summary>
+    /// <remarks>
+    /// The batch shares one quad-patterned index buffer. Pre-fix, <c>FillEllipse</c> emitted
+    /// three vertices per segment while the index buffer advanced four vertices per quad, so
+    /// the drawn triangles indexed fan vertices as if they were quads. That produced
+    /// "garbage" triangles built entirely from perimeter points (never touching the center),
+    /// corrupting the shape. A correct fan has every visible triangle anchored at the center.
+    /// </remarks>
+    [Fact]
+    public void FillCircle_DrawnTriangles_AreAllCenterAnchoredWedges()
+    {
+        const int segments = 8;
+        var center = new Vector2(100f, 120f);
+
+        renderer.Begin();
+        renderer.FillCircle(center.X, center.Y, 50f, new Vector4(1f, 1f, 1f, 1f), segments);
+        renderer.End();
+
+        var triangles = ReconstructDrawnTriangles();
+
+        int nonDegenerate = 0;
+        int garbageWithoutCenter = 0;
+        foreach (var (a, b, c) in triangles)
+        {
+            if (IsDegenerate(a, b, c))
+            {
+                continue;
+            }
+
+            nonDegenerate++;
+
+            bool touchesCenter =
+                ApproximatelyEqual(a, center) ||
+                ApproximatelyEqual(b, center) ||
+                ApproximatelyEqual(c, center);
+
+            if (!touchesCenter)
+            {
+                garbageWithoutCenter++;
+            }
+        }
+
+        // Pre-fix code produces at least one perimeter-only triangle; the fix produces none.
+        Assert.Equal(0, garbageWithoutCenter);
+
+        // A correct fan yields exactly one visible wedge per segment.
+        Assert.Equal(segments, nonDegenerate);
+    }
+
+    #endregion
+
+    #region #1187 - Begin(projection) honored through Flush
+
+    /// <summary>
+    /// Regression test for #1187: a custom projection supplied to <c>Begin</c> must remain
+    /// bound through the <c>Flush</c> that issues the draw call, instead of being overwritten
+    /// by the internal screen projection.
+    /// </summary>
+    [Fact]
+    public void Begin_WithCustomProjection_KeepsItBoundAtDrawTime()
+    {
+        // A projection clearly different from the 800x600 screen ortho.
+        var custom = Matrix4x4.CreateOrthographicOffCenter(0f, 320f, 240f, 0f, -1f, 1f);
+        var screen = Matrix4x4.CreateOrthographicOffCenter(0f, ScreenWidth, ScreenHeight, 0f, -1f, 1f);
+
+        renderer.Begin(custom);
+        renderer.FillRect(10f, 10f, 50f, 50f, new Vector4(1f, 0f, 0f, 1f));
+        renderer.End();
+
+        var boundProjection = GetBoundProjection();
+
+        Assert.Equal(custom, boundProjection);
+        Assert.NotEqual(screen, boundProjection);
+    }
+
+    /// <summary>
+    /// The default <c>Begin()</c> overload must draw using the screen projection.
+    /// </summary>
+    [Fact]
+    public void Begin_Default_UsesScreenProjection()
+    {
+        var screen = Matrix4x4.CreateOrthographicOffCenter(0f, ScreenWidth, ScreenHeight, 0f, -1f, 1f);
+
+        renderer.Begin();
+        renderer.FillRect(10f, 10f, 50f, 50f, new Vector4(1f, 0f, 0f, 1f));
+        renderer.End();
+
+        Assert.Equal(screen, GetBoundProjection());
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Reconstructs the triangles drawn by the last triangle draw call, applying the shared
+    /// quad-patterned index layout (v+0, v+1, v+2, v+2, v+3, v+0) to the uploaded vertices.
+    /// </summary>
+    private List<(Vector2 A, Vector2 B, Vector2 C)> ReconstructDrawnTriangles()
+    {
+        var draw = device.DrawCalls.Last(d => d.PrimitiveType == PrimitiveType.Triangles && d.IsIndexed);
+        int indexCount = draw.VertexCount;
+
+        // The 2D vertex buffer is the array buffer holding only the freshly uploaded vertices
+        // (the rounded-rect buffer keeps its far larger initial allocation).
+        var vboData = device.Buffers.Values
+            .Where(b => b.Target == BufferTarget.ArrayBuffer && b.Data is not null)
+            .OrderBy(b => b.Data!.Length)
+            .First()
+            .Data!;
+
+        var floats = MemoryMarshal.Cast<byte, float>(vboData);
+
+        var triangles = new List<(Vector2, Vector2, Vector2)>();
+        for (int baseIndex = 0, v = 0; baseIndex + 6 <= indexCount; baseIndex += 6, v += 4)
+        {
+            // Quad pattern: (v+0, v+1, v+2) and (v+2, v+3, v+0).
+            triangles.Add((ReadPosition(floats, v + 0), ReadPosition(floats, v + 1), ReadPosition(floats, v + 2)));
+            triangles.Add((ReadPosition(floats, v + 2), ReadPosition(floats, v + 3), ReadPosition(floats, v + 0)));
+        }
+
+        return triangles;
+    }
+
+    private static Vector2 ReadPosition(ReadOnlySpan<float> floats, int vertexIndex)
+    {
+        int offset = vertexIndex * FloatsPerVertex;
+        return new Vector2(floats[offset], floats[offset + 1]);
+    }
+
+    private static bool IsDegenerate(Vector2 a, Vector2 b, Vector2 c)
+    {
+        float cross = ((b.X - a.X) * (c.Y - a.Y)) - ((b.Y - a.Y) * (c.X - a.X));
+        return MathF.Abs(cross) < 1e-3f;
+    }
+
+    private static bool ApproximatelyEqual(Vector2 a, Vector2 b)
+    {
+        return Vector2.DistanceSquared(a, b) < 1e-6f;
+    }
+
+    /// <summary>
+    /// Reads the projection matrix bound to the main 2D shader program (identified by its
+    /// <c>uTexture</c> uniform, which the rounded-rect shader lacks).
+    /// </summary>
+    private Matrix4x4 GetBoundProjection()
+    {
+        var program = device.Programs.Values.Single(p => p.UniformLocations.ContainsKey("uTexture"));
+        int location = program.UniformLocations["uProjection"];
+        return (Matrix4x4)program.UniformValues[location];
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes the graphics review cluster from the deep-functional-review epic (#1093).

- **#1183** — `Silk2DRenderer.FillEllipse` now emits each wedge as a 4-vertex quad with a degenerate second triangle, aligning with the batch's shared quad-patterned index buffer (was corrupting the fan).
- **#1184** — `InstanceBatchingSystem` tracks GPU capacity per `PreparedBatch` instead of via the shared CPU staging array length, so a second batch growing no longer crashes `UpdateInstanceBuffer`.
- **#1187** — `Begin(projection)` is now stored in `activeProjection` and bound through `Flush`/`FlushRoundedRects` (and `FontStashRenderer`), instead of being overwritten by the internal screen projection.

## Test plan
- [x] New headless tests (`MockGraphicsDevice`) for ellipse wedges, per-batch growth, and bound projection; fail-on-old/pass-on-new proven via source revert
- [x] `FontStashRenderer` fix is structurally identical, verified by code trace
- [x] Graphics.Tests 562; full suite 14,565 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1183
Closes #1184
Closes #1187