### PR TITLE
fix(core): Deduplicate component entries in EntityBuilder to prevent archetype corruption

### DIFF
--- a/src/KeenEyes.Core/Entities/EntityBuilder.cs
+++ b/src/KeenEyes.Core/Entities/EntityBuilder.cs
@@ -66,19 +66,33 @@ public sealed class EntityBuilder : IEntityBuilder<EntityBuilder>
     public EntityBuilder With<T>(T component) where T : struct, IComponent
     {
         var info = world.Components.GetOrRegister<T>();
+        AddOrReplace(info, component);
+        return this;
+    }
 
-        // Remove existing component of same type to support overrides
+    /// <summary>
+    /// Adds a component entry, replacing any existing entry of the same component type.
+    /// </summary>
+    /// <remarks>
+    /// Deduplication is required because the archetype layer collapses duplicate component
+    /// types into a single backing array per chunk while advancing the per-entity count once.
+    /// A builder that emitted two entries for the same type would append two values into that
+    /// single array per entity, filling the chunk twice as fast and crashing at capacity.
+    /// Deduplicating here keeps the archetype's component set and per-chunk storage consistent
+    /// (last-write-wins for data components; idempotent for tags).
+    /// </remarks>
+    private void AddOrReplace(ComponentInfo info, object data)
+    {
         for (int i = components.Count - 1; i >= 0; i--)
         {
-            if (components[i].Info.Type == typeof(T))
+            if (components[i].Info.Type == info.Type)
             {
                 components.RemoveAt(i);
                 break;
             }
         }
 
-        components.Add((info, component));
-        return this;
+        components.Add((info, data));
     }
 
     /// <summary>
@@ -132,7 +146,7 @@ public sealed class EntityBuilder : IEntityBuilder<EntityBuilder>
     public EntityBuilder WithTag<T>() where T : struct, ITagComponent
     {
         var info = world.Components.GetOrRegister<T>(isTag: true);
-        components.Add((info, default(T)!));
+        AddOrReplace(info, default(T)!);
         return this;
     }
 
@@ -215,7 +229,7 @@ public sealed class EntityBuilder : IEntityBuilder<EntityBuilder>
                 nameof(value));
         }
 
-        components.Add((info, value));
+        AddOrReplace(info, value);
         return this;
     }
 

--- a/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
+++ b/tests/KeenEyes.Core.Tests/EntityBuilderTests.cs
@@ -580,4 +580,71 @@ public class WorldGetAllEntitiesTests
     }
 
     #endregion
+
+    #region Duplicate Component Deduplication (#1147)
+
+    [Fact]
+    public void Build_WithDuplicateTagComponent_CreatesSingleStorageEntry()
+    {
+        using var world = new World();
+
+        var entity = world.Spawn()
+            .WithTag<BuilderTestTag>()
+            .WithTag<BuilderTestTag>()
+            .Build();
+
+        // A duplicated tag must collapse to a single component entry; otherwise the
+        // archetype's component set and per-chunk storage disagree (see #1147).
+        Assert.True(world.Has<BuilderTestTag>(entity));
+        Assert.Equal(1, world.GetComponents(entity).Count(c => c.Type == typeof(BuilderTestTag)));
+    }
+
+    [Fact]
+    public void Build_WithDuplicateBoxedComponent_UsesLastValueAsSingleEntry()
+    {
+        using var world = new World();
+        var info = world.Components.Register<BuilderTestPosition>();
+
+        var entity = world.Spawn()
+            .WithBoxed(info, new BuilderTestPosition { X = 1f, Y = 2f })
+            .WithBoxed(info, new BuilderTestPosition { X = 3f, Y = 4f })
+            .Build();
+
+        Assert.Equal(1, world.GetComponents(entity).Count(c => c.Type == typeof(BuilderTestPosition)));
+
+        // Last-write-wins for data components.
+        ref readonly var component = ref world.Get<BuilderTestPosition>(entity);
+        Assert.Equal(3f, component.X);
+        Assert.Equal(4f, component.Y);
+    }
+
+    [Fact]
+    public void Build_WithDuplicateTagBeyondChunkCapacity_DoesNotCorruptStorage()
+    {
+        using var world = new World();
+
+        // Before the fix, a duplicated tag appended two values into a single backing
+        // array per entity while the chunk count advanced by one, filling the 128-slot
+        // chunk twice as fast and throwing "chunk is at capacity" at the 65th entity.
+        // Spawning well past a full chunk (and into a second) proves storage stays sound.
+        const int entityCount = ArchetypeChunk.DefaultCapacity * 2 + 1;
+        var entities = new Entity[entityCount];
+
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities[i] = world.Spawn()
+                .WithTag<BuilderTestTag>()
+                .WithTag<BuilderTestTag>()
+                .Build();
+        }
+
+        foreach (var entity in entities)
+        {
+            Assert.True(world.IsAlive(entity));
+            Assert.True(world.Has<BuilderTestTag>(entity));
+            Assert.Equal(1, world.GetComponents(entity).Count(c => c.Type == typeof(BuilderTestTag)));
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Fixes #1147 from the deep-functional-review epic (#1093).

- **Root cause:** `With<T>()` deduplicated same-type entries, but `WithTag<T>()` and `WithBoxed()` appended unconditionally. The archetype collapses duplicate component types into one backing array per chunk while advancing the per-entity count once, so each duplicate wrote two values per entity — filling the 128-slot chunk twice as fast and throwing `chunk is at capacity (128)` at the 65th entity.
- **Fix:** extracted the dedup logic from `With<T>()` into a shared `AddOrReplace` helper (dedupe on `info.Type`) and routed `With<T>`, `WithTag<T>`, and `WithBoxed` through it. Last-write-wins for data components, idempotent for tags. Built on top of #1148's `Build()` snapshot logic (untouched).

## Test plan
- [x] 3 new tests including a 257-entity two-chunk repro of the reported crash; fail-on-old/pass-on-new proven via source revert
- [x] Core.Tests 2332; full suite 14,626 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1147