### PR TITLE
fix(samples): Rewrite InputDebugger sample against current Graphics APIs and gate it in slnx

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -17,6 +17,7 @@
     <Project Path="samples/KeenEyes.Sample.CollisionDetection/KeenEyes.Sample.CollisionDetection.csproj" />
     <Project Path="samples/KeenEyes.Sample.Graphics/KeenEyes.Sample.Graphics.csproj" />
     <Project Path="samples/KeenEyes.Sample.Input/KeenEyes.Sample.Input.csproj" />
+    <Project Path="samples/KeenEyes.Sample.InputDebugger/KeenEyes.Sample.InputDebugger.csproj" />
     <Project Path="samples/KeenEyes.Sample.MassSimulation/KeenEyes.Sample.MassSimulation.csproj" />
     <Project Path="samples/KeenEyes.Sample.Messaging/KeenEyes.Sample.Messaging.csproj" />
     <Project Path="samples/KeenEyes.Sample.Multiplayer/KeenEyes.Sample.Multiplayer.csproj" />

--- a/samples/KeenEyes.Sample.InputDebugger/Program.cs
+++ b/samples/KeenEyes.Sample.InputDebugger/Program.cs
@@ -182,7 +182,9 @@ void SetupInputEvents(IInputContext input)
         if (args.Key == Key.Escape)
         {
             Console.WriteLine("Escape pressed - closing...");
-            Environment.Exit(0);
+            // Fully qualify System.Environment: KeenEyes.Graphics.Abstractions also
+            // defines an Environment component, so the unqualified name is ambiguous here.
+            System.Environment.Exit(0);
         }
     };
 
@@ -245,10 +247,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.2f, 0.25f, 0.2f, 1f),
-            Metallic = 0f,
-            Roughness = 0.95f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.2f, 0.25f, 0.2f, 1f),
+            MetallicFactor = 0f,
+            RoughnessFactor = 0.95f
         })
         .Build();
 
@@ -259,10 +261,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(1f, 1f, 0f, 1f),
-            Metallic = 0.5f,
-            Roughness = 0.3f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(1f, 1f, 0f, 1f),
+            MetallicFactor = 0.5f,
+            RoughnessFactor = 0.3f
         })
         .WithTag<MouseMarkerTag>()
         .Build();
@@ -285,10 +287,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.5f, 0.5f, 0.5f, 1f),
-            Metallic = 0f,
-            Roughness = 0.9f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.5f, 0.5f, 0.5f, 1f),
+            MetallicFactor = 0f,
+            RoughnessFactor = 0.9f
         })
         .Build();
 
@@ -300,10 +302,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.25f, 0.25f, 0.3f, 1f),
-            Metallic = 0f,
-            Roughness = 0.9f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.25f, 0.25f, 0.3f, 1f),
+            MetallicFactor = 0f,
+            RoughnessFactor = 0.9f
         })
         .Build();
 
@@ -314,10 +316,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.3f, 0.7f, 1f, 1f),
-            Metallic = 0.6f,
-            Roughness = 0.3f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.3f, 0.7f, 1f, 1f),
+            MetallicFactor = 0.6f,
+            RoughnessFactor = 0.3f
         })
         .WithTag<LeftStickMarkerTag>()
         .Build();
@@ -329,10 +331,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.25f, 0.25f, 0.3f, 1f),
-            Metallic = 0f,
-            Roughness = 0.9f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.25f, 0.25f, 0.3f, 1f),
+            MetallicFactor = 0f,
+            RoughnessFactor = 0.9f
         })
         .Build();
 
@@ -343,10 +345,10 @@ void CreateDebugScene(World world, IGraphicsContext graphics)
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(1f, 0.5f, 0.3f, 1f),
-            Metallic = 0.6f,
-            Roughness = 0.3f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(1f, 0.5f, 0.3f, 1f),
+            MetallicFactor = 0.6f,
+            RoughnessFactor = 0.3f
         })
         .WithTag<RightStickMarkerTag>()
         .Build();
@@ -376,10 +378,10 @@ void CreateKeyVisualizer(World world, IGraphicsContext graphics, MeshHandle mesh
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.4f, 0.4f, 0.4f, 1f),
-            Metallic = 0.2f,
-            Roughness = 0.6f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.4f, 0.4f, 0.4f, 1f),
+            MetallicFactor = 0.2f,
+            RoughnessFactor = 0.6f
         })
         .WithTag<KeyVisualizerTag>()
         .With(new KeyBinding { Key = key })
