### PR TITLE
fix(network): Harden network/replay deserialization against malformed input (DoS)

### DIFF
--- a/src/KeenEyes.Network.Abstractions/Serialization/BitReader.cs
+++ b/src/KeenEyes.Network.Abstractions/Serialization/BitReader.cs
@@ -72,6 +72,12 @@ public ref struct BitReader
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ReadBool()
     {
+        if (bytePosition >= buffer.Length)
+        {
+            throw new NetworkProtocolException(
+                "Attempted to read past the end of the buffer while reading a boolean.");
+        }
+
         var value = (buffer[bytePosition] >> bitOffset) & 1;
         AdvanceBits(1);
         return value == 1;
@@ -90,6 +96,12 @@ public ref struct BitReader
         if (bits < 1 || bits > 32)
         {
             throw new ArgumentOutOfRangeException(nameof(bits), "Bits must be between 1 and 32.");
+        }
+
+        if (bits > BitsRemaining)
+        {
+            throw new NetworkProtocolException(
+                $"Attempted to read {bits} bits but only {BitsRemaining} remain in the buffer.");
         }
 
         uint value = 0;
@@ -209,8 +221,22 @@ public ref struct BitReader
     /// </summary>
     /// <param name="count">The number of bytes to read.</param>
     /// <returns>A new byte array containing the read data.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when count is negative.</exception>
+    /// <exception cref="NetworkProtocolException">
+    /// Thrown when count exceeds the number of bytes remaining in the buffer.
+    /// </exception>
     public byte[] ReadBytes(int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        // Validate against the remaining buffer BEFORE allocating so an
+        // attacker-controlled length cannot drive a large speculative allocation.
+        if ((long)count * 8 > BitsRemaining)
+        {
+            throw new NetworkProtocolException(
+                $"Attempted to read {count} bytes but only {BitsRemaining / 8} remain in the buffer.");
+        }
+
         var result = new byte[count];
         ReadBytes(result);
         return result;

--- a/src/KeenEyes.Network.Abstractions/Serialization/NetworkProtocolException.cs
+++ b/src/KeenEyes.Network.Abstractions/Serialization/NetworkProtocolException.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.Network.Serialization;
+
+/// <summary>
+/// Thrown when network data cannot be deserialized because it is truncated,
+/// malformed, or otherwise violates the wire protocol.
+/// </summary>
+/// <remarks>
+/// This is a defined, catchable failure mode for untrusted input. Deserialization
+/// paths throw this instead of leaking low-level exceptions such as
+/// <see cref="IndexOutOfRangeException"/>, so callers draining packets can catch a
+/// single type and drop the offending message.
+/// </remarks>
+public sealed class NetworkProtocolException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NetworkProtocolException"/> class.
+    /// </summary>
+    public NetworkProtocolException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NetworkProtocolException"/> class
+    /// with a message describing the protocol violation.
+    /// </summary>
+    /// <param name="message">The message describing the protocol violation.</param>
+    public NetworkProtocolException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NetworkProtocolException"/> class
+    /// with a message and the underlying cause.
+    /// </summary>
+    /// <param name="message">The message describing the protocol violation.</param>
+    /// <param name="innerException">The exception that caused this protocol failure.</param>
+    public NetworkProtocolException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/KeenEyes.Network/NetworkClientPlugin.cs
+++ b/src/KeenEyes.Network/NetworkClientPlugin.cs
@@ -383,74 +383,86 @@ public sealed class NetworkClientPlugin(INetworkTransport transport, ClientNetwo
 
     private void OnDataReceived(int connectionId, ReadOnlySpan<byte> data)
     {
-        var reader = new NetworkMessageReader(data);
-        reader.ReadHeader(out var messageType, out var tick);
-
-        UpdateTick(tick);
-
-        switch (messageType)
+        // Guard the per-message dispatch: this runs every frame from the transport
+        // drain loop (TcpTransport.Update()/UdpTransport.Update()), so one malformed
+        // or truncated packet from the server must be dropped, not allowed to crash
+        // the loop and take down the client.
+        try
         {
-            case MessageType.ConnectionAccepted:
-                localClientId = reader.ReadSignedBits(16);
-                isConnected = true;
-                Connected?.Invoke();
-                break;
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var messageType, out var tick);
 
-            case MessageType.ConnectionRejected:
-                HandleConnectionRejected(ref reader);
-                break;
+            UpdateTick(tick);
 
-            case MessageType.EntitySpawn:
-                reader.ReadEntitySpawn(out var spawnNetworkId, out var ownerId);
-                // Dedupe: a fresh client can receive both a FullSnapshot and the
-                // NeedsFullSync EntitySpawn broadcast for the same network ID in one tick.
-                // Spawning unconditionally created a second ghost and orphaned the first
-                // (RegisterMapping overwrites), so reuse the existing entity if present (#1101).
-                if (!networkIdManager.TryGetLocalEntity(spawnNetworkId, out var spawnedEntity))
-                {
-                    spawnedEntity = SpawnNetworkedEntity(spawnNetworkId, ownerId);
-                }
+            switch (messageType)
+            {
+                case MessageType.ConnectionAccepted:
+                    localClientId = reader.ReadSignedBits(16);
+                    isConnected = true;
+                    Connected?.Invoke();
+                    break;
 
-                // Read and apply initial components
-                ApplyComponentUpdates(spawnedEntity, ref reader);
-                break;
+                case MessageType.ConnectionRejected:
+                    HandleConnectionRejected(ref reader);
+                    break;
 
-            case MessageType.EntityDespawn:
-                reader.ReadEntityDespawn(out var despawnNetworkId);
-                DespawnNetworkedEntity(despawnNetworkId);
-                break;
+                case MessageType.EntitySpawn:
+                    reader.ReadEntitySpawn(out var spawnNetworkId, out var ownerId);
+                    // Dedupe: a fresh client can receive both a FullSnapshot and the
+                    // NeedsFullSync EntitySpawn broadcast for the same network ID in one tick.
+                    // Spawning unconditionally created a second ghost and orphaned the first
+                    // (RegisterMapping overwrites), so reuse the existing entity if present (#1101).
+                    if (!networkIdManager.TryGetLocalEntity(spawnNetworkId, out var spawnedEntity))
+                    {
+                        spawnedEntity = SpawnNetworkedEntity(spawnNetworkId, ownerId);
+                    }
 
-            case MessageType.FullSnapshot:
-                HandleFullSnapshot(ref reader);
-                break;
+                    // Read and apply initial components
+                    ApplyComponentUpdates(spawnedEntity, ref reader);
+                    break;
 
-            case MessageType.DeltaSnapshot:
-                HandleDeltaSnapshot(ref reader);
-                break;
+                case MessageType.EntityDespawn:
+                    reader.ReadEntityDespawn(out var despawnNetworkId);
+                    DespawnNetworkedEntity(despawnNetworkId);
+                    break;
 
-            case MessageType.ComponentUpdate:
-                HandleComponentUpdate(ref reader);
-                break;
+                case MessageType.FullSnapshot:
+                    HandleFullSnapshot(ref reader);
+                    break;
 
-            case MessageType.ComponentDelta:
-                HandleComponentDelta(ref reader);
-                break;
+                case MessageType.DeltaSnapshot:
+                    HandleDeltaSnapshot(ref reader);
+                    break;
 
-            case MessageType.Pong:
-                HandlePong();
-                break;
+                case MessageType.ComponentUpdate:
+                    HandleComponentUpdate(ref reader);
+                    break;
 
-            case MessageType.OwnershipTransfer:
-                HandleOwnershipTransfer(ref reader);
-                break;
+                case MessageType.ComponentDelta:
+                    HandleComponentDelta(ref reader);
+                    break;
 
-            case MessageType.HierarchyChange:
-                HandleHierarchyChange(ref reader);
-                break;
+                case MessageType.Pong:
+                    HandlePong();
+                    break;
+
+                case MessageType.OwnershipTransfer:
+                    HandleOwnershipTransfer(ref reader);
+                    break;
+
+                case MessageType.HierarchyChange:
+                    HandleHierarchyChange(ref reader);
+                    break;
+            }
+
+            // Acknowledge received tick
+            AcknowledgeTick(tick);
         }
-
-        // Acknowledge received tick
-        AcknowledgeTick(tick);
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[NetworkClient] Dropped malformed message from connection {connectionId}: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     private void HandleFullSnapshot(ref NetworkMessageReader reader)

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -474,37 +474,49 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
             return;
         }
 
-        var reader = new NetworkMessageReader(data);
-        reader.ReadHeader(out var messageType, out var tick);
-
-        switch (messageType)
+        // Guard the per-message dispatch: this runs every frame from the transport
+        // drain loop (TcpTransport.Update()/UdpTransport.Update()), so one malformed
+        // or truncated packet from any client must be dropped, not allowed to crash
+        // the loop and take down the server (remote DoS).
+        try
         {
-            case MessageType.ClientAck:
-                clientState.LastAckedTick = tick;
-                break;
+            var reader = new NetworkMessageReader(data);
+            reader.ReadHeader(out var messageType, out var tick);
 
-            case MessageType.ClientInput:
-                // Notify listeners with remaining data as input payload
-                // The remaining bytes in the message after the header contain the input
-                var inputPayload = data[5..]; // Skip header (1 byte type + 4 bytes tick)
-                ClientInputReceived?.Invoke(clientId, tick, inputPayload);
-                break;
+            switch (messageType)
+            {
+                case MessageType.ClientAck:
+                    clientState.LastAckedTick = tick;
+                    break;
 
-            case MessageType.OwnerStateUpdate:
-                HandleOwnerStateUpdate(clientId, ref reader);
-                break;
+                case MessageType.ClientInput:
+                    // Notify listeners with remaining data as input payload
+                    // The remaining bytes in the message after the header contain the input
+                    var inputPayload = data[5..]; // Skip header (1 byte type + 4 bytes tick)
+                    ClientInputReceived?.Invoke(clientId, tick, inputPayload);
+                    break;
 
-            case MessageType.OwnershipRequest:
-                HandleOwnershipRequest(clientId, ref reader);
-                break;
+                case MessageType.OwnerStateUpdate:
+                    HandleOwnerStateUpdate(clientId, ref reader);
+                    break;
 
-            case MessageType.Ping:
-                // Respond with pong
-                Span<byte> pongBuffer = stackalloc byte[8];
-                var pongWriter = new NetworkMessageWriter(pongBuffer);
-                pongWriter.WriteHeader(MessageType.Pong, tick);
-                transport.Send(clientId, pongWriter.GetWrittenSpan(), DeliveryMode.Unreliable);
-                break;
+                case MessageType.OwnershipRequest:
+                    HandleOwnershipRequest(clientId, ref reader);
+                    break;
+
+                case MessageType.Ping:
+                    // Respond with pong
+                    Span<byte> pongBuffer = stackalloc byte[8];
+                    var pongWriter = new NetworkMessageWriter(pongBuffer);
+                    pongWriter.WriteHeader(MessageType.Pong, tick);
+                    transport.Send(clientId, pongWriter.GetWrittenSpan(), DeliveryMode.Unreliable);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[NetworkServer] Dropped malformed message from client {clientId}: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/src/KeenEyes.Replay/Ghost/GhostFileFormat.cs
+++ b/src/KeenEyes.Replay/Ghost/GhostFileFormat.cs
@@ -458,6 +458,16 @@ public static class GhostFileFormat
             throw new InvalidDataException("Invalid ghost file: invalid metadata or data length.");
         }
 
+        // Bound declared lengths against the bytes actually remaining in the stream
+        // before they are fed to ReadBytes. A corrupted or malicious header could
+        // otherwise force a multi-gigabyte allocation for data that is not present.
+        var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+        if ((long)metadataLength + dataLength > remaining)
+        {
+            throw new InvalidDataException(
+                "Invalid ghost file: declared metadata/data length exceeds the remaining stream size.");
+        }
+
         return (flags, metadataLength, dataLength);
     }
 

--- a/src/KeenEyes.Replay/ReplayFileFormat.cs
+++ b/src/KeenEyes.Replay/ReplayFileFormat.cs
@@ -465,6 +465,16 @@ public static class ReplayFileFormat
             throw new InvalidDataException("Invalid replay file: invalid metadata or data length.");
         }
 
+        // Bound declared lengths against the bytes actually remaining in the stream
+        // before they are fed to ReadBytes. A corrupted or malicious header could
+        // otherwise force a multi-gigabyte allocation for data that is not present.
+        var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+        if ((long)metadataLength + dataLength > remaining)
+        {
+            throw new InvalidDataException(
+                "Invalid replay file: declared metadata/data length exceeds the remaining stream size.");
+        }
+
         return (flags, metadataLength, dataLength);
     }
 

