### PR TITLE
fix(testing): Fix deterministic IDs, mock network/hierarchy/keyboard, log wildcard query, debug auto-capture

### DIFF
--- a/src/KeenEyes.Core/Pooling/EntityPool.cs
+++ b/src/KeenEyes.Core/Pooling/EntityPool.cs
@@ -22,12 +22,28 @@ namespace KeenEyes;
 /// simultaneously.
 /// </para>
 /// </remarks>
-public sealed class EntityPool
+/// <param name="recyclingEnabled">
+/// When <see langword="true"/> (the default), released IDs are returned to the pool
+/// and reused by later <see cref="Acquire"/> calls. When <see langword="false"/>, IDs
+/// are never reused: <see cref="Acquire"/> always allocates the next sequential ID
+/// starting from 0, giving deterministic, non-recycling ID assignment for testing.
+/// </param>
+public sealed class EntityPool(bool recyclingEnabled = true)
 {
     private readonly ConcurrentStack<int> recycledIds = new();
     private readonly ConcurrentDictionary<int, int> versions = new();
     private int nextNewId;
     private long recycleCount;
+    private long retiredCount;
+
+    /// <summary>
+    /// Gets a value indicating whether released IDs are recycled for reuse.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="false"/>, <see cref="Acquire"/> assigns IDs sequentially from 0
+    /// without ever reusing a released ID.
+    /// </remarks>
+    public bool RecyclingEnabled => recyclingEnabled;
 
     /// <summary>
     /// Gets the number of entity IDs currently available for reuse.
@@ -42,7 +58,7 @@ public sealed class EntityPool
     /// <summary>
     /// Gets the number of entities currently in use.
     /// </summary>
-    public int ActiveCount => nextNewId - recycledIds.Count;
+    public int ActiveCount => nextNewId - recycledIds.Count - (int)Interlocked.Read(ref retiredCount);
 
     /// <summary>
     /// Gets the number of times entity IDs have been recycled.
@@ -61,7 +77,7 @@ public sealed class EntityPool
         int id;
         int version;
 
-        if (recycledIds.TryPop(out id))
+        if (recyclingEnabled && recycledIds.TryPop(out id))
         {
             // Reuse recycled ID - version was already incremented on release
             version = versions[id];
@@ -114,8 +130,17 @@ public sealed class EntityPool
             return false;
         }
 
-        // Add to recycled pool
-        recycledIds.Push(entity.Id);
+        if (recyclingEnabled)
+        {
+            // Add to recycled pool for reuse
+            recycledIds.Push(entity.Id);
+        }
+        else
+        {
+            // Non-recycling mode: the ID is retired permanently. Track it so
+            // ActiveCount still reflects the number of alive entities.
+            Interlocked.Increment(ref retiredCount);
+        }
 
         return true;
     }
@@ -164,5 +189,6 @@ public sealed class EntityPool
         versions.Clear();
         Interlocked.Exchange(ref nextNewId, 0);
         Interlocked.Exchange(ref recycleCount, 0);
+        Interlocked.Exchange(ref retiredCount, 0);
     }
 }

--- a/src/KeenEyes.Core/World.cs
+++ b/src/KeenEyes.Core/World.cs
@@ -155,6 +155,11 @@ public sealed partial class World : IWorld,
     /// If null, uses a time-based seed. If specified, enables deterministic behavior
     /// for replays and testing.
     /// </param>
+    /// <param name="recycleEntityIds">
+    /// When <see langword="true"/> (the default), IDs of despawned entities are recycled
+    /// and reused by later spawns. When <see langword="false"/>, entity IDs are assigned
+    /// sequentially from 0 without recycling, giving deterministic IDs for testing.
+    /// </param>
     /// <remarks>
     /// <para>
     /// Each world has its own isolated random number generator state. Providing a seed
@@ -172,10 +177,10 @@ public sealed partial class World : IWorld,
     /// var world3 = new World(seed: 12345); // Same sequence as world2
     /// </code>
     /// </example>
-    public World(int? seed = null)
+    public World(int? seed = null, bool recycleEntityIds = true)
     {
         random = seed.HasValue ? new Random(seed.Value) : new Random();
-        entityPool = new EntityPool();
+        entityPool = new EntityPool(recycleEntityIds);
         archetypeManager = new ArchetypeManager(Components);
         queryManager = new QueryManager(archetypeManager);
         hierarchyManager = new HierarchyManager(this);

--- a/src/KeenEyes.Debugging/DebugPlugin.cs
+++ b/src/KeenEyes.Debugging/DebugPlugin.cs
@@ -163,6 +163,13 @@ public sealed class DebugPlugin(DebugOptions? options = null) : IWorldPlugin
                             logCapture.StopCapture();
                         }
                     };
