### PR TITLE
fix(replay): Replace reflection in InvokeCustomHandler with a typed handler registry

### DIFF
--- a/src/KeenEyes.Replay/ReplayPlayer.cs
+++ b/src/KeenEyes.Replay/ReplayPlayer.cs
@@ -50,7 +50,7 @@ public sealed class ReplayPlayer : IDisposable
 {
     private readonly Lock syncRoot = new();
     private readonly Dictionary<InputEventType, List<Action<InputEvent>>> inputHandlers = [];
-    private readonly Dictionary<string, List<Delegate>> customInputHandlers = [];
+    private readonly Dictionary<string, List<Action<object>>> customInputHandlers = [];
 
     private ReplayData? replayData;
     private ReplayFileInfo? fileInfo;
@@ -1992,6 +1992,17 @@ public sealed class ReplayPlayer : IDisposable
         ArgumentNullException.ThrowIfNull(handler);
         ThrowIfDisposed();
 
+        // Wrap the typed handler in a type-checking Action<object> closing over T.
+        // This lets dispatch perform a typed check without reflection: data that is
+        // not assignable to T is silently skipped, matching the previous behavior.
+        void TypedHandler(object data)
+        {
+            if (data is T typed)
+            {
+                handler(typed);
+            }
+        }
+
         lock (syncRoot)
         {
             if (!customInputHandlers.TryGetValue(customType, out var handlers))
@@ -2000,7 +2011,7 @@ public sealed class ReplayPlayer : IDisposable
                 customInputHandlers[customType] = handlers;
             }
 
-            handlers.Add(handler);
+            handlers.Add(TypedHandler);
         }
     }
 
@@ -2106,7 +2117,7 @@ public sealed class ReplayPlayer : IDisposable
 
         IReadOnlyList<InputEvent> inputEvents;
         Dictionary<InputEventType, List<Action<InputEvent>>>? handlersCopy;
-        Dictionary<string, List<Delegate>>? customHandlersCopy;
+        Dictionary<string, List<Action<object>>>? customHandlersCopy;
 
         lock (syncRoot)
         {
@@ -2192,7 +2203,7 @@ public sealed class ReplayPlayer : IDisposable
 
         IReadOnlyList<InputEvent> inputEvents;
         Dictionary<InputEventType, List<Action<InputEvent>>>? handlersCopy;
-        Dictionary<string, List<Delegate>>? customHandlersCopy;
+        Dictionary<string, List<Action<object>>>? customHandlersCopy;
 
         lock (syncRoot)
         {
@@ -2308,28 +2319,17 @@ public sealed class ReplayPlayer : IDisposable
         }
     }
 
-    private static void InvokeCustomHandler(Delegate handler, object? data)
+    private static void InvokeCustomHandler(Action<object> handler, object? data)
     {
         if (data is null)
         {
             return;
         }
 
-        try
-        {
-            // Get the handler's expected parameter type
-            var parameterType = handler.Method.GetParameters()[0].ParameterType;
-
-            // Check if the data is assignable to the parameter type
-            if (parameterType.IsInstanceOfType(data))
-            {
-                handler.DynamicInvoke(data);
-            }
-        }
-        catch (Exception)
-        {
-            // Ignore type mismatch errors - handler simply won't be invoked
-        }
+        // The handler is a type-checking wrapper (see RegisterInputHandler{T}):
+        // it silently skips data that is not assignable to the expected type,
+        // so no reflection is needed here.
+        handler(data);
     }
 
     #endregion

--- a/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayInputTests.cs
@@ -1010,6 +1010,43 @@ public class ReplayInputTests
         Assert.Equal(InputEventType.KeyUp, allEvents[1].Type);
     }
 
+    [Fact]
+    public void ApplyInputFrame_WithCustomEvent_InvokesMatchingTypeAndSkipsMismatchedType()
+    {
+        // Arrange - record a single custom event carrying TestGestureData
+        using var world = new World();
+        var serializer = new MockComponentSerializer();
+        var recorder = new ReplayRecorder(world, serializer);
+
+        var gestureData = new TestGestureData("Pinch", 1.5f);
+        recorder.StartRecording();
+        recorder.BeginFrame(0.016f);
+        recorder.RecordCustomInput("GestureData", gestureData);
+        recorder.EndFrame(0.016f);
+        var replayData = recorder.StopRecording();
+
+        using var player = new ReplayPlayer();
+        player.LoadReplay(replayData!);
+
+        // Register two handlers for the SAME custom-type name but different payload types.
+        // Only the handler whose type matches the recorded payload must be invoked.
+        TestGestureData? capturedGesture = null;
+        var mismatchedHandlerCalled = false;
+        player.RegisterInputHandler<TestGestureData>("GestureData", data => capturedGesture = data);
+        player.RegisterInputHandler<TestClickData>("GestureData", _ => mismatchedHandlerCalled = true);
+
+        // Act
+        player.ApplyInputFrame();
+
+        // Assert - matching type fired with the correct typed payload
+        Assert.NotNull(capturedGesture);
+        Assert.Equal("Pinch", capturedGesture.GestureType);
+        Assert.Equal(1.5f, capturedGesture.Scale);
+
+        // Assert - the non-matching type handler was NOT invoked
+        Assert.False(mismatchedHandlerCalled);
+    }
+
     #endregion
 }
 
@@ -1017,3 +1054,8 @@ public class ReplayInputTests
 /// Test data class for custom input events.
 /// </summary>
 public record TestGestureData(string GestureType, float Scale);
+
+/// <summary>
+/// Second, distinct test data class used to verify type-based handler dispatch.
+/// </summary>
+public record TestClickData(int Button);


### PR DESCRIPTION
## Summary
Fixes #1232 (from nightly review #1208 triage). `ReplayPlayer.InvokeCustomHandler` used reflection (`handler.Method.GetParameters()`, `IsInstanceOfType`, `DynamicInvoke`) on every custom input-event dispatch — a violation of the repo's no-reflection/AOT rule for `src/`.

- Registry changed from `Dictionary<string, List<Delegate>>` to `Dictionary<string, List<Action<object>>>`.
- `RegisterInputHandler<T>` wraps the typed handler in an `Action<object>` closure (`data => { if (data is T typed) handler(typed); }`) — the type check is baked in at registration.
- `InvokeCustomHandler` is now a null-guard + direct call; all reflection removed (grep-confirmed: no `GetParameters`/`IsInstanceOfType`/`DynamicInvoke` remain).

## Test plan
- [x] New test: same custom-type key with two typed handlers; matching type fires with correct payload, mismatched type does not
- [x] Behavior-preserving refactor — the fail-on-old signal is the reflection-gone grep (present at old lines 2321/2324/2326, absent now); the new test guards the type-dispatch semantics
- [x] Replay.Tests 615; full suite 14,673, 0 failed; 0 warnings; format clean

## Related
Closes #1232