### PR TITLE
test: Strengthen tautological/assertion-free tests to real assertions

### DIFF
--- a/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
+++ b/tests/KeenEyes.Animation.Tests/AnimationSystemTests.cs
@@ -29,11 +29,24 @@ public class AnimationSystemTests : IDisposable
         world = new World();
         world.InstallPlugin(new AnimationPlugin());
 
+        var manager = world.GetExtension<AnimationManager>();
+        var clip = new AnimationClip { Name = "TestClip", Duration = 2f };
+        var clipId = manager.RegisterClip(clip);
+
+        var entity = world.Spawn()
+            .With(AnimationPlayer.ForClip(clipId))
+            .Build();
+
         var system = new AnimationPlayerSystem();
         world.AddSystem(system);
 
-        // Should not throw during update
-        system.Update(1f / 60f);
+        // Locating the AnimationManager lets the system resolve the clip and advance
+        // playback. If the manager were not found, the clip would be unresolved and the
+        // time would stay at zero (see AnimationPlayerSystem_SkipsInvalidClipId).
+        system.Update(0.5f);
+
+        ref readonly var player = ref world.Get<AnimationPlayer>(entity);
+        player.Time.ShouldBe(0.5f, 0.001f);
     }
 
     [Fact]
@@ -45,8 +58,10 @@ public class AnimationSystemTests : IDisposable
         var system = new AnimationPlayerSystem();
         world.AddSystem(system);
 
-        // Should not throw
-        system.Update(1f / 60f);
+        // With no AnimationManager registered, updating must be a safe no-op.
+        var exception = Record.Exception(() => system.Update(1f / 60f));
+
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/tests/KeenEyes.Assets.Tests/MeshAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/MeshAssetTests.cs
@@ -442,9 +442,11 @@ public class MeshAssetTests
         var mesh = new MeshAsset("Test", [], [], [], Vector3.Zero, Vector3.One);
 
         mesh.Dispose();
-        mesh.Dispose(); // Should not throw
 
-        Assert.True(true); // If we got here, no exception was thrown
+        // Disposing a second time must be a safe no-op.
+        var exception = Record.Exception(() => mesh.Dispose());
+
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/tests/KeenEyes.Core.Tests/ComponentValidationManagerTests.cs
+++ b/tests/KeenEyes.Core.Tests/ComponentValidationManagerTests.cs
@@ -259,17 +259,21 @@ public class ComponentValidationManagerTests
         using var world = new World();
         var manager = new ComponentValidationManager(world) { Mode = ValidationMode.Disabled };
 
-        // Register a failing validator
-        ComponentValidator<TestPosition> validator = (w, e, comp) => false;
+        // Register a validator that records whether it was ever invoked.
+        var validatorInvoked = false;
+        ComponentValidator<TestPosition> validator = (w, e, comp) =>
+        {
+            validatorInvoked = true;
+            return false;
+        };
         manager.RegisterValidator(validator);
 
         var entity = world.Spawn().Build();
 
-        // With mode disabled, validation should be skipped even with a failing validator
+        // With mode disabled, validation must be skipped even with a failing validator.
         manager.ValidateAdd(entity, new TestPosition { X = 1, Y = 2 });
 
-        // No exception thrown
-        Assert.True(true);
+        Assert.False(validatorInvoked);
     }
 
     [Fact]
@@ -278,15 +282,36 @@ public class ComponentValidationManagerTests
         using var world = new World();
         var manager = new ComponentValidationManager(world) { Mode = ValidationMode.Disabled };
 