+
+                    // The DebugController constructor sets the initial mode without raising
+                    // DebugModeChanged, so honor the initial state explicitly at install time.
+                    if (controller.IsDebugMode && !logCapture.IsCapturing)
+                    {
+                        logCapture.StartCapture();
+                    }
                 }
             }
         }

--- a/src/KeenEyes.Logging/Providers/LogCategoryPattern.cs
+++ b/src/KeenEyes.Logging/Providers/LogCategoryPattern.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+
+namespace KeenEyes.Logging.Providers;
+
+/// <summary>
+/// Shared helper for matching log categories against wildcard patterns.
+/// </summary>
+/// <remarks>
+/// Implements the wildcard semantics documented on <see cref="LogQuery.CategoryPattern"/>:
+/// <c>*</c> matches any sequence of characters and <c>?</c> matches any single character.
+/// Matching is anchored (whole-string) and case-insensitive. Shared by all
+/// <see cref="ILogQueryable"/> providers so category filtering is consistent.
+/// </remarks>
+internal static class LogCategoryPattern
+{
+    /// <summary>
+    /// Converts a wildcard category pattern into an anchored, case-insensitive regex.
+    /// </summary>
+    /// <param name="pattern">The wildcard pattern (supporting <c>*</c> and <c>?</c>).</param>
+    /// <returns>A compiled regex that matches categories against the pattern.</returns>
+    public static Regex ToRegex(string pattern)
+    {
+        // Escape regex special characters except * and ?
+        var escaped = Regex.Escape(pattern);
+
+        // Replace wildcard characters with regex equivalents
+        // * matches any sequence of characters
+        // ? matches any single character
+        var regexPattern = escaped
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".");
+
+        // Timeout guards against pathological patterns (S6444); wildcard-derived
+        // patterns are simple, so 100ms is far beyond any legitimate match time.
+        return new Regex($"^{regexPattern}$", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+    }
+}

--- a/src/KeenEyes.Logging/Providers/RingBufferLogProvider.cs
+++ b/src/KeenEyes.Logging/Providers/RingBufferLogProvider.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 
 namespace KeenEyes.Logging.Providers;
 
@@ -146,7 +145,7 @@ public sealed class RingBufferLogProvider : ILogProvider, ILogQueryable
         // Apply category filter
         if (!string.IsNullOrEmpty(query.CategoryPattern))
         {
-            var pattern = WildcardToRegex(query.CategoryPattern);
+            var pattern = LogCategoryPattern.ToRegex(query.CategoryPattern);
             result = result.Where(e => pattern.IsMatch(e.Category));
         }
 
@@ -297,22 +296,5 @@ public sealed class RingBufferLogProvider : ILogProvider, ILogQueryable
                     break;
             }
         }
-    }
-
-    private static Regex WildcardToRegex(string pattern)
-    {
-        // Escape regex special characters except * and ?
-        var escaped = Regex.Escape(pattern);
-
-        // Replace wildcard characters with regex equivalents
-        // * matches any sequence of characters
-        // ? matches any single character
-        var regexPattern = escaped
-            .Replace("\\*", ".*")
-            .Replace("\\?", ".");
-
-        // Timeout guards against pathological patterns (S6444); wildcard-derived
-        // patterns are simple, so 100ms is far beyond any legitimate match time.
-        return new Regex($"^{regexPattern}$", RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
     }
 }

--- a/src/KeenEyes.Logging/Providers/TestLogProvider.cs
+++ b/src/KeenEyes.Logging/Providers/TestLogProvider.cs
@@ -205,20 +205,12 @@ public sealed class TestLogProvider : ILogProvider, ILogQueryable
                 result = result.Where(e => e.Level <= query.MaxLevel.Value);
             }
 
-            // Apply category filter (simple contains for TestLogProvider)
+            // Apply category filter using the documented wildcard semantics
+            // (shared with RingBufferLogProvider via LogCategoryPattern).
             if (!string.IsNullOrEmpty(query.CategoryPattern))
             {
-                var pattern = query.CategoryPattern;
-                if (pattern.Contains('*') || pattern.Contains('?'))
-                {
-                    // Simple wildcard - just check prefix for "Pattern.*"
-                    var prefix = pattern.TrimEnd('*', '?', '.');
-                    result = result.Where(e => e.Category.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
-                }
-                else
-                {
-                    result = result.Where(e => e.Category.Equals(pattern, StringComparison.OrdinalIgnoreCase));
-                }
+                var pattern = LogCategoryPattern.ToRegex(query.CategoryPattern);
+                result = result.Where(e => pattern.IsMatch(e.Category));
             }
 
             // Apply message filter

--- a/src/KeenEyes.Testing/Capabilities/MockHierarchyCapability.cs
+++ b/src/KeenEyes.Testing/Capabilities/MockHierarchyCapability.cs
@@ -35,6 +35,7 @@ public sealed class MockHierarchyCapability : IHierarchyCapability
 
         if (!parent.IsValid)
         {
+            RemoveFromCurrentParent(child);
             parents.Remove(child);
             return;
         }
@@ -45,6 +46,9 @@ public sealed class MockHierarchyCapability : IHierarchyCapability
             throw new InvalidOperationException(
                 $"Setting {parent} as parent of {child} would create a circular reference.");
         }
