### PR TITLE
fix(codegen): Fix enum bit-width, IBundle immutability, and generator polish

### DIFF
--- a/editor/KeenEyes.Generators/BundleGenerator.cs
+++ b/editor/KeenEyes.Generators/BundleGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using KeenEyes.Generators.Utilities;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
@@ -322,7 +323,38 @@ public sealed class BundleGenerator : IIncrementalGenerator
             }
             return false;
         }
+
+        // KEEN033: bundle structs must be partial so the generator can implement IBundle.
+        // Mirrors the Component/System/Query MustBePartial branches in AttributeUsageAnalyzer.
+        if (!IsPartialType(typeSymbol))
+        {
+            var location = typeSymbol.Locations.FirstOrDefault();
+            if (location is not null)
+            {
+                diagnostics.Add(new DiagnosticInfo(
+                    Diagnostics.BundleMustBePartial,
+                    location,
+                    ImmutableArray.Create(typeSymbol.Name)));
+            }
+            return false;
+        }
+
         return true;
+    }
+
+    private static bool IsPartialType(INamedTypeSymbol typeSymbol)
+    {
+        // Check if any declaration has the partial modifier.
+        foreach (var syntaxRef in typeSymbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl &&
+                typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static List<ComponentFieldInfo>? ExtractAndValidateFields(
@@ -572,8 +604,10 @@ public sealed class BundleGenerator : IIncrementalGenerator
         sb.AppendLine($"partial struct {info.Name} : global::KeenEyes.IBundle");
         sb.AppendLine("{");
 
-        // Generate ComponentTypes static property for IBundle interface implementation
-        // Uses flattened component types to handle nested bundles correctly
+        // Generate ComponentTypes static property for IBundle interface implementation.
+        // Uses flattened component types to handle nested bundles correctly.
+        // The backing array is private and exposed only through a ReadOnlyCollection so
+        // callers cannot mutate (or cast back to) the shared static storage.
         sb.AppendLine("    private static readonly global::System.Type[] s_componentTypes = new global::System.Type[]");
         sb.AppendLine("    {");
         foreach (var componentType in info.FlattenedComponentTypes)
@@ -582,11 +616,14 @@ public sealed class BundleGenerator : IIncrementalGenerator
         }
         sb.AppendLine("    };");
         sb.AppendLine();
+        sb.AppendLine("    private static readonly global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Type> s_componentTypesReadOnly =");
+        sb.AppendLine("        new global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Type>(s_componentTypes);");
+        sb.AppendLine();
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Gets the component types that comprise this bundle.");
         sb.AppendLine("    /// Used for archetype pre-allocation optimization.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    public static global::System.Type[] ComponentTypes => s_componentTypes;");
+        sb.AppendLine("    public static global::System.Collections.Generic.IReadOnlyList<global::System.Type> ComponentTypes => s_componentTypesReadOnly;");
         sb.AppendLine();
 
         // Generate constructor
@@ -922,8 +959,13 @@ public sealed class BundleGenerator : IIncrementalGenerator
             sb.AppendLine($"    {{");
             sb.AppendLine($"        return new {info.FullName}Ref(");
 
-            var refParams = info.Fields.Select(f => $"            ref world.Get<{GetComponentType(f)}>(entity)");
-            sb.AppendLine(string.Join(",\r\n", refParams));
+            // Emit one constructor argument per line via AppendLine so the line endings match
+            // the rest of the generated output (a hardcoded "\r\n" broke on non-Windows agents).
+            for (var fieldIndex = 0; fieldIndex < info.Fields.Length; fieldIndex++)
+            {
+                var separator = fieldIndex < info.Fields.Length - 1 ? "," : string.Empty;
+                sb.AppendLine($"            ref world.Get<{GetComponentType(info.Fields[fieldIndex])}>(entity){separator}");
+            }
 
             sb.AppendLine($"        );");
             sb.AppendLine($"    }}");
@@ -1306,6 +1348,18 @@ internal static partial class Diagnostics
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Bundles must be value types (structs) to maintain consistency with component semantics.");
+
+    /// <summary>
+    /// KEEN033: Bundle struct must be partial.
+    /// </summary>
+    public static readonly DiagnosticDescriptor BundleMustBePartial = new(
+        id: "KEEN033",
+        title: "Bundle must be partial",
+        messageFormat: "Bundle struct '{0}' must be declared with 'partial' modifier",
+        category: "KeenEyes.Bundle",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Bundle structs must be declared as 'partial' to allow source generators to implement the IBundle interface.");
 
     /// <summary>
     /// KEEN021: Bundle field must be a component type.

--- a/editor/KeenEyes.Generators/ReplicatedGenerator.cs
+++ b/editor/KeenEyes.Generators/ReplicatedGenerator.cs
@@ -32,6 +32,18 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Diagnostic reported when a replicated enum field is backed by a 64-bit
+    /// underlying type whose values cannot round-trip through the 32-bit bit-packing channel.
+    /// </summary>
+    private static readonly DiagnosticDescriptor EnumValueExceedsPackedWidth = new(
+        id: "KEEN101",
+        title: "Enum value exceeds bit-packed width",
+        messageFormat: "Enum field '{0}' has an underlying type '{1}' with a value that does not fit in the {2}-bit replication channel. Values above the channel width are truncated. Use a 32-bit-or-smaller underlying type or a custom serializer.",
+        category: "KeenEyes.Network",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -69,6 +81,20 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                         component.Location,
                         component.Name,
                         component.Fields.Length));
+                }
+
+                // Warn about enum fields whose values cannot fit the bit-packed channel.
+                foreach (var field in component.Fields)
+                {
+                    if (field is { SerializationType: FieldSerializationType.Enum, EnumOverflow: true })
+                    {
+                        ctx.ReportDiagnostic(Diagnostic.Create(
+                            EnumValueExceedsPackedWidth,
+                            field.Location,
+                            field.Name,
+                            field.TypeName,
+                            field.EnumBits));
+                    }
                 }
 
                 var partialSource = GenerateNetworkSerializable(component);
@@ -161,12 +187,26 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                 // If types don't match, quantized remains null (skip quantization)
             }
 