-        var components = new List<(ComponentInfo Info, object Data)>();
-        var info = world.Components.GetOrRegister<TestPosition>();
-        components.Add((info, new TestPosition { X = 1, Y = 2 }));
+        // Register a constraint provider that records whether it was consulted. It also
+        // requires TestPosition for TestVelocity, so if validation ran on the build set
+        // below (which omits TestPosition) it would throw.
+        var providerConsulted = false;
+        ComponentValidationManager.TryGetConstraintsDelegate provider =
+            (Type componentType, out Type[] required, out Type[] conflicts) =>
+            {
+                providerConsulted = true;
+                if (componentType == typeof(TestVelocity))
+                {
+                    required = [typeof(TestPosition)];
+                    conflicts = [];
+                    return true;
+                }
 
-        // With mode disabled, validation should be skipped
+                required = [];
+                conflicts = [];
+                return false;
+            };
+        manager.RegisterConstraintProvider(provider);
+
+        var components = new List<(ComponentInfo Info, object Data)>();
+        var info = world.Components.GetOrRegister<TestVelocity>();
+        components.Add((info, new TestVelocity { X = 1, Y = 2 }));
+
+        // With mode disabled, validation must be skipped: no throw and the provider is
+        // never consulted.
         manager.ValidateBuild(components);
 
-        // No exception thrown
-        Assert.True(true);
+        Assert.False(providerConsulted);
     }
 
     [Fact]
@@ -295,8 +320,13 @@ public class ComponentValidationManagerTests
         using var world = new World();
         var manager = new ComponentValidationManager(world) { Mode = ValidationMode.Disabled };
 
-        // Register a failing validator
-        ComponentValidator<TestPosition> validator = (w, e, comp) => false;
+        // Register a validator that records whether it was ever invoked.
+        var validatorInvoked = false;
+        ComponentValidator<TestPosition> validator = (w, e, comp) =>
+        {
+            validatorInvoked = true;
+            return false;
+        };
         manager.RegisterValidator(validator);
 
         var entity = world.Spawn().Build();
@@ -304,11 +334,10 @@ public class ComponentValidationManagerTests
         var info = world.Components.GetOrRegister<TestPosition>();
         components.Add((info, new TestPosition { X = 1, Y = 2 }));
 
-        // With mode disabled, validation should be skipped
+        // With mode disabled, custom validation must be skipped.
         manager.ValidateBuildCustom(entity, components);
 
-        // No exception thrown
-        Assert.True(true);
+        Assert.False(validatorInvoked);
     }
 
     #endregion

--- a/tests/KeenEyes.Core.Tests/MultiWorldIsolationTests.cs
+++ b/tests/KeenEyes.Core.Tests/MultiWorldIsolationTests.cs
@@ -24,6 +24,12 @@ public partial class MultiWorldIsolationTests
     [TagComponent]
     public partial struct TestTag;
 
+    [Component]
+    public partial struct UpdateMarker
+    {
+        public int Count;
+    }
+
     #endregion
 
     [Fact]
@@ -104,15 +110,24 @@ public partial class MultiWorldIsolationTests
         using var world1 = builder.Build();
         using var world2 = builder.Build();
 
-        // Each world should have its own system instance
-        // Verify worlds are different instances
-        Assert.NotEqual(world1.Id, world2.Id);
+        // Give each world its own entity for the system to process.
+        var entity1 = world1.Spawn().With(new UpdateMarker()).Build();
+        var entity2 = world2.Spawn().With(new UpdateMarker()).Build();
 
-        // Update one world and verify the other is unaffected
+        // Run the system in world1 only, twice.
+        world1.Update(1.0f);
         world1.Update(1.0f);
 
-        // Both worlds should still exist independently
-        Assert.NotEqual(world1.Id, world2.Id);
+        // world1's system instance mutated only world1's data; world2's separate instance
+        // never ran, so its marker is untouched. A shared system/state would leak the count.
+        Assert.Equal(2, world1.Get<UpdateMarker>(entity1).Count);
+        Assert.Equal(0, world2.Get<UpdateMarker>(entity2).Count);
+
+        // Running world2 advances only world2's state, confirming full independence.
+        world2.Update(1.0f);
+
+        Assert.Equal(2, world1.Get<UpdateMarker>(entity1).Count);
+        Assert.Equal(1, world2.Get<UpdateMarker>(entity2).Count);
     }
 
     [Fact]
