### PR TITLE
fix(core): Fix plugin orphaning, command-buffer placeholder resolution, and WorldBuilder reuse

### DIFF
--- a/src/KeenEyes.Abstractions/CommandBuffer.cs
+++ b/src/KeenEyes.Abstractions/CommandBuffer.cs
@@ -93,6 +93,53 @@ public sealed class CommandBuffer : ICommandBuffer
         return entityMap;
     }
 
+    /// <summary>
+    /// Executes all queued commands against a shared placeholder-to-entity map, enabling
+    /// resolution of placeholders created by buffers flushed earlier in the same batch.
+    /// </summary>
+    /// <param name="world">The world to execute commands on.</param>
+    /// <param name="sharedEntityMap">
+    /// A placeholder-to-entity map shared across buffers. Spawn commands add this buffer's
+    /// new entities to it (making them resolvable by later buffers), and placeholder
+    /// references are resolved against it.
+    /// </param>
+    /// <returns>The entities spawned by this buffer, keyed by their local placeholder ID.</returns>
+    /// <remarks>
+    /// Used by the command buffer pool to thread cross-buffer placeholder resolution
+    /// across a staged flush. Placeholder IDs are only unique within a single buffer, so when
+    /// two buffers reuse the same local ID the most recently flushed spawn wins for that ID.
+    /// </remarks>
+    internal Dictionary<int, Entity> Flush(IWorld world, Dictionary<int, Entity> sharedEntityMap)
+    {
+        // This buffer allocates placeholder IDs contiguously starting at -1 (see Spawn), so at
+        // flush time the IDs it created are exactly the range (nextPlaceholderId, -1]. Capture
+        // the boundary before Clear() resets it so we can report this buffer's own spawns.
+        var lowestPlaceholderId = nextPlaceholderId;
+
+        try
+        {
+            foreach (var command in commands)
+            {
+                command.Execute(world, sharedEntityMap);
+            }
+        }
+        finally
+        {
+            Clear();
+        }
+
+        var localEntityMap = new Dictionary<int, Entity>();
+        for (var placeholderId = -1; placeholderId > lowestPlaceholderId; placeholderId--)
+        {
+            if (sharedEntityMap.TryGetValue(placeholderId, out var entity))
+            {
+                localEntityMap[placeholderId] = entity;
+            }
+        }
+
+        return localEntityMap;
+    }
+
     /// <inheritdoc/>
     public void Clear()
     {

--- a/src/KeenEyes.Core/Parallelism/CommandBufferPool.cs
+++ b/src/KeenEyes.Core/Parallelism/CommandBufferPool.cs
@@ -16,9 +16,12 @@ namespace KeenEyes;
 /// safely rent and return buffers concurrently.
 /// </para>
 /// <para>
-/// <strong>Placeholder Resolution:</strong> When merging buffers, placeholder IDs
-/// are remapped to avoid conflicts between buffers. Cross-buffer entity references
-/// are resolved during the merge operation.
+/// <strong>Placeholder Resolution:</strong> Buffers are flushed in order against a shared
+/// placeholder-to-entity map, so a buffer flushed later can resolve placeholders for entities
+/// created by a buffer flushed earlier. Because local placeholder IDs are only unique within a
+/// single buffer (each buffer numbers its own placeholders starting at -1), when two buffers
+/// reuse the same local ID the most recently flushed spawn wins for that ID. The returned map
+/// keys each spawned entity by a globally unique ID via <see cref="GetGlobalPlaceholderId"/>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -141,10 +144,14 @@ public sealed class CommandBufferPool
 
         var globalEntityMap = new Dictionary<long, Entity>();
 
+        // Shared placeholder map threaded across all buffers so that a buffer flushed later
+        // can resolve placeholders created by a buffer flushed earlier (cross-buffer references).
+        var sharedEntityMap = new Dictionary<int, Entity>();
+
         foreach (var tracked in sortedBuffers)
         {
-            // Flush buffer and get local entity map
-            var localEntityMap = tracked.Buffer.Flush(world);
+            // Flush buffer against the shared map and get the entities this buffer spawned
+            var localEntityMap = tracked.Buffer.Flush(world, sharedEntityMap);
 
             // Remap placeholder IDs to global scope using buffer ID as prefix
             foreach (var (placeholderId, entity) in localEntityMap)
@@ -188,6 +195,10 @@ public sealed class CommandBufferPool
     {
         var globalEntityMap = new Dictionary<long, Entity>();
 
+        // Shared placeholder map threaded across every batch so that systems in later batches
+        // can resolve placeholders for entities created by systems in earlier batches.
+        var sharedEntityMap = new Dictionary<int, Entity>();
+
         foreach (var batch in systemIdBatches)
         {
             // Sort systems within batch for deterministic ordering
@@ -197,7 +208,7 @@ public sealed class CommandBufferPool
             {
                 if (activeBuffers.TryGetValue(systemId, out var tracked))
                 {
-                    var localEntityMap = tracked.Buffer.Flush(world);
+                    var localEntityMap = tracked.Buffer.Flush(world, sharedEntityMap);
 
                     foreach (var (placeholderId, entity) in localEntityMap)
                     {

--- a/src/KeenEyes.Core/PluginManager.cs
+++ b/src/KeenEyes.Core/PluginManager.cs
@@ -76,7 +76,10 @@ internal sealed class PluginManager
         }
         catch
         {
-            // If Install throws, remove the plugin from the registry
+            // Install may have registered systems into the world before it threw.
+            // Roll those systems back so they are not left orphaned, then remove the
+            // plugin from the registry.
+            RemoveRegisteredSystems(context);
             lock (syncRoot)
             {
                 plugins.Remove(plugin.Name);
@@ -231,17 +234,33 @@ internal sealed class PluginManager
             plugins.Remove(name);
         }
 
-        // Call the plugin's uninstall hook (outside lock to allow plugins to use world APIs)
-        entry.Plugin.Uninstall(entry.Context);
+        // Call the plugin's uninstall hook (outside lock to allow plugins to use world APIs).
+        // Wrap in try/finally so a throwing Uninstall cannot leave the plugin's systems
+        // orphaned: the registry entry is already gone (removed above), so without this the
+        // systems would remain registered with no way to remove them.
+        try
+        {
+            entry.Plugin.Uninstall(entry.Context);
+        }
+        finally
+        {
+            RemoveRegisteredSystems(entry.Context);
+        }
 
-        // Remove and dispose all systems registered by the plugin
-        foreach (var system in entry.Context.RegisteredSystems)
+        return true;
+    }
+
+    /// <summary>
+    /// Removes and disposes all systems a plugin registered through its context.
+    /// </summary>
+    /// <param name="context">The plugin context whose registered systems should be torn down.</param>
+    private void RemoveRegisteredSystems(PluginContext context)
+    {
+        foreach (var system in context.RegisteredSystems)
         {
             systemManager.RemoveSystem(system);
             system.Dispose();
         }
-
-        return true;
     }
 
     /// <summary>

--- a/src/KeenEyes.Core/WorldBuilder.cs
+++ b/src/KeenEyes.Core/WorldBuilder.cs
@@ -43,6 +43,7 @@ public sealed class WorldBuilder
 {
     private readonly List<PluginRegistration> plugins = [];
     private readonly List<SystemRegistration> systems = [];
+    private bool built;
 
     /// <summary>
     /// Adds a plugin to be installed when the world is built.
@@ -167,6 +168,13 @@ public sealed class WorldBuilder
     /// <para>
     /// Use this overload when you need to pass a pre-configured system instance.
     /// </para>
+    /// <para>
+    /// Because the same instance is shared, a builder holding a system instance can only
+    /// build a single world; calling <see cref="Build"/> a second time throws
+    /// <see cref="InvalidOperationException"/> rather than rebind the instance to a new
+    /// world. Use the generic <see cref="WithSystem{T}(SystemPhase, int)"/> overload for
+    /// reusable builders.
+    /// </para>
     /// </remarks>
     public WorldBuilder WithSystem(ISystem system, SystemPhase phase = SystemPhase.Update, int order = 0)
     {
@@ -203,6 +211,12 @@ public sealed class WorldBuilder
     /// <param name="phase">The execution phase for this group. Defaults to <see cref="SystemPhase.Update"/>.</param>
     /// <param name="order">The execution order within the phase. Lower values execute first. Defaults to 0.</param>
     /// <returns>This builder for method chaining.</returns>
+    /// <remarks>
+    /// Because the group and its systems are shared instances, a builder holding a system
+    /// group can only build a single world; calling <see cref="Build"/> a second time throws
+    /// <see cref="InvalidOperationException"/> rather than rebind the shared systems to a new
+    /// world.
+    /// </remarks>
     /// <example>
     /// <code>
     /// var gameplayGroup = new SystemGroup("Gameplay")
@@ -236,9 +250,18 @@ public sealed class WorldBuilder
     /// </para>
     /// <para>
     /// After calling Build(), the builder can be reused to create additional
-    /// world instances with the same configuration.
+    /// world instances with the same configuration, provided it holds only generic/factory
+    /// registrations. A builder that holds system instances (added via
+    /// <see cref="WithSystem(ISystem, SystemPhase, int)"/> or
+    /// <see cref="WithSystemGroup(SystemGroup, SystemPhase, int)"/>) can build only once;
+    /// a second call throws <see cref="InvalidOperationException"/>.
     /// </para>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the builder holds system instances and <see cref="Build"/> has already
+    /// been called, since reusing a shared system instance would corrupt the previously
+    /// built world.
+    /// </exception>
     /// <example>
     /// <code>
     /// var world = new WorldBuilder()
@@ -252,6 +275,22 @@ public sealed class WorldBuilder
     /// </example>
     public World Build()
     {
+        // A builder that holds system instances (via WithSystem(ISystem) or WithSystemGroup)
+        // cannot be reused: World.AddSystem calls ISystem.Initialize(world), which rebinds the
+        // shared instance to the new world. Building a second world would therefore re-point a
+        // system already owned by an earlier world, corrupting that earlier world's systems.
+        // Factory/generic registrations are safe to reuse because each Build() creates a fresh
+        // instance, so only guard when instances are present.
+        if (built && systems.Exists(static registration => registration.Instance is not null))
+        {
+            throw new InvalidOperationException(
+                "This WorldBuilder holds one or more system instances (added via WithSystem(ISystem) " +
+                "or WithSystemGroup) and has already built a world. Building again would re-initialize " +
+                "the shared instance against the new world, corrupting the previously built world's " +
+                "systems. Use the generic WithSystem<T>() overload for reusable builders, or create a " +
+                "new WorldBuilder.");
+        }
+
         var world = new World();
 
         // Install all plugins first
@@ -273,6 +312,7 @@ public sealed class WorldBuilder
                 registration.RunsAfter);
         }
 
+        built = true;
         return world;
     }
 

--- a/tests/KeenEyes.Core.Tests/CommandBufferPoolTests.cs
+++ b/tests/KeenEyes.Core.Tests/CommandBufferPoolTests.cs
@@ -301,6 +301,40 @@ public class CommandBufferPoolTests
         Assert.Equal(2, world.GetAllEntities().Count());
     }
 
+    [Fact]
+    public void FlushBatches_LaterBatchReferencesEarlierBatchPlaceholder_ResolvesEntity()
+    {
+        // Regression test for #1151: a command in a later batch that references a placeholder
+        // for an entity spawned in an earlier batch must resolve to that entity. Previously
+        // each buffer flushed against its own fresh map, so the reference was a silent no-op.
+        using var world = new World();
+        var pool = new CommandBufferPool();
+
+        var buffer1 = pool.Rent(systemId: 1);
+        var buffer2 = pool.Rent(systemId: 2);
+
+        var bufferId1 = pool.GetBufferId(1);
+
+        // Batch 1: spawn a parent entity.
+        var parentCmd = buffer1.Spawn().With(new Position { X = 1, Y = 2 });
+
+        // Batch 2: add a component to the parent spawned in batch 1, referenced by placeholder ID.
+        buffer2.AddComponent(parentCmd.PlaceholderId, new Velocity { X = 3, Y = 4 });
+
+        var batches = new[]
+        {
+            new[] { 1 },
+            new[] { 2 }
+        };
+
+        var entityMap = pool.FlushBatches(world, batches);
+
+        var parent = entityMap[CommandBufferPool.GetGlobalPlaceholderId(bufferId1, parentCmd.PlaceholderId)];
+        Assert.True(world.IsAlive(parent));
+        Assert.True(world.Has<Velocity>(parent));
+        Assert.Equal(3, world.Get<Velocity>(parent).X);
+    }
+
     #endregion
 
     #region Global Placeholder ID Tests

--- a/tests/KeenEyes.Core.Tests/PluginManagerEdgeCaseTests.cs
+++ b/tests/KeenEyes.Core.Tests/PluginManagerEdgeCaseTests.cs
@@ -41,6 +41,75 @@ public class PluginManagerEdgeCaseTests
         public void Uninstall(IPluginContext context) { }
     }
 
+    private sealed class ThrowingUninstallPlugin : IWorldPlugin
+    {
+        public string Name => "ThrowingUninstall";
+
+        public TestPluginSystem? System { get; private set; }
+
+        public void Install(IPluginContext context)
+        {
+            System = context.AddSystem<TestPluginSystem>();
+        }
+
+        public void Uninstall(IPluginContext context)
+        {
+            throw new InvalidOperationException("Uninstall failed deliberately.");
+        }
+    }
+
+    private sealed class ThrowingInstallPlugin : IWorldPlugin
+    {
+        public string Name => "ThrowingInstall";
+
+        public TestPluginSystem? System { get; private set; }
+
+        public void Install(IPluginContext context)
+        {
+            System = context.AddSystem<TestPluginSystem>();
+            throw new InvalidOperationException("Install failed deliberately.");
+        }
+
+        public void Uninstall(IPluginContext context) { }
+    }
+
+    #endregion
+
+    #region Lifecycle Failure Tests
+
+    [Fact]
+    public void UninstallPlugin_WhenUninstallThrows_StillRemovesRegisteredSystems()
+    {
+        // Regression test for #1150: a throwing Uninstall must not leave the plugin's systems
+        // orphaned. The registry entry is removed before Uninstall runs, so without guaranteed
+        // cleanup the system would remain registered with no way to remove it.
+        using var world = new World();
+        var plugin = new ThrowingUninstallPlugin();
+        world.InstallPlugin(plugin);
+
+        Assert.NotNull(world.GetSystem<TestPluginSystem>());
+
+        Assert.Throws<InvalidOperationException>(() => world.UninstallPlugin<ThrowingUninstallPlugin>());
+
+        Assert.Null(world.GetSystem<TestPluginSystem>());
+        Assert.True(plugin.System!.Disposed);
+    }
+
+    [Fact]
+    public void InstallPlugin_WhenInstallThrows_RollsBackRegisteredSystems()
+    {
+        // Regression test for #1150: if Install registers systems and then throws, those
+        // systems must be rolled back rather than left orphaned in the world.
+        using var world = new World();
+        var plugin = new ThrowingInstallPlugin();
+
+        Assert.Throws<InvalidOperationException>(() => world.InstallPlugin(plugin));
+
+        Assert.Null(world.GetSystem<TestPluginSystem>());
+        Assert.False(world.HasPlugin<ThrowingInstallPlugin>());
+        Assert.True(plugin.System!.Disposed);
+    }
+
     #endregion
 
     #region GetPlugin<T> Tests

--- a/tests/KeenEyes.Core.Tests/WorldBuilderTests.cs
+++ b/tests/KeenEyes.Core.Tests/WorldBuilderTests.cs
@@ -162,6 +162,36 @@ public class WorldBuilderTests
     }
 
     [Fact]
+    public void Build_ReusedWithSystemInstance_ThrowsInvalidOperationException()
+    {
+        // Regression test for #1152: reusing a builder that holds a system instance would
+        // re-initialize the shared instance against the second world, rebinding it away from
+        // the first world and corrupting the first world's systems. Building twice must throw
+        // instead of silently rebinding.
+        var system = new TestPluginSystem();
+        var builder = new WorldBuilder()
+            .WithSystem(system);
+
+        using var world1 = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void Build_ReusedWithSystemGroup_ThrowsInvalidOperationException()
+    {
+        // Regression test for #1152: system groups are shared instances and suffer the same
+        // cross-world rebinding hazard as bare system instances.
+        var group = new SystemGroup("TestGroup").Add(new TestPluginSystem());
+        var builder = new WorldBuilder()
+            .WithSystemGroup(group);
+
+        using var world1 = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
     public void WithPlugin_Null_ThrowsArgumentNullException()
     {
         var builder = new WorldBuilder();


### PR DESCRIPTION
## Summary
Fixes the core plugin/builder review items from the deep-functional-review epic (#1093).

- **#1150** — `PluginManager` uninstall/install now roll back registered systems on a throwing hook (`try/finally` + rollback), so a failing plugin no longer orphans systems with no removal path.
- **#1151** — implemented the documented cross-buffer/cross-batch placeholder resolution: `CommandBuffer.Flush` gained a shared-entity-map overload threaded through `FlushAll`/`FlushBatches`, so a later batch can resolve an earlier batch's placeholder. (Docs corrected; the working global-output-map surface retained.)
- **#1152** — `WorldBuilder.Build()` throws on reuse when it holds concrete `ISystem` instances (which would otherwise be rebound to a new world via `Initialize`); factory/generic registrations stay reusable. (Cloning arbitrary systems isn't AOT-feasible, so guard + document.)

## Test plan
- [x] New `PluginManagerEdgeCaseTests`, `CommandBufferPoolTests`, `WorldBuilderTests`; fail-on-old/pass-on-new proven per issue via source revert
- [x] Core.Tests 2314; full suite 14,565 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1150
Closes #1151
Closes #1152