### PR TITLE
fix(samples): Teaching-code cleanups from nightly review

### DIFF
--- a/samples/KeenEyes.Sample.AIProximity/Components.cs
+++ b/samples/KeenEyes.Sample.AIProximity/Components.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+
+namespace KeenEyes.Sample.AIProximity;
+
+/// <summary>
+/// Guard AI state machine.
+/// </summary>
+public enum GuardState
+{
+    /// <summary>Patrolling, no threats detected.</summary>
+    Idle,
+
+    /// <summary>Heard something, investigating.</summary>
+    Searching,
+
+    /// <summary>Saw player, actively pursuing.</summary>
+    Alert
+}
+
+/// <summary>
+/// Component for guard AI agents.
+/// </summary>
+[Component]
+public partial struct Guard
+{
+    /// <summary>Maximum distance at which the guard can see a player.</summary>
+    public float VisionRange;
+
+    /// <summary>Maximum distance at which the guard can hear a noisy player.</summary>
+    public float HearingRange;
+
+    /// <summary>Distance within which the guard broadcasts alerts to other guards.</summary>
+    public float AlertRange;
+
+    /// <summary>Current AI state.</summary>
+    public GuardState State;
+
+    /// <summary>Seconds remaining before a searching guard returns to idle.</summary>
+    public float SearchTimer;
+}
+
+/// <summary>
+/// Component for entity velocity.
+/// </summary>
+[Component]
+public partial struct Velocity
+{
+    /// <summary>Velocity vector in world units per second.</summary>
+    public Vector3 Value;
+}
+
+/// <summary>
+/// Component for noise generation (affects hearing detection).
+/// </summary>
+[Component]
+public partial struct Noisy
+{
+    /// <summary>Noise level from 0.0 (silent) to 1.0 (very loud).</summary>
+    public float NoiseLevel;
+}
+
+/// <summary>
+/// Tag component for player entities.
+/// </summary>
+[TagComponent]
+public partial struct Player;

--- a/samples/KeenEyes.Sample.AIProximity/Program.cs
+++ b/samples/KeenEyes.Sample.AIProximity/Program.cs
@@ -1,8 +1,9 @@
 using System.Diagnostics;
 using System.Numerics;
-using KeenEyes;
 using KeenEyes.Common;
 using KeenEyes.Spatial;
+
+namespace KeenEyes.Sample.AIProximity;
 
 /// <summary>
 /// Demonstrates AI proximity detection for vision and hearing using spatial queries.
