### PR TITLE
fix(editor): Fix plugin init subscription leak, unreachable play-mode reload, and hot-reload CTS race

### DIFF
--- a/editor/KeenEyes.Editor/HotReload/HotReloadManager.cs
+++ b/editor/KeenEyes.Editor/HotReload/HotReloadManager.cs
@@ -39,6 +39,10 @@ public sealed class HotReloadManager : IDisposable
     private GameAssemblyContext? _gameContext;
     private Assembly? _gameAssembly;
     private FileSystemWatcher? _sourceWatcher;
+
+    // Synchronizes the debounce CTS swap/dispose so a concurrently-dispatched
+    // watcher event cannot dispose the source between creation and token read (#1182).
+    private readonly Lock _debounceLock = new();
     private CancellationTokenSource? _debounceCts;
     private bool _isReloading;
     private bool _disposed;
@@ -158,9 +162,17 @@ public sealed class HotReloadManager : IDisposable
             _sourceWatcher = null;
         }
 
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = null;
+        // Detach and dispose the pending debounce source under the lock so a
+        // concurrent watcher callback never races the swap (#1182).
+        CancellationTokenSource? pending;
+        lock (_debounceLock)
+        {
+            pending = _debounceCts;
+            _debounceCts = null;
+        }
+
+        pending?.Cancel();
+        pending?.Dispose();
     }
 
     /// <summary>
@@ -413,19 +425,31 @@ public sealed class HotReloadManager : IDisposable
 
         SourceFileChanged?.Invoke(filePath);
 
-        // Cancel any pending debounce
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = new CancellationTokenSource();
+        // Cancel any pending debounce and start a fresh one. The swap and the
+        // token read happen under a lock so a concurrently-dispatched watcher
+        // event cannot dispose the source between creation and token read (#1182).
+        CancellationToken token;
+        lock (_debounceLock)
+        {
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = new CancellationTokenSource();
+            token = _debounceCts.Token;
+        }
 
         try
         {
-            await Task.Delay(_debounceDelay, _debounceCts.Token);
+            await Task.Delay(_debounceDelay, token);
             await ReloadAsync();
         }
         catch (OperationCanceledException)
         {
-            // Debounce was cancelled by a newer change
+            // Debounce was cancelled by a newer change.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The debounce source was disposed by a concurrent swap or by
+            // StopWatching while this delay was pending; treat as cancellation.
         }
     }
 

--- a/editor/KeenEyes.Editor/HotReload/HotReloadService.cs
+++ b/editor/KeenEyes.Editor/HotReload/HotReloadService.cs
@@ -62,6 +62,7 @@ public sealed class HotReloadService : IDisposable
     private PlayModeManager? playModeManager;
     private bool isPlayModeActive;
     private bool pendingReloadAfterPlayMode;
+    private DateTime playModeEnteredUtc;
     private bool disposed;
 
     /// <summary>
@@ -336,9 +337,11 @@ public sealed class HotReloadService : IDisposable
 
         if (isPlayModeActive && !wasPlayMode)
         {
-            // Entering play mode - pause file watching
+            // Entering play mode - pause file watching. Record when we paused so
+            // edits made while the watcher is disabled can be detected on exit.
             manager.StopWatching();
             pendingReloadAfterPlayMode = false;
+            playModeEnteredUtc = DateTime.UtcNow;
             Console.WriteLine("[HotReload] Paused - play mode active");
         }
         else if (!isPlayModeActive && wasPlayMode && EditorSettings.HotReloadAutoReload)
@@ -347,7 +350,16 @@ public sealed class HotReloadService : IDisposable
             manager.StartWatching();
             Console.WriteLine("[HotReload] Resumed - play mode ended");
 
-            // Check if we need to reload after play mode
+            // The file watcher was disabled for the whole play-mode duration, so
+            // its change callback never ran and could not queue a reload. Scan the
+            // project sources for edits made since we entered play mode; without
+            // this the deferred-reload path is unreachable and edits are lost (#1178).
+            if (!pendingReloadAfterPlayMode && HasSourceChangesSince(playModeEnteredUtc))
+            {
+                pendingReloadAfterPlayMode = true;
+            }
+
+            // Reload if changes were queued or detected while in play mode.
             if (pendingReloadAfterPlayMode)
             {
                 pendingReloadAfterPlayMode = false;
@@ -355,6 +367,47 @@ public sealed class HotReloadService : IDisposable
                 _ = ReloadAsync(); // Fire and forget
             }
         }
