### PR TITLE
perf(core): Reduce hot-path allocations and boxing across archetype/query/events/AI/physics

### DIFF
--- a/src/KeenEyes.AI/Core/Blackboard.cs
+++ b/src/KeenEyes.AI/Core/Blackboard.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace KeenEyes.AI;
 
 /// <summary>
@@ -22,8 +24,27 @@ public sealed class Blackboard
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <param name="key">The key to store the value under.</param>
     /// <param name="value">The value to store.</param>
+    /// <remarks>
+    /// Value-type values are stored in a reusable typed cell rather than boxed directly, so
+    /// repeatedly writing the same key with the same value type (a common per-frame pattern,
+    /// e.g. updating a target position) reuses the existing cell and allocates nothing after
+    /// the first write. Reference-type values are stored as-is.
+    /// </remarks>
     public void Set<T>(string key, T value) where T : notnull
     {
+        if (typeof(T).IsValueType)
+        {
+            // Reuse an existing cell of the exact same type to avoid re-boxing on hot writes.
+            if (data.TryGetValue(key, out var existing) && existing is ValueCell<T> cell)
+            {
+                cell.Value = value;
+                return;
+            }
+
+            data[key] = new ValueCell<T>(value);
+            return;
+        }
+
         data[key] = value;
     }
 
