### PR TITLE
fix: Wire MCP heartbeat timeout, correct encrypted slot size, fix localization raw-preload cache poisoning

### DIFF
--- a/src/KeenEyes.Localization/LocalizationManager.cs
+++ b/src/KeenEyes.Localization/LocalizationManager.cs
@@ -259,17 +259,27 @@ public sealed class LocalizationManager : ILocalization, IDisposable
     {
         try
         {
-            // Preload as RawAsset - this caches the file contents
-            // The actual typed load will happen when the asset is used
-            await assetManager.LoadAsync<KeenEyes.Assets.RawAsset>(
-                path,
-                KeenEyes.Assets.LoadPriority.Low,
-                cancellationToken);
+            // Warm the file into the OS cache without registering a typed asset entry.
+            //
+            // The asset cache is keyed by path only and ignores the requested type on a
+            // hit, so preloading through the manager as RawAsset would poison the cache:
+            // a later typed Load<T> of the same path returns the cached RawAsset (the
+            // wrong type), which surfaces as a silent null. Because the localization layer
+            // cannot know the eventual asset type, it warms the underlying file directly
+            // instead, leaving the typed load to populate the cache correctly on first use.
+            var fullPath = Path.Combine(assetManager.RootPath, path);
+            if (!File.Exists(fullPath))
+            {
+                return;
+            }
+
+            await using var stream = File.OpenRead(fullPath);
+            await stream.CopyToAsync(Stream.Null, cancellationToken);
         }
         catch
         {
             // Silently ignore preload failures - the asset might not exist
-            // or might need a specialized loader. The actual load will report errors.
+            // or be inaccessible. The actual typed load will report errors.
         }
     }
 

--- a/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
+++ b/src/KeenEyes.Persistence/EncryptedPersistenceApi.cs
@@ -140,13 +140,12 @@ public sealed class EncryptedPersistenceApi
         var fileData = SaveFileFormat.Write(slotInfo, encryptedData, options);
         File.WriteAllBytes(filePath, fileData);
 
-        // Update slot info with sizes
-        return slotInfo with
-        {
-            UncompressedSize = snapshotData.Length,
-            CompressedSize = encryptedData.Length,
-            Compression = options.Compression
-        };
+        // Return the slot info exactly as persisted so its reported sizes match the
+        // on-disk (encrypted, then compressed) bytes. SaveFileFormat.Write stamps the
+        // container metadata with the size of the encrypted payload it received and the
+        // compressed length it wrote; reading that back keeps the returned SlotInfo
+        // consistent with what a later GetSlotInfo() call reports.
+        return SaveFileFormat.ReadMetadata(fileData);
     }
 
     /// <summary>
@@ -267,12 +266,9 @@ public sealed class EncryptedPersistenceApi
         var fileData = SaveFileFormat.Write(slotInfo, encryptedData, options);
         await File.WriteAllBytesAsync(filePath, fileData, cancellationToken).ConfigureAwait(false);
 
-        return slotInfo with
-        {
-            UncompressedSize = snapshotData.Length,
-            CompressedSize = encryptedData.Length,
-            Compression = options.Compression
-        };
+        // Return the slot info exactly as persisted so its reported sizes match the
+        // on-disk (encrypted, then compressed) bytes. See SaveToSlot for details.
+        return SaveFileFormat.ReadMetadata(fileData);
     }
 
     /// <summary>

