### PR TITLE
fix: Instance nav request IDs, true PeekMessageType, named autosave const, builder docs

### DIFF
--- a/src/KeenEyes.Abstractions/IEntityBuilder.cs
+++ b/src/KeenEyes.Abstractions/IEntityBuilder.cs
@@ -44,15 +44,22 @@ public interface IEntityBuilder<TSelf> : IEntityBuilder where TSelf : IEntityBui
     /// <summary>
     /// Adds a component to the entity being built.
     /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="component">The component data.</param>
+    /// <returns>This builder for chaining.</returns>
     new TSelf With<T>(T component) where T : struct, IComponent;
 
     /// <summary>
     /// Adds a tag component to the entity being built.
     /// </summary>
+    /// <typeparam name="T">The tag component type.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     new TSelf WithTag<T>() where T : struct, ITagComponent;
 
     /// <summary>
     /// Sets the parent entity for the entity being built.
     /// </summary>
+    /// <param name="parent">The parent entity.</param>
+    /// <returns>This builder for chaining.</returns>
     new TSelf WithParent(Entity parent);
 }

--- a/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
+++ b/src/KeenEyes.Core/Systems/AutoSaveSystem.cs
@@ -38,6 +38,11 @@ namespace KeenEyes.Systems;
 public sealed class AutoSaveSystem<TSerializer> : SystemBase
     where TSerializer : IComponentSerializer, IBinaryComponentSerializer
 {
+    // Extra delta slots scanned/cleaned beyond MaxDeltasBeforeBaseline. Provides a
+    // safety margin so stragglers written just before a baseline rollover are not
+    // missed by cleanup or highest-sequence discovery.
+    private const int BaselineRetentionMargin = 5;
+
     private readonly TSerializer serializer;
     private AutoSaveConfig config;
 
@@ -313,7 +318,7 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     private void CleanupOldDeltas(ISaveLoadCapability saveLoad)
     {
         // Remove old delta files when a new baseline is created
-        for (int i = 1; i <= config.MaxDeltasBeforeBaseline + 5; i++)
+        for (int i = 1; i <= config.MaxDeltasBeforeBaseline + BaselineRetentionMargin; i++)
         {
             var slotName = config.GetDeltaSlotName(i);
             if (saveLoad.SaveSlotExists(slotName))
@@ -326,7 +331,7 @@ public sealed class AutoSaveSystem<TSerializer> : SystemBase
     private int FindHighestDeltaSequence(ISaveLoadCapability saveLoad)
     {
         int highest = 0;
-        for (int i = 1; i <= config.MaxDeltasBeforeBaseline + 5; i++)
+        for (int i = 1; i <= config.MaxDeltasBeforeBaseline + BaselineRetentionMargin; i++)
         {
             if (saveLoad.SaveSlotExists(config.GetDeltaSlotName(i)))
             {

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastPathRequest.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastPathRequest.cs
@@ -6,20 +6,19 @@ namespace KeenEyes.Navigation.DotRecast;
 /// <summary>
 /// Represents an asynchronous path computation request for navmesh navigation.
 /// </summary>
+/// <param name="id">The per-provider unique request identifier.</param>
 /// <param name="start">The starting position.</param>
 /// <param name="end">The destination position.</param>
 /// <param name="agent">The agent settings.</param>
 /// <param name="areaMask">The area mask for filtering.</param>
-internal sealed class DotRecastPathRequest(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask) : IPathRequest
+internal sealed class DotRecastPathRequest(int id, Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask) : IPathRequest
 {
-    private static int nextId;
-
     private readonly TaskCompletionSource<NavPath> taskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private PathRequestStatus status = PathRequestStatus.Pending;
     private NavPath result = NavPath.Empty;
 
     /// <inheritdoc/>
-    public int Id { get; } = Interlocked.Increment(ref nextId);
+    public int Id { get; } = id;
 
     /// <inheritdoc/>
     public PathRequestStatus Status => status;

--- a/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
+++ b/src/KeenEyes.Navigation.DotRecast/DotRecastProvider.cs
@@ -30,6 +30,7 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
     private readonly Lock requestLock = new();
     private readonly float[] areaCosts = new float[32];
 
+    private int nextRequestId;
     private NavMeshData? activeMesh;
     private NavMeshQueryPool? queryPool;
     private DotRecastCrowdManager? crowdManager;
@@ -242,7 +243,7 @@ public sealed class DotRecastProvider : ICrowdNavigationProvider
     {
         ThrowIfDisposed();
 
-        var request = new DotRecastPathRequest(start, end, agent, areaMask);
+        var request = new DotRecastPathRequest(Interlocked.Increment(ref nextRequestId), start, end, agent, areaMask);
 
         lock (requestLock)
         {

--- a/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
+++ b/src/KeenEyes.Navigation.Grid/GridNavigationProvider.cs
@@ -24,6 +24,7 @@ public sealed class GridNavigationProvider : INavigationProvider
     private readonly AStarPathfinder pathfinder;
     private readonly Queue<GridPathRequest> pendingRequests;
     private readonly Lock requestLock = new();
+    private int nextRequestId;
     private bool disposed;
 
     /// <summary>
@@ -154,7 +155,7 @@ public sealed class GridNavigationProvider : INavigationProvider
     {
         ThrowIfDisposed();
 
-        var request = new GridPathRequest(start, end, agent, areaMask);
+        var request = new GridPathRequest(Interlocked.Increment(ref nextRequestId), start, end, agent, areaMask);
 
         lock (requestLock)
         {

--- a/src/KeenEyes.Navigation.Grid/GridPathRequest.cs
+++ b/src/KeenEyes.Navigation.Grid/GridPathRequest.cs
@@ -6,20 +6,19 @@ namespace KeenEyes.Navigation.Grid;
 /// <summary>
 /// Represents an asynchronous path computation request for grid navigation.
 /// </summary>
+/// <param name="id">The per-provider unique request identifier.</param>
 /// <param name="start">The starting position.</param>
 /// <param name="end">The destination position.</param>
 /// <param name="agent">The agent settings.</param>
 /// <param name="areaMask">The area mask for filtering.</param>
-internal sealed class GridPathRequest(Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask) : IPathRequest
+internal sealed class GridPathRequest(int id, Vector3 start, Vector3 end, AgentSettings agent, NavAreaMask areaMask) : IPathRequest
 {
-    private static int nextId;
-
     private readonly TaskCompletionSource<NavPath> taskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private PathRequestStatus status = PathRequestStatus.Pending;
     private NavPath result = NavPath.Empty;
 
     /// <inheritdoc/>
-    public int Id { get; } = Interlocked.Increment(ref nextId);
+    public int Id { get; } = id;
 
     /// <inheritdoc/>
     public PathRequestStatus Status => status;

--- a/src/KeenEyes.Network/Protocol/NetworkMessageReader.cs
+++ b/src/KeenEyes.Network/Protocol/NetworkMessageReader.cs
@@ -44,12 +44,15 @@ public ref struct NetworkMessageReader(ReadOnlySpan<byte> data)
     /// </summary>
     /// <returns>The message type.</returns>
     /// <remarks>
-    /// Note: This is a simplified approach that consumes the byte.
-    /// In production you'd want proper peek support.
+    /// The reader position is restored after reading, so subsequent reads
+    /// (such as <see cref="ReadHeader"/>) observe the message type byte again.
     /// </remarks>
-    public MessageType PeekMessageType()
+    public readonly MessageType PeekMessageType()
     {
-        return (MessageType)reader.ReadByte();
+        // BitReader is a value type; copy it, read from the copy, and leave
+        // the underlying reader position untouched so this is a true peek.
+        var peek = reader;
+        return (MessageType)peek.ReadByte();
     }
 
     /// <summary>

--- a/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
+++ b/tests/KeenEyes.Navigation.DotRecast.Tests/DotRecastProviderTests.cs
@@ -155,6 +155,36 @@ public class DotRecastProviderTests : IDisposable
 
     #region Async Request Tests
 
+    [Fact]
+    public void RequestPath_MultipleRequests_ProduceUniqueIds()
+    {
+        using var p = new DotRecastProvider(TestHelper.CreateTestConfig());
+
+        using var request1 = p.RequestPath(Vector3.Zero, new Vector3(5f, 0f, 5f), AgentSettings.Default);
+        using var request2 = p.RequestPath(Vector3.Zero, new Vector3(6f, 0f, 6f), AgentSettings.Default);
+        using var request3 = p.RequestPath(Vector3.Zero, new Vector3(7f, 0f, 7f), AgentSettings.Default);
+
+        Assert.NotEqual(request1.Id, request2.Id);
+        Assert.NotEqual(request2.Id, request3.Id);
+        Assert.NotEqual(request1.Id, request3.Id);
+    }
+
+    [Fact]
+    public void RequestPath_SeparateProviders_UseIndependentIdCounters()
+    {
+        // Request IDs are per-provider (instance) state, not process-wide.
+        // A freshly constructed provider must restart its own counter regardless
+        // of how many requests any other provider has issued.
+        using var providerA = new DotRecastProvider(TestHelper.CreateTestConfig());
+        using var requestA1 = providerA.RequestPath(Vector3.Zero, new Vector3(5f, 0f, 5f), AgentSettings.Default);
+        _ = providerA.RequestPath(Vector3.Zero, new Vector3(6f, 0f, 6f), AgentSettings.Default);
+
+        using var providerB = new DotRecastProvider(TestHelper.CreateTestConfig());
+        using var requestB1 = providerB.RequestPath(Vector3.Zero, new Vector3(5f, 0f, 5f), AgentSettings.Default);
+
+        Assert.Equal(requestA1.Id, requestB1.Id);
+    }
+
     [Fact(Skip = SkipReason)]
     public void RequestPath_ReturnsPathRequest()
     {

--- a/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
+++ b/tests/KeenEyes.Navigation.Grid.Tests/GridNavigationProviderTests.cs
@@ -153,6 +153,34 @@ public class GridNavigationProviderTests : IDisposable
     }
 
     [Fact]
+    public void RequestPath_MultipleRequests_ProduceUniqueIds()
+    {
+        using var request1 = provider.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+        using var request2 = provider.RequestPath(Vector3.Zero, new Vector3(6, 0, 6), AgentSettings.Default);
+        using var request3 = provider.RequestPath(Vector3.Zero, new Vector3(7, 0, 7), AgentSettings.Default);
+
+        Assert.NotEqual(request1.Id, request2.Id);
+        Assert.NotEqual(request2.Id, request3.Id);
+        Assert.NotEqual(request1.Id, request3.Id);
+    }
+
+    [Fact]
+    public void RequestPath_SeparateProviders_UseIndependentIdCounters()
+    {
+        // Request IDs are per-provider (instance) state, not process-wide.
+        // A freshly constructed provider must restart its own counter regardless
+        // of how many requests any other provider has issued.
+        using var providerA = new GridNavigationProvider(config);
+        using var requestA1 = providerA.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+        _ = providerA.RequestPath(Vector3.Zero, new Vector3(6, 0, 6), AgentSettings.Default);
+
+        using var providerB = new GridNavigationProvider(config);
+        using var requestB1 = providerB.RequestPath(Vector3.Zero, new Vector3(5, 0, 5), AgentSettings.Default);
+
+        Assert.Equal(requestA1.Id, requestB1.Id);
+    }
+
+    [Fact]
     public void RequestPath_AfterUpdate_CompletesPath()
     {
         using var request = provider.RequestPath(

--- a/tests/KeenEyes.Network.Tests/NetworkMessageProtocolTests.cs
+++ b/tests/KeenEyes.Network.Tests/NetworkMessageProtocolTests.cs
@@ -250,6 +250,28 @@ public class NetworkMessageProtocolTests
         Assert.Equal(MessageType.EntitySpawn, peekedType);
     }
 
+    [Fact]
+    public void PeekMessageType_DoesNotAdvanceReader()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.EntitySpawn, 42);
+
+        var reader = new NetworkMessageReader(writer.GetWrittenSpan());
+        var bitsBeforePeek = reader.BitsRemaining;
+
+        var peekedType = reader.PeekMessageType();
+
+        // A true peek must leave the reader position untouched...
+        Assert.Equal(MessageType.EntitySpawn, peekedType);
+        Assert.Equal(bitsBeforePeek, reader.BitsRemaining);
+
+        // ...so the full header (including the message type byte) reads back correctly.
+        reader.ReadHeader(out var type, out var tick);
+        Assert.Equal(MessageType.EntitySpawn, type);
+        Assert.Equal(42u, tick);
+    }
+
     #endregion
 
     #region Writer Properties Tests


### PR DESCRIPTION
## Summary
Fixes #1241 (from nightly review #1208 triage).

- **Nav request IDs → instance** — removed the process-wide `static int nextId` from `GridPathRequest`/`DotRecastPathRequest`; the counter is now a `nextRequestId` instance field on `GridNavigationProvider`/`DotRecastProvider` (per-World state). IDs were already unique — this is purely the "No Static State" isolation fix.
- **`PeekMessageType` is now a true peek** — reads from a copy of the (value-type) `BitReader` and leaves the underlying reader unadvanced; method is now `readonly` and the doc corrected. (It's referenced by tests, so it wasn't dead.)
- **AutoSave magic const** — extracted `BaselineRetentionMargin = 5`, used in both `CleanupOldDeltas` and `FindHighestDeltaSequence` (byte-identical behavior).
- **`IEntityBuilder<TSelf>` docs** — added missing `<typeparam>`/`<param>`/`<returns>` tags.

## Test plan
- [x] Nav: separate providers use independent counters + unique IDs (fail-on-old: static counter carried across providers). Peek: `BitsRemaining` unchanged + correct type (fail-on-old: byte was consumed)
- [x] Grid 170, DotRecast 123, Network 326, Core 2337; full suite 14,677, 0 failed; 0 warnings; format clean

## Related
Closes #1241