+
+        // Detach from the previous parent so the parent/children maps stay consistent.
+        RemoveFromCurrentParent(child);
 
         parents[child] = parent;
 
@@ -191,6 +195,15 @@ public sealed class MockHierarchyCapability : IHierarchyCapability
             }
 
             childSet.Add(child);
+        }
+    }
+
+    private void RemoveFromCurrentParent(Entity child)
+    {
+        if (parents.TryGetValue(child, out var currentParent) &&
+            children.TryGetValue(currentParent, out var childSet))
+        {
+            childSet.Remove(child);
         }
     }
 

--- a/src/KeenEyes.Testing/Input/MockKeyboard.cs
+++ b/src/KeenEyes.Testing/Input/MockKeyboard.cs
@@ -98,7 +98,9 @@ public sealed class MockKeyboard : IKeyboard
     public void SimulateKeyDown(Key key, KeyModifiers modifiers = KeyModifiers.None, bool isRepeat = false)
     {
         keysDown.Add(key);
-        this.modifiers = modifiers;
+        // Merge (rather than overwrite) so modifiers held from earlier key events are
+        // preserved. The explicit parameter augments the currently-held modifier state.
+        this.modifiers |= modifiers;
         UpdateModifiersFromKey(key, true);
         OnKeyDown?.Invoke(new KeyEventArgs(key, this.modifiers, isRepeat));
     }
@@ -111,7 +113,9 @@ public sealed class MockKeyboard : IKeyboard
     public void SimulateKeyUp(Key key, KeyModifiers modifiers = KeyModifiers.None)
     {
         keysDown.Remove(key);
-        this.modifiers = modifiers;
+        // Merge (rather than overwrite) so modifiers held from earlier key events are
+        // preserved. UpdateModifiersFromKey then clears the bit for the released key.
+        this.modifiers |= modifiers;
         UpdateModifiersFromKey(key, false);
         OnKeyUp?.Invoke(new KeyEventArgs(key, this.modifiers, IsRepeat: false));
     }

--- a/src/KeenEyes.Testing/Network/MockNetworkContext.cs
+++ b/src/KeenEyes.Testing/Network/MockNetworkContext.cs
@@ -33,10 +33,15 @@ namespace KeenEyes.Testing.Network;
 /// network.TryReceive&lt;ServerResponse&gt;(out var response).Should().BeTrue();
 /// </code>
 /// </example>