--- a/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
+++ b/tests/KeenEyes.Network.Abstractions.Tests/BitReaderTests.cs
@@ -331,4 +331,92 @@ public class BitReaderTests
 
         Assert.InRange(result, 99f, 101f);
     }
+
+    [Fact]
+    public void ReadBool_PastEndOfBuffer_ThrowsNetworkProtocolException()
+    {
+        // A single byte holds 8 bits; the 9th ReadBool must fail cleanly rather
+        // than indexing past the buffer with an IndexOutOfRangeException.
+        var ex = Record.Exception(() =>
+        {
+            byte[] data = [0xFF];
+            var reader = new BitReader(data);
+            for (var i = 0; i < 9; i++)
+            {
+                reader.ReadBool();
+            }
+        });
+
+        Assert.IsType<NetworkProtocolException>(ex);
+    }
+
+    [Fact]
+    public void ReadBits_PastEndOfBuffer_ThrowsNetworkProtocolException()
+    {
+        // Two bytes hold 16 bits; requesting a further 8 bits must be rejected.
+        var ex = Record.Exception(() =>
+        {
+            byte[] data = [0x01, 0x02];
+            var reader = new BitReader(data);
+            reader.ReadBits(16);
+            reader.ReadBits(8);
+        });
+
+        Assert.IsType<NetworkProtocolException>(ex);
+    }
+
+    [Fact]
+    public void ReadBits_TruncatedBuffer_DoesNotThrowIndexOutOfRange()
+    {
+        // Regression guard: the failure mode for truncated input must be the
+        // defined NetworkProtocolException, never a raw IndexOutOfRangeException.
+        var ex = Record.Exception(() =>
+        {
+            byte[] data = [0x01];
+            var reader = new BitReader(data);
+            reader.ReadBits(32);
+        });
+
+        Assert.IsType<NetworkProtocolException>(ex);
+        Assert.IsNotType<IndexOutOfRangeException>(ex);
+    }
+
+    [Fact]
+    public void ReadBytes_CountExceedingBuffer_ThrowsNetworkProtocolException()
+    {
+        // An attacker-controlled length must be rejected before allocating the array.
+        var ex = Record.Exception(() =>
+        {
+            byte[] data = [0x01, 0x02, 0x03, 0x04];
+            var reader = new BitReader(data);
+            reader.ReadBytes(int.MaxValue);
+        });
+
+        Assert.IsType<NetworkProtocolException>(ex);
+    }
+
+    [Fact]
+    public void ReadBytes_NegativeCount_ThrowsArgumentOutOfRangeException()
+    {
+        var ex = Record.Exception(() =>
+        {
+            byte[] data = [0x01, 0x02, 0x03, 0x04];
+            var reader = new BitReader(data);
+            reader.ReadBytes(-1);
+        });
+
+        Assert.IsType<ArgumentOutOfRangeException>(ex);
+    }
+
+    [Fact]
+    public void ReadBytes_CountWithinBuffer_ReturnsData()
+    {
+        // Positive case: a valid length still round-trips correctly.
+        byte[] data = [0x0A, 0x0B, 0x0C, 0x0D];
+        var reader = new BitReader(data);
+
+        var result = reader.ReadBytes(4);
+
+        Assert.Equal(data, result);
+    }
 }