@@ -249,7 +264,11 @@ public partial class MultiWorldIsolationTests
     {
         public override void Update(float deltaTime)
         {
-            // Simple system for testing
+            foreach (var entity in World.Query<UpdateMarker>())
+            {
+                ref var marker = ref World.Get<UpdateMarker>(entity);
+                marker.Count++;
+            }
         }
     }
 

--- a/tests/KeenEyes.Physics.Tests/PhysicsCollisionCoverageTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsCollisionCoverageTests.cs
@@ -27,7 +27,9 @@ public class PhysicsCollisionCoverageTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
         var physics = world.GetExtension<PhysicsWorld>();
 
-        // Create two bodies with incompatible collision filters
+        // Create two overlapping bodies with incompatible collision filters. Starting them
+        // overlapping guarantees the narrow phase would report contact if filtering were
+        // broken, so a clean run proves the filter actually suppressed the collision.
         var entity1 = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
@@ -40,7 +42,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .Build();
 
         var entity2 = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 3f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 4.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter
@@ -50,14 +52,24 @@ public class PhysicsCollisionCoverageTests : IDisposable
             })
             .Build();
 
+        var collisionDetected = false;
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
+        {
+            if ((collision.EntityA == entity1 && collision.EntityB == entity2) ||
+                (collision.EntityA == entity2 && collision.EntityB == entity1))
+            {
+                collisionDetected = true;
+            }
+        });
+
         // Step simulation multiple times to allow potential collision
         for (int i = 0; i < 60; i++)
         {
             physics.Step(1f / 60f);
         }
 
-        // Both entities should pass through each other (no collision response)
-        // We can verify they didn't stop each other
+        // Incompatible filters must suppress the collision even though the bodies overlap.
+        Assert.False(collisionDetected);
         Assert.True(physics.HasPhysicsBody(entity1));
         Assert.True(physics.HasPhysicsBody(entity2));
     }
@@ -70,11 +82,12 @@ public class PhysicsCollisionCoverageTests : IDisposable
         var physics = world.GetExtension<PhysicsWorld>();
 
         var collisionDetected = false;
-        world.OnComponentAdded<Transform3D>((_, _) => { });
 
-        // Create two bodies that can collide with each other
+        // Create two overlapping bodies whose filters permit collision. Overlapping start
+        // positions force a deterministic contact on the first step, so the collision event
+        // is guaranteed to fire when filtering works.
         var entity1 = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter
@@ -85,7 +98,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .Build();
 
         var entity2 = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 8f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 4.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(new CollisionFilter
@@ -111,8 +124,8 @@ public class PhysicsCollisionCoverageTests : IDisposable
             physics.Step(1f / 60f);
         }
 
-        // Should have detected collision since filters match
-        Assert.True(collisionDetected || physics.HasPhysicsBody(entity1));
+        // Matching filters plus overlapping bodies must produce a collision event.
+        Assert.True(collisionDetected);
     }
 
     #endregion
@@ -134,26 +147,34 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .With(CollisionFilter.Trigger())
             .Build();
 
-        // Create a dynamic body that will fall through the trigger
+        // Create a dynamic body overlapping the trigger volume so a contact is guaranteed.
         var entity = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 10f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 1f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
 
+        var triggerCollisionDetected = false;
         using var subscription = world.Subscribe<CollisionEvent>(collision =>
         {
-            // Subscribe to verify no crash occurs with triggers
+            if (((collision.EntityA == trigger && collision.EntityB == entity) ||
+                 (collision.EntityA == entity && collision.EntityB == trigger)) &&
+                collision.IsTrigger)
+            {
+                triggerCollisionDetected = true;
+            }
         });
 
-        // Step simulation
+        // Step simulation.
         for (int i = 0; i < 60; i++)
         {
             physics.Step(1f / 60f);
         }
 
-        // Trigger event might be detected depending on timing
-        // At minimum, both entities should still exist
+        // The overlap is detected and reported as a trigger collision (IsTrigger), meaning
+        // it was recorded without generating a solid contact constraint. If the trigger were
+        // (incorrectly) treated as solid, IsTrigger would be false and this would never flip.
+        Assert.True(triggerCollisionDetected);
         Assert.True(physics.HasPhysicsBody(trigger));
         Assert.True(physics.HasPhysicsBody(entity));
     }
