### PR TITLE
fix(testbridge): Fix TCP socket leak on reconnect and serialize concurrent IPC sends

### DIFF
--- a/src/KeenEyes.TestBridge.Ipc/Transport/IpcFrameProtocol.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Transport/IpcFrameProtocol.cs
@@ -1,0 +1,76 @@
+using System.Buffers;
+
+namespace KeenEyes.TestBridge.Ipc.Transport;
+
+/// <summary>
+/// Shared framing helper for the IPC transports. Messages are framed with a
+/// 4-byte little-endian length prefix followed by the payload.
+/// </summary>
+/// <remarks>
+/// Both <see cref="TcpIpcTransport"/> and <see cref="NamedPipeTransport"/> use this
+/// helper so the write path — and its concurrency guarantees — live in one place.
+/// </remarks>
+internal static class IpcFrameProtocol
+{
+    /// <summary>Size, in bytes, of the little-endian length prefix that precedes each payload.</summary>
+    public const int HeaderSize = 4;
+
+    /// <summary>Maximum payload size, in bytes, that a single frame may carry (16 MB, sized for screenshots).</summary>
+    public const int MaxMessageSize = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// Writes a single framed message to <paramref name="stream"/>, serializing the
+    /// write and flush behind <paramref name="sendLock"/>.
+    /// </summary>
+    /// <param name="stream">The destination stream.</param>
+    /// <param name="sendLock">
+    /// The per-transport send gate. Holding it across the write and flush guarantees
+    /// concurrent senders cannot interleave bytes from different frames on the shared
+    /// stream and corrupt the length framing.
+    /// </param>
+    /// <param name="data">The payload to frame and send.</param>
+    /// <param name="cancellationToken">A token to cancel the send.</param>
+    /// <returns>A task that completes once the frame has been written and flushed.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="data"/> exceeds <see cref="MaxMessageSize"/>.</exception>
+    public static async ValueTask WriteFrameAsync(
+        Stream stream,
+        SemaphoreSlim sendLock,
+        ReadOnlyMemory<byte> data,
+        CancellationToken cancellationToken)
+    {
+        if (data.Length > MaxMessageSize)
+        {
+            throw new ArgumentException($"Message size {data.Length} exceeds maximum {MaxMessageSize}.", nameof(data));
+        }
+
+        // Create framed message: [4-byte length][payload]
+        var frameSize = HeaderSize + data.Length;
+        var buffer = ArrayPool<byte>.Shared.Rent(frameSize);
+
+        try
+        {
+            // Write length header (little-endian)
+            BitConverter.TryWriteBytes(buffer.AsSpan(0, HeaderSize), data.Length);
+
+            // Write payload
+            data.Span.CopyTo(buffer.AsSpan(HeaderSize));
+
+            // Serialize the write+flush so concurrent senders cannot interleave
+            // bytes from different frames on the shared stream and corrupt framing.
+            await sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await stream.WriteAsync(buffer.AsMemory(0, frameSize), cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                sendLock.Release();
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/KeenEyes.TestBridge.Ipc/Transport/NamedPipeTransport.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Transport/NamedPipeTransport.cs
@@ -17,12 +17,10 @@ namespace KeenEyes.TestBridge.Ipc.Transport;
 /// </remarks>
 public sealed class NamedPipeTransport : IIpcTransport
 {
-    private const int HeaderSize = 4;
-    private const int MaxMessageSize = 16 * 1024 * 1024; // 16MB for screenshots
-
     private readonly string pipeName;
     private readonly bool isServer;
     private readonly Lock stateLock = new();
+    private readonly SemaphoreSlim sendLock = new(1, 1);
 
     private NamedPipeServerStream? serverPipe;
     private NamedPipeClientStream? clientPipe;
@@ -168,30 +166,7 @@ public sealed class NamedPipeTransport : IIpcTransport
             pipe = activePipe;
         }
 
-        if (data.Length > MaxMessageSize)
-        {
-            throw new ArgumentException($"Message size {data.Length} exceeds maximum {MaxMessageSize}.", nameof(data));
-        }
-
-        // Create framed message: [4-byte length][payload]
-        var frameSize = HeaderSize + data.Length;
-        var buffer = ArrayPool<byte>.Shared.Rent(frameSize);
-
-        try
-        {
-            // Write length header (little-endian)
-            BitConverter.TryWriteBytes(buffer.AsSpan(0, HeaderSize), data.Length);
-
-            // Write payload
-            data.Span.CopyTo(buffer.AsSpan(HeaderSize));
-
-            await pipe.WriteAsync(buffer.AsMemory(0, frameSize), cancellationToken).ConfigureAwait(false);
-            await pipe.FlushAsync(cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+        await IpcFrameProtocol.WriteFrameAsync(pipe, sendLock, data, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -238,6 +213,7 @@ public sealed class NamedPipeTransport : IIpcTransport
         serverPipe?.Dispose();
         clientPipe?.Dispose();
         readCts?.Dispose();
+        sendLock.Dispose();
 
         lock (stateLock)
         {
@@ -254,7 +230,7 @@ public sealed class NamedPipeTransport : IIpcTransport
 
     private async Task ReadLoopAsync(CancellationToken cancellationToken)
     {
-        var headerBuffer = new byte[HeaderSize];
+        var headerBuffer = new byte[IpcFrameProtocol.HeaderSize];
 
         try
         {
@@ -272,7 +248,7 @@ public sealed class NamedPipeTransport : IIpcTransport
 
                 // Read header
                 var headerBytesRead = await ReadExactAsync(pipe, headerBuffer, cancellationToken).ConfigureAwait(false);
-                if (headerBytesRead < HeaderSize)
+                if (headerBytesRead < IpcFrameProtocol.HeaderSize)
                 {
                     // Connection closed
                     break;
@@ -280,7 +256,7 @@ public sealed class NamedPipeTransport : IIpcTransport
 
                 // Parse message length
                 var messageLength = BitConverter.ToInt32(headerBuffer, 0);
-                if (messageLength <= 0 || messageLength > MaxMessageSize)
+                if (messageLength <= 0 || messageLength > IpcFrameProtocol.MaxMessageSize)
                 {
                     // Invalid message, disconnect
                     break;

--- a/src/KeenEyes.TestBridge.Ipc/Transport/TcpIpcTransport.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Transport/TcpIpcTransport.cs
@@ -19,13 +19,11 @@ namespace KeenEyes.TestBridge.Ipc.Transport;
 /// </remarks>
 public sealed class TcpIpcTransport : IIpcTransport
 {
-    private const int HeaderSize = 4;
-    private const int MaxMessageSize = 16 * 1024 * 1024; // 16MB for screenshots
-
     private readonly string bindAddress;
     private readonly int port;
     private readonly bool isServer;
     private readonly Lock stateLock = new();
+    private readonly SemaphoreSlim sendLock = new(1, 1);
 
     private TcpListener? listener;
     private TcpClient? client;
@@ -175,30 +173,7 @@ public sealed class TcpIpcTransport : IIpcTransport
             networkStream = stream;
         }
 
-        if (data.Length > MaxMessageSize)
-        {
-            throw new ArgumentException($"Message size {data.Length} exceeds maximum {MaxMessageSize}.", nameof(data));
-        }
-
-        // Create framed message: [4-byte length][payload]
-        var frameSize = HeaderSize + data.Length;
-        var buffer = ArrayPool<byte>.Shared.Rent(frameSize);
-
-        try
-        {
-            // Write length header (little-endian)
-            BitConverter.TryWriteBytes(buffer.AsSpan(0, HeaderSize), data.Length);
-
-            // Write payload
-            data.Span.CopyTo(buffer.AsSpan(HeaderSize));
-
-            await networkStream.WriteAsync(buffer.AsMemory(0, frameSize), cancellationToken).ConfigureAwait(false);
-            await networkStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+        await IpcFrameProtocol.WriteFrameAsync(networkStream, sendLock, data, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -243,17 +218,22 @@ public sealed class TcpIpcTransport : IIpcTransport
         readCts?.Cancel();
         Cleanup();
         readCts?.Dispose();
+        sendLock.Dispose();
     }
 
     private void StartReadLoop()
     {
+        // Dispose the previous token source so reconnects do not leak one CTS
+        // per accepted connection. The prior read loop has already exited by
+        // the time a new connection is accepted on this point-to-point transport.
+        readCts?.Dispose();
         readCts = new CancellationTokenSource();
         readTask = ReadLoopAsync(readCts.Token);
     }
 
     private async Task ReadLoopAsync(CancellationToken cancellationToken)
     {
-        var headerBuffer = new byte[HeaderSize];
+        var headerBuffer = new byte[IpcFrameProtocol.HeaderSize];
 
         try
         {
@@ -271,7 +251,7 @@ public sealed class TcpIpcTransport : IIpcTransport
 
                 // Read header
                 var headerBytesRead = await ReadExactAsync(networkStream, headerBuffer, cancellationToken).ConfigureAwait(false);
-                if (headerBytesRead < HeaderSize)
+                if (headerBytesRead < IpcFrameProtocol.HeaderSize)
                 {
                     // Connection closed
                     break;
@@ -279,7 +259,7 @@ public sealed class TcpIpcTransport : IIpcTransport
 
                 // Parse message length
                 var messageLength = BitConverter.ToInt32(headerBuffer, 0);
-                if (messageLength <= 0 || messageLength > MaxMessageSize)
+                if (messageLength <= 0 || messageLength > IpcFrameProtocol.MaxMessageSize)
                 {
                     // Invalid message, disconnect
                     break;
@@ -322,18 +302,10 @@ public sealed class TcpIpcTransport : IIpcTransport
             // Stream disposed
         }
 
-        // Handle disconnection
-        bool wasConnected;
-        lock (stateLock)
-        {
-            wasConnected = isConnected;
-            isConnected = false;
-        }
-
-        if (wasConnected)
-        {
-            ConnectionChanged?.Invoke(false);
-        }
+        // Handle disconnection: dispose the socket/stream here so a reconnect
+        // does not leak the previous TcpClient/NetworkStream. Mirrors the
+        // named-pipe transport, which calls CleanupAsync on read-loop exit.
+        Cleanup();
     }
 
     private static async Task<int> ReadExactAsync(NetworkStream stream, Memory<byte> buffer, CancellationToken cancellationToken)

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/TransportConcurrencyTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/TransportConcurrencyTests.cs
@@ -1,0 +1,339 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using KeenEyes.TestBridge.Ipc.Transport;
+
+namespace KeenEyes.TestBridge.Tests.Ipc;
+
+/// <summary>
+/// Regression tests for the IPC transport bug cluster: concurrent-send frame
+/// interleaving (#1181) and the TCP read-loop socket leak on disconnect (#1180).
+/// </summary>
+public class TransportConcurrencyTests
+{
+    #region #1181 - concurrent send frame integrity (shared write path)
+
+    /// <summary>
+    /// Deterministically proves that <see cref="IpcFrameProtocol.WriteFrameAsync"/> — the
+    /// write path shared by both transports — serializes concurrent frame writes so their
+    /// bytes cannot interleave on the shared stream.
+    /// </summary>
+    /// <remarks>
+    /// The write is driven over a stream whose <c>WriteAsync</c> yields between small chunks,
+    /// so <em>without</em> the send lock two concurrent frame writes are guaranteed to
+    /// interleave and corrupt the framing. Real OS sockets/pipes on some platforms serialize
+    /// writes internally, hiding the hazard; this stream removes that platform dependency and
+    /// makes the fix's effect observable on every run.
+    /// </remarks>
+    [Fact]
+    public async Task WriteFrameAsync_ConcurrentWrites_DoNotInterleaveOnSharedStream()
+    {
+        const int payloadSize = 4096;
+        const int chunkSize = 64;
+        const int senderCount = 8;
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var sink = new ChunkedYieldingStream(chunkSize);
+        using var sendLock = new SemaphoreSlim(1, 1);
+
+        var tasks = new Task[senderCount];
+        for (var i = 0; i < senderCount; i++)
+        {
+            var payload = new byte[payloadSize];
+            Array.Fill(payload, (byte)i);
+            tasks[i] = IpcFrameProtocol.WriteFrameAsync(sink, sendLock, payload, cancellationToken).AsTask();
+        }
+
+        await Task.WhenAll(tasks);
+
+        // Parse the concatenated bytes back into frames. If two writes interleaved, a frame's
+        // payload will contain bytes from more than one message ("not solid") or the framing
+        // desyncs and the trailing bytes will not parse into exactly senderCount frames.
+        var bytes = sink.ToArray();
+        var frames = ParseFrames(bytes, payloadSize);
+
+        frames.Count.ShouldBe(
+            senderCount,
+            "Concurrent frame writes interleaved and the length framing no longer parses into whole frames.");
+        foreach (var (solid, length) in frames)
+        {
+            length.ShouldBe(payloadSize);
+            solid.ShouldBeTrue("A frame contained bytes from more than one message — concurrent writes interleaved.");
+        }
+    }
+
+    [Fact]
+    public async Task TcpTransport_ConcurrentSends_PreserveFrameIntegrity()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var port = GetFreePort();
+
+        using var server = new TcpIpcTransport("127.0.0.1", port, isServer: true);
+        using var client = new TcpIpcTransport("127.0.0.1", port, isServer: false);
+
+        var listenTask = server.ListenAsync(cancellationToken);
+        await client.ConnectAsync(cancellationToken);
+        await listenTask;
+
+        await AssertConcurrentSendsPreserveFramingAsync(server, client, cancellationToken);
+    }
+
+    [Fact]
+    public async Task NamedPipeTransport_ConcurrentSends_PreserveFrameIntegrity()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var pipeName = $"KeenEyes.TestBridge.Tests.{Guid.NewGuid():N}";
+
+        using var server = new NamedPipeTransport(pipeName, isServer: true);
+        using var client = new NamedPipeTransport(pipeName, isServer: false);
+
+        var listenTask = server.ListenAsync(cancellationToken);
+        await client.ConnectAsync(cancellationToken);
+        await listenTask;
+
+        await AssertConcurrentSendsPreserveFramingAsync(server, client, cancellationToken);
+    }
+
+    /// <summary>
+    /// End-to-end check over a real transport pair: many concurrent <c>SendAsync</c> calls
+    /// must all arrive as intact, correctly framed messages. Complements the deterministic
+    /// <see cref="WriteFrameAsync_ConcurrentWrites_DoNotInterleaveOnSharedStream"/> test.
+    /// </summary>
+    private static async Task AssertConcurrentSendsPreserveFramingAsync(
+        IIpcTransport sender,
+        IIpcTransport receiver,
+        CancellationToken cancellationToken)
+    {
+        const int payloadSize = 256 * 1024;
+        const int senderCount = 16;
+        const int rounds = 2;
+        var expected = senderCount * rounds;
+
+        var received = new System.Collections.Concurrent.ConcurrentQueue<(int Length, bool Solid)>();
+        var allReceived = new TaskCompletionSource();
+        var countLock = new Lock();
+        var count = 0;
+
+        receiver.MessageReceived += memory =>
+        {
+            var span = memory.Span;
+            var first = span.Length > 0 ? span[0] : (byte)0;
+            var solid = true;
+            for (var i = 1; i < span.Length; i++)
+            {
+                if (span[i] != first)
+                {
+                    solid = false;
+                    break;
+                }
+            }
+
+            received.Enqueue((span.Length, solid));
+            lock (countLock)
+            {
+                count++;
+                if (count >= expected)
+                {
+                    allReceived.TrySetResult();
+                }
+            }
+        };
+
+        for (var round = 0; round < rounds; round++)
+        {
+            var tasks = new Task[senderCount];
+            for (var i = 0; i < senderCount; i++)
+            {
+                var value = (byte)((round * senderCount) + i);
+                var payload = new byte[payloadSize];
+                Array.Fill(payload, value);
+                tasks[i] = sender.SendAsync(payload, cancellationToken).AsTask();
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        var completed = await Task.WhenAny(allReceived.Task, Task.Delay(TimeSpan.FromSeconds(20), cancellationToken));
+        completed.ShouldBe(
+            allReceived.Task,
+            "Not every frame was received — interleaved writes corrupted the length framing and frames were lost.");
+
+        received.Count.ShouldBe(expected);
+        foreach (var (length, solid) in received)
+        {
+            length.ShouldBe(payloadSize, "A received frame had the wrong length — writes interleaved and corrupted framing.");
+            solid.ShouldBeTrue("A received frame contained bytes from more than one message — concurrent writes interleaved.");
+        }
+    }
+
+    #endregion
+
+    #region #1180 - TCP read-loop socket leak on disconnect
+
+    [Fact]
+    public async Task TcpTransport_ReadLoopDisconnect_DisposesSocketInsteadOfLeaking()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var port = GetFreePort();
+
+        using var server = new TcpIpcTransport("127.0.0.1", port, isServer: true);
+        using var client = new TcpIpcTransport("127.0.0.1", port, isServer: false);
+
+        var listenTask = server.ListenAsync(cancellationToken);
+        await client.ConnectAsync(cancellationToken);
+        await listenTask;
+
+        server.IsConnected.ShouldBeTrue();
+
+        // The accepted TcpClient is held in a private field; capture it to prove the
+        // read-loop disconnect path releases it rather than leaking one socket per
+        // reconnect. (Test-only reflection is permitted per project conventions.)
+        var clientField = typeof(TcpIpcTransport).GetField(
+            "client",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        clientField.ShouldNotBeNull();
+        clientField.GetValue(server).ShouldNotBeNull("Server should hold the accepted TcpClient while connected.");
+
+        // Close the peer so the server's read loop observes the closed connection
+        // and runs its disconnect handling (the buggy path).
+        await client.DisconnectAsync();
+
+        // The fixed disconnect path calls Cleanup(), which disposes the socket/stream
+        // and clears the field. The old path only flipped isConnected and left the
+        // TcpClient/NetworkStream leaked (field stayed populated).
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (clientField.GetValue(server) is not null && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20, cancellationToken);
+        }
+
+        server.IsConnected.ShouldBeFalse();
+        clientField.GetValue(server).ShouldBeNull(
+            "Read-loop disconnect must dispose and release the accepted socket; a non-null field means it was leaked.");
+    }
+
+    #endregion
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Parses a byte buffer of concatenated [4-byte length][payload] frames. Returns one
+    /// entry per whole frame with whether the payload was "solid" (all bytes equal) and its
+    /// declared length. Stops when the remaining bytes cannot form another complete frame.
+    /// </summary>
+    private static List<(bool Solid, int Length)> ParseFrames(byte[] bytes, int expectedLength)
+    {
+        var frames = new List<(bool Solid, int Length)>();
+        var offset = 0;
+        while (offset + 4 <= bytes.Length)
+        {
+            var length = BitConverter.ToInt32(bytes, offset);
+            offset += 4;
+
+            // A corrupted length is itself proof of interleaving; record an impossible frame.
+            if (length < 0 || offset + length > bytes.Length)
+            {
+                frames.Add((false, length));
+                break;
+            }
+
+            var first = length > 0 ? bytes[offset] : (byte)0;
+            var solid = true;
+            for (var i = 0; i < length; i++)
+            {
+                if (bytes[offset + i] != first)
+                {
+                    solid = false;
+                    break;
+                }
+            }
+
+            frames.Add((solid, length));
+            offset += length;
+
+            // Guard against a runaway parse when framing has desynced badly.
+            if (length != expectedLength)
+            {
+                break;
+            }
+        }
+
+        return frames;
+    }
+
+    /// <summary>
+    /// A write-only stream that appends each write to an in-memory buffer in small chunks,
+    /// yielding between chunks. Concurrent unsynchronized writes therefore interleave
+    /// deterministically, which lets a test observe whether the caller serialized its writes.
+    /// </summary>
+    private sealed class ChunkedYieldingStream(int chunkSize) : Stream
+    {
+        private readonly List<byte> buffer = [];
+        private readonly Lock bufferLock = new();
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public byte[] ToArray()
+        {
+            lock (bufferLock)
+            {
+                return buffer.ToArray();
+            }
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> memory, CancellationToken cancellationToken = default)
+        {
+            for (var offset = 0; offset < memory.Length; offset += chunkSize)
+            {
+                var length = Math.Min(chunkSize, memory.Length - offset);
+                var chunk = memory.Slice(offset, length).ToArray();
+                lock (bufferLock)
+                {
+                    buffer.AddRange(chunk);
+                }
+
+                // Yield so a concurrent (unserialized) writer can interleave its own chunk.
+                await Task.Yield();
+            }
+        }
+
+        public override void Flush()
+        {
+            // No-op: writes are captured synchronously.
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the TestBridge IPC review cluster from the deep-functional-review epic (#1093).

- **#1180** — `TcpIpcTransport` read-loop disconnect now `Cleanup()`s the accepted socket/stream/CTS (mirroring the named-pipe transport), so the reused transport no longer leaks a socket on every reconnect.
- **#1181** — extracted the framed write into a shared `IpcFrameProtocol.WriteFrameAsync` that guards write+flush behind a per-transport `SemaphoreSlim`; both TCP and named-pipe transports delegate to it, preventing byte-interleaving corruption under concurrent sends.

## Test plan
- [x] `TransportConcurrencyTests`; fail-on-old/pass-on-new proven via source revert (interleave repro uses an in-memory stream since Unix sockets serialize per-socket — the original NEEDS-REPRO caveat)
- [x] TestBridge.Tests 252; full suite 14,564 tests, 0 failed; 0 warnings; format clean

## Related Issues
Closes #1180
Closes #1181