--- a/tests/KeenEyes.Localization.Tests/LocalizationAssetPreloadTests.cs
+++ b/tests/KeenEyes.Localization.Tests/LocalizationAssetPreloadTests.cs
@@ -1,0 +1,108 @@
+using KeenEyes.Assets;
+
+namespace KeenEyes.Localization.Tests;
+
+/// <summary>
+/// Tests that preloading locale assets does not poison the asset cache so that later
+/// typed loads of the same path still resolve (regression guard for #1194).
+/// </summary>
+public sealed class LocalizationAssetPreloadTests : IDisposable
+{
+    private readonly string rootPath;
+    private readonly World world;
+    private readonly AssetManager assetManager;
+
+    public LocalizationAssetPreloadTests()
+    {
+        rootPath = Path.Combine(Path.GetTempPath(), $"keen_eye_loc_preload_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(rootPath);
+        File.WriteAllBytes(Path.Combine(rootPath, "greeting.dat"), [1, 2, 3, 4, 5]);
+
+        world = new World();
+        assetManager = new AssetManager(new AssetsConfig { RootPath = rootPath });
+        assetManager.RegisterLoader(new StubAssetLoader());
+
+        world.SetExtension(assetManager, owned: false);
+        world.SetExtension<ILocalizedAssetResolver>(new StubResolver("greeting.dat"), owned: false);
+    }
+
+    public void Dispose()
+    {
+        assetManager.Dispose();
+        world.Dispose();
+        if (Directory.Exists(rootPath))
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PreloadLocaleAssetsAsync_ThenTypedLoad_ResolvesTypedAsset()
+    {
+        using var manager = new LocalizationManager(LocalizationConfig.Default, world);
+
+        await manager.PreloadLocaleAssetsAsync(
+            Locale.EnglishUS,
+            ["greeting"],
+            TestContext.Current.CancellationToken);
+
+        // The subsequent typed load of the same path must produce a real StubAsset.
+        // Before the fix, preloading as RawAsset poisoned the path-keyed cache, so this
+        // handle reported IsLoaded == true but Asset == null (RawAsset cast to StubAsset).
+        var handle = assetManager.Load<StubAsset>("greeting.dat");
+
+        handle.IsLoaded.ShouldBeTrue();
+        handle.Asset.ShouldNotBeNull();
+        handle.Asset!.Data.Length.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task PreloadLocaleAssetsAsync_DoesNotCacheAssetAsWrongType()
+    {
+        using var manager = new LocalizationManager(LocalizationConfig.Default, world);
+
+        await manager.PreloadLocaleAssetsAsync(
+            Locale.EnglishUS,
+            ["greeting"],
+            TestContext.Current.CancellationToken);
+
+        // Preloading must not register any asset-cache entry (correct- or wrong-typed,
+        // loaded or failed) that would shadow the eventual typed load.
+        assetManager.GetCacheStats().TotalAssets.ShouldBe(0);
+    }
+
+    private sealed class StubAsset(byte[] data) : IDisposable
+    {
+        public byte[] Data { get; } = data;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubAssetLoader : IAssetLoader<StubAsset>
+    {
+        public IReadOnlyList<string> Extensions => [".dat"];
+
+        public StubAsset Load(Stream stream, AssetLoadContext context)
+        {
+            using var memory = new MemoryStream();
+            stream.CopyTo(memory);
+            return new StubAsset(memory.ToArray());
+        }
+
+        public Task<StubAsset> LoadAsync(Stream stream, AssetLoadContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(Load(stream, context));
+
+        public long EstimateSize(StubAsset asset) => asset.Data.Length;
+    }
+
+    private sealed class StubResolver(string resolvedPath) : ILocalizedAssetResolver
+    {
+        public string? Resolve(string assetKey, Locale locale) => resolvedPath;
+
+        public IEnumerable<string> GetAllPaths(string assetKey) => [resolvedPath];
+
+        public bool HasLocaleVariant(string assetKey, Locale locale) => true;
+    }
+}

--- a/tests/KeenEyes.Mcp.TestBridge.Tests/Connection/BridgeConnectionManagerTests.cs
+++ b/tests/KeenEyes.Mcp.TestBridge.Tests/Connection/BridgeConnectionManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using KeenEyes.Mcp.TestBridge.Connection;
 
 namespace KeenEyes.Mcp.TestBridge.Tests.Connection;
@@ -199,6 +200,64 @@ public sealed class BridgeConnectionManagerTests : IAsyncDisposable
 
         result.ShouldBeFalse();
         bridge.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region Ping Timeout Tests
+
+    [Fact]
+    public async Task PingWithTimeoutAsync_WhenPingStalls_CancelsAtPingTimeout()
+    {
+        // A short PingTimeout must abort a ping that never completes on its own.
+        // Before the fix the configured PingTimeout was never applied to the ping call,
+        // so a stalled ping would hang until the client's much larger request timeout.
+        manager = new BridgeConnectionManager
+        {
+            PingTimeout = TimeSpan.FromMilliseconds(150),
+            ConnectionTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await manager.PingWithTimeoutAsync(
+                () => Task.Delay(Timeout.InfiniteTimeSpan),
+                CancellationToken.None));
+
+        stopwatch.Stop();
+
+        // Enforced by PingTimeout (~150ms), well under ConnectionTimeout (30s).
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task PingWithTimeoutAsync_WhenPingCompletesQuickly_DoesNotThrow()
+    {
+        manager = new BridgeConnectionManager
+        {
+            PingTimeout = TimeSpan.FromSeconds(5)
+        };
+
+        await Should.NotThrowAsync(async () =>
+            await manager.PingWithTimeoutAsync(() => Task.CompletedTask, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PingWithTimeoutAsync_WhenLoopTokenCancelled_Cancels()
+    {
+        manager = new BridgeConnectionManager
+        {
+            PingTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await manager.PingWithTimeoutAsync(
+                () => Task.Delay(Timeout.InfiniteTimeSpan),
+                cts.Token));
     }
 
     #endregion

--- a/tests/KeenEyes.Persistence.Tests/EncryptedSlotSizeTests.cs
+++ b/tests/KeenEyes.Persistence.Tests/EncryptedSlotSizeTests.cs
@@ -1,0 +1,94 @@
+using KeenEyes.Serialization;
+
+namespace KeenEyes.Persistence.Tests;
+
+/// <summary>
+/// Tests that <see cref="EncryptedPersistenceApi"/> reports slot sizes that match the
+/// actual bytes written to disk (regression guard for #1166).
+/// </summary>
+public class EncryptedSlotSizeTests : IDisposable
+{
+    private readonly string testSaveDirectory;
+    private readonly TestPersistenceSerializer serializer;
+
+    public EncryptedSlotSizeTests()
+    {
+        testSaveDirectory = Path.Combine(Path.GetTempPath(), $"keen_eye_slot_size_tests_{Guid.NewGuid():N}");
+        serializer = new TestPersistenceSerializer()
+            .WithComponent<TestPosition>()
+            .WithComponent<TestVelocity>()
+            .WithComponent<TestHealth>();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(testSaveDirectory))
+        {
+            Directory.Delete(testSaveDirectory, recursive: true);
+        }
+    }
+
+    private World CreateEncryptedWorld()
+    {
+        var world = new World { SaveDirectory = testSaveDirectory };
+        var config = PersistenceConfig.WithEncryption("test-password", testSaveDirectory);
+        world.InstallPlugin(new PersistencePlugin(config));
+        world.Spawn("Player")
+            .With(new TestPosition { X = 10, Y = 20 })
+            .With(new TestVelocity { X = 1, Y = 2 })
+            .With(new TestHealth { Current = 50, Max = 100 })
+            .Build();
+        return world;
+    }
+
+    [Fact]
+    public void SaveToSlot_Encrypted_ReturnedSizesMatchPersistedSlotInfo()
+    {
+        using var world = CreateEncryptedWorld();
+        var api = world.GetExtension<EncryptedPersistenceApi>();
+
+        // Default options use AES encryption + GZip compression, so both the
+        // encrypted length and the compressed length differ from the plaintext length.
+        var returned = api.SaveToSlot("encrypted_slot", serializer);
+        var persisted = api.GetSlotInfo("encrypted_slot");
+
+        persisted.ShouldNotBeNull();
+        returned.UncompressedSize.ShouldBe(persisted.UncompressedSize);
+        returned.CompressedSize.ShouldBe(persisted.CompressedSize);
+    }
+
+    [Fact]
+    public void SaveToSlot_Encrypted_UncompressedSizeReflectsEncryptedBytes()
+    {
+        using var world = CreateEncryptedWorld();
+        var api = world.GetExtension<EncryptedPersistenceApi>();
+
+        var returned = api.SaveToSlot("encrypted_slot", serializer);
+
+        // The container's UncompressedSize is the length of the encrypted payload handed
+        // to the writer, which (AES adds an IV and block padding) exceeds the plaintext
+        // snapshot length. Before the fix the returned value was the plaintext length.
+        var plaintextLength = SnapshotManager.ToBinary(
+            SnapshotManager.CreateSnapshot(world, serializer),
+            serializer).Length;
+
+        returned.UncompressedSize.ShouldBeGreaterThan(plaintextLength);
+    }
+
+    [Fact]
+    public async Task SaveToSlotAsync_Encrypted_ReturnedSizesMatchPersistedSlotInfo()
+    {
+        using var world = CreateEncryptedWorld();
+        var api = world.GetExtension<EncryptedPersistenceApi>();
+
+        var returned = await api.SaveToSlotAsync(
+            "encrypted_async_slot",
+            serializer,
+            cancellationToken: TestContext.Current.CancellationToken);
+        var persisted = api.GetSlotInfo("encrypted_async_slot");
+
+        persisted.ShouldNotBeNull();
+        returned.UncompressedSize.ShouldBe(persisted.UncompressedSize);
+        returned.CompressedSize.ShouldBe(persisted.CompressedSize);
+    }
+}

--- a/tools/KeenEyes.Mcp.TestBridge/Connection/BridgeConnectionManager.cs
+++ b/tools/KeenEyes.Mcp.TestBridge/Connection/BridgeConnectionManager.cs
@@ -247,11 +247,8 @@ public sealed class BridgeConnectionManager : IAsyncDisposable
                 var sw = Stopwatch.StartNew();
                 try
                 {
-                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    timeoutCts.CancelAfter(PingTimeout);
-
-                    // Use entity count as a lightweight ping
-                    await client.State.GetEntityCountAsync();
+                    // Use entity count as a lightweight ping, bounded by PingTimeout.
+                    await PingWithTimeoutAsync(() => client.State.GetEntityCountAsync(), ct);
                     sw.Stop();
 
                     LastPingLatencyMs = sw.Elapsed.TotalMilliseconds;
@@ -275,6 +272,30 @@ public sealed class BridgeConnectionManager : IAsyncDisposable
                 break;
             }
         }
+    }
+
+    /// <summary>
+    /// Executes a heartbeat ping operation, cancelling it if it exceeds <see cref="PingTimeout"/>.
+    /// </summary>
+    /// <param name="ping">The ping operation to execute (typically a lightweight state query).</param>
+    /// <param name="ct">A token that cancels the heartbeat loop itself.</param>
+    /// <returns>A task that completes when the ping succeeds.</returns>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the ping does not complete within <see cref="PingTimeout"/> (or <paramref name="ct"/> is cancelled).
+    /// </exception>
+    /// <remarks>
+    /// The underlying ping call exposes no cancellation token of its own, so the configured
+    /// <see cref="PingTimeout"/> is enforced via <see cref="Task.WaitAsync(CancellationToken)"/>.
+    /// Without this, a stalled ping could only surface after the client's own request timeout.
+    /// </remarks>
+    internal async Task PingWithTimeoutAsync(Func<Task> ping, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ping);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(PingTimeout);
+
+        await ping().WaitAsync(timeoutCts.Token).ConfigureAwait(false);
     }
 
     private async Task HandlePingFailureAsync()


### PR DESCRIPTION
## Summary
Fixes three single-subsystem review items from the deep-functional-review epic (#1093).

- **#1179 (mcp)** — the heartbeat created a `timeoutCts` from `KEENEYES_HEARTBEAT_TIMEOUT` but never used its token, so ping timeout had no effect. Routed the ping through a `PingWithTimeoutAsync` seam that enforces `PingTimeout` via `Task.WaitAsync`.
- **#1166 (persistence)** — `SaveToSlot`/`SaveToSlotAsync` stamped `SlotInfo` with plaintext lengths, disagreeing with the on-disk encrypted bytes; both now return `SaveFileFormat.ReadMetadata(fileData)` so metadata matches disk and a later `GetSlotInfo()`.
- **#1194 (localization)** — preloading via `LoadAsync<RawAsset>` poisoned the path-keyed cache so later typed loads returned null; preloading now warms the underlying file without inserting a cache entry, leaving typed loads to populate correctly.

## Test plan
- [x] New tests for each; fail-on-old/pass-on-new proven via source revert
- [x] Persistence 82, Localization 280, Mcp.TestBridge 105; full suite 14,568 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1179
Closes #1166
Closes #1194