-public sealed class MockNetworkContext : INetworkContext
+/// <param name="packetLossSeed">
+/// Optional seed for the deterministic generator that drives packet-loss decisions.
+/// Provide a seed to make packet loss reproducible in tests; when <see langword="null"/>,
+/// a time-based seed is used.
+/// </param>
+public sealed class MockNetworkContext(int? packetLossSeed = null) : INetworkContext
 {
     private readonly Queue<ReceivedMessage> receiveQueue = new();
-    private int packetLossCounter;
+    private ulong packetLossState = SeedToState(packetLossSeed);
     private NetworkConnectionState connectionState = NetworkConnectionState.Disconnected;
     private string? connectedEndpoint;
     private bool disposed;
@@ -44,6 +49,12 @@ public sealed class MockNetworkContext : INetworkContext
     /// <summary>
     /// Gets or sets the network options.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="Latency"/> and <see cref="PacketLoss"/> properties reflect the
+    /// corresponding values on this options object, so configuring options directly
+    /// (for example via <see cref="KeenEyes.Testing.TestWorldBuilder.WithMockNetwork"/>) affects
+    /// simulated behavior just as the SimulateXxx helpers do.
+    /// </remarks>
     public NetworkOptions Options { get; set; } = new();
 
     /// <summary>
@@ -85,10 +96,10 @@ public sealed class MockNetworkContext : INetworkContext
     public bool IsConnected => connectionState == NetworkConnectionState.Connected;
 
     /// <inheritdoc />
-    public float Latency { get; private set; }
+    public float Latency => Options.SimulatedLatency;
 
     /// <inheritdoc />
-    public float PacketLoss { get; private set; }
+    public float PacketLoss => Options.SimulatedPacketLoss;
 
     /// <inheritdoc />
     public string? ConnectedEndpoint => connectedEndpoint;
@@ -171,16 +182,16 @@ public sealed class MockNetworkContext : INetworkContext
     /// <inheritdoc />
     public void SendTo<T>(string endpoint, T data, bool reliable = true, int channel = 0) where T : notnull
     {
-        // Simulate packet loss for unreliable messages using deterministic counter
-        if (!reliable && PacketLoss > 0)
+        // Simulate packet loss for unreliable messages. The loss probability is read
+        // from Options.SimulatedPacketLoss (exposed via PacketLoss) so both the
+        // SimulatePacketLoss helper and directly-configured options are honored.
+        // Loss is probabilistic (correct across the full 0..1 range, unlike an integer
+        // interval which breaks above 0.5) and driven by the seedable RNG for
+        // deterministic tests.
+        var loss = PacketLoss;
+        if (!reliable && loss > 0f && NextPacketLossSample() < loss)
         {
-            packetLossCounter++;
-            // Deterministic packet loss: lose every Nth packet where N = 1/PacketLoss
-            var lossInterval = (int)(1f / PacketLoss);
-            if (lossInterval > 0 && packetLossCounter % lossInterval == 0)
-            {
-                return; // Message "lost"
-            }
+            return; // Message "lost"
         }
 
         SentMessages.Add(new SentMessage(
@@ -199,19 +210,27 @@ public sealed class MockNetworkContext : INetworkContext
     /// <inheritdoc />
     public bool TryReceive<T>(out T? data) where T : class
     {
-        while (receiveQueue.Count > 0)
+        data = default;
+        var found = false;
+
+        // Cycle through the queue exactly once, removing only the first message that
+        // matches T. Non-matching messages (and any after the match) are re-enqueued in
+        // their original order so they remain available to later receive calls.
+        var count = receiveQueue.Count;
+        for (var i = 0; i < count; i++)
         {
             var message = receiveQueue.Dequeue();
-            if (message.Data is T typedData)
+            if (!found && message.Data is T typedData)
             {
                 data = typedData;
-                return true;
+                found = true;
+                continue;
             }
-            // Put back non-matching messages? For simplicity, we'll discard them
+
+            receiveQueue.Enqueue(message);
         }
 
-        data = default;
-        return false;
+        return found;
     }
 
     /// <inheritdoc />
@@ -302,7 +321,6 @@ public sealed class MockNetworkContext : INetworkContext
     /// <param name="latencyMs">The latency in milliseconds.</param>
     public void SimulateLatency(float latencyMs)
     {
-        Latency = latencyMs;
         Options.SimulatedLatency = latencyMs;
     }
 
@@ -312,8 +330,7 @@ public sealed class MockNetworkContext : INetworkContext
     /// <param name="ratio">The packet loss ratio (0 to 1).</param>
     public void SimulatePacketLoss(float ratio)
     {
-        PacketLoss = Math.Clamp(ratio, 0f, 1f);
-        Options.SimulatedPacketLoss = PacketLoss;
+        Options.SimulatedPacketLoss = Math.Clamp(ratio, 0f, 1f);
     }
 
     #endregion
@@ -332,8 +349,6 @@ public sealed class MockNetworkContext : INetworkContext
         ConnectAttemptCount = 0;
         DisconnectCount = 0;
         UpdateCount = 0;
-        Latency = 0;
-        PacketLoss = 0;
         AutoConnect = false;
         AutoFail = false;
         Options = new NetworkOptions();
@@ -373,6 +388,36 @@ public sealed class MockNetworkContext : INetworkContext
     }
 
     private sealed record ReceivedMessage(object Data, string SenderEndpoint, int Channel);
+
+    /// <summary>
+    /// Derives a well-distributed non-zero 64-bit state from the seed (or the system
+    /// clock when unseeded) using a SplitMix64 mixing step.
+    /// </summary>
+    private static ulong SeedToState(int? seed)
+    {
+        var value = (ulong)(seed ?? Environment.TickCount64);
+        value += 0x9E3779B97F4A7C15UL;
+        value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9UL;
+        value = (value ^ (value >> 27)) * 0x94D049BB133111EBUL;
+        value ^= value >> 31;
+        return value == 0 ? 0x9E3779B97F4A7C15UL : value;
+    }
+
+    /// <summary>
+    /// Returns the next deterministic sample in [0, 1) for packet-loss decisions,
+    /// using a xorshift64 generator seeded via the constructor.
+    /// </summary>
+    private double NextPacketLossSample()
+    {
+        var x = packetLossState;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        packetLossState = x;
+
+        // Map the top 53 bits into the unit interval.
+        return (x >> 11) * (1.0 / 9007199254740992.0);
+    }
 }
 
 /// <summary>

--- a/src/KeenEyes.Testing/TestWorldBuilder.cs
+++ b/src/KeenEyes.Testing/TestWorldBuilder.cs
@@ -428,7 +428,9 @@ public sealed class TestWorldBuilder
     /// <returns>A new test world with all configured plugins, systems, and settings.</returns>
     public TestWorld Build()
     {
-        var world = new World();
+        // When deterministic IDs are requested, disable ID recycling so entity IDs
+        // are assigned sequentially from 0 without reuse (see TestWorld.HasDeterministicIds).
+        var world = new World(recycleEntityIds: !deterministicIds);
 
         // Install all plugins first
         foreach (var registration in plugins)

--- a/tests/KeenEyes.Debugging.Tests/DebugPluginTests.cs
+++ b/tests/KeenEyes.Debugging.Tests/DebugPluginTests.cs
@@ -1,5 +1,6 @@
 using KeenEyes.Capabilities;
 using KeenEyes.Debugging.Timeline;
+using KeenEyes.Logging.Providers;
 using KeenEyes.Testing.Capabilities;
 using KeenEyes.Testing.Plugins;
 
@@ -218,6 +219,77 @@ public partial class DebugPluginTests
         // Assert
         var hasTimeline = world.TryGetExtension<TimelineRecorder>(out _);
         Assert.False(hasTimeline);
+    }
+
+    #endregion
+
+    #region Log Capture Auto-Start Tests (Issue #1167)
+
+    [Fact]
+    public void Install_WithInitialDebugModeAndAutoStartLogCapture_StartsCaptureImmediately()
+    {
+        // Regression for #1167: when the plugin is installed already in debug mode,
+        // auto-start log capture must fire on install (the DebugController constructor
+        // does not raise DebugModeChanged).
+        using var world = new World();
+        using var logProvider = new TestLogProvider();
+        var options = new DebugOptions
+        {
+            InitialDebugMode = true,
+            EnableLogCapture = true,
+            AutoStartLogCaptureOnDebugMode = true,
+            LogQueryable = logProvider,
+        };
+
+        world.InstallPlugin(new DebugPlugin(options));
+
+        var logCapture = world.GetExtension<LogCapture>();
+        Assert.NotNull(logCapture);
+        Assert.True(logCapture.IsCapturing);
+    }
+
+    [Fact]
+    public void Install_WithoutInitialDebugMode_DoesNotStartCaptureUntilDebugEnabled()
+    {
+        using var world = new World();
+        using var logProvider = new TestLogProvider();
+        var options = new DebugOptions
+        {
+            InitialDebugMode = false,
+            EnableLogCapture = true,
+            AutoStartLogCaptureOnDebugMode = true,
+            LogQueryable = logProvider,
+        };
+
+        world.InstallPlugin(new DebugPlugin(options));
+
+        var logCapture = world.GetExtension<LogCapture>();
+        Assert.NotNull(logCapture);
+        Assert.False(logCapture.IsCapturing);
+
+        // Enabling debug mode at runtime should start capture via the event subscription.
+        world.GetExtension<DebugController>().IsDebugMode = true;
+        Assert.True(logCapture.IsCapturing);
+    }
+
+    [Fact]
+    public void Install_WithInitialDebugModeButAutoStartDisabled_DoesNotStartCapture()
+    {
+        using var world = new World();
+        using var logProvider = new TestLogProvider();
+        var options = new DebugOptions
+        {
+            InitialDebugMode = true,
+            EnableLogCapture = true,
+            AutoStartLogCaptureOnDebugMode = false,
+            LogQueryable = logProvider,
+        };
+
+        world.InstallPlugin(new DebugPlugin(options));
+
+        var logCapture = world.GetExtension<LogCapture>();
+        Assert.NotNull(logCapture);
+        Assert.False(logCapture.IsCapturing);
     }
 
     #endregion

--- a/tests/KeenEyes.Logging.Tests/Providers/TestLogProviderTests.cs
+++ b/tests/KeenEyes.Logging.Tests/Providers/TestLogProviderTests.cs
@@ -222,4 +222,65 @@ public class TestLogProviderTests
 
         provider.MessageCount.ShouldBe(100);
     }
+
+    #region CategoryPattern Wildcard Query (Issue #1163)
+
+    [Fact]
+    public void Query_ByCategoryPattern_Exact_ReturnsMatchingEntries()
+    {
+        using var provider = new TestLogProvider();
+        provider.Log(LogLevel.Info, "CategoryA", "Message A", null);
+        provider.Log(LogLevel.Info, "CategoryB", "Message B", null);
+
+        var results = provider.Query(new LogQuery { CategoryPattern = "CategoryA" });
+
+        results.Count.ShouldBe(1);
+        results[0].Category.ShouldBe("CategoryA");
+    }
+
+    [Fact]
+    public void Query_ByCategoryPattern_TrailingWildcard_ReturnsMatchingEntries()
+    {
+        using var provider = new TestLogProvider();
+        provider.Log(LogLevel.Info, "KeenEyes.Core", "Core message", null);
+        provider.Log(LogLevel.Info, "KeenEyes.Physics", "Physics message", null);
+        provider.Log(LogLevel.Info, "Other.System", "Other message", null);
+
+        var results = provider.Query(new LogQuery { CategoryPattern = "KeenEyes.*" });
+
+        results.Count.ShouldBe(2);
+        results.ShouldAllBe(e => e.Category.StartsWith("KeenEyes"));
+    }
+
+    [Fact]
+    public void Query_ByCategoryPattern_LeadingWildcard_ReturnsMatchingEntries()
+    {
+        // Regression for #1163: a leading '*' must match a suffix. The old prefix-based
+        // logic kept the '*' in the search text and never matched.
+        using var provider = new TestLogProvider();
+        provider.Log(LogLevel.Info, "KeenEyes.Physics", "Physics message", null);
+        provider.Log(LogLevel.Info, "KeenEyes.Core", "Core message", null);
+
+        var results = provider.Query(new LogQuery { CategoryPattern = "*Physics" });
+
+        results.Count.ShouldBe(1);
+        results[0].Category.ShouldBe("KeenEyes.Physics");
+    }
+
+    [Fact]
+    public void Query_ByCategoryPattern_QuestionMark_MatchesSingleCharacter()
+    {
+        using var provider = new TestLogProvider();
+        provider.Log(LogLevel.Info, "Log1", "One", null);
+        provider.Log(LogLevel.Info, "Log2", "Two", null);
+        provider.Log(LogLevel.Info, "Log42", "FortyTwo", null);
+
+        var results = provider.Query(new LogQuery { CategoryPattern = "Log?" });
+
+        results.Count.ShouldBe(2);
+        results.ShouldContain(e => e.Category == "Log1");
+        results.ShouldContain(e => e.Category == "Log2");
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Testing.Tests/Capabilities/MockHierarchyCapabilityTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Capabilities/MockHierarchyCapabilityTests.cs
@@ -47,6 +47,37 @@ public class MockHierarchyCapabilityTests
     }
 
     [Fact]
+    public void SetParent_Reparenting_RemovesChildFromOldParent()
+    {
+        // Regression for #1162: reparenting must detach the child from its previous
+        // parent so the parent/children maps stay consistent.
+        var capability = new MockHierarchyCapability();
+        var oldParent = new Entity(1, 0);
+        var newParent = new Entity(2, 0);
+        var child = new Entity(3, 0);
+
+        capability.SetParent(child, oldParent);
+        capability.SetParent(child, newParent);
+
+        Assert.DoesNotContain(child, capability.GetChildren(oldParent));
+        Assert.Contains(child, capability.GetChildren(newParent));
+        Assert.Equal(newParent, capability.GetParent(child));
+    }
+
+    [Fact]
+    public void SetParent_WithNullParent_RemovesChildFromOldParentChildren()
+    {
+        var capability = new MockHierarchyCapability();
+        var parent = new Entity(1, 0);
+        var child = new Entity(2, 0);
+        capability.SetParent(child, parent);
+
+        capability.SetParent(child, Entity.Null);
+
+        Assert.DoesNotContain(child, capability.GetChildren(parent));
+    }
+
+    [Fact]
     public void SetParent_WithThrowOnInvalidOperation_ThrowsOnCircularReference()
     {
         var capability = new MockHierarchyCapability { ThrowOnInvalidOperation = true };

--- a/tests/KeenEyes.Testing.Tests/Input/MockKeyboardTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Input/MockKeyboardTests.cs
@@ -260,6 +260,24 @@ public class MockKeyboardTests
         Assert.True(keyboard.Modifiers.HasFlag(KeyModifiers.Shift));
     }
 
+    [Fact]
+    public void SimulateKeyDown_AfterHeldModifier_PreservesModifierState()
+    {
+        // Regression for #1164: pressing a non-modifier key must not wipe a
+        // previously-held modifier.
+        var keyboard = new MockKeyboard();
+        KeyEventArgs? receivedArgs = null;
+        keyboard.OnKeyDown += args => receivedArgs = args;
+
+        keyboard.SimulateKeyDown(Key.LeftShift);
+        keyboard.SimulateKeyDown(Key.A);
+
+        Assert.True(keyboard.IsKeyDown(Key.LeftShift));
+        Assert.True(keyboard.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.NotNull(receivedArgs);
+        Assert.True(receivedArgs.Value.Modifiers.HasFlag(KeyModifiers.Shift));
+    }
+
     #endregion
 
     #region SimulateKeyUp
@@ -303,6 +321,24 @@ public class MockKeyboardTests
         keyboard.SimulateKeyUp(Key.LeftShift);
 
         Assert.False(keyboard.Modifiers.HasFlag(KeyModifiers.Shift));
+    }
+
+    [Fact]
+    public void SimulateKeyUp_NonModifierKey_PreservesHeldModifier()
+    {
+        // Regression for #1164: releasing a non-modifier key must not wipe a
+        // still-held modifier.
+        var keyboard = new MockKeyboard();
+        keyboard.SimulateKeyDown(Key.LeftShift);
+        keyboard.SimulateKeyDown(Key.A);
+        KeyEventArgs? receivedArgs = null;
+        keyboard.OnKeyUp += args => receivedArgs = args;
+
+        keyboard.SimulateKeyUp(Key.A);
+
+        Assert.True(keyboard.Modifiers.HasFlag(KeyModifiers.Shift));
+        Assert.NotNull(receivedArgs);
+        Assert.True(receivedArgs.Value.Modifiers.HasFlag(KeyModifiers.Shift));
     }
 
     #endregion

--- a/tests/KeenEyes.Testing.Tests/Network/MockNetworkContextTests.cs
+++ b/tests/KeenEyes.Testing.Tests/Network/MockNetworkContextTests.cs
@@ -337,7 +337,8 @@ public class MockNetworkContextTests
     [Fact]
     public void SendUnreliable_WithPacketLoss_DropsMessages()
     {
-        using var network = new MockNetworkContext();
+        // Seed the RNG so packet-loss decisions are deterministic and this test is stable.
+        using var network = new MockNetworkContext(packetLossSeed: 12345);
         network.SimulatePacketLoss(0.5f); // 50% loss
 
         // Send 10 unreliable messages
@@ -346,8 +347,9 @@ public class MockNetworkContextTests
             network.SendTo("peer", new TestMessage(), reliable: false);
         }
 
-        // With 50% loss and deterministic behavior, every other message should be dropped
+        // With 50% loss some messages are dropped, but not all (unlike reliable sends).
         network.SentMessages.Count.ShouldBeLessThan(10);
+        network.SentMessages.Count.ShouldBeGreaterThan(0);
     }
 
     [Fact]