--- a/tests/KeenEyes.Network.Tests/NetworkClientPluginTests.cs
+++ b/tests/KeenEyes.Network.Tests/NetworkClientPluginTests.cs
@@ -553,4 +553,43 @@ public sealed class NetworkClientPluginTests
     }
 
     #endregion
+
+    #region Malformed Message Handling
+
+    [Fact]
+    public async Task OnDataReceived_WithTruncatedPacket_DropsMessageWithoutThrowing()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var world = new World();
+        using var serverWorld = new World();
+
+        await server.ListenAsync(7777);
+        var serverPlugin = new NetworkServerPlugin(server);
+        serverWorld.InstallPlugin(serverPlugin);
+
+        var config = new ClientNetworkConfig { ServerAddress = "localhost", ServerPort = 7777 };
+        var plugin = new NetworkClientPlugin(client, config);
+        world.InstallPlugin(plugin);
+
+        await plugin.ConnectAsync();
+        server.Update();
+        client.Update();
+        Assert.True(plugin.IsConnected); // Established before the malformed packet arrives.
+
+        // A truncated packet cannot hold the full header, so parsing reads past the
+        // end of the buffer. The client must drop it rather than let the exception
+        // crash the transport drain loop and disconnect the still-valid session.
+        byte[] truncated = [0x16];
+        server.SendToAll(truncated, DeliveryMode.Unreliable);
+
+        var ex = Record.Exception(() => client.Update());
+
+        Assert.Null(ex);
+        Assert.True(plugin.IsConnected);
+
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Network.Tests/NetworkServerPluginTests.cs
+++ b/tests/KeenEyes.Network.Tests/NetworkServerPluginTests.cs
@@ -705,4 +705,37 @@ public sealed class NetworkServerPluginTests
     }
 
     #endregion