+            var serializationType = GetFieldSerializationType(field.Type);
+
+            // For enums, compute the bit width from the underlying type rather than
+            // assuming 8 bits (which silently truncates values >= 256).
+            var enumBits = 0;
+            var enumOverflow = false;
+            if (serializationType == FieldSerializationType.Enum)
+            {
+                (enumBits, enumOverflow) = ComputeEnumBitWidth(field.Type);
+            }
+
             fields.Add(new ReplicatedFieldInfo(
                 field.Name,
                 field.Type.ToDisplayString(),
-                GetFieldSerializationType(field.Type),
+                serializationType,
                 quantized,
-                IsInterpolatable(field.Type)));
+                IsInterpolatable(field.Type),
+                enumBits,
+                enumOverflow,
+                field.Locations.FirstOrDefault()));
         }
 
         return new ReplicatedComponentInfo(
@@ -221,6 +261,70 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
             "System.Numerics.Vector4" => FieldSerializationType.Vector4,
             "System.Numerics.Quaternion" => FieldSerializationType.Quaternion,
             _ => FieldSerializationType.Unsupported
+        };
+    }
+
+    /// <summary>
+    /// Determines the number of bits required to bit-pack an enum field based on its
+    /// underlying type, and whether any declared value overflows the 32-bit channel.
+    /// </summary>
+    private static (int Bits, bool Overflow) ComputeEnumBitWidth(ITypeSymbol type)
+    {
+        // The bit-packing channel (BitWriter.WriteBits / BitReader.ReadBits) supports 1-32 bits.
+        const int channelMax = 32;
+
+        var underlying = type is INamedTypeSymbol { EnumUnderlyingType: { } underlyingType }
+            ? underlyingType.SpecialType
+            : SpecialType.System_Int32;
+
+        var underlyingBits = underlying switch
+        {
+            SpecialType.System_Byte or SpecialType.System_SByte => 8,
+            SpecialType.System_Int16 or SpecialType.System_UInt16 => 16,
+            SpecialType.System_Int32 or SpecialType.System_UInt32 => 32,
+            SpecialType.System_Int64 or SpecialType.System_UInt64 => 64,
+            _ => 32
+        };
+
+        var bits = underlyingBits < channelMax ? underlyingBits : channelMax;
+
+        // Only 64-bit-backed enums can hold values that do not fit the 32-bit channel.
+        var overflow = false;
+        if (underlyingBits > channelMax && type is INamedTypeSymbol enumType)
+        {
+            foreach (var member in enumType.GetMembers())
+            {
+                if (member is IFieldSymbol { IsConst: true, HasConstantValue: true } constField &&
+                    constField.ConstantValue is not null &&
+                    !FitsInBits(constField.ConstantValue, bits))
+                {
+                    overflow = true;
+                    break;
+                }
+            }
+        }
+
+        return (bits, overflow);
+    }
+
+    /// <summary>
+    /// Determines whether an enum constant value round-trips through an unsigned channel of the given bit width.
+    /// </summary>
+    private static bool FitsInBits(object constantValue, int bits)
+    {
+        var max = bits >= 64 ? ulong.MaxValue : (1UL << bits) - 1UL;
+
+        return constantValue switch
+        {
+            ulong u => u <= max,
+            long l => l >= 0 && (ulong)l <= max,
+            uint ui => ui <= max,
+            int i => i >= 0 && (ulong)i <= max,
+            ushort us => us <= max,
+            short s => s >= 0 && (ulong)s <= max,
+            byte b => b <= max,
+            sbyte sb => sb >= 0 && (ulong)sb <= max,
+            _ => false
         };
     }
 