+    }
+
+    /// <summary>
+    /// Determines whether any source file under the configured game project has
+    /// been modified since the specified UTC timestamp.
+    /// </summary>
+    /// <param name="thresholdUtc">The UTC time to compare file write times against.</param>
+    /// <returns>True if at least one C# source file changed after the threshold.</returns>
+    private static bool HasSourceChangesSince(DateTime thresholdUtc)
+    {
+        var projectPath = EditorSettings.GameProjectPath;
+        if (string.IsNullOrEmpty(projectPath))
+        {
+            return false;
+        }
+
+        var projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+        if (projectDir == null || !Directory.Exists(projectDir))
+        {
+            return false;
+        }
+
+        var objSegment = $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}";
+        var binSegment = $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}";
+
+        foreach (var file in Directory.EnumerateFiles(projectDir, "*.cs", SearchOption.AllDirectories))
+        {
+            // Skip generated/build output, mirroring the watcher's filtering.
+            if (file.Contains(objSegment, StringComparison.Ordinal) ||
+                file.Contains(binSegment, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (File.GetLastWriteTimeUtc(file) > thresholdUtc)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void OnReloadStarted()

--- a/editor/KeenEyes.Editor/Plugins/EditorPluginManager.cs
+++ b/editor/KeenEyes.Editor/Plugins/EditorPluginManager.cs
@@ -240,7 +240,19 @@ internal sealed class EditorPluginManager : IDisposable, IEditorPluginLogger
         }
 
         var context = new EditorPluginContext(this, plugin);
-        plugin.Initialize(context);
+
+        try
+        {
+            plugin.Initialize(context);
+        }
+        catch
+        {
+            // Initialization failed after the context may have registered event
+            // subscriptions. Dispose them so a dead plugin's handlers never fire (#1177).
+            context.DisposeSubscriptions();
+            throw;
+        }
+
         plugins[plugin.Name] = new EditorPluginEntry(plugin, context);
     }
 
@@ -463,10 +475,12 @@ internal sealed class EditorPluginManager : IDisposable, IEditorPluginLogger
             }
         }
 