@@ -169,7 +190,8 @@ public class PhysicsCollisionCoverageTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
         var physics = world.GetExtension<PhysicsWorld>();
 
-        // Create two bodies with different materials
+        // Create two overlapping bodies with different materials so a contact is guaranteed
+        // and the material-combination code path runs.
         var entity1 = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
@@ -178,11 +200,21 @@ public class PhysicsCollisionCoverageTests : IDisposable
             .Build();
 
         var entity2 = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 3f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 4.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .With(PhysicsMaterial.Ice)
             .Build();
+
+        var collisionDetected = false;
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
+        {
+            if ((collision.EntityA == entity1 && collision.EntityB == entity2) ||
+                (collision.EntityA == entity2 && collision.EntityB == entity1))
+            {
+                collisionDetected = true;
+            }
+        });
 
         // Step simulation to allow collision
         for (int i = 0; i < 60; i++)
@@ -190,7 +222,8 @@ public class PhysicsCollisionCoverageTests : IDisposable
             physics.Step(1f / 60f);
         }
 
-        // Verify bodies still exist (collision occurred with combined material properties)
+        // The overlap must produce a collision, exercising the combined-material contact path.
+        Assert.True(collisionDetected);
         Assert.True(physics.HasPhysicsBody(entity1));
         Assert.True(physics.HasPhysicsBody(entity2));
     }
@@ -202,7 +235,7 @@ public class PhysicsCollisionCoverageTests : IDisposable
         world.InstallPlugin(new PhysicsPlugin());
         var physics = world.GetExtension<PhysicsWorld>();
 
-        // Entity with material
+        // Entity with material, overlapping the second body to guarantee a contact.
         var entity1 = world.Spawn()
             .With(new Transform3D(new Vector3(0f, 5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
@@ -212,10 +245,20 @@ public class PhysicsCollisionCoverageTests : IDisposable
 
         // Entity without material (will use default)
         var entity2 = world.Spawn()
-            .With(new Transform3D(new Vector3(0f, 3f, 0f), Quaternion.Identity, Vector3.One))
+            .With(new Transform3D(new Vector3(0f, 4.5f, 0f), Quaternion.Identity, Vector3.One))
             .With(PhysicsShape.Sphere(1f))
             .With(RigidBody.Dynamic(1f))
             .Build();
+
+        var collisionDetected = false;
+        using var subscription = world.Subscribe<CollisionEvent>(collision =>
+        {
+            if ((collision.EntityA == entity1 && collision.EntityB == entity2) ||
+                (collision.EntityA == entity2 && collision.EntityB == entity1))
+            {
+                collisionDetected = true;
+            }
+        });
 
         // Step simulation
         for (int i = 0; i < 60; i++)
@@ -223,6 +266,8 @@ public class PhysicsCollisionCoverageTests : IDisposable
             physics.Step(1f / 60f);
         }
 
+        // The body missing a material must still collide, using the default material.
+        Assert.True(collisionDetected);
         Assert.True(physics.HasPhysicsBody(entity1));
         Assert.True(physics.HasPhysicsBody(entity2));
     }

--- a/tests/KeenEyes.Physics.Tests/PhysicsCoverageImprovementTests.cs
+++ b/tests/KeenEyes.Physics.Tests/PhysicsCoverageImprovementTests.cs
@@ -431,14 +431,23 @@ public class PhysicsCoverageImprovementTests : IDisposable
         world = new World();
         // Don't install physics plugin
 
+        // Spawn a dynamic body whose Transform3D the sync system would interpolate if a
+        // physics world were present. With no physics world, Update must return early and
+        // leave the transform exactly as authored.
+        var authoredPosition = new Vector3(3f, 7f, 11f);
+        var entity = world.Spawn()
+            .With(new Transform3D(authoredPosition, Quaternion.Identity, Vector3.One))
+            .With(RigidBody.Dynamic(1f))
+            .Build();
+
         var system = new KeenEyes.Physics.Systems.PhysicsSyncSystem();
         world.AddSystem(system, SystemPhase.LateUpdate);
 
-        // Should not throw when physics world is not available
+        // Should return early (no physics world) without touching any transform.
         system.Update(1f / 60f);
 
-        // Just verify no exception occurred
-        Assert.NotNull(system);
+        ref readonly var transform = ref world.Get<Transform3D>(entity);
+        Assert.Equal(authoredPosition, transform.Position);
     }
 
     #endregion