@@ -394,10 +396,10 @@ void CreateGamepadButtonVisualizer(World world, IGraphicsContext graphics, MeshH
         .With(new Material
         {
             ShaderId = graphics.LitShader.Id,
-            TextureId = graphics.WhiteTexture.Id,
-            Color = new Vector4(0.3f, 0.3f, 0.3f, 1f),
-            Metallic = 0.2f,
-            Roughness = 0.6f
+            BaseColorTextureId = graphics.WhiteTexture.Id,
+            BaseColorFactor = new Vector4(0.3f, 0.3f, 0.3f, 1f),
+            MetallicFactor = 0.2f,
+            RoughnessFactor = 0.6f
         })
         .WithTag<GamepadButtonTag>()
         .With(new GamepadButtonBinding { Button = button })

--- a/samples/KeenEyes.Sample.InputDebugger/Systems.cs
+++ b/samples/KeenEyes.Sample.InputDebugger/Systems.cs
@@ -179,10 +179,10 @@ public class MouseVisualizerSystem : SystemBase
                 .With(new Material
                 {
                     ShaderId = graphics.LitShader.Id,
-                    TextureId = graphics.WhiteTexture.Id,
-                    Color = color,
-                    Metallic = 0.8f,
-                    Roughness = 0.2f
+                    BaseColorTextureId = graphics.WhiteTexture.Id,
+                    BaseColorFactor = color,
+                    MetallicFactor = 0.8f,
+                    RoughnessFactor = 0.2f
                 })
                 .WithTag<ClickMarkerTag>()
                 .With(new FadeOut { TimeRemaining = ClickMarkerDuration, TotalDuration = ClickMarkerDuration })
@@ -216,7 +216,7 @@ public class KeyboardVisualizerSystem : SystemBase
 
             bool isPressed = keyboard.IsKeyDown(binding.Key);
 
-            material.Color = isPressed
+            material.BaseColorFactor = isPressed
                 ? new Vector4(0.2f, 1f, 0.2f, 1f)
                 : new Vector4(0.4f, 0.4f, 0.4f, 1f);
         }
@@ -269,7 +269,7 @@ public class GamepadVisualizerSystem : SystemBase
 
             bool isPressed = cachedGamepad.IsButtonDown(binding.Button);
 
-            material.Color = isPressed
+            material.BaseColorFactor = isPressed
                 ? new Vector4(1f, 0.8f, 0.2f, 1f)
                 : new Vector4(0.3f, 0.3f, 0.3f, 1f);
         }
@@ -321,7 +321,7 @@ public class FadeOutSystem : SystemBase
             else
             {
                 float alpha = fadeOut.TimeRemaining / fadeOut.TotalDuration;
-                material.Color = new Vector4(material.Color.X, material.Color.Y, material.Color.Z, alpha);
+                material.BaseColorFactor = new Vector4(material.BaseColorFactor.X, material.BaseColorFactor.Y, material.BaseColorFactor.Z, alpha);
             }
         }
 

--- a/samples/KeenEyes.Sample.InputDebugger/packages.lock.json
+++ b/samples/KeenEyes.Sample.InputDebugger/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.17.0.131074, )",
-        "resolved": "10.17.0.131074",
-        "contentHash": "N8agHzX1pK3Xv/fqMig/mHspPAmh/aKkGg7lUC1xfezAhFtPTuRqBjuyas622Tvy5jnsN5zCXJVclvNkfJJ4rQ=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "Cyotek.Drawing.BitmapFont": {
         "type": "Transitive",
@@ -15,15 +15,15 @@
       },
       "FontStashSharp.Base": {
         "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "t2PT+/Sat9WPLm4AVYU1Aa/PrOgNQ4npSUGDHTYufXzLUHxrN3+BaRhAU0DZXkJNfuGCS5iKaQNopNXe9ES24g=="
+        "resolved": "1.2.3",
+        "contentHash": "kw8ovakGHz8jCah+H5M7qI8aOvtESF0jQRpcpubXUMsSid86dRO6DoDPlh+Tk/XAW5a3XgzGDgsHfeZTfZTr+Q=="
       },
       "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
         "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "OoXoGkxNMhyQeYR/wjeN6Bs8Guea7FisKXLcVJdeNtSYT+5iKxIh4ETi9x9OIk7GEQtNbE0yVhG3rb8RS04Kmg==",
+        "resolved": "1.2.3",
+        "contentHash": "xjzgWeiaODbW7DR/kI05V7C3CVtDvtB+4TrgX4EKNpRGzxb42vsvXKWrXORQWU2LCLnPPqdBNNSgtRujnpK2ww==",
         "dependencies": {
-          "FontStashSharp.Base": "1.2.2",
+          "FontStashSharp.Base": "1.2.3",
           "StbTrueTypeSharp": "1.26.12"
         }
       },