@@ -10,16 +11,28 @@ using KeenEyes.Spatial;
 /// </summary>
 public static class Program
 {
+    /// <summary>Number of guard AI agents to spawn.</summary>
     public const int GuardCount = 50;
+
+    /// <summary>Number of player targets to spawn.</summary>
     public const int PlayerCount = 10;
+
+    /// <summary>Width and depth of the square world in units.</summary>
     public const float WorldSize = 500f;
+
+    /// <summary>Number of simulation frames to run.</summary>
     public const int FrameCount = 200;
 
-    // AI sensory ranges
+    /// <summary>Distance within which a guard can see a player.</summary>
     public const float VisionRange = 50f;
+
+    /// <summary>Distance within which a guard can hear a noisy player.</summary>
     public const float HearingRange = 100f;
+
+    /// <summary>Distance within which a guard broadcasts alerts to other guards.</summary>
     public const float AlertRange = 150f;
 
+    /// <summary>Application entry point.</summary>
     public static void Main()
     {
         Console.WriteLine("=== AI Proximity Detection Sample ===\n");
@@ -128,279 +141,5 @@ public static class Program
         Console.WriteLine($"\nAverage per frame:");
         Console.WriteLine($"  Vision checks: {stats.TotalVisionDetections / (float)FrameCount:F1}");
         Console.WriteLine($"  Hearing checks: {stats.TotalHearingDetections / (float)FrameCount:F1}");
-    }
-}
-
-/// <summary>
-/// Stats for tracking AI detection performance.
-/// </summary>
-public class DetectionStats
-{
-    public int TotalVisionDetections;
-    public int TotalHearingDetections;
-    public int TotalAlertBroadcasts;
-    public int GuardsInAlertState;
-    public int GuardsInSearchingState;
-}
-
-/// <summary>
-/// Guard AI state machine.
-/// </summary>
-public enum GuardState
-{
-    Idle,       // Patrolling, no threats detected
-    Searching,  // Heard something, investigating
-    Alert       // Saw player, actively pursuing
-}
-
-/// <summary>
-/// Component for guard AI agents.
-/// </summary>
-[Component]
-public partial struct Guard
-{
-    public float VisionRange;
-    public float HearingRange;
-    public float AlertRange;
-    public GuardState State;
-    public float SearchTimer;
-}
-
-/// <summary>
-/// Component for entity velocity.
-/// </summary>
-[Component]
-public partial struct Velocity
-{
-    public Vector3 Value;
-}
-
-/// <summary>
-/// Component for noise generation (affects hearing detection).
-/// </summary>
-[Component]
-public partial struct Noisy
-{
-    public float NoiseLevel;  // 0.0 = silent, 1.0 = very loud
-}
-
-/// <summary>
-/// Tag component for player entities.
-/// </summary>
-[TagComponent]
-public partial struct Player
-{
-}
-
-/// <summary>
-/// System that moves players around the world.
-/// </summary>
-public class PlayerMovementSystem : SystemBase
-{
-    public override void Update(float deltaTime)
-    {
-        foreach (var entity in World.Query<Transform3D, Velocity>().With<Player>())
-        {
-            ref var transform = ref World.Get<Transform3D>(entity);
-            ref var velocity = ref World.Get<Velocity>(entity);
-
-            // Move player
-            transform.Position += velocity.Value * deltaTime;
-
-            // Wrap around world bounds (toroidal world)
-            const float halfSize = Program.WorldSize / 2;
-            if (transform.Position.X < -halfSize)
-            {
-                transform.Position.X += Program.WorldSize;
-            }
-
-            if (transform.Position.X > halfSize)
-            {
-                transform.Position.X -= Program.WorldSize;
-            }
-
-            if (transform.Position.Z < -halfSize)
-            {
-                transform.Position.Z += Program.WorldSize;
-            }
-
-            if (transform.Position.Z > halfSize)
-            {
-                transform.Position.Z -= Program.WorldSize;
-            }
-
-            // Randomly change direction occasionally
-            // Use World's seeded RNG for deterministic replay support
-            if (World.NextFloat() < 0.02f)
-            {
-                velocity.Value = new Vector3(
-                    World.NextFloat() * 20f - 10f,
-                    0,
-                    World.NextFloat() * 20f - 10f);
-            }
-        }
-    }
-}
-
-/// <summary>
-/// System that handles guard AI sensory detection and state management.
-/// </summary>
-public class GuardAISystem(DetectionStats stats) : SystemBase
-{
-    private SpatialQueryApi? spatial;
-
-    protected override void OnInitialize()
-    {
-        spatial = World.GetExtension<SpatialQueryApi>();
-    }
-
-    public override void Update(float deltaTime)
-    {
-        // Reset per-frame stats
-        stats.GuardsInAlertState = 0;
-        stats.GuardsInSearchingState = 0;
-
-        foreach (var guardEntity in World.Query<Transform3D, Guard>())
-        {
-            ref readonly var guardTransform = ref World.Get<Transform3D>(guardEntity);
-            ref var guard = ref World.Get<Guard>(guardEntity);
-
-            // Update guard state based on sensory input
-            UpdateGuardState(guardEntity, ref guard, guardTransform, deltaTime);
-
-            // Count guards by state
-            if (guard.State == GuardState.Alert)
-            {
-                stats.GuardsInAlertState++;
-            }
-            else if (guard.State == GuardState.Searching)
-            {
-                stats.GuardsInSearchingState++;
-            }
-        }
-    }
-
-    private void UpdateGuardState(Entity guardEntity, ref Guard guard, Transform3D guardTransform, float deltaTime)
-    {
-        switch (guard.State)
-        {
-            case GuardState.Idle:
-                CheckForThreats(guardEntity, ref guard, guardTransform);
-                break;
-
-            case GuardState.Searching:
-                guard.SearchTimer -= deltaTime;
-                if (guard.SearchTimer <= 0)
-                {
-                    guard.State = GuardState.Idle;
-                }
-                else
-                {
-                    // While searching, still check for visual confirmation
-                    CheckForThreats(guardEntity, ref guard, guardTransform);
-                }
-                break;
-
-            case GuardState.Alert:
-                // In alert state, check if player is still visible
-                if (!CanSeePlayer(guardTransform, guard.VisionRange))
-                {
-                    // Lost sight, return to searching
-                    guard.State = GuardState.Searching;
-                    guard.SearchTimer = 5.0f;
-                }
-                else
-                {
-                    // Broadcast alert to nearby guards
-                    BroadcastAlert(guardEntity, guardTransform, guard.AlertRange);
-                }
-                break;
-        }
-    }
-
-    private void CheckForThreats(Entity guardEntity, ref Guard guard, Transform3D guardTransform)
-    {
-        // guardEntity reserved for future target tracking
-        _ = guardEntity;
-
-        // Vision check (can see players)
-        if (CanSeePlayer(guardTransform, guard.VisionRange))
-        {
-            guard.State = GuardState.Alert;
-            stats.TotalVisionDetections++;
-            return;
-        }
-
-        // Hearing check (can hear noisy players further away)
-        if (CanHearPlayer(guardTransform, guard.HearingRange) && guard.State == GuardState.Idle)
-        {
-            guard.State = GuardState.Searching;
-            guard.SearchTimer = 3.0f;
-            stats.TotalHearingDetections++;
-        }
-    }
-
-    private bool CanSeePlayer(Transform3D guardTransform, float visionRange)
-    {
-        // Query nearby entities within vision range
-        foreach (var entity in spatial!.QueryRadius<Player>(guardTransform.Position, visionRange))
-        {
-            ref readonly var playerTransform = ref World.Get<Transform3D>(entity);
-
-            // Line-of-sight check (simplified - no obstacles)
-            float distSq = Vector3.DistanceSquared(guardTransform.Position, playerTransform.Position);
-            if (distSq <= visionRange * visionRange)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private bool CanHearPlayer(Transform3D guardTransform, float hearingRange)
-    {
-        // Query nearby entities within hearing range
-        foreach (var entity in spatial!.QueryRadius<Player>(guardTransform.Position, hearingRange))
-        {
-            if (!World.Has<Noisy>(entity))
-            {
-                continue;
-            }
-
-            ref readonly var playerTransform = ref World.Get<Transform3D>(entity);
-            ref readonly var noisy = ref World.Get<Noisy>(entity);
-
-            // Hearing distance affected by noise level
-            float effectiveRange = hearingRange * noisy.NoiseLevel;
-            float distSq = Vector3.DistanceSquared(guardTransform.Position, playerTransform.Position);
-
-            if (distSq <= effectiveRange * effectiveRange)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private void BroadcastAlert(Entity sourceGuard, Transform3D sourceTransform, float alertRange)
-    {
-        // Alert nearby guards (they join the alert state)
-        foreach (var otherGuard in spatial!.QueryRadius<Guard>(sourceTransform.Position, alertRange))
-        {
-            if (otherGuard == sourceGuard)
-            {
-                continue;
-            }
-
-            ref var guard = ref World.Get<Guard>(otherGuard);
-            if (guard.State == GuardState.Idle)
-            {
-                guard.State = GuardState.Searching;
-                guard.SearchTimer = 4.0f;
-                stats.TotalAlertBroadcasts++;
-            }
-        }
     }
 }

--- a/samples/KeenEyes.Sample.AIProximity/Systems.cs
+++ b/samples/KeenEyes.Sample.AIProximity/Systems.cs
@@ -1,0 +1,239 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Spatial;
+
+namespace KeenEyes.Sample.AIProximity;
+
+/// <summary>
+/// Stats for tracking AI detection performance.
+/// </summary>
+public class DetectionStats
+{
+    /// <summary>Total number of vision-based detections across the run.</summary>
+    public int TotalVisionDetections;
+
+    /// <summary>Total number of hearing-based detections across the run.</summary>
+    public int TotalHearingDetections;
+
+    /// <summary>Total number of alert broadcasts between guards.</summary>
+    public int TotalAlertBroadcasts;
+
+    /// <summary>Number of guards currently in the Alert state.</summary>
+    public int GuardsInAlertState;
+
+    /// <summary>Number of guards currently in the Searching state.</summary>
+    public int GuardsInSearchingState;
+}
+
+/// <summary>
+/// System that moves players around the world.
+/// </summary>
+public class PlayerMovementSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Transform3D, Velocity>().With<Player>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            ref var velocity = ref World.Get<Velocity>(entity);
+
+            // Move player
+            transform.Position += velocity.Value * deltaTime;
+
+            // Wrap around world bounds (toroidal world)
+            const float halfSize = Program.WorldSize / 2;
+            if (transform.Position.X < -halfSize)
+            {
+                transform.Position.X += Program.WorldSize;
+            }
+
+            if (transform.Position.X > halfSize)
+            {
+                transform.Position.X -= Program.WorldSize;
+            }
+
+            if (transform.Position.Z < -halfSize)
+            {
+                transform.Position.Z += Program.WorldSize;
+            }
+
+            if (transform.Position.Z > halfSize)
+            {
+                transform.Position.Z -= Program.WorldSize;
+            }
+
+            // Randomly change direction occasionally
+            // Use World's seeded RNG for deterministic replay support
+            if (World.NextFloat() < 0.02f)
+            {
+                velocity.Value = new Vector3(
+                    World.NextFloat() * 20f - 10f,
+                    0,
+                    World.NextFloat() * 20f - 10f);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// System that handles guard AI sensory detection and state management.
+/// </summary>
+public class GuardAISystem(DetectionStats stats) : SystemBase
+{
+    private SpatialQueryApi? spatial;
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        spatial = World.GetExtension<SpatialQueryApi>();
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Reset per-frame stats
+        stats.GuardsInAlertState = 0;
+        stats.GuardsInSearchingState = 0;
+
+        foreach (var guardEntity in World.Query<Transform3D, Guard>())
+        {
+            ref readonly var guardTransform = ref World.Get<Transform3D>(guardEntity);
+            ref var guard = ref World.Get<Guard>(guardEntity);
+
+            // Update guard state based on sensory input
+            UpdateGuardState(guardEntity, ref guard, guardTransform, deltaTime);
+
+            // Count guards by state
+            if (guard.State == GuardState.Alert)
+            {
+                stats.GuardsInAlertState++;
+            }
+            else if (guard.State == GuardState.Searching)
+            {
+                stats.GuardsInSearchingState++;
+            }
+        }
+    }
+
+    private void UpdateGuardState(Entity guardEntity, ref Guard guard, Transform3D guardTransform, float deltaTime)
+    {
+        switch (guard.State)
+        {
+            case GuardState.Idle:
+                CheckForThreats(ref guard, guardTransform);
+                break;
+
+            case GuardState.Searching:
+                guard.SearchTimer -= deltaTime;
+                if (guard.SearchTimer <= 0)
+                {
+                    guard.State = GuardState.Idle;
+                }
+                else
+                {
+                    // While searching, still check for visual confirmation
+                    CheckForThreats(ref guard, guardTransform);
+                }
+                break;
+
+            case GuardState.Alert:
+                // In alert state, check if player is still visible
+                if (!CanSeePlayer(guardTransform, guard.VisionRange))
+                {
+                    // Lost sight, return to searching
+                    guard.State = GuardState.Searching;
+                    guard.SearchTimer = 5.0f;
+                }
+                else
+                {
+                    // Broadcast alert to nearby guards
+                    BroadcastAlert(guardEntity, guardTransform, guard.AlertRange);
+                }
+                break;
+        }
+    }
+
+    private void CheckForThreats(ref Guard guard, Transform3D guardTransform)
+    {
+        // Vision check (can see players)
+        if (CanSeePlayer(guardTransform, guard.VisionRange))
+        {
+            guard.State = GuardState.Alert;
+            stats.TotalVisionDetections++;
+            return;
+        }
+
+        // Hearing check (can hear noisy players further away)
+        if (CanHearPlayer(guardTransform, guard.HearingRange) && guard.State == GuardState.Idle)
+        {
+            guard.State = GuardState.Searching;
+            guard.SearchTimer = 3.0f;
+            stats.TotalHearingDetections++;
+        }
+    }
+
+    private bool CanSeePlayer(Transform3D guardTransform, float visionRange)
+    {
+        // Query nearby entities within vision range
+        foreach (var entity in spatial!.QueryRadius<Player>(guardTransform.Position, visionRange))
+        {
+            ref readonly var playerTransform = ref World.Get<Transform3D>(entity);
+
+            // Line-of-sight check (simplified - no obstacles)
+            float distSq = Vector3.DistanceSquared(guardTransform.Position, playerTransform.Position);
+            if (distSq <= visionRange * visionRange)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool CanHearPlayer(Transform3D guardTransform, float hearingRange)
+    {
+        // Query nearby entities within hearing range
+        foreach (var entity in spatial!.QueryRadius<Player>(guardTransform.Position, hearingRange))
+        {
+            if (!World.Has<Noisy>(entity))
+            {
+                continue;
+            }
+
+            ref readonly var playerTransform = ref World.Get<Transform3D>(entity);
+            ref readonly var noisy = ref World.Get<Noisy>(entity);
+
+            // Hearing distance affected by noise level
+            float effectiveRange = hearingRange * noisy.NoiseLevel;
+            float distSq = Vector3.DistanceSquared(guardTransform.Position, playerTransform.Position);
+
+            if (distSq <= effectiveRange * effectiveRange)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void BroadcastAlert(Entity sourceGuard, Transform3D sourceTransform, float alertRange)
+    {
+        // Alert nearby guards (they join the alert state)
+        foreach (var otherGuard in spatial!.QueryRadius<Guard>(sourceTransform.Position, alertRange))
+        {
+            if (otherGuard == sourceGuard)
+            {
+                continue;
+            }
+
+            ref var guard = ref World.Get<Guard>(otherGuard);
+            if (guard.State == GuardState.Idle)
+            {
+                guard.State = GuardState.Searching;
+                guard.SearchTimer = 4.0f;
+                stats.TotalAlertBroadcasts++;
+            }
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.Aot/Components.cs
+++ b/samples/KeenEyes.Sample.Aot/Components.cs
@@ -1,0 +1,63 @@
+namespace KeenEyes.Sample.Aot;
+
+// ============================================================================
+// Component Definitions (AOT-compatible)
+// ============================================================================
+// Note: There are TWO ways to define components in KeenEyes:
+//
+// 1. [Component] attribute (RECOMMENDED):
+//    [Component]
+//    public partial struct Position { public float X, Y; }
+//
+//    The source generator will implement IComponent automatically and
+//    generate fluent builder methods like WithPosition().
+//
+// 2. Explicit IComponent (shown below):
+//    public struct Position : IComponent { public float X, Y; }
+//
+//    This is also AOT-compatible and demonstrates that no reflection is
+//    used. Useful when you want full control or minimal generated code.
+//
+// Both approaches are equally AOT-compatible. The [Component] attribute is
+// recommended for most use cases as it generates helpful extension methods.
+// ============================================================================
+
+/// <summary>Position component for 2D coordinates.</summary>
+public struct Position : IComponent
+{
+    /// <summary>X coordinate.</summary>
+    public float X;
+
+    /// <summary>Y coordinate.</summary>
+    public float Y;
+}
+
+/// <summary>Velocity component for movement speed.</summary>
+public struct Velocity : IComponent
+{
+    /// <summary>Horizontal velocity.</summary>
+    public float Dx;
+
+    /// <summary>Vertical velocity.</summary>
+    public float Dy;
+}
+
+/// <summary>Health component for entity health tracking.</summary>
+public struct Health : IComponent
+{
+    /// <summary>Current health value.</summary>
+    public int Current;
+
+    /// <summary>Maximum health value.</summary>
+    public int Max;
+}
+
+/// <summary>Tag component marking enemy entities.</summary>
+public struct EnemyTag : ITagComponent;
+
+/// <summary>Singleton for game-wide settings.</summary>
+public struct GameSettings
+{
+    /// <summary>Time scale multiplier.</summary>
+    public float TimeScale;
+}

--- a/samples/KeenEyes.Sample.Aot/Program.cs
+++ b/samples/KeenEyes.Sample.Aot/Program.cs
@@ -17,6 +17,7 @@
 // ============================================================================
 
 using KeenEyes;
+using KeenEyes.Sample.Aot;
 
 Console.WriteLine("KeenEyes Native AOT Sample");
 Console.WriteLine(new string('=', 40));
@@ -114,105 +115,3 @@ Console.WriteLine($"\nGame settings (singleton): TimeScale = {settings.TimeScale
 
 Console.WriteLine("\n" + new string('=', 40));
 Console.WriteLine("Native AOT sample completed successfully!");
-
-// ============================================================================
-// Component Definitions (AOT-compatible)
-// ============================================================================
-// Note: There are TWO ways to define components in KeenEyes:
-//
-// 1. [Component] attribute (RECOMMENDED):
-//    [Component]
-//    public partial struct Position { public float X, Y; }
-//
-//    The source generator will implement IComponent automatically and
-//    generate fluent builder methods like WithPosition().
-//
-// 2. Explicit IComponent (shown below):
-//    public struct Position : IComponent { public float X, Y; }
-//
-//    This is also AOT-compatible and demonstrates that no reflection is
-//    used. Useful when you want full control or minimal generated code.
-//
-// Both approaches are equally AOT-compatible. The [Component] attribute is
-// recommended for most use cases as it generates helpful extension methods.
-// ============================================================================
-
-/// <summary>Position component for 2D coordinates.</summary>
-public struct Position : IComponent
-{
-    /// <summary>X coordinate.</summary>
-    public float X;
-
-    /// <summary>Y coordinate.</summary>
-    public float Y;
-}
-
-/// <summary>Velocity component for movement speed.</summary>
-public struct Velocity : IComponent
-{
-    /// <summary>Horizontal velocity.</summary>
-    public float Dx;
-
-    /// <summary>Vertical velocity.</summary>
-    public float Dy;
-}
-
-/// <summary>Health component for entity health tracking.</summary>
-public struct Health : IComponent
-{
-    /// <summary>Current health value.</summary>
-    public int Current;
-
-    /// <summary>Maximum health value.</summary>
-    public int Max;
-}
-
-/// <summary>Tag component marking enemy entities.</summary>
-public struct EnemyTag : ITagComponent;
-
-/// <summary>Singleton for game-wide settings.</summary>
-public struct GameSettings
-{
-    /// <summary>Time scale multiplier.</summary>
-    public float TimeScale;
-}
-
-// ============================================================================
-// System Definitions (AOT-compatible)
-// ============================================================================
-
-/// <summary>System that updates entity positions based on velocity.</summary>
-public class MovementSystem : SystemBase
-{
-    /// <inheritdoc />
-    public override void Update(float deltaTime)
-    {
-        foreach (var entity in World.Query<Position, Velocity>())
-        {
-            ref var pos = ref World.Get<Position>(entity);
-            ref readonly var vel = ref World.Get<Velocity>(entity);
-
-            pos.X += vel.Dx * deltaTime;
-            pos.Y += vel.Dy * deltaTime;
-        }
-    }
-}
-
-/// <summary>System that regenerates health for non-enemy entities.</summary>
-public class HealthRegenSystem : SystemBase
-{
-    /// <inheritdoc />
-    public override void Update(float deltaTime)
-    {
-        foreach (var entity in World.Query<Health>())
-        {
-            ref var health = ref World.Get<Health>(entity);
-
-            // Regenerate 1 health per second for non-enemies
-            if (!World.Has<EnemyTag>(entity) && health.Current < health.Max)
-            {
-                health.Current = Math.Min(health.Current + (int)(10 * deltaTime), health.Max);
-            }
-        }
-    }
-}

--- a/samples/KeenEyes.Sample.Aot/Systems.cs
+++ b/samples/KeenEyes.Sample.Aot/Systems.cs
@@ -1,0 +1,41 @@
+namespace KeenEyes.Sample.Aot;
+
+// ============================================================================
+// System Definitions (AOT-compatible)
+// ============================================================================
+
+/// <summary>System that updates entity positions based on velocity.</summary>
+public class MovementSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Position, Velocity>())
+        {
+            ref var pos = ref World.Get<Position>(entity);
+            ref readonly var vel = ref World.Get<Velocity>(entity);
+
+            pos.X += vel.Dx * deltaTime;
+            pos.Y += vel.Dy * deltaTime;
+        }
+    }
+}
+
+/// <summary>System that regenerates health for non-enemy entities.</summary>
+public class HealthRegenSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Health>())
+        {
+            ref var health = ref World.Get<Health>(entity);
+
+            // Regenerate 1 health per second for non-enemies
+            if (!World.Has<EnemyTag>(entity) && health.Current < health.Max)
+            {
+                health.Current = Math.Min(health.Current + (int)(10 * deltaTime), health.Max);
+            }
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.CollisionDetection/Components.cs
+++ b/samples/KeenEyes.Sample.CollisionDetection/Components.cs
@@ -1,0 +1,23 @@
+using System.Numerics;
+
+namespace KeenEyes.Sample.CollisionDetection;
+
+/// <summary>
+/// Component representing entity velocity.
+/// </summary>
+[Component]
+public partial struct Velocity
+{
+    /// <summary>Velocity vector in world units per second.</summary>
+    public Vector3 Value;
+}
+
+/// <summary>
+/// Component representing collision radius.
+/// </summary>
+[Component]
+public partial struct CollisionRadius
+{
+    /// <summary>Collision radius in world units.</summary>
+    public float Value;
+}

--- a/samples/KeenEyes.Sample.CollisionDetection/Program.cs
+++ b/samples/KeenEyes.Sample.CollisionDetection/Program.cs
@@ -1,8 +1,9 @@
 using System.Diagnostics;
 using System.Numerics;
-using KeenEyes;
 using KeenEyes.Common;
 using KeenEyes.Spatial;
+
+namespace KeenEyes.Sample.CollisionDetection;
 
 /// <summary>
 /// Demonstrates broadphase/narrowphase collision detection using spatial partitioning.
@@ -10,12 +11,22 @@ using KeenEyes.Spatial;
 /// </summary>
 public static class Program
 {
+    /// <summary>Number of entities to simulate.</summary>
     public const int EntityCount = 1000;
+
+    /// <summary>Width and depth of the square world in units.</summary>
     public const float WorldSize = 1000f;
+
+    /// <summary>Collision radius for each entity.</summary>
     public const float EntityRadius = 5f;
+
+    /// <summary>Maximum entity speed in units per second.</summary>
     public const float MaxSpeed = 50f;
+
+    /// <summary>Number of simulation frames to run per strategy.</summary>
     public const int FrameCount = 100;
 
+    /// <summary>Application entry point.</summary>
     public static void Main()
     {
         Console.WriteLine("=== Collision Detection Sample ===\n");
@@ -138,180 +149,5 @@ public static class Program
         {
             Console.WriteLine($"Total entity pair checks: {stats.BroadphaseChecks}");
         }
-    }
-}
-
-/// <summary>
-/// Class for tracking collision statistics.
-/// </summary>
-public class CollisionStats
-{
-    public int TotalCollisions;
-    public int BroadphaseChecks;
-    public int NarrowphaseChecks;
-}
-
-/// <summary>
-/// Component representing entity velocity.
-/// </summary>
-[Component]
-public partial struct Velocity
-{
-    public Vector3 Value;
-}
-
-/// <summary>
-/// Component representing collision radius.
-/// </summary>
-[Component]
-public partial struct CollisionRadius
-{
-    public float Value;
-}
-
-/// <summary>
-/// System that moves entities based on their velocity.
-/// </summary>
-public class MovementSystem : SystemBase
-{
-    public override void Update(float deltaTime)
-    {
-        foreach (var entity in World.Query<Transform3D, Velocity>())
-        {
-            ref var transform = ref World.Get<Transform3D>(entity);
-            ref readonly var velocity = ref World.Get<Velocity>(entity);
-
-            // Move entity
-            transform.Position += velocity.Value * deltaTime;
-
-            // Wrap around world bounds (simple toroidal world)
-            const float halfSize = Program.WorldSize / 2;
-            if (transform.Position.X < -halfSize)
-            {
-                transform.Position.X += Program.WorldSize;
-            }
-
-            if (transform.Position.X > halfSize)
-            {
-                transform.Position.X -= Program.WorldSize;
-            }
-
-            if (transform.Position.Z < -halfSize)
-            {
-                transform.Position.Z += Program.WorldSize;
-            }
-
-            if (transform.Position.Z > halfSize)
-            {
-                transform.Position.Z -= Program.WorldSize;
-            }
-        }
-    }
-}
-
-/// <summary>
-/// System that detects collisions using spatial partitioning (broadphase + narrowphase).
-/// </summary>
-public class SpatialCollisionSystem(CollisionStats stats) : SystemBase
-{
-    private SpatialQueryApi? spatial;
-
-    protected override void OnInitialize()
-    {
-        spatial = World.GetExtension<SpatialQueryApi>();
-    }
-
-    public override void Update(float deltaTime)
-    {
-        // Check collisions for all entities
-        foreach (var entity in World.Query<Transform3D, CollisionRadius>())
-        {
-            ref readonly var transform = ref World.Get<Transform3D>(entity);
-            ref readonly var radius = ref World.Get<CollisionRadius>(entity);
-
-            // Broadphase: query nearby entities using spatial index
-            foreach (var other in spatial!.QueryRadius(transform.Position, radius.Value * 2))
-            {
-                if (other.Id <= entity.Id)
-                {
-                    continue;  // Skip self and avoid duplicate pairs
-                }
-
-                stats.BroadphaseChecks++;
-
-                // Narrowphase: exact sphere-sphere collision test
-                ref readonly var otherTransform = ref World.Get<Transform3D>(other);
-                ref readonly var otherRadius = ref World.Get<CollisionRadius>(other);
-
-                float combinedRadius = radius.Value + otherRadius.Value;
-                float distSq = Vector3.DistanceSquared(transform.Position, otherTransform.Position);
-
-                stats.NarrowphaseChecks++;
-
-                if (distSq <= combinedRadius * combinedRadius)
-                {
-                    // Collision detected!
-                    stats.TotalCollisions++;
-                    HandleCollision(entity, other);
-                }
-            }
-        }
-    }
-
-    private void HandleCollision(Entity a, Entity b)
-    {
-        // In a real game, you might:
-        // - Trigger events
-        // - Apply physics forces
-        // - Deal damage
-        // - Play sound effects
-        // For this sample, we just count collisions
-    }
-}
-
-/// <summary>
-/// System that detects collisions using naive O(n²) approach (no spatial partitioning).
-/// </summary>
-public class NaiveCollisionSystem(CollisionStats stats) : SystemBase
-{
-
-    public override void Update(float deltaTime)
-    {
-        // Get all entities (inefficient!)
-#pragma warning disable KEEN031 // Intentionally inefficient for performance comparison
-        var entities = World.Query<Transform3D, CollisionRadius>().ToList();
-#pragma warning restore KEEN031
-
-        // Check every pair (O(n²))
-        for (int i = 0; i < entities.Count; i++)
-        {
-            var entity = entities[i];
-            ref readonly var transform = ref World.Get<Transform3D>(entity);
-            ref readonly var radius = ref World.Get<CollisionRadius>(entity);
-
-            for (int j = i + 1; j < entities.Count; j++)
-            {
-                var other = entities[j];
-                stats.BroadphaseChecks++;  // Count all pair checks
-
-                ref readonly var otherTransform = ref World.Get<Transform3D>(other);
-                ref readonly var otherRadius = ref World.Get<CollisionRadius>(other);
-
-                float combinedRadius = radius.Value + otherRadius.Value;
-                float distSq = Vector3.DistanceSquared(transform.Position, otherTransform.Position);
-
-                if (distSq <= combinedRadius * combinedRadius)
-                {
-                    // Collision detected!
-                    stats.TotalCollisions++;
-                    HandleCollision(entity, other);
-                }
-            }
-        }
-    }
-
-    private void HandleCollision(Entity a, Entity b)
-    {
-        // For this sample, we just count collisions
     }
 }

--- a/samples/KeenEyes.Sample.CollisionDetection/Systems.cs
+++ b/samples/KeenEyes.Sample.CollisionDetection/Systems.cs
@@ -1,0 +1,170 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Spatial;
+
+namespace KeenEyes.Sample.CollisionDetection;
+
+/// <summary>
+/// Class for tracking collision statistics.
+/// </summary>
+public class CollisionStats
+{
+    /// <summary>Total number of confirmed collisions.</summary>
+    public int TotalCollisions;
+
+    /// <summary>Number of broadphase candidate pair checks.</summary>
+    public int BroadphaseChecks;
+
+    /// <summary>Number of narrowphase exact collision tests.</summary>
+    public int NarrowphaseChecks;
+}
+
+/// <summary>
+/// System that moves entities based on their velocity.
+/// </summary>
+public class MovementSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        foreach (var entity in World.Query<Transform3D, Velocity>())
+        {
+            ref var transform = ref World.Get<Transform3D>(entity);
+            ref readonly var velocity = ref World.Get<Velocity>(entity);
+
+            // Move entity
+            transform.Position += velocity.Value * deltaTime;
+
+            // Wrap around world bounds (simple toroidal world)
+            const float halfSize = Program.WorldSize / 2;
+            if (transform.Position.X < -halfSize)
+            {
+                transform.Position.X += Program.WorldSize;
+            }
+
+            if (transform.Position.X > halfSize)
+            {
+                transform.Position.X -= Program.WorldSize;
+            }
+
+            if (transform.Position.Z < -halfSize)
+            {
+                transform.Position.Z += Program.WorldSize;
+            }
+
+            if (transform.Position.Z > halfSize)
+            {
+                transform.Position.Z -= Program.WorldSize;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// System that detects collisions using spatial partitioning (broadphase + narrowphase).
+/// </summary>
+public class SpatialCollisionSystem(CollisionStats stats) : SystemBase
+{
+    private SpatialQueryApi? spatial;
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        spatial = World.GetExtension<SpatialQueryApi>();
+    }
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Check collisions for all entities
+        foreach (var entity in World.Query<Transform3D, CollisionRadius>())
+        {
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+            ref readonly var radius = ref World.Get<CollisionRadius>(entity);
+
+            // Broadphase: query nearby entities using spatial index
+            foreach (var other in spatial!.QueryRadius(transform.Position, radius.Value * 2))
+            {
+                if (other.Id <= entity.Id)
+                {
+                    continue;  // Skip self and avoid duplicate pairs
+                }
+
+                stats.BroadphaseChecks++;
+
+                // Narrowphase: exact sphere-sphere collision test
+                ref readonly var otherTransform = ref World.Get<Transform3D>(other);
+                ref readonly var otherRadius = ref World.Get<CollisionRadius>(other);
+
+                float combinedRadius = radius.Value + otherRadius.Value;
+                float distSq = Vector3.DistanceSquared(transform.Position, otherTransform.Position);
+
+                stats.NarrowphaseChecks++;
+
+                if (distSq <= combinedRadius * combinedRadius)
+                {
+                    // Collision detected!
+                    stats.TotalCollisions++;
+                    HandleCollision(entity, other);
+                }
+            }
+        }
+    }
+
+    private void HandleCollision(Entity a, Entity b)
+    {
+        // In a real game, you might:
+        // - Trigger events
+        // - Apply physics forces
+        // - Deal damage
+        // - Play sound effects
+        // For this sample, we just count collisions
+    }
+}
+
+/// <summary>
+/// System that detects collisions using naive O(n²) approach (no spatial partitioning).
+/// </summary>
+public class NaiveCollisionSystem(CollisionStats stats) : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Get all entities (inefficient!)
+#pragma warning disable KEEN031 // Intentionally inefficient for performance comparison
+        var entities = World.Query<Transform3D, CollisionRadius>().ToList();
+#pragma warning restore KEEN031
+
+        // Check every pair (O(n²))
+        for (int i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            ref readonly var transform = ref World.Get<Transform3D>(entity);
+            ref readonly var radius = ref World.Get<CollisionRadius>(entity);
+
+            for (int j = i + 1; j < entities.Count; j++)
+            {
+                var other = entities[j];
+                stats.BroadphaseChecks++;  // Count all pair checks
+
+                ref readonly var otherTransform = ref World.Get<Transform3D>(other);
+                ref readonly var otherRadius = ref World.Get<CollisionRadius>(other);
+
+                float combinedRadius = radius.Value + otherRadius.Value;
+                float distSq = Vector3.DistanceSquared(transform.Position, otherTransform.Position);
+
+                if (distSq <= combinedRadius * combinedRadius)
+                {
+                    // Collision detected!
+                    stats.TotalCollisions++;
+                    HandleCollision(entity, other);
+                }
+            }
+        }
+    }
+
+    private void HandleCollision(Entity a, Entity b)
+    {
+        // For this sample, we just count collisions
+    }
+}

--- a/samples/KeenEyes.Sample.MassSimulation/Program.cs
+++ b/samples/KeenEyes.Sample.MassSimulation/Program.cs
@@ -78,7 +78,6 @@ while (stopwatch.Elapsed < warmupEnd)
 {
     var frameStart = stopwatch.Elapsed.TotalMilliseconds;
     world.Update(FixedDeltaTime);
-    _ = stopwatch.Elapsed.TotalMilliseconds - frameStart;  // Timing captured but unused
 
     // Print progress every 0.5 seconds
     if (frameCount % 30 == 0)

--- a/samples/KeenEyes.Sample.RenderingCulling/Program.cs
+++ b/samples/KeenEyes.Sample.RenderingCulling/Program.cs
@@ -79,7 +79,7 @@ public static class Program
                 new Vector3(0, 200, 500),
                 Quaternion.Identity,
                 Vector3.One))
-            .With(new Camera())
+            .WithTag<Camera>()
             .Build();
 
         // Create stats tracker
@@ -148,13 +148,10 @@ public partial struct Renderable
 }
 
 /// <summary>
-/// Component representing a camera.
+/// Tag component marking an entity as a camera.
 /// </summary>
-[Component]
-public partial struct Camera
-{
-    public bool IsActive;
-}
+[TagComponent]
+public partial struct Camera;
 
 /// <summary>
 /// System that orbits the camera around the origin.

--- a/samples/KeenEyes.Sample.Simulation/Components.cs
+++ b/samples/KeenEyes.Sample.Simulation/Components.cs
@@ -132,6 +132,17 @@ public partial struct Player;
 [TagComponent]
 public partial struct Enemy;
 
+/// <summary>
+/// Marks an enemy as capable of firing projectiles at the player.
+/// </summary>
+/// <remarks>
+/// This semantic tag drives shooting behavior instead of inspecting presentation
+/// data (the rendered symbol), keeping Separation of Concerns intact: systems query
+/// on what an entity <em>is</em>, not on how it happens to be drawn.
+/// </remarks>
+[TagComponent]
+public partial struct RangedAttacker;
+
 /// <summary>Marks an entity as a projectile.</summary>
 [TagComponent]
 public partial struct Projectile;

--- a/samples/KeenEyes.Sample.Simulation/Systems.cs
+++ b/samples/KeenEyes.Sample.Simulation/Systems.cs
@@ -416,6 +416,7 @@ public partial class SpawnerSystem : SystemBase
         char symbol;
         ConsoleColor color;
         int health;
+        bool ranged = false;
 
         int type = World.NextInt(EnemyTypeCount);
         switch (type)
@@ -432,23 +433,35 @@ public partial class SpawnerSystem : SystemBase
                 color = ConsoleColor.Red;
                 health = 2;
                 break;
-            default: // Slow, tough
+            default: // Slow, tough - fires projectiles back at the player
                 symbol = '@';
                 color = ConsoleColor.Magenta;
                 health = 3;
+                ranged = true;
                 vx *= SlowEnemySpeedMultiplier;
                 vy *= SlowEnemySpeedMultiplier;
                 break;
         }
 
-        World.Spawn()
+        var builder = World.Spawn()
             .WithPosition(x: x, y: y)
             .WithVelocity(x: vx, y: vy)
             .WithHealth(current: health, max: health)
             .WithCollider(radius: EnemyColliderRadius)
             .WithRenderable(symbol: symbol, color: color)
-            .WithEnemy()
-            .Build();
+            .WithEnemy();
+
+        // Tough enemies shoot back. The behavior is driven by the semantic
+        // RangedAttacker tag (queried by EnemyShootingSystem) rather than the
+        // rendered symbol, and the Cooldown component gives them a fire-rate timer.
+        if (ranged)
+        {
+            builder = builder
+                .WithCooldown(remaining: 0)
+                .WithRangedAttacker();
+        }
+
+        builder.Build();
     }
 }
 
@@ -590,23 +603,13 @@ public partial class EnemyShootingSystem : SystemBase
 
         ref readonly var playerPos = ref World.Get<Position>(player.Value);
 
-        // Iterate directly - CommandBuffer defers projectile spawns
-        foreach (var entity in World.Query<Position, Cooldown>().With<Enemy>().Without<Dead>())
+        // Iterate directly - CommandBuffer defers projectile spawns.
+        // Query on the semantic RangedAttacker tag rather than the rendered symbol:
+        // systems should filter on what an entity is, not on how it is drawn.
+        foreach (var entity in World.Query<Position, Cooldown>().With<Enemy>().With<RangedAttacker>().Without<Dead>())
         {
             ref readonly var pos = ref World.Get<Position>(entity);
             ref var cooldown = ref World.Get<Cooldown>(entity);
-
-            // Only tough enemies (@) shoot back
-            if (!World.Has<Renderable>(entity))
-            {
-                continue;
-            }
-
-            ref readonly var render = ref World.Get<Renderable>(entity);
-            if (render.Symbol != '@')
-            {
-                continue;
-            }
 
             if (cooldown.Remaining <= 0)
             {

--- a/samples/KeenEyes.Sample.StringTags/Components.cs
+++ b/samples/KeenEyes.Sample.StringTags/Components.cs
@@ -25,18 +25,6 @@ public partial struct Health
 }
 
 /// <summary>
-/// AI behavior component.
-/// </summary>
-[Component]
-public partial struct AIBehavior
-{
-    /// <summary>Current AI state name.</summary>
-    public string State;
-    /// <summary>State timer in seconds.</summary>
-    public float Timer;
-}
-
-/// <summary>
 /// Loot drop table.
 /// </summary>
 [Component]

--- a/samples/KeenEyes.Sample.StringTags/Program.cs
+++ b/samples/KeenEyes.Sample.StringTags/Program.cs
@@ -164,7 +164,6 @@ Console.WriteLine("\n[5] Dynamic State Management with Tags\n");
 var patrollingGuard = world.Spawn()
     .WithPosition(x: 0, y: 0)
     .WithHealth(current: 100, max: 100)
-    .WithAIBehavior(state: "Patrol", timer: 0)
     .WithTag("Guard")
     .WithTag("State:Patrol")
     .Build();

--- a/samples/KeenEyes.Sample.UI/Nodes/MathNodes.cs
+++ b/samples/KeenEyes.Sample.UI/Nodes/MathNodes.cs
@@ -33,7 +33,7 @@ public sealed class NumberNode : INodeTypeDefinition
     /// <inheritdoc />
     public void Initialize(Entity node, IWorld world)
     {
-        // Could add component for storing the value
+        // No per-node state to initialize; the constant value lives in the output port default.
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
Fixes #1240 (from nightly review #1208 triage). Teaching-code cleanups across samples (users copy these).

- **Sample.Simulation** — added `[TagComponent] RangedAttacker`; `EnemyShootingSystem` now queries `.With<RangedAttacker>()` instead of gating on `render.Symbol != '@'`. (The old query also required a `Cooldown` enemies never had — a dead path — so enemies are now tagged + given a `Cooldown` at spawn, making the 'enemies shoot back' behavior actually run.)
- **Sample.AIProximity / CollisionDetection / Aot** — split into `Components.cs`/`Systems.cs` under file-scoped namespaces (were global-namespace top-level-statement files); removed AIProximity's unused `guardEntity` speculative param.
- **Sample.MassSimulation** — removed a computed-then-discarded timing line.
- **Sample.RenderingCulling** — removed unused `Camera.IsActive`; `Camera` is now a `[TagComponent]`.
- **Sample.UI/MathNodes** — corrected the misleading empty-`Initialize` comment.
- **Sample.StringTags** — removed the `AIBehavior` component (spawned but never read; the sample runs on string tags).

## Test plan
- [x] Every touched sample builds `-c Release` 0/0; full `dotnet build KeenEyes.slnx` 0 warnings; format clean
- [x] Samples-only change (no src/tests touched); test suite unaffected (14,672, 0 failed via direct executables)

## Related
Closes #1240