--- a/tests/KeenEyes.Replay.Tests/ReplayPlaybackPluginTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayPlaybackPluginTests.cs
@@ -376,14 +376,14 @@ public class ReplayPlaybackPluginTests
     [Fact]
     public void RepeatedInstallUninstall_DoesNotLeakMemory()
     {
-        // Force initial GC
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
+        // Verifies repeated install/uninstall cycles do not root the churned worlds:
+        // once the cycles complete and the disposed worlds fall out of scope, every one
+        // must be eligible for garbage collection. A leaked reference would keep a world
+        // alive and fail the assertion below.
         const int iterations = 100;
 
-        for (int i = 0; i < iterations; i++)
+        // Run each cycle in its own stack frame so no local reference keeps a world alive.
+        static WeakReference RunCycle()
         {
             using var world = new World();
             var plugin = new ReplayPlaybackPlugin();
@@ -401,14 +401,26 @@ public class ReplayPlaybackPluginTests
             }
 
             world.UninstallPlugin<ReplayPlaybackPlugin>();
+
+            return new WeakReference(world);
         }
 
-        // Force cleanup
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        var weakWorlds = new List<WeakReference>(iterations);
+        for (int i = 0; i < iterations; i++)
+        {
+            weakWorlds.Add(RunCycle());
+        }
 
-        Assert.True(true);
+        // Force collection. Retry a few times so a world merely awaiting finalization is not
+        // mistaken for a leak; a genuinely rooted world stays alive across every attempt.
+        for (int attempt = 0; attempt < 10 && weakWorlds.Exists(weakWorld => weakWorld.IsAlive); attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        // Every churned world must have been collected; a survivor indicates a leak.
+        Assert.All(weakWorlds, weakWorld => Assert.False(weakWorld.IsAlive));
     }
 
     [Fact]