@@ -369,8 +473,8 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                     sb.AppendLine($"        writer.WriteFloat((float){field.Name});");
                     break;
                 case FieldSerializationType.Enum:
-                    // Assume 8-bit enum
-                    sb.AppendLine($"        writer.WriteBits((uint){field.Name}, 8);");
+                    // Bit width is derived from the enum's underlying type (capped at the 32-bit channel).
+                    sb.AppendLine($"        writer.WriteBits(unchecked((uint){field.Name}), {field.EnumBits});");
                     break;
                 case FieldSerializationType.Vector2:
                     sb.AppendLine($"        writer.WriteFloat({field.Name}.X);");
@@ -444,7 +548,7 @@ public sealed class ReplicatedGenerator : IIncrementalGenerator
                     sb.AppendLine($"        {field.Name} = reader.ReadFloat();");
                     break;
                 case FieldSerializationType.Enum:
-                    sb.AppendLine($"        {field.Name} = ({field.TypeName})reader.ReadBits(8);");
+                    sb.AppendLine($"        {field.Name} = ({field.TypeName})reader.ReadBits({field.EnumBits});");
                     break;
                 case FieldSerializationType.Vector2:
                     sb.AppendLine($"        {field.Name} = new System.Numerics.Vector2(reader.ReadFloat(), reader.ReadFloat());");
@@ -850,7 +954,10 @@ internal sealed record ReplicatedFieldInfo(
     string TypeName,
     FieldSerializationType SerializationType,
     QuantizedInfo? Quantized,
-    bool IsInterpolatable);
+    bool IsInterpolatable,
+    int EnumBits,
+    bool EnumOverflow,
+    Location? Location);
 
 internal sealed record QuantizedInfo(float Min, float Max, float Resolution);
 