+        // Declared outside the try so a failed Initialize can still dispose any
+        // subscriptions the context registered before throwing (#1177).
+        var context = new EditorPluginContext(this, loadedPlugin.Instance);
+
         try
         {
-            var context = new EditorPluginContext(this, loadedPlugin.Instance);
-
             // Wrap in SecurePluginContext if permissions are enabled
             IEditorContext pluginContext = permissionManager != null
                 ? new SecurePluginContext(context, permissionManager, pluginId)
@@ -484,6 +498,7 @@ internal sealed class EditorPluginManager : IDisposable, IEditorPluginLogger
         }
         catch (PermissionDeniedException ex)
         {
+            context.DisposeSubscriptions();
             loadedPlugin.State = PluginState.Failed;
             loadedPlugin.ErrorMessage = $"Permission denied: {ex.RequiredPermission.GetDisplayName()}";
             LogError($"Plugin '{pluginId}' was denied permission: {ex.Message}");
@@ -491,6 +506,7 @@ internal sealed class EditorPluginManager : IDisposable, IEditorPluginLogger
         }
         catch (Exception ex)
         {
+            context.DisposeSubscriptions();
             loadedPlugin.State = PluginState.Failed;
             loadedPlugin.ErrorMessage = $"Enable failed: {ex.Message}";
             LogError($"Failed to enable plugin '{loadedPlugin.Manifest.Id}': {ex.Message}");
@@ -808,9 +824,18 @@ internal sealed class EditorPluginManager : IDisposable, IEditorPluginLogger
     /// </summary>
     internal void RaiseSceneOpened(IWorld world)
     {
+        // Guard each handler so one plugin's fault cannot prevent other plugins'
+        // handlers from running (and cannot escape into the caller) (#1177).
         foreach (var handler in sceneOpenedHandlers)
         {
-            handler(world);
+            try
+            {
+                handler(world);
+            }
+            catch (Exception ex)
+            {
+                LogError($"A scene-opened handler threw an exception: {ex.Message}");
+            }
         }
     }
 

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadManagerTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using KeenEyes.Editor.HotReload;
 
 namespace KeenEyes.Editor.Tests.HotReload;
@@ -339,6 +341,79 @@ public class HotReloadManagerTests
 
             manager.Dispose();
             manager.Dispose(); // Should not throw
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
+    #region Debounce Concurrency Tests
+
+    [Fact]
+    public async Task HandleFileChange_ConcurrentInvocations_NeverThrowObjectDisposedException()
+    {
+        var tempProject = CreateTempProjectFile();
+        try
+        {
+            using var world = new World();
+            // A long debounce keeps every invocation parked at the delay until a
+            // newer swap cancels it, so no invocation ever reaches an actual build.
+            var manager = new HotReloadManager(tempProject, world, TimeSpan.FromSeconds(30));
+
+            var handleFileChange = typeof(HotReloadManager).GetMethod(
+                "HandleFileChangeAsync",
+                BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var sourcePath = Path.Combine(Path.GetDirectoryName(tempProject)!, "Concurrent.cs");
+
+            const int workers = 8;
+            const int perWorker = 3000;
+            var returned = new Task[workers * perWorker];
+
+            // Hammer the debounce-CTS swap from many threads concurrently. On the
+            // pre-fix code the unsynchronized Cancel/Dispose/assign + Token read
+            // races and throws ObjectDisposedException; the fix serializes the swap
+            // under a lock so it never does (#1182).
+            var workerTasks = new Task[workers];
+            for (var w = 0; w < workers; w++)
+            {
+                var offset = w * perWorker;
+                workerTasks[w] = Task.Run(() =>
+                {
+                    for (var i = 0; i < perWorker; i++)
+                    {
+                        returned[offset + i] = (Task)handleFileChange.Invoke(manager, [sourcePath])!;
+                    }
+                }, TestContext.Current.CancellationToken);
+            }
+
+            await Task.WhenAll(workerTasks);
+
+            // Dispose cancels the final pending debounce timer; earlier ones were
+            // cancelled by subsequent swaps. Every parked delay then unblocks.
+            manager.Dispose();
+
+            var objectDisposedCount = 0;
+            foreach (var task in returned)
+            {
+                try
+                {
+                    await task;
+                }
+                catch (ObjectDisposedException)
+                {
+                    objectDisposedCount++;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected: debounce cancelled by a newer swap or by disposal.
+                }
+            }
+
+            Assert.Equal(0, objectDisposedCount);
         }
         finally
         {

--- a/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
+++ b/tests/KeenEyes.Editor.Tests/HotReload/HotReloadServiceTests.cs
@@ -319,7 +319,78 @@ public class HotReloadServiceTests : IDisposable
 
     #endregion
 
+    #region PlayMode Deferred Reload Tests
+
+    [Fact]
+    public void PlayModeExit_WithSourceEditDuringPlayMode_TriggersDeferredReload()
+    {
+        var tempProject = CreateTempProjectWithSource(out var sourceFile);
+        try
+        {
+            using var world = new World();
+            using var service = new HotReloadService(world);
+            var serializer = new EditorComponentSerializer();
+            var playMode = new PlayModeManager(world, serializer);
+
+            EditorSettings.GameProjectPath = tempProject;
+            service.Initialize();
+            service.ConnectPlayMode(playMode);
+
+            var buildingObserved = false;
+            using var terminalReached = new ManualResetEventSlim(false);
+            service.StatusChanged += (_, e) =>
+            {
+                if (e.Status == HotReloadStatus.Building)
+                {
+                    buildingObserved = true;
+                }
+                else if (e.Status is HotReloadStatus.Ready or HotReloadStatus.Failed)
+                {
+                    terminalReached.Set();
+                }
+            };
+
+            // Enter play mode: the file watcher is disabled for the whole duration.
+            Assert.True(playMode.Play());
+
+            // Simulate an edit made while in play mode. The write time is
+            // deterministically after the moment play mode was entered, so no
+            // reliance on wall-clock timing or the (disabled) watcher.
+            File.SetLastWriteTimeUtc(sourceFile, DateTime.UtcNow.AddMinutes(1));
+
+            // Exit play mode: the deferred-reload path must detect the queued edit
+            // and initiate a reload. Before #1178 this path was unreachable.
+            Assert.True(playMode.Stop());
+
+            // The reload is kicked off synchronously as play mode exits, so the
+            // status transitions to Building within the Stop() call chain.
+            Assert.True(buildingObserved);
+
+            // Let the fire-and-forget reload finish (the stub project build fails
+            // fast) so disposal does not race an in-flight reload.
+            terminalReached.Wait(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            CleanupTempProject(tempProject);
+        }
+    }
+
+    #endregion
+
     #region Helpers
+
+    private static string CreateTempProjectWithSource(out string sourceFile)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "HotReloadServiceTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var projectPath = Path.Combine(tempDir, "TestProject.csproj");
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>");
+
+        sourceFile = Path.Combine(tempDir, "Game.cs");
+        File.WriteAllText(sourceFile, "// game source");
+        return projectPath;
+    }
 
     private static string CreateTempProjectFile()
     {

--- a/tests/KeenEyes.Editor.Tests/Plugins/EditorPluginManagerLifecycleTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Plugins/EditorPluginManagerLifecycleTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Keen Eye, LLC. All rights reserved.
+// Licensed under the MIT License.
+
+using KeenEyes.Editor.Abstractions;
+using KeenEyes.Editor.Plugins;
+
+namespace KeenEyes.Editor.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="EditorPluginManager"/> plugin lifecycle failure handling (#1177).
+/// </summary>
+public sealed class EditorPluginManagerLifecycleTests : IDisposable
+{
+    private readonly World world;
+    private readonly StubEditorWorldManager worldManager = new();
+    private readonly StubSelectionManager selection = new();
+    private readonly StubUndoRedoManager undoRedo = new();
+    private readonly StubAssetDatabase assets = new();
+
+    public EditorPluginManagerLifecycleTests()
+    {
+        world = new World();
+    }
+
+    public void Dispose()
+    {
+        world.Dispose();
+    }
+
+    private EditorPluginManager CreateManager()
+    {
+        return new EditorPluginManager(worldManager, selection, undoRedo, assets, world);
+    }
+
+    #region Failed Initialize Cleanup Tests
+
+    [Fact]
+    public void InstallPlugin_WhenInitializeThrows_DisposesSubscriptionsSoDeadHandlerNeverFires()
+    {
+        using var manager = CreateManager();
+        var badPlugin = new ThrowingInitPlugin();
+
+        // Initialize throws after subscribing to OnSceneOpened; the failure propagates.
+        Assert.Throws<InvalidOperationException>(() => manager.InstallPlugin(badPlugin));
+
+        // The subscription registered before the throw must have been disposed, so
+        // raising the scene-opened event must not invoke the dead plugin's handler.
+        manager.RaiseSceneOpened(world);
+
+        Assert.False(badPlugin.HandlerFired);
+    }
+
+    [Fact]
+    public void RaiseSceneOpened_WhenOneHandlerThrows_StillInvokesOtherHandlersAndDoesNotEscape()
+    {
+        using var manager = CreateManager();
+        var faulting = new SceneOpenedPlugin("Faulting", throwOnScene: true);
+        var healthy = new SceneOpenedPlugin("Healthy", throwOnScene: false);
+
+        manager.InstallPlugin(faulting);
+        manager.InstallPlugin(healthy);
+
+        // A throwing handler must not escape the raise loop nor prevent later handlers.
+        var exception = Record.Exception(() => manager.RaiseSceneOpened(world));
+
+        Assert.Null(exception);
+        Assert.True(healthy.HandlerFired);
+    }
+
+    #endregion
+
+    #region Test Plugins
+
+    /// <summary>
+    /// Plugin that subscribes to scene-opened then fails during initialization.
+    /// </summary>
+    private sealed class ThrowingInitPlugin : IEditorPlugin
+    {
+        public string Name => "ThrowingInitPlugin";
+        public string Version => "1.0.0";
+        public string? Description => null;
+
+        public bool HandlerFired { get; private set; }
+
+        public void Initialize(IEditorContext context)
+        {
+            context.OnSceneOpened(_ => HandlerFired = true);
+            throw new InvalidOperationException("Initialization failed after subscribing.");
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Plugin that subscribes to scene-opened; its handler optionally throws.
+    /// </summary>
+    private sealed class SceneOpenedPlugin(string name, bool throwOnScene) : IEditorPlugin
+    {
+        public string Name => name;
+        public string Version => "1.0.0";
+        public string? Description => null;
+
+        public bool HandlerFired { get; private set; }
+
+        public void Initialize(IEditorContext context)
+        {
+            context.OnSceneOpened(_ =>
+            {
+                HandlerFired = true;
+                if (throwOnScene)
+                {
+                    throw new InvalidOperationException("Handler failure.");
+                }
+            });
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+
+    #endregion
+
+    #region Service Stubs
+
+#pragma warning disable CS0067 // Events are never used by these test stubs.
+    private sealed class StubEditorWorldManager : IEditorWorldManager
+    {
+        public IWorld? CurrentSceneWorld => null;
+        public string? CurrentScenePath => null;
+        public bool HasUnsavedChanges => false;
+        public event EventHandler<SceneEventArgs>? SceneOpened;
+        public event EventHandler? SceneClosed;
+        public event EventHandler? SceneModified;
+
+        public void NewScene() { }
+        public bool LoadScene(string path) => false;
+        public bool SaveScene() => false;
+        public bool SaveSceneAs(string path) => false;
+        public void CloseScene() { }
+        public void MarkModified() { }
+        public IEnumerable<Entity> GetRootEntities() => [];
+        public IEnumerable<Entity> GetChildren(Entity parent) => [];
+        public string GetEntityName(Entity entity) => string.Empty;
+    }
+
+    private sealed class StubSelectionManager : ISelectionManager
+    {
+        public Entity PrimarySelection => Entity.Null;
+        public IReadOnlyCollection<Entity> SelectedEntities => Array.Empty<Entity>();
+        public bool HasSelection => false;
+        public bool HasMultipleSelection => false;
+        public int SelectionCount => 0;
+        public event EventHandler<SelectionChangedEventArgs>? SelectionChanged;
+
+        public void Select(Entity entity) { }
+        public void AddToSelection(Entity entity) { }
+        public void RemoveFromSelection(Entity entity) { }
+        public void ToggleSelection(Entity entity) { }
+        public void SelectMultiple(IEnumerable<Entity> entities) { }
+        public void ClearSelection() { }
+        public bool IsSelected(Entity entity) => false;
+    }
+
+    private sealed class StubUndoRedoManager : IUndoRedoManager
+    {
+        public bool CanUndo => false;
+        public bool CanRedo => false;
+        public string? NextUndoDescription => null;
+        public string? NextRedoDescription => null;
+        public int MaxHistorySize { get; set; } = 100;
+        public event Action? StateChanged;
+
+        public void Execute(IEditorCommand command) { }
+        public bool Undo() => false;
+        public bool Redo() => false;
+        public void Clear() { }
+        public void BeginBatch(string description) { }
+        public void EndBatch() { }
+        public void CancelBatch() { }
+    }
+
+    private sealed class StubAssetDatabase : IAssetDatabase
+    {
+        public string ProjectRoot => string.Empty;
+        public IReadOnlyDictionary<string, AssetEntry> AllAssets => new Dictionary<string, AssetEntry>();
+        public event EventHandler<AssetEventArgs>? AssetAdded;
+        public event EventHandler<AssetEventArgs>? AssetRemoved;
+        public event EventHandler<AssetEventArgs>? AssetModified;
+
+        public void Scan(params string[] extensions) { }
+        public void StartWatching() { }
+        public void StopWatching() { }
+        public AssetEntry? GetAsset(string relativePath) => null;
+        public IEnumerable<AssetEntry> GetAssetsByType(AssetType assetType) => [];
+        public void Refresh(string relativePath) { }
+    }
+#pragma warning restore CS0067
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes the editor review cluster from the deep-functional-review epic (#1093).

- **#1177** — `EditorPluginManager` disposes a plugin's event subscriptions when `Initialize()` throws (both install paths), and guards each `SceneOpened` handler so a dead/faulting plugin can't fire stale handlers or suppress healthy ones.
- **#1178** — hot-reload now records play-mode entry time and, on exit, scans project `*.cs` for edits after it, setting `pendingReloadAfterPlayMode` — making the previously-dead deferred-reload path reachable so edits during play mode apply on exit.
- **#1182** — `HotReloadManager` guards the debounce CTS cancel/dispose/swap and token read under a `Lock`, eliminating the `ObjectDisposedException` that escaped the async-void watcher handler.

## Test plan
- [x] New/updated tests: plugin init-throw + handler isolation, deterministic play-mode-exit reload, 8-thread×3000 concurrent CTS-swap race; fail-on-old/pass-on-new proven via source revert
- [x] Editor.Tests 1302; full suite 14,564 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1177
Closes #1178
Closes #1182