@@ -34,60 +34,60 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "NSmDw3K0ozNDgShSIpsZcbFIzBX4w28nDag+TfaQujkXGazBm+lid5onlWoCBy4VsLxqnnKjEBbGSJVWJMf43g=="
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
       },
       "Silk.NET.Core": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "XbDilPmvsQIrvxZkeVCNNX3LyRtA3hN6UykAiyZjlu/JkYh68U3WQummpP+j7jsxlX8s/pOrrU3vbN8LnMl0VA==",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
-          "Microsoft.Extensions.DependencyModel": "8.0.0"
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
         }
       },
       "Silk.NET.GLFW": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "I1u6CmwwtD+5OIHditbMBVHRQUHZWhfW3Z38mvydxwkZpAvjs5BCxyen6ecOVpbYD6I0EOjZ42M3IsaZbwiYUg==",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
+          "Silk.NET.Core": "2.23.0",
           "Ultz.Native.GLFW": "3.4.0"
         }
       },
       "Silk.NET.Input.Common": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "DZy30akJABBmTnn8OICik0TFEuXrkd7YCQvoq+oh50eJzXt8JgEYYa+sJYBib/Phs5WULZg/QR7fM8Gi1G3tXg==",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
         "dependencies": {
-          "Silk.NET.Windowing.Common": "2.22.0"
+          "Silk.NET.Windowing.Common": "2.23.0"
         }
       },
       "Silk.NET.Input.Glfw": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "LZPZT1e/RxnjKfkqlp2Wp8KJFP1Av/ErTCZ00EzZpFR1lhUSBgSmgJwXg6XlWoEJHyeJcsXV688zjoEe6YW0BA==",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
         "dependencies": {
-          "Silk.NET.Input.Common": "2.22.0",
-          "Silk.NET.Windowing.Glfw": "2.22.0"
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
         }
       },
       "Silk.NET.Windowing.Common": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "ynasHSQ4jGrmpn/07UagE3qVNRLzWvg+fbM8uHI0d5LF95y++Kuno42QLkP/UEruC1YovI+NRhMfGJy0gDQaZg==",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
-          "Silk.NET.Maths": "2.22.0"
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
         }
       },
       "Silk.NET.Windowing.Glfw": {
         "type": "Transitive",
-        "resolved": "2.22.0",
-        "contentHash": "hBNxNSLvx/jdfvbU6oCsXcgLfqf9hMlEc6Mq/rllJ0eUTLloacuOZHTM8V702QGf7hOR+Mo4bTFqTqBnC0CM7g==",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
         "dependencies": {
-          "Silk.NET.GLFW": "2.22.0",
-          "Silk.NET.Windowing.Common": "2.22.0"
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
         }
       },
       "StbTrueTypeSharp": {
@@ -103,6 +103,16 @@
       "keeneyes.abstractions": {
         "type": "Project"
       },
+      "keeneyes.ai": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Navigation": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
       "keeneyes.common": {
         "type": "Project",
         "dependencies": {
@@ -113,6 +123,14 @@
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.debugging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.graphics": {
@@ -133,13 +151,14 @@
       "keeneyes.graphics.silk": {
         "type": "Project",
         "dependencies": {
-          "FontStashSharp.PlatformAgnostic": "[1.5.2, )",
+          "FontStashSharp.PlatformAgnostic": "[1.5.6, )",
           "KeenEyes.Common": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Maths": "[2.22.0, )",
-          "Silk.NET.OpenGL": "[2.22.0, )"
+          "Silk.NET.Maths": "[2.23.0, )",
+          "Silk.NET.OpenGL": "[2.23.0, )",
+          "StbImageSharp": "[2.30.15, )"
         }
       },
       "keeneyes.input": {
@@ -161,10 +180,23 @@
           "KeenEyes.Input": "[1.0.0, )",
           "KeenEyes.Input.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Input": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )"
         }
       },
       "keeneyes.logging": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Navigation.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.navigation.abstractions": {
         "type": "Project",
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )"
@@ -188,15 +220,23 @@
         "dependencies": {
           "KeenEyes.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.Input": "[2.22.0, )",
-          "Silk.NET.Windowing": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
         }
       },
       "keeneyes.platform.silk.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Silk.NET.Input": "[2.22.0, )",