@@ -35,7 +56,7 @@ public sealed class Blackboard
     /// <returns>The value if found and of the correct type; otherwise, default.</returns>
     public T? Get<T>(string key)
     {
-        if (data.TryGetValue(key, out var value) && value is T typed)
+        if (data.TryGetValue(key, out var value) && TryUnwrap<T>(value, out var typed))
         {
             return typed;
         }
@@ -52,7 +73,7 @@ public sealed class Blackboard
     /// <returns>The value if found and of the correct type; otherwise, the default value.</returns>
     public T Get<T>(string key, T defaultValue)
     {
-        if (data.TryGetValue(key, out var value) && value is T typed)
+        if (data.TryGetValue(key, out var value) && TryUnwrap<T>(value, out var typed))
         {
             return typed;
         }
@@ -69,7 +90,7 @@ public sealed class Blackboard
     /// <returns>True if the key was found and the value is of the correct type; otherwise, false.</returns>
     public bool TryGet<T>(string key, out T? value)
     {
-        if (data.TryGetValue(key, out var obj) && obj is T typed)
+        if (data.TryGetValue(key, out var obj) && TryUnwrap<T>(obj, out var typed))
         {
             value = typed;
             return true;
@@ -102,4 +123,56 @@ public sealed class Blackboard
     /// Gets the number of entries in the blackboard.
     /// </summary>
     public int Count => data.Count;
+
+    // Resolves a stored value to the requested type, matching the semantics of the original
+    // `stored is T` check. Values written through the value-type fast path live inside a
+    // ValueCell; the exact-type branch unwraps them without boxing, while the IValueCell branch
+    // falls back to the boxed value so cross-type / object / interface lookups behave exactly as
+    // a plain Dictionary<string, object> store would.
+    private static bool TryUnwrap<T>(object stored, [MaybeNullWhen(false)] out T typed)
+    {
+        if (stored is ValueCell<T> exact)
+        {
+            typed = exact.Value;
+            return true;
+        }
+
+        if (stored is IValueCell cell)
+        {
+            if (cell.BoxedValue is T boxed)
+            {
+                typed = boxed;
+                return true;
+            }
+
+            typed = default;
+            return false;
+        }
+
+        if (stored is T direct)
+        {
+            typed = direct;
+            return true;
+        }
+
+        typed = default;
+        return false;
+    }
+
+    // Non-generic view over a typed value cell, used to recover the boxed value on the rare
+    // cross-type lookup path.
+    private interface IValueCell
+    {
+        object BoxedValue { get; }
+    }
+
+    // Holds a value-type value so repeated same-type writes mutate in place instead of
+    // allocating a fresh box each time. Only ever instantiated for value types (see Set),
+    // so the boxed value is never null.
+    private sealed class ValueCell<T>(T value) : IValueCell
+    {
+        public T Value = value;
+
+        public object BoxedValue => Value!;
+    }
 }

--- a/src/KeenEyes.Core/Archetypes/ArchetypeId.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeId.cs
@@ -18,6 +18,12 @@ namespace KeenEyes;
 /// </remarks>
 public readonly struct ArchetypeId : IEquatable<ArchetypeId>
 {
+    // Ordinal comparison of Type.FullName, cached to avoid a per-sort delegate allocation.
+    // Must match the ordering used by the IEnumerable ctor (StringComparer.Ordinal on FullName)
+    // and the CompareOrdinal-based binary search in Has() so archetype identity stays stable.
+    private static readonly Comparison<Type> typeFullNameComparison =
+        static (a, b) => StringComparer.Ordinal.Compare(a.FullName, b.FullName);
+
     private readonly int hashCode;
     private readonly ImmutableArray<Type> componentTypes;
 
@@ -57,6 +63,38 @@ public readonly struct ArchetypeId : IEquatable<ArchetypeId>
     {
         componentTypes = sortedTypes;
         hashCode = precomputedHash;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ArchetypeId"/> from an unsorted span of component types, sorting
+    /// in place and computing the identity hash without any LINQ or iterator allocation.
+    /// </summary>
+    /// <param name="types">
+    /// The component types. The span is sorted in place (the caller must not rely on the
+    /// original ordering afterwards); a copy is taken for the immutable identity.
+    /// </param>
+    /// <returns>The archetype identifier for those component types.</returns>
+    /// <remarks>
+    /// This is the allocation-lean equivalent of <see cref="ArchetypeId(IEnumerable{Type})"/>
+    /// used on the entity-creation hot path. It produces a bit-for-bit identical identity: the
+    /// same ordinal sort order over <see cref="Type.FullName"/> and the same
+    /// <see cref="HashCode"/> accumulation over the sorted types.
+    /// </remarks>
+    internal static ArchetypeId FromUnsortedTypes(Span<Type> types)
+    {
+        // Sort in place with the same ordinal FullName ordering the IEnumerable ctor uses.
+        // FullNames are unique within an archetype, so sort stability does not affect the result.
+        types.Sort(typeFullNameComparison);
+
+        var sorted = ImmutableArray.Create((ReadOnlySpan<Type>)types);
+
+        var hash = new HashCode();
+        foreach (var type in sorted)
+        {
+            hash.Add(type);
+        }
+
+        return new ArchetypeId(sorted, hash.ToHashCode());
     }
 
     /// <summary>

--- a/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
+++ b/src/KeenEyes.Core/Archetypes/ArchetypeManager.cs
@@ -204,7 +204,25 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         {
             lock (syncRoot)
             {
-                var archetype = GetOrCreateArchetypeNoLock(GetTypesSpan(componentArray, componentCount));
+                // Build the archetype identity from the component types using the sorted fast path.
+                // Extract the types into a rented buffer, sort+hash without any LINQ/iterator
+                // allocation, then return the buffer immediately (the id copies it internally).
+                Archetype archetype;
+                var typeBuffer = ArrayPool<Type>.Shared.Rent(componentCount == 0 ? 1 : componentCount);
+                try
+                {
+                    for (int i = 0; i < componentCount; i++)
+                    {
+                        typeBuffer[i] = componentArray[i].Info.Type;
+                    }
+
+                    var id = ArchetypeId.FromUnsortedTypes(typeBuffer.AsSpan(0, componentCount));
+                    archetype = GetOrCreateArchetypeNoLock(id);
+                }
+                finally
+                {
+                    ArrayPool<Type>.Shared.Return(typeBuffer);
+                }
 
                 // Add entity to archetype and write its components into the SAME chunk so the
                 // entity and its component data stay co-located (see issue #1092).
@@ -224,14 +242,6 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         finally
         {
             ArrayPool<(ComponentInfo, object)>.Shared.Return(componentArray);
-        }
-    }
-
-    private static IEnumerable<Type> GetTypesSpan((ComponentInfo Info, object Data)[] components, int count)
-    {
-        for (int i = 0; i < count; i++)
-        {
-            yield return components[i].Info.Type;
         }
     }
 
@@ -645,13 +655,6 @@ public sealed class ArchetypeManager(ComponentRegistry componentRegistry, ChunkP
         }
 
         return true;
-    }
-
-    // Lock-free version for use within locked sections
-    private Archetype GetOrCreateArchetypeNoLock(IEnumerable<Type> componentTypes)
-    {
-        var id = new ArchetypeId(componentTypes);
-        return GetOrCreateArchetypeNoLock(id);
     }
 
     // Lock-free version for use within locked sections

--- a/src/KeenEyes.Core/Events/ComponentEventHandlers.cs
+++ b/src/KeenEyes.Core/Events/ComponentEventHandlers.cs
@@ -199,11 +199,20 @@ internal sealed class ComponentEventHandlers
         private readonly Lock syncRoot = new();
         private readonly List<THandler> list = [];
 
+        // Immutable copy-on-write snapshot of the handler list in registration order.
+        // Rebuilt only when the handler set changes (Add/Remove), so firing a component
+        // lifecycle event never allocates. Invoke methods capture the current reference; the
+        // array is never mutated in place, so handlers that subscribe/unsubscribe during
+        // dispatch do not affect the in-flight invocation (the guarantee the old per-fire
+        // snapshot provided).
+        private THandler[] snapshot = [];
+
         public void Add(THandler handler)
         {
             lock (syncRoot)
             {
                 list.Add(handler);
+                Volatile.Write(ref snapshot, [.. list]);
             }
         }
 
@@ -211,67 +220,41 @@ internal sealed class ComponentEventHandlers
         {
             lock (syncRoot)
             {
-                list.Remove(handler);
+                if (list.Remove(handler))
+                {
+                    Volatile.Write(ref snapshot, [.. list]);
+                }
             }
         }
 
         public void InvokeAdded<T>(Entity entity, in T component) where T : struct, IComponent
         {
-            // Take a snapshot under lock, then invoke outside lock
-            // This prevents deadlocks if handlers try to subscribe/unsubscribe
-            THandler[] snapshot;
-            lock (syncRoot)
-            {
-                if (list.Count == 0)
-                {
-                    return;
-                }
-
-                snapshot = [.. list];
-            }
+            var current = Volatile.Read(ref snapshot);
 
             // Invoke in reverse order to match original behavior
-            for (int i = snapshot.Length - 1; i >= 0; i--)
+            for (int i = current.Length - 1; i >= 0; i--)
             {
-                ((Action<Entity, T>)(object)snapshot[i])(entity, component);
+                ((Action<Entity, T>)(object)current[i])(entity, component);
             }
         }
 
         public void InvokeRemoved(Entity entity)
         {
-            THandler[] snapshot;
-            lock (syncRoot)
-            {
-                if (list.Count == 0)
-                {
-                    return;
-                }
+            var current = Volatile.Read(ref snapshot);
 
-                snapshot = [.. list];
-            }
-
-            for (int i = snapshot.Length - 1; i >= 0; i--)
+            for (int i = current.Length - 1; i >= 0; i--)
             {
-                ((Action<Entity>)(object)snapshot[i])(entity);
+                ((Action<Entity>)(object)current[i])(entity);
             }
         }
 
         public void InvokeChanged<T>(Entity entity, in T oldValue, in T newValue) where T : struct, IComponent
         {
-            THandler[] snapshot;
-            lock (syncRoot)
-            {
-                if (list.Count == 0)
-                {
-                    return;
-                }
+            var current = Volatile.Read(ref snapshot);
 
-                snapshot = [.. list];
-            }
-
-            for (int i = snapshot.Length - 1; i >= 0; i--)
+            for (int i = current.Length - 1; i >= 0; i--)
             {
-                ((Action<Entity, T, T>)(object)snapshot[i])(entity, oldValue, newValue);
+                ((Action<Entity, T, T>)(object)current[i])(entity, oldValue, newValue);
             }
         }
     }

--- a/src/KeenEyes.Core/Events/EventBus.cs
+++ b/src/KeenEyes.Core/Events/EventBus.cs
@@ -205,6 +205,13 @@ public sealed class EventBus
         private readonly Lock syncRoot = new();
         private readonly List<THandler> list = [];
 
+        // Immutable copy-on-write snapshot of the handler list in registration order.
+        // Rebuilt only when the handler set changes (Add/Remove), so publishing a hot event
+        // never allocates. Invoke captures the current reference; because the array is never
+        // mutated in place, handlers that subscribe/unsubscribe during dispatch do not affect
+        // the in-flight invocation (the same guarantee the old per-publish snapshot provided).
+        private THandler[] snapshot = [];
+
         public int Count
         {
             get
@@ -221,6 +228,7 @@ public sealed class EventBus
             lock (syncRoot)
             {
                 list.Add(handler);
+                Volatile.Write(ref snapshot, [.. list]);
             }
         }
 
@@ -228,31 +236,24 @@ public sealed class EventBus
         {
             lock (syncRoot)
             {
-                list.Remove(handler);
+                if (list.Remove(handler))
+                {
+                    Volatile.Write(ref snapshot, [.. list]);
+                }
             }
         }
 
         public void Invoke<T>(in T evt)
         {
-            // Take a snapshot under lock, then invoke outside lock
-            // This prevents deadlocks if handlers try to subscribe/unsubscribe
-            THandler[] snapshot;
-            lock (syncRoot)
-            {
-                if (list.Count == 0)
-                {
-                    return;
-                }
+            // Read the current immutable snapshot without locking. Any concurrent Add/Remove
+            // installs a new array rather than mutating this one, so iteration is stable and
+            // handlers may subscribe/unsubscribe mid-dispatch without affecting this invocation.
+            var current = Volatile.Read(ref snapshot);
 
-                snapshot = [.. list];
-            }
-
-            // Invoke in registration order, as documented. The snapshot taken under
-            // lock lets handlers subscribe or unsubscribe during iteration without
-            // affecting the current dispatch.
-            for (int i = 0; i < snapshot.Length; i++)
+            // Invoke in registration order, as documented.
+            for (int i = 0; i < current.Length; i++)
             {
-                ((Action<T>)(object)snapshot[i])(evt);
+                ((Action<T>)(object)current[i])(evt);
             }
         }
     }

--- a/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
+++ b/src/KeenEyes.Core/Parallelism/ParallelQueryExtensions.cs
@@ -503,7 +503,22 @@ public static class ParallelQueryExtensions
 
     private static List<ArchetypeChunk> CollectChunks(IReadOnlyList<Archetype> archetypes)
     {
-        var chunks = new List<ArchetypeChunk>();
+        // Pre-size the buffer to the exact non-empty chunk count so the list never reallocates
+        // its backing array while filling. A fresh list per call is required for thread-safety:
+        // parallel queries may run concurrently, so a shared reused field would be unsafe.
+        var capacity = 0;
+        foreach (var archetype in archetypes)
+        {
+            foreach (var chunk in archetype.Chunks)
+            {
+                if (chunk.Count > 0)
+                {
+                    capacity++;
+                }
+            }
+        }
+
+        var chunks = new List<ArchetypeChunk>(capacity);
         foreach (var archetype in archetypes)
         {
             foreach (var chunk in archetype.Chunks)

--- a/src/KeenEyes.Parallelism/ParallelSystemScheduler.cs
+++ b/src/KeenEyes.Parallelism/ParallelSystemScheduler.cs
@@ -39,6 +39,14 @@ public sealed class ParallelSystemScheduler
     private IReadOnlyList<SystemBatch>? cachedBatches;
     private bool batchesDirty = true;
 
+    // Reusable scratch buffers for ExecuteBatch, reused across batches to avoid a per-batch,
+    // per-frame List<int> plus a single-element wrapper array allocation. UpdateParallel runs
+    // batches sequentially and is driven by a single game-loop thread, so these buffers are
+    // never used by two batches concurrently. The wrapper holds a stable reference to
+    // batchBufferIds; only the list's contents change per batch.
+    private readonly List<int> batchBufferIds = [];
+    private readonly IEnumerable<int>[] batchBufferIdWrapper;
+
     /// <summary>
     /// Gets the dependency tracker used by this scheduler.
     /// </summary>
@@ -82,6 +90,7 @@ public sealed class ParallelSystemScheduler
         batcher = new ParallelSystemBatcher(dependencyTracker);
         commandBufferPool = new CommandBufferPool();
         parallelOptions = options ?? new ParallelOptions();
+        batchBufferIdWrapper = [batchBufferIds];
     }
 
     /// <summary>
@@ -230,7 +239,9 @@ public sealed class ParallelSystemScheduler
         }
 
         // Collect the stable command-buffer ids for this batch upfront for buffer management.
-        var bufferIds = new List<int>(systems.Count);
+        // Reuse the scratch list/wrapper (batches run sequentially) to avoid per-batch allocation.
+        var bufferIds = batchBufferIds;
+        bufferIds.Clear();
         for (int i = 0; i < systems.Count; i++)
         {
             bufferIds.Add(GetSystemId(systems[i]));
@@ -256,7 +267,7 @@ public sealed class ParallelSystemScheduler
             }
 
             // Flush all command buffers from this batch (also returns them to pool)
-            commandBufferPool.FlushBatches(world, [bufferIds]);
+            commandBufferPool.FlushBatches(world, batchBufferIdWrapper);
         }
         catch
         {

--- a/src/KeenEyes.Physics/Core/BodyLookup.cs
+++ b/src/KeenEyes.Physics/Core/BodyLookup.cs
@@ -119,12 +119,20 @@ internal sealed class BodyLookup
     /// <summary>
     /// Gets all entities with dynamic or kinematic bodies.
     /// </summary>
-    public IEnumerable<Entity> DynamicEntities => entityToBody.Keys;
+    /// <remarks>
+    /// Returns the concrete <see cref="Dictionary{TKey, TValue}.KeyCollection"/> so callers
+    /// enumerate via its value-type enumerator without boxing on every fixed step.
+    /// </remarks>
+    public Dictionary<Entity, BodyHandle>.KeyCollection DynamicEntities => entityToBody.Keys;
 
     /// <summary>
     /// Gets all entities with static bodies.
     /// </summary>
-    public IEnumerable<Entity> StaticEntities => entityToStatic.Keys;
+    /// <remarks>
+    /// Returns the concrete <see cref="Dictionary{TKey, TValue}.KeyCollection"/> so callers
+    /// enumerate via its value-type enumerator without boxing on every fixed step.
+    /// </remarks>
+    public Dictionary<Entity, StaticHandle>.KeyCollection StaticEntities => entityToStatic.Keys;
 
     /// <summary>
     /// Gets the total number of tracked bodies (dynamic + static).

--- a/tests/KeenEyes.AI.Tests/BlackboardHotPathTests.cs
+++ b/tests/KeenEyes.AI.Tests/BlackboardHotPathTests.cs
@@ -1,0 +1,183 @@
+using System.Numerics;
+using KeenEyes.AI;
+using Shouldly;
+
+namespace KeenEyes.AI.Tests;
+
+/// <summary>
+/// Behavior-preservation tests for the Blackboard value-type fast path (issue #1238).
+/// The typed cell that avoids boxing on value-type writes must not change any observable
+/// semantics of the string-keyed get/set API, including cross-type overwrites, boxed/object
+/// lookups, and nullable-value-type handling.
+/// </summary>
+public class BlackboardHotPathTests
+{
+    #region Value-type round trips
+
+    [Fact]
+    public void Set_Vector3_ThenGet_ReturnsSameValue()
+    {
+        var blackboard = new Blackboard();
+        var value = new Vector3(1, 2, 3);
+
+        blackboard.Set("target", value);
+
+        blackboard.Get<Vector3>("target").ShouldBe(value);
+    }
+
+    [Fact]
+    public void Set_SameKeySameType_OverwritesValue()
+    {
+        var blackboard = new Blackboard();
+
+        blackboard.Set("pos", new Vector3(1, 1, 1));
+        blackboard.Set("pos", new Vector3(9, 9, 9));
+
+        blackboard.Get<Vector3>("pos").ShouldBe(new Vector3(9, 9, 9));
+        blackboard.Count.ShouldBe(1);
+    }
+
+    #endregion
+
+    #region Type-mismatch semantics preserved
+
+    [Fact]
+    public void Get_WithWrongValueType_ReturnsDefault()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", 5);
+
+        // A stored int must not satisfy a Get<long>; matches the original `is T` semantics.
+        blackboard.Get<long>("x").ShouldBe(0L);
+    }
+
+    [Fact]
+    public void Get_AsObject_AfterValueTypeSet_ReturnsBoxedValue()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", 42);
+
+        // Get<object> must recover the boxed value, exactly as a Dictionary<string, object>
+        // store would, even though the value lives in a typed cell.
+        var boxed = blackboard.Get<object>("x");
+
+        boxed.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Set_OverwriteValueTypeWithReferenceType_SwitchesStorage()
+    {
+        var blackboard = new Blackboard();
+
+        blackboard.Set("k", 7);
+        blackboard.Set("k", "hello");
+
+        blackboard.Get<string>("k").ShouldBe("hello");
+        blackboard.Get<int>("k").ShouldBe(0);
+        blackboard.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Set_OverwriteReferenceTypeWithValueType_SwitchesStorage()
+    {
+        var blackboard = new Blackboard();
+
+        blackboard.Set("k", "hello");
+        blackboard.Set("k", 7);
+
+        blackboard.Get<int>("k").ShouldBe(7);
+        blackboard.Get<string>("k").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Set_OverwriteValueTypeWithDifferentValueType_SwitchesStorage()
+    {
+        var blackboard = new Blackboard();
+
+        blackboard.Set("k", 7);
+        blackboard.Set("k", 1.5f);
+
+        blackboard.Get<float>("k").ShouldBe(1.5f);
+        blackboard.Get<int>("k").ShouldBe(0);
+    }
+
+    #endregion
+
+    #region Nullable, Has, Remove, TryGet
+
+    [Fact]
+    public void Get_NullableIntType_MatchesUnderlyingBoxedInt()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", 5);
+
+        // A boxed int satisfies both int and int? checks (Nullable boxing rules), preserved
+        // by the boxed-value fallback path.
+        blackboard.Get<int?>("x").ShouldBe(5);
+    }
+
+    [Fact]
+    public void TryGet_ValueType_ReturnsTrueAndValue()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", new Vector3(4, 5, 6));
+
+        blackboard.TryGet<Vector3>("x", out var value).ShouldBeTrue();
+        value.ShouldBe(new Vector3(4, 5, 6));
+    }
+
+    [Fact]
+    public void TryGet_WrongType_ReturnsFalse()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", 5);
+
+        blackboard.TryGet<string>("x", out var value).ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HasAndRemove_WorkForValueTypeCells()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("x", new Vector3(1, 2, 3));
+
+        blackboard.Has("x").ShouldBeTrue();
+        blackboard.Remove("x").ShouldBeTrue();
+        blackboard.Has("x").ShouldBeFalse();
+        blackboard.Count.ShouldBe(0);
+    }
+
+    #endregion
+
+    #region Allocation regression guard
+
+    [Fact]
+    public void Set_RepeatedSameKeyValueType_DoesNotAllocateAfterFirstWrite()
+    {
+        // The old Dictionary<string, object> store boxed the Vector3 on every Set. The typed
+        // cell is allocated once and mutated in place, so a steady-state write loop allocates
+        // nothing.
+        var blackboard = new Blackboard();
+        blackboard.Set("pos", Vector3.Zero);
+
+        // Warm up JIT/tiering and the initial cell allocation.
+        for (int i = 0; i < 512; i++)
+        {
+            blackboard.Set("pos", new Vector3(i, i, i));
+        }
+
+        const int iterations = 4096;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+        {
+            blackboard.Set("pos", new Vector3(i, i, i));
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        allocated.ShouldBeLessThan(1024, $"Expected ~0 steady-state allocation, saw {allocated} bytes.");
+        blackboard.Get<Vector3>("pos").ShouldBe(new Vector3(iterations - 1, iterations - 1, iterations - 1));
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Core.Tests/HotPathAllocationTests.cs
+++ b/tests/KeenEyes.Core.Tests/HotPathAllocationTests.cs
@@ -1,0 +1,236 @@
+using KeenEyes.Events;
+using Health = KeenEyes.Tests.TestHealth;
+using Position = KeenEyes.Tests.TestPosition;
+using Velocity = KeenEyes.Tests.TestVelocity;
+
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Behavior-preservation tests for the hot-path allocation/boxing reductions (issue #1238):
+/// the archetype-identity fast path, the entity-creation type extraction, and the
+/// copy-on-write event snapshots. These assert that the optimized paths preserve the exact
+/// semantics of the code they replaced (identity, hash, dispatch ordering, mid-dispatch safety).
+/// </summary>
+public class HotPathAllocationTests
+{
+    #region ArchetypeId Fast Path
+
+    [Fact]
+    public void FromUnsortedTypes_MatchesEnumerableCtor_IdentityAndHash()
+    {
+        // Every permutation of the same type set must yield an identity that is bit-for-bit
+        // equal (equality + hash) to the LINQ-sorting IEnumerable constructor it replaces.
+        Type[][] orderings =
+        [
+            [typeof(Position), typeof(Velocity), typeof(Health)],
+            [typeof(Health), typeof(Position), typeof(Velocity)],
+            [typeof(Velocity), typeof(Health), typeof(Position)],
+        ];
+
+        var reference = new ArchetypeId([typeof(Position), typeof(Velocity), typeof(Health)]);
+
+        foreach (var ordering in orderings)
+        {
+            var fast = ArchetypeId.FromUnsortedTypes(ordering.AsSpan());
+
+            Assert.Equal(reference, fast);
+            Assert.Equal(reference.GetHashCode(), fast.GetHashCode());
+            Assert.Equal(reference.ComponentTypes, fast.ComponentTypes);
+        }
+    }
+
+    [Fact]
+    public void FromUnsortedTypes_SingleType_MatchesEnumerableCtor()
+    {
+        var reference = new ArchetypeId([typeof(Position)]);
+        var fast = ArchetypeId.FromUnsortedTypes([typeof(Position)]);
+
+        Assert.Equal(reference, fast);
+        Assert.Equal(reference.GetHashCode(), fast.GetHashCode());
+    }
+
+    [Fact]
+    public void FromUnsortedTypes_Empty_MatchesEnumerableCtor()
+    {
+        var reference = new ArchetypeId([]);
+        var fast = ArchetypeId.FromUnsortedTypes([]);
+
+        Assert.Equal(reference, fast);
+        Assert.Equal(reference.GetHashCode(), fast.GetHashCode());
+    }
+
+    [Fact]
+    public void Spawn_WithDifferentComponentOrders_LandsInSameArchetype()
+    {
+        using var world = new World();
+
+        // Two entities whose components are supplied in different orders must resolve to the
+        // same archetype identity (the AddEntity hot path now uses the sorted fast path).
+        var a = world.Spawn()
+            .With(new Position { X = 1, Y = 2 })
+            .With(new Velocity { X = 3, Y = 4 })
+            .Build();
+
+        var b = world.Spawn()
+            .With(new Velocity { X = 5, Y = 6 })
+            .With(new Position { X = 7, Y = 8 })
+            .Build();
+
+        var locA = world.ArchetypeManager.GetEntityLocation(a);
+        var locB = world.ArchetypeManager.GetEntityLocation(b);
+
+        Assert.Same(locA.Archetype, locB.Archetype);
+        Assert.Equal(1, world.ArchetypeManager.ArchetypeCount);
+
+        // Component values remain intact through the co-located write.
+        Assert.Equal(1f, world.Get<Position>(a).X);
+        Assert.Equal(6f, world.Get<Velocity>(b).Y);
+    }
+
+    #endregion
+
+    #region EventBus copy-on-write snapshot
+
+    private readonly record struct TestEvent(int Value);
+
+    [Fact]
+    public void Publish_HandlerSubscribingMidDispatch_DoesNotInvokeNewHandlerThisDispatch()
+    {
+        var bus = new EventBus();
+        var firstInvoked = 0;
+        var lateInvoked = 0;
+
+        bus.Subscribe<TestEvent>(_ =>
+        {
+            firstInvoked++;
+            // Subscribe a new handler during dispatch; it must not run for the current publish.
+            bus.Subscribe<TestEvent>(_ => lateInvoked++);
+        });
+
+        bus.Publish(new TestEvent(1));
+
+        Assert.Equal(1, firstInvoked);
+        Assert.Equal(0, lateInvoked);
+
+        // The late handler is now part of the set for subsequent publishes.
+        bus.Publish(new TestEvent(2));
+        Assert.Equal(2, firstInvoked);
+        Assert.Equal(1, lateInvoked);
+    }
+
+    [Fact]
+    public void Publish_HandlerUnsubscribingMidDispatch_StillInvokesAllForCurrentDispatch()
+    {
+        var bus = new EventBus();
+        var order = new List<int>();
+        EventSubscription? second = null;
+
+        bus.Subscribe<TestEvent>(_ =>
+        {
+            order.Add(1);
+            // Remove the second handler mid-dispatch; the current dispatch must still call it.
+            second?.Dispose();
+        });
+        second = bus.Subscribe<TestEvent>(_ => order.Add(2));
+
+        bus.Publish(new TestEvent(1));
+
+        Assert.Equal([1, 2], order);
+
+        // After removal, subsequent publish only calls the first handler.
+        order.Clear();
+        bus.Publish(new TestEvent(2));
+        Assert.Equal([1], order);
+    }
+
+    [Fact]
+    public void Publish_PreservesRegistrationOrder()
+    {
+        var bus = new EventBus();
+        var order = new List<int>();
+
+        bus.Subscribe<TestEvent>(_ => order.Add(1));
+        bus.Subscribe<TestEvent>(_ => order.Add(2));
+        bus.Subscribe<TestEvent>(_ => order.Add(3));
+
+        bus.Publish(new TestEvent(0));
+
+        Assert.Equal([1, 2, 3], order);
+    }
+
+    [Fact]
+    public void Publish_SteadyState_DoesNotAllocate()
+    {
+        // Allocation regression guard: with a fixed handler set, the old code snapshotted the
+        // handler list ([.. list]) on EVERY publish. The copy-on-write snapshot allocates only
+        // on subscribe/unsubscribe, so a steady-state publish loop must allocate nothing.
+        var bus = new EventBus();
+        var sum = 0;
+        bus.Subscribe<TestEvent>(e => sum += e.Value);
+
+        // Warm up JIT/tiering so measurement covers only steady-state execution.
+        for (int i = 0; i < 512; i++)
+        {
+            bus.Publish(new TestEvent(1));
+        }
+
+        const int iterations = 4096;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+        {
+            bus.Publish(new TestEvent(1));
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // Old behavior allocated one array per publish (tens of KB across the loop); new
+        // behavior allocates nothing. A small allowance absorbs incidental runtime noise.
+        Assert.True(allocated < 1024, $"Expected ~0 steady-state allocation, saw {allocated} bytes.");
+        Assert.NotEqual(0, sum);
+    }
+
+    #endregion
+
+    #region Component lifecycle copy-on-write snapshot
+
+    [Fact]
+    public void OnComponentAdded_HandlerSubscribingMidDispatch_DoesNotRunNewHandlerThisDispatch()
+    {
+        using var world = new World();
+        var firstInvoked = 0;
+        var lateInvoked = 0;
+
+        world.OnComponentAdded<Health>((_, _) =>
+        {
+            firstInvoked++;
+            world.OnComponentAdded<Health>((_, _) => lateInvoked++);
+        });
+
+        world.Spawn().With(new Health { Current = 1, Max = 1 }).Build();
+
+        Assert.Equal(1, firstInvoked);
+        Assert.Equal(0, lateInvoked);
+
+        world.Spawn().With(new Health { Current = 2, Max = 2 }).Build();
+        Assert.Equal(2, firstInvoked);
+        Assert.Equal(1, lateInvoked);
+    }
+
+    [Fact]
+    public void OnComponentAdded_InvokesHandlersInReverseRegistrationOrder()
+    {
+        using var world = new World();
+        var order = new List<int>();
+
+        world.OnComponentAdded<Health>((_, _) => order.Add(1));
+        world.OnComponentAdded<Health>((_, _) => order.Add(2));
+        world.OnComponentAdded<Health>((_, _) => order.Add(3));
+
+        world.Spawn().With(new Health { Current = 1, Max = 1 }).Build();
+
+        // ComponentEventHandlers dispatches in reverse registration order; preserved by the
+        // copy-on-write snapshot.
+        Assert.Equal([3, 2, 1], order);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Parallelism.Tests/HotPathAllocationTests.cs
+++ b/tests/KeenEyes.Parallelism.Tests/HotPathAllocationTests.cs
@@ -1,0 +1,169 @@
+using KeenEyes.Parallelism;
+
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Behavior-preservation tests for the parallel hot-path allocation reductions (issue #1238):
+/// the pre-sized chunk buffer in ParallelQueryExtensions.CollectChunks and the reused
+/// per-batch scratch buffers in ParallelSystemScheduler.ExecuteBatch. These assert that
+/// reusing/pre-sizing buffers does not change query coverage or command-buffer flushing.
+/// </summary>
+[Collection("ParallelismTests")]
+public class HotPathAllocationTests
+{
+    #region Test Components
+
+    private struct HotPosition : IComponent
+    {
+        public float X;
+        public float Y;
+    }
+
+    private struct HotSpawned : IComponent
+    {
+        public int Value;
+    }
+
+    #endregion
+
+    #region CollectChunks (pre-sized buffer)
+
+    [Fact]
+    public void ForEachParallel_AcrossManyChunks_ProcessesEveryEntityExactlyOnce()
+    {
+        using var world = new World();
+
+        // Spawn enough entities to span many chunks so CollectChunks collects a large buffer.
+        const int entityCount = 5000;
+        for (int i = 0; i < entityCount; i++)
+        {
+            world.Spawn().With(new HotPosition { X = i, Y = 0 }).Build();
+        }
+
+        var processed = new int[entityCount];
+
+        world.Query<HotPosition>().ForEachParallel<HotPosition>(
+            (Entity entity, ref HotPosition pos) =>
+            {
+                Interlocked.Increment(ref processed[(int)pos.X]);
+            },
+            minEntityCount: 1); // Force the parallel path.
+
+        // Every entity processed exactly once - no chunk dropped or double-counted.
+        Assert.All(processed, count => Assert.Equal(1, count));
+    }
+
+    [Fact]
+    public void ForEachParallel_EmptyResult_DoesNotThrow()
+    {
+        using var world = new World();
+
+        var invoked = 0;
+        world.Query<HotPosition>().ForEachParallel<HotPosition>(
+            (Entity entity, ref HotPosition pos) => Interlocked.Increment(ref invoked),
+            minEntityCount: 1);
+
+        Assert.Equal(0, invoked);
+    }
+
+    #endregion
+
+    #region ExecuteBatch (reused scratch buffers)
+
+    private sealed class SpawningSystem : SystemBase, ICommandBufferConsumer, ISystemDependencyProvider
+    {
+        private ICommandBuffer? commandBuffer;
+
+        public void GetDependencies(ISystemDependencyBuilder builder)
+        {
+            builder.Writes<HotSpawned>();
+        }
+
+        public void SetCommandBuffer(ICommandBuffer buffer) => commandBuffer = buffer;
+
+        public override void Update(float deltaTime)
+        {
+            commandBuffer?.Spawn().With(new HotSpawned { Value = 1 });
+        }
+    }
+
+    private sealed class SecondSpawningSystem : SystemBase, ICommandBufferConsumer, ISystemDependencyProvider
+    {
+        private ICommandBuffer? commandBuffer;
+
+        public void GetDependencies(ISystemDependencyBuilder builder)
+        {
+            // No declared conflict with SpawningSystem, so the two may share or split batches;
+            // either way both command buffers must flush each frame.
+            builder.Writes<HotPosition>();
+        }
+
+        public void SetCommandBuffer(ICommandBuffer buffer) => commandBuffer = buffer;
+
+        public override void Update(float deltaTime)
+        {
+            commandBuffer?.Spawn().With(new HotSpawned { Value = 2 });
+        }
+    }
+
+    [Fact]
+    public void UpdateParallel_MultipleFrames_FlushesCommandBuffersEachFrame()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin());
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        var system = new SpawningSystem();
+        system.Initialize(world);
+        scheduler.RegisterSystem(system);
+
+        const int frames = 5;
+        for (int i = 0; i < frames; i++)
+        {
+            scheduler.UpdateParallel(0.016f);
+        }
+
+        // One entity spawned and flushed per frame; reusing the scratch bufferIds across frames
+        // must not drop or duplicate flushes.
+        var count = 0;
+        foreach (var _ in world.Query<HotSpawned>())
+        {
+            count++;
+        }
+
+        Assert.Equal(frames, count);
+    }
+
+    [Fact]
+    public void UpdateParallel_MultipleSystemsMultipleFrames_FlushesAllBuffers()
+    {
+        using var world = new World();
+        world.InstallPlugin(new ParallelSystemPlugin());
+        var scheduler = world.GetExtension<ParallelSystemScheduler>()!;
+
+        var first = new SpawningSystem();
+        var second = new SecondSpawningSystem();
+        first.Initialize(world);
+        second.Initialize(world);
+        scheduler.RegisterSystem(first);
+        scheduler.RegisterSystem(second);
+
+        const int frames = 4;
+        for (int i = 0; i < frames; i++)
+        {
+            scheduler.UpdateParallel(0.016f);
+        }
+
+        // Two systems each spawn one entity per frame; the reused batch wrapper must flush every
+        // system's buffer across every batch and frame.
+        var count = 0;
+        foreach (var _ in world.Query<HotSpawned>())
+        {
+            count++;
+        }
+
+        Assert.Equal(frames * 2, count);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Physics.Tests/BodyLookupHotPathTests.cs
+++ b/tests/KeenEyes.Physics.Tests/BodyLookupHotPathTests.cs
@@ -1,0 +1,106 @@
+using BepuPhysics;
+using KeenEyes.Physics.Core;
+
+namespace KeenEyes.Physics.Tests;
+
+/// <summary>
+/// Behavior-preservation tests for the BodyLookup key-enumeration change (issue #1238).
+/// DynamicEntities/StaticEntities now expose the concrete Dictionary KeyCollection so the
+/// per-fixed-step foreach uses the value-type enumerator instead of boxing an IEnumerator.
+/// These assert the concrete type is returned and that enumeration yields the correct keys.
+/// </summary>
+public class BodyLookupHotPathTests
+{
+    [Fact]
+    public void DynamicEntities_ReturnsConcreteKeyCollection()
+    {
+        var lookup = new BodyLookup();
+        lookup.RegisterBody(new Entity(1, 0), new BodyHandle(10));
+
+        // Assigning to the concrete KeyCollection type compiles only if the property returns
+        // it; foreach over this type binds to the struct enumerator (no boxing).
+        Dictionary<Entity, BodyHandle>.KeyCollection keys = lookup.DynamicEntities;
+
+        Assert.Single(keys);
+    }
+
+    [Fact]
+    public void StaticEntities_ReturnsConcreteKeyCollection()
+    {
+        var lookup = new BodyLookup();
+        lookup.RegisterStatic(new Entity(2, 0), new StaticHandle(20));
+
+        Dictionary<Entity, StaticHandle>.KeyCollection keys = lookup.StaticEntities;
+
+        Assert.Single(keys);
+    }
+
+    [Fact]
+    public void DynamicEntities_EnumeratesAllRegisteredEntities()
+    {
+        var lookup = new BodyLookup();
+        var e1 = new Entity(1, 0);
+        var e2 = new Entity(2, 0);
+        var e3 = new Entity(3, 0);
+        lookup.RegisterBody(e1, new BodyHandle(1));
+        lookup.RegisterBody(e2, new BodyHandle(2));
+        lookup.RegisterBody(e3, new BodyHandle(3));
+
+        var seen = new HashSet<Entity>();
+        foreach (var entity in lookup.DynamicEntities)
+        {
+            seen.Add(entity);
+        }
+
+        HashSet<Entity> expected = [e1, e2, e3];
+        Assert.Equal(expected, seen);
+    }
+
+    [Fact]
+    public void StaticEntities_EnumeratesAllRegisteredEntities()
+    {
+        var lookup = new BodyLookup();
+        var e1 = new Entity(10, 0);
+        var e2 = new Entity(11, 0);
+        lookup.RegisterStatic(e1, new StaticHandle(1));
+        lookup.RegisterStatic(e2, new StaticHandle(2));
+
+        var seen = new HashSet<Entity>();
+        foreach (var entity in lookup.StaticEntities)
+        {
+            seen.Add(entity);
+        }
+
+        HashSet<Entity> expected = [e1, e2];
+        Assert.Equal(expected, seen);
+    }
+
+    [Fact]
+    public void DynamicEntities_ReflectsRegisterAndUnregister()
+    {
+        var lookup = new BodyLookup();
+        var entity = new Entity(5, 0);
+        lookup.RegisterBody(entity, new BodyHandle(99));
+
+        Assert.Single(lookup.DynamicEntities);
+
+        lookup.Unregister(entity);
+
+        Assert.Empty(lookup.DynamicEntities);
+    }
+
+    [Fact]
+    public void DynamicAndStaticEntities_AreDisjoint()
+    {
+        var lookup = new BodyLookup();
+        var dynamicEntity = new Entity(1, 0);
+        var staticEntity = new Entity(2, 0);
+        lookup.RegisterBody(dynamicEntity, new BodyHandle(1));
+        lookup.RegisterStatic(staticEntity, new StaticHandle(1));
+
+        Assert.Contains(dynamicEntity, lookup.DynamicEntities);
+        Assert.DoesNotContain(staticEntity, lookup.DynamicEntities);
+        Assert.Contains(staticEntity, lookup.StaticEntities);
+        Assert.DoesNotContain(dynamicEntity, lookup.StaticEntities);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1238 (from nightly review #1208 triage). Behavior-preserving allocation/boxing reduction on per-entity / per-frame / per-fixed-step paths. **Correctness-first** — identity/ordering/dispatch semantics unchanged.

- **ArchetypeId** — wired the previously-dead `ImmutableArray` fast path into entity creation via `FromUnsortedTypes(Span<Type>)` (same ordinal `FullName` sort + `HashCode` accumulation as the old ctor → bit-for-bit identical identity). `ArchetypeManager.AddEntity` extracts types into an `ArrayPool`-rented buffer instead of a `yield` iterator; removed the dead `GetTypesSpan` iterator and `IEnumerable` overload.
- **EventBus + ComponentEventHandlers** — copy-on-write handler snapshot rebuilt only on Add/Remove; `Invoke` reads it via `Volatile.Read` with no lock and no per-publish allocation. Mid-dispatch subscribe/unsubscribe safety and dispatch order (forward / reverse respectively) preserved.
- **Blackboard** — value-type `Set<T>` stores into a reusable `ValueCell<T>` (zero steady-state alloc on repeat writes); `TryUnwrap<T>` reproduces exact `is T` / cross-type-overwrite / `Get<object>` / nullable semantics.
- **ParallelQueryExtensions.CollectChunks** — pre-sized to the exact chunk count (fresh per-call list, thread-safe); the 8 `Parallel.ForEach` loops untouched.
- **ParallelSystemScheduler.ExecuteBatch** — reuses an instance scratch `List<int>` + single-element wrapper across batches (batches run sequentially under the single game-loop driver).
- **BodyLookup** — `Dynamic/StaticEntities` return the concrete `Dictionary.KeyCollection` instead of `IEnumerable<Entity>`, so the per-fixed-step `foreach` doesn't box the enumerator.

## Test plan
- [x] 32 new behavior-preservation tests: fast-path identity == old ctor across permutations; EventBus/component mid-dispatch sub/unsub + order; Blackboard round-trips/overwrite/nullable/`Get<object>`; parallel query exact-once over 5000 entities; command-buffer flush across frames/systems
- [x] Deterministic allocation guards for EventBus publish + Blackboard `Set<Vector3>` — **fail on old code** (proven via revert); BodyLookup type change proven by compile-break
- [x] Core 2347, Parallelism 115, Physics 392, AI 250; full suite **14,704, 0 failed** (parallel); 0 warnings; format clean

## Related
Closes #1238