--- a/editor/KeenEyes.Generators/WorldConfigGenerator.cs
+++ b/editor/KeenEyes.Generators/WorldConfigGenerator.cs
@@ -189,19 +189,24 @@ public sealed class WorldConfigGenerator : IIncrementalGenerator
 
     private static string? FindSimilarType(Compilation compilation, string typeName)
     {
-        var allTypes = compilation.GetSymbolsWithName(
-            name => true,
-            SymbolFilter.Type)
+        var loweredTypeName = typeName.ToLowerInvariant();
+
+        // Push the name-similarity test into the GetSymbolsWithName predicate so Roslyn only
+        // binds the (typically few) symbols whose name is a plausible typo match, instead of
+        // resolving every type symbol in the compilation just to filter afterwards.
+        return compilation.GetSymbolsWithName(IsSimilarName, SymbolFilter.Type)
             .OfType<INamedTypeSymbol>()
             .Where(t => t.TypeKind == TypeKind.Struct)
             .Select(t => t.Name)
-            .ToList();
+            .FirstOrDefault();
 
-        var loweredTypeName = typeName.ToLowerInvariant();
-        return allTypes
-            .FirstOrDefault(t => t.ToLowerInvariant().Contains(loweredTypeName) ||
-                       loweredTypeName.Contains(t.ToLowerInvariant()) ||
-                       LevenshteinDistance(t.ToLowerInvariant(), loweredTypeName) <= 2);
+        bool IsSimilarName(string name)
+        {
+            var lowered = name.ToLowerInvariant();
+            return lowered.Contains(loweredTypeName) ||
+                   loweredTypeName.Contains(lowered) ||
+                   LevenshteinDistance(lowered, loweredTypeName) <= 2;
+        }
     }
 
     private static int LevenshteinDistance(string s1, string s2)

--- a/src/KeenEyes.Abstractions/IBundle.cs
+++ b/src/KeenEyes.Abstractions/IBundle.cs
@@ -54,6 +54,8 @@ public interface IBundle
     /// <remarks>
     /// This static abstract member is implemented by the source generator
     /// and provides AOT-compatible access to bundle component types without reflection.
+    /// The returned list is read-only so callers cannot mutate the shared backing
+    /// storage and corrupt bundle metadata process-wide.
     /// </remarks>
-    static abstract Type[] ComponentTypes { get; }
+    static abstract IReadOnlyList<Type> ComponentTypes { get; }
 }

--- a/src/KeenEyes.Core/World.Archetypes.cs
+++ b/src/KeenEyes.Core/World.Archetypes.cs
@@ -143,7 +143,7 @@ public sealed partial class World
     {
         // Use static abstract interface member for AOT-compatible access (no reflection)
         var componentTypes = TBundle.ComponentTypes;
-        if (componentTypes.Length > 0)
+        if (componentTypes.Count > 0)
         {
             archetypeManager.PreallocateArchetype(componentTypes, initialCapacity);
         }

--- a/tests/KeenEyes.Core.Tests/WorldArchetypePreallocationAdditionalTests.cs
+++ b/tests/KeenEyes.Core.Tests/WorldArchetypePreallocationAdditionalTests.cs
@@ -27,7 +27,7 @@ public sealed class WorldArchetypePreallocationAdditionalTests
 
     private readonly struct TestBundle : IBundle
     {
-        public static Type[] ComponentTypes => [typeof(Component1), typeof(Component2)];
+        public static IReadOnlyList<Type> ComponentTypes => [typeof(Component1), typeof(Component2)];
 
         public Component1 Component1 { get; init; }
         public Component2 Component2 { get; init; }
@@ -35,7 +35,7 @@ public sealed class WorldArchetypePreallocationAdditionalTests
 
     private readonly struct EmptyBundle : IBundle
     {
-        public static Type[] ComponentTypes => [];
+        public static IReadOnlyList<Type> ComponentTypes => [];
     }
 
     private static void RegisterComponents(World world)

--- a/tests/KeenEyes.Generators.Tests/BundleGeneratorTests.cs
+++ b/tests/KeenEyes.Generators.Tests/BundleGeneratorTests.cs
@@ -59,6 +59,75 @@ public class BundleGeneratorTests
     }
 
     [Fact]
+    public void BundleGenerator_ComponentTypes_IsReadOnlyAndNotMutableArray()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Position
+            {
+                public float X;
+                public float Y;
+            }
+
+            [Bundle]
+            public partial struct SimpleBundle
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, generatedTrees) = RunGenerator(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+        // #1234: ComponentTypes must be exposed as a read-only list, never a mutable Type[]
+        // (which callers could mutate to corrupt the shared static backing store).
+        Assert.Contains(generatedTrees, t =>
+            t.Contains("global::System.Collections.Generic.IReadOnlyList<global::System.Type> ComponentTypes"));
+
+        // Regression guard: the old contract returned a mutable array.
+        Assert.DoesNotContain(generatedTrees, t => t.Contains("global::System.Type[] ComponentTypes"));
+
+        // The backing array must be wrapped so it cannot be cast back to Type[] and mutated.
+        Assert.Contains(generatedTrees, t => t.Contains("ReadOnlyCollection<global::System.Type>"));
+    }
+
+    [Fact]
+    public void BundleGenerator_OnNonPartialStruct_ProducesMustBePartialDiagnostic()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace TestApp;
+
+            [Component]
+            public partial struct Position
+            {
+                public float X;
+                public float Y;
+            }
+
+            [Bundle]
+            public struct NotPartialBundle
+            {
+                public Position Position;
+            }
+            """;
+
+        var (diagnostics, _) = RunGenerator(source);
+
+        // #1239(a): a non-partial [Bundle] must get a targeted KEEN033 diagnostic rather than
+        // a raw CS0260 pointing at generated code.
+        Assert.Contains(diagnostics, d =>
+            d.Id == "KEEN033" &&
+            d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
     public void BundleGenerator_ImplementsIBundle()
     {
         var source = """