+
+    #region Malformed Message Handling
+
+    [Fact]
+    public async Task OnDataReceived_WithTruncatedPacket_DropsMessageWithoutThrowing()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using var world = new World();
+
+        await server.ListenAsync(7777);
+        var plugin = new NetworkServerPlugin(server);
+        world.InstallPlugin(plugin);
+
+        await client.ConnectAsync("localhost", 7777);
+        server.Update(); // Drain the connect event so the client is registered.
+
+        // A truncated 1-byte packet cannot hold the full 5-byte header, so parsing
+        // reads past the end of the buffer. Draining it from the transport must not
+        // crash the per-frame loop or take down the server (remote DoS guard).
+        byte[] truncated = [0x22];
+        client.Send(0, truncated, DeliveryMode.Unreliable);
+
+        var ex = Record.Exception(() => server.Update());
+
+        Assert.Null(ex);
+        Assert.Equal(1, plugin.ClientCount);
+
+        world.UninstallPlugin("NetworkServer");
+        client.Dispose();
+        server.Dispose();
+    }
+
+    #endregion
 }

--- a/tests/KeenEyes.Replay.Tests/Ghost/GhostFileFormatTests.cs
+++ b/tests/KeenEyes.Replay.Tests/Ghost/GhostFileFormatTests.cs
@@ -297,6 +297,37 @@ public class GhostFileFormatTests
     }
 
     [Fact]