@@ -557,6 +559,112 @@ public class MockNetworkContextTests
         var msg2 = new SentMessage("endpoint2", data, typeof(TestMessage), true, 0, timestamp);
 
         msg1.ShouldNotBe(msg2);
+    }
+
+    #endregion
+
+    #region Options Honoring (Issue #1161)
+
+    [Fact]
+    public void PacketLoss_ReflectsOptions()
+    {
+        using var network = new MockNetworkContext();
+
+        network.Options = new NetworkOptions { SimulatedPacketLoss = 0.3f };
+
+        network.PacketLoss.ShouldBe(0.3f);
+    }
+
+    [Fact]
+    public void Latency_ReflectsOptions()
+    {
+        using var network = new MockNetworkContext();
+
+        network.Options = new NetworkOptions { SimulatedLatency = 42f };
+
+        network.Latency.ShouldBe(42f);
+    }
+
+    [Fact]
+    public void SendUnreliable_WithPacketLossSetViaOptions_DropsMessages()
+    {
+        // Configuring Options directly (as WithMockNetwork(options) does) must affect
+        // packet loss. Full loss (1.0) drops every unreliable message deterministically.
+        using var network = new MockNetworkContext();
+        network.Options = new NetworkOptions { SimulatedPacketLoss = 1.0f };
+
+        for (int i = 0; i < 20; i++)
+        {
+            network.SendTo("peer", new TestMessage(), reliable: false);
+        }
+
+        network.SentMessages.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SendUnreliable_WithHighPacketLoss_DeliversProportionalFraction()
+    {
+        // Above 0.5 the old integer-interval math dropped 100% of packets. Probabilistic
+        // loss must instead deliver roughly (1 - ratio) of them. Seeded for determinism.
+        using var network = new MockNetworkContext(packetLossSeed: 20240724);
+        network.SimulatePacketLoss(0.75f);
+
+        const int total = 1000;
+        for (int i = 0; i < total; i++)
+        {
+            network.SendTo("peer", new TestMessage(), reliable: false);
+        }
+
+        // Expect ~25% delivered; a generous band keeps the seeded test stable while
+        // still failing the old behavior (which delivered 0).
+        network.SentMessages.Count.ShouldBeInRange(180, 320);
+    }
+
+    #endregion
+
+    #region TryReceive Requeue (Issue #1165)
+
+    [Fact]
+    public void TryReceive_WithNonMatchingMessageQueued_DoesNotDiscardIt()
+    {
+        using var network = new MockNetworkContext();
+        network.SimulateReceive(new OtherMessage { Text = "chat" }, "peer");
+        network.SimulateReceive(new TestMessage { Value = 7 }, "peer");
+
+        // Receiving the TestMessage must not drop the earlier queued OtherMessage.
+        network.TryReceive<TestMessage>(out var moved).ShouldBeTrue();
+        moved!.Value.ShouldBe(7);
+
+        network.TryReceive<OtherMessage>(out var chat).ShouldBeTrue();
+        chat!.Text.ShouldBe("chat");
+    }
+
+    [Fact]
+    public void TryReceive_WithMultipleMatchingMessages_ReturnsInFifoOrder()
+    {
+        using var network = new MockNetworkContext();
+        network.SimulateReceive(new TestMessage { Value = 1 }, "peer");
+        network.SimulateReceive(new TestMessage { Value = 2 }, "peer");
+
+        network.TryReceive<TestMessage>(out var first).ShouldBeTrue();
+        first!.Value.ShouldBe(1);
+
+        network.TryReceive<TestMessage>(out var second).ShouldBeTrue();
+        second!.Value.ShouldBe(2);
+    }
+
+    [Fact]
+    public void TryReceive_WithNoMatch_LeavesQueueIntact()
+    {
+        using var network = new MockNetworkContext();
+        network.SimulateReceive(new TestMessage { Value = 5 }, "peer");
+
+        network.TryReceive<OtherMessage>(out _).ShouldBeFalse();
+
+        // The non-matching message is still available.
+        network.ReceiveQueueCount.ShouldBe(1);
+        network.TryReceive<TestMessage>(out var kept).ShouldBeTrue();
+        kept!.Value.ShouldBe(5);
     }
 
     #endregion

--- a/tests/KeenEyes.Testing.Tests/TestWorldBuilderTests.cs
+++ b/tests/KeenEyes.Testing.Tests/TestWorldBuilderTests.cs
@@ -61,6 +61,36 @@ public class TestWorldBuilderTests
         testWorld.HasDeterministicIds.ShouldBeFalse();
     }
 