--- a/tests/KeenEyes.Generators.Tests/GeneratorShapeTests.cs
+++ b/tests/KeenEyes.Generators.Tests/GeneratorShapeTests.cs
@@ -499,4 +499,158 @@ public class GeneratorShapeTests
     }
 
     #endregion
+
+    #region #1234 - IBundle.ComponentTypes is immutable at runtime
+
+    [Fact]
+    public void BundleGenerator_ComponentTypes_CannotBeCastToMutableArray()
+    {
+        var source = """
+            using KeenEyes;
+
+            namespace ShapeApp;
+
+            [Component]
+            public partial struct Position { public float X; public float Y; }
+
+            [Component]
+            public partial struct Velocity { public float X; public float Y; }
+
+            [Bundle]
+            public partial struct MotionBundle
+            {
+                public Position Position;
+                public Velocity Velocity;
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ComponentGenerator(), new BundleGenerator());
+
+        AssertNoCompileErrors(output);
+
+        var assembly = EmitAndLoad(output);
+        var bundleType = assembly.GetType("ShapeApp.MotionBundle")!;
+        var componentTypes = bundleType.GetProperty("ComponentTypes")!.GetValue(null)!;
+
+        // The exposed value must be read-only and must not be castable back to a mutable Type[].
+        Assert.IsNotType<Type[]>(componentTypes, exactMatch: false);
+        Assert.IsType<System.Collections.Generic.IReadOnlyList<Type>>(componentTypes, exactMatch: false);
+
+        var list = (System.Collections.Generic.IReadOnlyList<Type>)componentTypes;
+        Assert.Equal(2, list.Count);
+    }
+
+    #endregion
+
+    #region #1233 - [Replicated] enum fields use the underlying-type bit width (not a fixed 8 bits)
+
+    [Fact]
+    public void ReplicatedGenerator_EnumFieldWithValueAtLeast256_RoundTrips()
+    {
+        // Facing.Far == 300 requires more than 8 bits. The old generator hardcoded 8-bit
+        // enum packing, silently truncating 300 to 44 (300 & 0xFF). With the underlying
+        // (short = 16-bit) width, the value must survive the serialize/deserialize round-trip.
+        var source = """
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            public enum Facing : short
+            {
+                North = 0,
+                Far = 300,
+            }
+
+            [Replicated]
+            public partial struct EnumComp
+            {
+                public Facing Direction;
+            }
+
+            public static class EnumRoundTrip
+            {
+                public static int RoundTrip(int input)
+                {
+                    var comp = new EnumComp { Direction = (Facing)input };
+                    System.Span<byte> buffer = stackalloc byte[64];
+                    var writer = new KeenEyes.Network.Serialization.BitWriter(buffer);
+                    comp.NetworkSerialize(ref writer);
+                    var reader = new KeenEyes.Network.Serialization.BitReader(buffer);
+                    var back = new EnumComp();
+                    back.NetworkDeserialize(ref reader);
+                    return (int)back.Direction;
+                }
+            }
+            """;
+
+        var (output, _, _) = Run(source, new ReplicatedGenerator());
+
+        AssertNoCompileErrors(output);
+
+        var assembly = EmitAndLoad(output);
+        var harness = assembly.GetType("ShapeApp.EnumRoundTrip")!;
+        var roundTrip = harness.GetMethod("RoundTrip")!;
+
+        var result = (int)roundTrip.Invoke(null, [300])!;
+
+        Assert.Equal(300, result);
+    }
+
+    [Fact]
+    public void ReplicatedGenerator_EnumField_EmitsUnderlyingTypeBitWidth()
+    {
+        var source = """
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            public enum Facing : short
+            {
+                North = 0,
+                Far = 300,
+            }
+
+            [Replicated]
+            public partial struct EnumComp
+            {
+                public Facing Direction;
+            }
+            """;
+
+        var (_, _, sources) = Run(source, new ReplicatedGenerator());
+
+        // Regression guard: the old generator emitted a hardcoded 8-bit width.
+        Assert.DoesNotContain(sources, s => s.Contains("ReadBits(8)"));
+        Assert.Contains(sources, s => s.Contains("ReadBits(16)") && s.Contains(", 16)"));
+    }
+
+    [Fact]
+    public void ReplicatedGenerator_LargeSixtyFourBitEnum_EmitsOverflowDiagnostic()
+    {
+        // A ulong-backed enum with a value above the 32-bit channel cannot be bit-packed
+        // losslessly, so the generator must warn (KEEN101) rather than truncate silently.
+        var source = """
+            using KeenEyes.Network;
+
+            namespace ShapeApp;
+
+            public enum HugeFlags : ulong
+            {
+                None = 0,
+                Big = 0x1_0000_0000UL,
+            }
+
+            [Replicated]
+            public partial struct HugeComp
+            {
+                public HugeFlags Flags;
+            }
+            """;
+
+        var (_, generatorDiagnostics, _) = Run(source, new ReplicatedGenerator());
+
+        Assert.Contains(generatorDiagnostics, d => d.Id == "KEEN101");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Fixes #1233, #1234, #1239 (from nightly review #1208 triage) — grouped because the IBundle contract change and BundleGenerator edits would otherwise conflict.

- **#1233** — `[Replicated]` enum fields now derive bit width from the underlying type (byte→8, short→16, int→32) instead of a hardcoded 8, so values ≥256 round-trip. Signed enums use `unchecked((uint)…)`. New `KEEN101` warning when a 64-bit-backed enum value can't fit the 32-bit channel. (Left the #1143 long/ulong paths alone.)
- **#1234** — `IBundle.ComponentTypes` changed from `Type[]` to `IReadOnlyList<Type>`; the generator keeps the backing array private behind a `ReadOnlyCollection<Type>`, so it can't be mutated or cast back. Ripple: `World.PreallocateArchetypeFor` `.Length`→`.Count` (only consumer) + two hand-written test `IBundle` impls.
- **#1239** — (a) non-partial `[Bundle]` structs get a targeted `KEEN033` error (mirroring Component/System/Query); (b) `FindSimilarType` pushes the similarity predicate into `GetSymbolsWithName` so Roslyn only binds plausible matches; (c) per-line `AppendLine` for consistent line endings (`Environment.NewLine` is RS1035-banned in analyzers).

## Test plan
- [x] #1233: emit-and-execute round-trip of a `short`-backed enum value 300 (old truncated to 44) + `ReadBits(16)` assertion + `KEEN101` diagnostic test — all fail-on-old
- [x] #1234: generated member is `IReadOnlyList`/`ReadOnlyCollection`, not castable to `Type[]`
- [x] #1239: `KEEN033` fires for a non-partial `[Bundle]`
- [x] full suite 14,678, 0 failed; 0 warnings; format clean

## Related
Closes #1233
Closes #1234
Closes #1239