+    public void Read_WithDataLengthExceedingStream_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var ghostData = CreateTestGhostData();
+        var bytes = GhostFileFormat.Write(ghostData);
+
+        // Overwrite the dataLength header field (offset 12, after the 4-byte magic,
+        // 2-byte version, 2-byte flags, and 4-byte metadataLength) with a value far
+        // larger than the file. It must be rejected before a multi-gigabyte allocation.
+        BitConverter.GetBytes(int.MaxValue).CopyTo(bytes, 12);
+
+        // Act & Assert
+        Assert.Throws<InvalidDataException>(() => GhostFileFormat.Read(bytes));
+    }
+
+    [Fact]
+    public void Read_WithMetadataLengthExceedingStream_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var ghostData = CreateTestGhostData();
+        var bytes = GhostFileFormat.Write(ghostData);
+
+        // Overwrite the metadataLength header field (offset 8) with a value far larger
+        // than the file. It must be rejected before a multi-gigabyte allocation.
+        BitConverter.GetBytes(int.MaxValue).CopyTo(bytes, 8);
+
+        // Act & Assert
+        Assert.Throws<InvalidDataException>(() => GhostFileFormat.Read(bytes));
+    }
+
+    [Fact]
     public void Read_AllCompressionModes_RoundTrips()
     {
         // Arrange

--- a/tests/KeenEyes.Replay.Tests/ReplayFileFormatTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayFileFormatTests.cs
@@ -308,6 +308,37 @@ public class ReplayFileFormatTests
     }
 
     [Fact]