-          "Silk.NET.Windowing": "[2.22.0, )"
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.replay": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )"
         }
       },
       "keeneyes.runtime": {
@@ -208,8 +248,12 @@
       "keeneyes.testbridge": {
         "type": "Project",
         "dependencies": {
+          "KeenEyes.AI": "[1.0.0, )",
           "KeenEyes.Core": "[1.0.0, )",
+          "KeenEyes.Debugging": "[1.0.0, )",
           "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Logging": "[1.0.0, )",
+          "KeenEyes.Replay": "[1.0.0, )",
           "KeenEyes.TestBridge.Abstractions": "[1.0.0, )",
           "KeenEyes.Testing": "[1.0.0, )",
           "StbImageWriteSharp": "[1.16.7, )"
@@ -245,50 +289,50 @@
       },
       "FontStashSharp.PlatformAgnostic": {
         "type": "CentralTransitive",
-        "requested": "[1.5.2, )",
-        "resolved": "1.5.2",
-        "contentHash": "/Srtf2DyIBBTbaZ4jpOQZnGFoEcbiXPMZnPuSft8MkMdbMYgCXPD5S123a992qTGVFKQjD9IGapd7Kyg2GD6sw==",
+        "requested": "[1.5.6, )",
+        "resolved": "1.5.6",
+        "contentHash": "aIuRgPeucC3zkCZvY8Y8E8JyrvukUX8MfKCUO31HWOg3yuYniHUA/3kjpNJE2apRGQzmreYhWFMatKv8cgGRxw==",
         "dependencies": {
           "Cyotek.Drawing.BitmapFont": "2.0.4",
-          "FontStashSharp.Base": "1.2.2",
-          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.2",
+          "FontStashSharp.Base": "1.2.3",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.3",
           "StbImageSharp": "2.30.15"
         }
       },
       "Silk.NET.Input": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "1gqbKHrKpBv2Vk983kVpMqXL4Uj36NaUIQ2YbQosFVa3pXJE8UMGiWqKtaeoMqnzItusZ1WYgDHKge37EvNm/w==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
         "dependencies": {
-          "Silk.NET.Input.Common": "2.22.0",
-          "Silk.NET.Input.Glfw": "2.22.0"
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
         }
       },
       "Silk.NET.Maths": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "W9b5UlUGCu5Ywb5f8ZyIWJ475ucY+mT/nEiSTo3JH098VxHaZS/02bYr9f29VWBaJhh3DwMkfxQvgTyXzTrHyw=="
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
       },
       "Silk.NET.OpenGL": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "AmbtflPvaGWw7fHEHrcFTd54OTAj0bemzx4WV2ELJdW2NBPSvtyz31nhyuBVTml20+NtW4Z3yhDGUpM6uouVDQ==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "CIakUoUqiAyRPykMk54tr1M1XpbJrT/iw12T85HDQcuRCFlBa1cxbX7v3FmtznKO5eM89esfmGNCgqDaKBiWfg==",
         "dependencies": {
-          "Silk.NET.Core": "2.22.0",
-          "Silk.NET.Maths": "2.22.0"
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
         }
       },
       "Silk.NET.Windowing": {
         "type": "CentralTransitive",
-        "requested": "[2.22.0, )",
-        "resolved": "2.22.0",
-        "contentHash": "yKGe/8REdm+T43LdtfUpFUx9eQARwx6wTmEoJ2bANVGQPCvWYC2Qi1+haT6n63dyNIX+iJWKg4++F4TFjg0/Fw==",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
         "dependencies": {
-          "Silk.NET.Windowing.Common": "2.22.0",
-          "Silk.NET.Windowing.Glfw": "2.22.0"
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
         }
       },
       "StbImageSharp": {


### PR DESCRIPTION
## Summary
Fixes #1091 — the InputDebugger sample had rotted (47 compile errors from API drift) and was missing from `KeenEyes.slnx`, so nothing caught the breakage.

- Updated all `Material` usages to the current glTF-style PBR naming: `TextureId`→`BaseColorTextureId`, `Color`→`BaseColorFactor`, `Metallic`→`MetallicFactor`, `Roughness`→`RoughnessFactor` (across `Program.cs` and `Systems.cs`).
- Resolved the `Environment` CS0104 ambiguity (`KeenEyes.Graphics.Abstractions.Environment` IBL component vs `System.Environment`) by fully qualifying `System.Environment.Exit`.
- Added the project to `KeenEyes.slnx` (after `Sample.Input`) so the whole-solution build compiles it and it can't rot silently again.
- Modeled on the working in-slnx `KeenEyes.Sample.Input`; purpose preserved (input-debugging visualizer + TestBridge/IPC integration), no gutting, teaching-code conventions held.

## Test plan
- [x] `dotnet build samples/KeenEyes.Sample.InputDebugger -c Release` — 0 warnings/0 errors
- [x] `dotnet build KeenEyes.slnx -c Release` — 0 warnings/0 errors (wired into slnx)
- [x] `dotnet format --verify-no-changes` clean; full suite 14,623 tests, 0 failed
- Requires a display to run; build gate + slnx inclusion is the acceptance bar

## Related Issues
Closes #1091