### PR TITLE
fix(assets): Reject path-traversal/absolute paths in AssetManager loads

### DIFF
--- a/src/KeenEyes.Assets/Core/AssetManager.cs
+++ b/src/KeenEyes.Assets/Core/AssetManager.cs
@@ -256,7 +256,7 @@ public sealed class AssetManager : IDisposable
 
         entry.State = AssetState.Loading;
 
-        var fullPath = Path.Combine(config.RootPath, path);
+        var fullPath = ResolveAndValidatePath(path);
         if (!File.Exists(fullPath))
         {
             entry.State = AssetState.Failed;
@@ -457,7 +457,7 @@ public sealed class AssetManager : IDisposable
             return;
         }
 
-        var fullPath = Path.Combine(config.RootPath, path);
+        var fullPath = ResolveAndValidatePath(path);
         if (!File.Exists(fullPath))
         {
             return;
@@ -511,7 +511,7 @@ public sealed class AssetManager : IDisposable
         var loader = loaders.GetLoader<T>(extension)
             ?? throw AssetLoadException.UnsupportedFormat(path, typeof(T), extension);
 
-        var fullPath = Path.Combine(config.RootPath, path);
+        var fullPath = ResolveAndValidatePath(path);
         if (!File.Exists(fullPath))
         {
             throw AssetLoadException.FileNotFound(path, typeof(T));
@@ -543,7 +543,7 @@ public sealed class AssetManager : IDisposable
         var loader = loaders.GetLoader<T>(extension)
             ?? throw AssetLoadException.UnsupportedFormat(path, typeof(T), extension);
 
-        var fullPath = Path.Combine(config.RootPath, path);
+        var fullPath = ResolveAndValidatePath(path);
         if (!File.Exists(fullPath))
         {
             throw AssetLoadException.FileNotFound(path, typeof(T));
@@ -607,5 +607,37 @@ public sealed class AssetManager : IDisposable
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(disposed, this);
+    }
+
+    /// <summary>
+    /// Resolves a caller-supplied asset path against the configured root and verifies the
+    /// resolved location is contained within that root.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Path.Combine(string, string)"/> passes rooted/absolute arguments through
+    /// unchanged and does not collapse <c>..</c> segments, so an unchecked path such as
+    /// <c>"../../secrets.txt"</c> or an absolute path would otherwise escape the root. This
+    /// normalizes with <see cref="Path.GetFullPath(string)"/> and rejects any result that does
+    /// not sit under the root, guarding against path traversal when assets originate from
+    /// untrusted sources.
+    /// </remarks>
+    /// <param name="path">The caller-supplied path, expected to be relative to the root.</param>
+    /// <returns>The validated, fully-qualified path within the root.</returns>
+    /// <exception cref="AssetLoadException">Thrown when the path resolves outside the root.</exception>
+    private string ResolveAndValidatePath(string path)
+    {
+        var rootFull = Path.GetFullPath(config.RootPath);
+        var rootPrefix = rootFull.EndsWith(Path.DirectorySeparatorChar)
+            ? rootFull
+            : rootFull + Path.DirectorySeparatorChar;
+
+        var fullPath = Path.GetFullPath(Path.Combine(config.RootPath, path));
+
+        if (!fullPath.StartsWith(rootPrefix, StringComparison.Ordinal))
+        {
+            throw AssetLoadException.PathEscapesRoot(path);
+        }
+
+        return fullPath;
     }
 }

--- a/src/KeenEyes.Assets/Loading/AssetLoadException.cs
+++ b/src/KeenEyes.Assets/Loading/AssetLoadException.cs
@@ -52,4 +52,16 @@ public sealed class AssetLoadException(
     /// <returns>A new exception instance.</returns>
     public static AssetLoadException ParseError(string assetPath, Type assetType, Exception innerException)
         => new(assetPath, assetType, $"Failed to parse asset: {assetPath}", innerException);
+
+    /// <summary>
+    /// Creates a new asset load exception for a path that escapes the asset root directory.
+    /// </summary>
+    /// <param name="assetPath">The offending path (e.g. one containing <c>..</c> segments or an absolute path).</param>
+    /// <returns>A new exception instance.</returns>
+    /// <remarks>
+    /// Thrown when a caller-supplied path resolves outside the configured root directory,
+    /// guarding against path-traversal escapes when assets originate from untrusted sources.
+    /// </remarks>
+    public static AssetLoadException PathEscapesRoot(string assetPath)
+        => new(assetPath, typeof(object), $"Asset path '{assetPath}' resolves outside the asset root directory and was rejected.");
 }

--- a/tests/KeenEyes.Assets.Tests/AssetManagerTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AssetManagerTests.cs
@@ -78,6 +78,81 @@ public class AssetManagerTests : IDisposable
 
     #endregion
 
+    #region Path Containment Tests
+
+    [Fact]
+    public void Load_WithParentTraversalPath_ThrowsContainmentException()
+    {
+        // A real file placed outside the root, reachable via "../" traversal. Before the fix
+        // Path.Combine let this escape and the file loaded; now it must be rejected.
+        var outsideName = $"KeenEyes_Traversal_{Guid.NewGuid():N}.txt";
+        var outsidePath = Path.Combine(Path.GetDirectoryName(testDir.RootPath)!, outsideName);
+        File.WriteAllText(outsidePath, "escaped");
+        try
+        {
+            var traversalPath = Path.Combine("..", outsideName);
+
+            var ex = Assert.Throws<AssetLoadException>(() => manager.Load<TestAsset>(traversalPath));
+            Assert.Contains("outside the asset root", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(outsidePath);
+        }
+    }
+
+    [Fact]
+    public void Load_WithAbsolutePath_ThrowsContainmentException()
+    {
+        // An absolute path outside the root. Path.Combine passes rooted arguments through
+        // unchanged, so before the fix this loaded the arbitrary file directly.
+        var outsidePath = Path.Combine(Path.GetTempPath(), $"KeenEyes_Absolute_{Guid.NewGuid():N}.txt");
+        File.WriteAllText(outsidePath, "escaped");
+        try
+        {
+            var ex = Assert.Throws<AssetLoadException>(() => manager.Load<TestAsset>(outsidePath));
+            Assert.Contains("outside the asset root", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(outsidePath);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithParentTraversalPath_ThrowsContainmentException()
+    {
+        var outsideName = $"KeenEyes_Traversal_{Guid.NewGuid():N}.txt";
+        var outsidePath = Path.Combine(Path.GetDirectoryName(testDir.RootPath)!, outsideName);
+        await File.WriteAllTextAsync(outsidePath, "escaped");
+        try
+        {
+            var traversalPath = Path.Combine("..", outsideName);
+
+            var ex = await Assert.ThrowsAsync<AssetLoadException>(
+                () => manager.LoadAsync<TestAsset>(traversalPath));
+            Assert.Contains("outside the asset root", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(outsidePath);
+        }
+    }
+
+    [Fact]
+    public void Load_WithNormalInRootRelativePath_LoadsSuccessfully()
+    {
+        // Legitimate in-root paths, including nested subdirectories, must still load unchanged.
+        var path = testDir.CreateFile(Path.Combine("nested", "asset.txt"), "In-root content");
+
+        using var handle = manager.Load<TestAsset>(path);
+
+        Assert.True(handle.IsLoaded);
+        Assert.Equal("In-root content", handle.Asset!.Content);
+    }
+
+    #endregion
+
     #region LoadAsync Tests
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes #1235 (from nightly review #1208 triage). `AssetManager` built `Path.Combine(config.RootPath, path)` from caller-supplied paths with no containment check, so `../` traversal or absolute paths reached `File.OpenRead` and escaped the asset root.

- Added `ResolveAndValidatePath(string)` — computes `Path.GetFullPath(Path.Combine(RootPath, path))` and throws unless it stays under `GetFullPath(RootPath) + separator`.
- New `AssetLoadException.PathEscapesRoot(string)`.
- Applied at all 4 file-open call sites (`LoadByTypeAsync`, `ReloadAsync`, `LoadAssetSync`, `LoadAssetAsync`); legitimate in-root `FileNotFound` behavior preserved.

## Test plan
- [x] Traversal + absolute paths rejected; normal in-root path still loads. Fail-on-old proven — old code actually **loaded** the escaped file (not just a different exception)
- [x] Assets.Tests 414; full suite 14,676, 0 failed; 0 warnings; format clean

## Related
Closes #1235