--- a/tests/KeenEyes.Replay.Tests/ReplayPluginTests.cs
+++ b/tests/KeenEyes.Replay.Tests/ReplayPluginTests.cs
@@ -594,19 +594,15 @@ public class ReplayPluginTests
     [Fact]
     public void RepeatedInstallUninstall_DoesNotLeakMemory()
     {
-        // This test verifies that repeated install/uninstall cycles don't accumulate resources
-        // by tracking GC collections and ensuring objects are properly cleaned up
-
-        // Force initial GC to establish baseline
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
+        // Verifies repeated install/uninstall cycles do not root the churned worlds:
+        // once the cycles complete and the disposed worlds fall out of scope, every one
+        // must be eligible for garbage collection. A leaked static/global reference would
+        // keep a world alive and fail the assertion below.
         var serializer = new MockComponentSerializer();
         const int iterations = 100;
 
-        // Act - repeated install/uninstall cycles
-        for (int i = 0; i < iterations; i++)
+        // Run each cycle in its own stack frame so no local reference keeps a world alive.
+        static WeakReference RunCycle(MockComponentSerializer serializer, int index)
         {
             using var world = new World();
             var plugin = new ReplayPlugin(serializer);
@@ -614,8 +610,7 @@ public class ReplayPluginTests
 
             var recorder = world.GetExtension<ReplayRecorder>();
 
-            // Do some recording work
-            recorder.StartRecording($"Test {i}");
+            recorder.StartRecording($"Test {index}");
             for (int frame = 0; frame < 10; frame++)
             {
                 recorder.BeginFrame(0.016f);
@@ -626,23 +621,32 @@ public class ReplayPluginTests
 
             world.UninstallPlugin<ReplayPlugin>();
 
-            // World is disposed by using statement
+            return new WeakReference(world);
         }
 
-        // Force GC to clean up
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        var weakWorlds = new List<WeakReference>(iterations);
+        for (int i = 0; i < iterations; i++)
+        {
+            weakWorlds.Add(RunCycle(serializer, i));
+        }
 
-        // If we made it here without running out of memory, the test passes
-        // A more sophisticated test could track WeakReferences to verify cleanup
-        Assert.True(true);
+        // Force collection. Retry a few times so a world merely awaiting finalization is not
+        // mistaken for a leak; a genuinely rooted world stays alive across every attempt.
+        for (int attempt = 0; attempt < 10 && weakWorlds.Exists(weakWorld => weakWorld.IsAlive); attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        // Every churned world must have been collected; a survivor indicates a leak.
+        Assert.All(weakWorlds, weakWorld => Assert.False(weakWorld.IsAlive));
     }
 
     [Fact]
-    public void RepeatedInstallUninstall_WithActiveRecording_CleansUpProperly()
+    public void RepeatedInstallUninstall_WithActiveRecording_StopsRecordingOnUninstall()
     {
-        // Verify that uninstalling while recording is active properly cleans up
+        // Verify that, across repeated churn, uninstalling the plugin while a recording is
+        // active always stops the recording (the recorder's cleanup path runs on uninstall).
         var serializer = new MockComponentSerializer();
         const int iterations = 50;
 
@@ -655,25 +659,19 @@ public class ReplayPluginTests
             var recorder = world.GetExtension<ReplayRecorder>();
             recorder.StartRecording();
 
-            // Record some frames
+            // Record some frames via a full world tick to exercise the recording pipeline.
             for (int frame = 0; frame < 5; frame++)
             {
                 world.Update(0.016f);
             }
 
-            // Uninstall while still recording (should cancel recording)
+            Assert.True(recorder.IsRecording);
+
+            // Uninstall while still recording; the plugin's uninstall must cancel recording.
             world.UninstallPlugin<ReplayPlugin>();
 
-            // Verify recording was stopped
             Assert.False(recorder.IsRecording);
         }
-
-        // Force cleanup
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-
-        Assert.True(true);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes #1236 (from nightly review #1208 triage). Tests that passed regardless of the behavior they name are now real, discriminating assertions (each verified to fail against wrong state). Test files only — no source changes.

- **PhysicsCollisionCoverageTests** — root cause: bodies sleep almost immediately under `Step()`, so contacts rarely formed. Now start bodies **overlapping** for deterministic contact; `AllowCollision` asserts `collisionDetected` directly (dropped the `|| HasPhysicsBody` tautology); trigger/prevent/material variants assert the right event. Verified they fail when the filter/trigger is broken.
- **AnimationSystemTests** — the two no-assert tests now assert playback time advances (manager found) / `Record.Exception` (no-manager).
- **PhysicsCoverageImprovementTests:441** — replaced `Assert.NotNull(system)` with a position-unchanged-after-`Update()` assertion proving early return.
- **ComponentValidationManagerTests** — flag inside the validator/provider, asserted never invoked when disabled (verified fails when enabled). `ValidateBuild` uses a constraint-provider flag since it doesn't run custom validators.
- **ReplayPluginTests/ReplayPlaybackPluginTests** — `WeakReference` + GC assertions for the leak tests; the one exercising `world.Update()` (genuine retention, out of tests-only scope) renamed to assert recording-stops-on-uninstall.
- **MultiWorldIsolationTests** — observes per-world system state via an `UpdateMarker` component instead of re-checking `world.Id`.
- **MeshAssetTests:447** — `Record.Exception` + `Assert.Null` for double-dispose.

## Test plan
- [x] Each rewrite confirmed discriminating (fails against deliberately-wrong state)
- [x] Physics 386, Animation 357, Core 2337, Replay 614, Assets 410; full suite 14,672, 0 failed; 0 warnings; format clean

## Related
Closes #1236