+    [Fact]
+    public void WithDeterministicIds_AfterDespawn_DoesNotRecycleId()
+    {
+        // Regression for #1160: deterministic mode must assign IDs sequentially
+        // without recycling, so a despawn followed by a spawn yields a fresh ID.
+        using var testWorld = new TestWorldBuilder()
+            .WithDeterministicIds()
+            .Build();
+
+        var first = testWorld.World.Spawn().Build();
+        testWorld.World.Despawn(first);
+        var second = testWorld.World.Spawn().Build();
+
+        first.Id.ShouldBe(0);
+        second.Id.ShouldBe(1);
+    }
+
+    [Fact]
+    public void WithoutDeterministicIds_AfterDespawn_RecyclesId()
+    {
+        // Default worlds still recycle IDs (contrast for #1160).
+        using var testWorld = new TestWorldBuilder().Build();
+
+        var first = testWorld.World.Spawn().Build();
+        testWorld.World.Despawn(first);
+        var second = testWorld.World.Spawn().Build();
+
+        second.Id.ShouldBe(first.Id);
+    }
+
     #endregion
 
     #region WithManualTime Tests


### PR DESCRIPTION
## Summary
Fixes the testing/logging/debugging review cluster from the deep-functional-review epic (#1093).

- **#1160** — `TestWorldBuilder.WithDeterministicIds()` now works: added a `recycleEntityIds` option to `World`/`EntityPool`, so deterministic mode assigns IDs sequentially from 0 without recycling.
- **#1161** — `MockNetworkContext` derives latency/loss from `Options` and uses a seedable deterministic PRNG with correct probabilistic packet loss across the full 0–1 range (`System.Random` is analyzer-forbidden here).
- **#1162** — `MockHierarchyCapability.SetParent` detaches the child from its previous parent's children set.
- **#1164** — `MockKeyboard` merges held modifiers instead of overwriting them.
- **#1165** — `MockNetworkContext.TryReceive<T>` removes only the first match and re-enqueues the rest in FIFO order.
- **#1163** — `TestLogProvider.Query` does proper wildcard→regex `CategoryPattern` matching (shared `LogCategoryPattern` helper, also adopted by `RingBufferLogProvider`).
- **#1167** — `DebugPlugin` starts log capture immediately when the controller is already in debug mode at install.

## Test plan
- [x] Tests across all seven issues; fail-on-old/pass-on-new proven via source revert
- [x] Testing 1435, Logging 283, Debugging 225; full suite 14,580 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1160
Closes #1161
Closes #1162
Closes #1163
Closes #1164
Closes #1165
Closes #1167