+    public void Read_WithDataLengthExceedingStream_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var replayData = CreateTestReplayData();
+        var bytes = ReplayFileFormat.Write(replayData);
+
+        // Overwrite the dataLength header field (offset 12, after the 4-byte magic,
+        // 2-byte version, 2-byte flags, and 4-byte metadataLength) with a value far
+        // larger than the file. It must be rejected before a multi-gigabyte allocation.
+        BitConverter.GetBytes(int.MaxValue).CopyTo(bytes, 12);
+
+        // Act & Assert
+        Assert.Throws<InvalidDataException>(() => ReplayFileFormat.Read(bytes));
+    }
+
+    [Fact]
+    public void Read_WithMetadataLengthExceedingStream_ThrowsInvalidDataException()
+    {
+        // Arrange
+        var replayData = CreateTestReplayData();
+        var bytes = ReplayFileFormat.Write(replayData);
+
+        // Overwrite the metadataLength header field (offset 8) with a value far larger
+        // than the file. It must be rejected before a multi-gigabyte allocation.
+        BitConverter.GetBytes(int.MaxValue).CopyTo(bytes, 8);
+
+        // Act & Assert
+        Assert.Throws<InvalidDataException>(() => ReplayFileFormat.Read(bytes));
+    }
+
+    [Fact]
     public void Read_AllCompressionModes_RoundTrips()
     {
         // Arrange


### PR DESCRIPTION
## Summary
Fixes #1231 (from nightly review #1208 triage). Three trust-boundary input-validation gaps where wire/file length or index fields were used before validation.

- **`BitReader`** — new `NetworkProtocolException`; `ReadBool`/`ReadBits` bounds-check before indexing `buffer[bytePosition]`; `ReadBytes(int count)` validates `count * 8 > BitsRemaining` **before** `new byte[count]`.
- **Transport plugins** — `NetworkServerPlugin`/`NetworkClientPlugin.OnDataReceived` wrap per-message dispatch in try/catch that logs and **drops** the offending packet, so one malformed packet can't crash the per-frame drain loop (`Tcp/UdpTransport.Update()`). The server's `clients.TryGetValue` guard stays outside the try.
- **Replay/ghost file formats** — `ReadHeader` bounds `metadataLength + dataLength` against remaining stream length before `ReadBytes`, preventing a crafted file from forcing a huge allocation.

## Test plan
- [x] Fail-on-old proven per finding: old code threw `IndexOutOfRangeException` / `OutOfMemoryException` / propagated out of `Update()`; new code throws the defined exception or drops the packet
- [x] Network.Abstractions 212, Network 328, Replay 618; full suite 14,684, 0 failed; 0 warnings; format clean

## Related
Closes #1231

Note: adds one new public type, `NetworkProtocolException`, in `KeenEyes.Network.Abstractions`.