### PR TITLE
feat(graphics): Expose blend modes in the 2D renderer pipeline

### DIFF
--- a/src/KeenEyes.Graphics.Abstractions/Rendering2D/BlendMode.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Rendering2D/BlendMode.cs
@@ -1,19 +1,22 @@
-using KeenEyes.Graphics.Abstractions;
-
-namespace KeenEyes.Particles.Data;
+namespace KeenEyes.Graphics.Abstractions;
 
 /// <summary>
-/// Blend modes for particle rendering.
+/// Blend modes for 2D rendering.
 /// </summary>
+/// <remarks>
+/// Each mode maps to a fixed pair of <see cref="BlendFactor"/> values applied by the
+/// renderer when a batch is flushed. Use <see cref="I2DRenderer.SetBlendMode"/> to
+/// switch modes between draws.
+/// </remarks>
 public enum BlendMode
 {
     /// <summary>Standard alpha blending (SrcAlpha, OneMinusSrcAlpha).</summary>
-    Transparent,
+    Alpha,
 
     /// <summary>Additive blending for glow effects (SrcAlpha, One).</summary>
     Additive,
 
-    /// <summary>Multiply blending (DstColor, Zero).</summary>
+    /// <summary>Multiply blending (DstColor, OneMinusSrcAlpha).</summary>
     Multiply,
 
     /// <summary>Pre-multiplied alpha (One, OneMinusSrcAlpha).</summary>
@@ -32,9 +35,8 @@ public static class BlendModeExtensions
     /// <returns>A tuple containing the source and destination blend factors.</returns>
     public static (BlendFactor Src, BlendFactor Dst) ToBlendFactors(this BlendMode mode) => mode switch
     {
-        BlendMode.Transparent => (BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha),
         BlendMode.Additive => (BlendFactor.SrcAlpha, BlendFactor.One),
-        BlendMode.Multiply => (BlendFactor.DstColor, BlendFactor.Zero),
+        BlendMode.Multiply => (BlendFactor.DstColor, BlendFactor.OneMinusSrcAlpha),
         BlendMode.Premultiplied => (BlendFactor.One, BlendFactor.OneMinusSrcAlpha),
         _ => (BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha)
     };

--- a/src/KeenEyes.Graphics.Abstractions/Rendering2D/I2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Rendering2D/I2DRenderer.cs
@@ -78,6 +78,27 @@ public interface I2DRenderer : IDisposable
 
     #endregion
 
+    #region Blend State
+
+    /// <summary>
+    /// Gets the blend mode applied to subsequent draw calls.
+    /// </summary>
+    BlendMode CurrentBlendMode { get; }
+
+    /// <summary>
+    /// Sets the blend mode for subsequent draw calls.
+    /// </summary>
+    /// <param name="mode">The blend mode to apply.</param>
+    /// <remarks>
+    /// Setting a mode different from <see cref="CurrentBlendMode"/> flushes the current
+    /// batch so already-queued geometry is drawn with the previous mode; draws issued
+    /// afterwards use the new mode. Setting the same mode is a no-op.
+    /// <see cref="Begin()"/> resets the blend mode to <see cref="BlendMode.Alpha"/>.
+    /// </remarks>
+    void SetBlendMode(BlendMode mode);
+
+    #endregion
+
     #region Rectangles
 
     /// <summary>

--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -51,6 +51,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     private int vertexCount;
     private int indexCount;
     private uint currentTexture;
+    private BlendMode currentBlendMode = BlendMode.Alpha;
     private bool isBatching;
     private Matrix4x4 screenProjection;
     private Matrix4x4 activeProjection;
@@ -89,6 +90,24 @@ public sealed class Silk2DRenderer : I2DRenderer
     {
         screenSize = new Vector2(width, height);
         UpdateProjection();
+    }
+
+    /// <inheritdoc />
+    public BlendMode CurrentBlendMode => currentBlendMode;
+
+    /// <inheritdoc />
+    public void SetBlendMode(BlendMode mode)
+    {
+        if (mode == currentBlendMode)
+        {
+            return;
+        }
+
+        // Draw everything queued so far with the previous mode before switching.
+        // (Rounded rects flush immediately on submission, so only the quad batch
+        // can hold pending geometry here.)
+        Flush();
+        currentBlendMode = mode;
     }
 
     private void InitializeBuffers()
@@ -310,6 +329,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         vertexCount = 0;
         indexCount = 0;
         currentTexture = whiteTexture;
+        currentBlendMode = BlendMode.Alpha;
 
         // Remember the caller-supplied projection so Flush/FlushRoundedRects re-bind
         // it (rather than the internal screen projection) before every draw call.
@@ -320,8 +340,14 @@ public sealed class Silk2DRenderer : I2DRenderer
         device.Uniform1(textureLocation, 0);
 
         device.Enable(RenderCapability.Blend);
-        device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
+        ApplyBlendFunc();
         device.Disable(RenderCapability.DepthTest);
+    }
+
+    private void ApplyBlendFunc()
+    {
+        var (src, dst) = currentBlendMode.ToBlendFactors();
+        device.BlendFunc(src, dst);
     }
 
     /// <inheritdoc />
@@ -351,7 +377,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         device.UniformMatrix4(projectionLocation, activeProjection);
         device.Uniform1(textureLocation, 0);
         device.Enable(RenderCapability.Blend);
-        device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
+        ApplyBlendFunc();
 
         device.BindVertexArray(vao);
         device.BindBuffer(BufferTarget.ArrayBuffer, vbo);
@@ -758,7 +784,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         device.UseProgram(roundedRectShaderProgram);
         device.UniformMatrix4(roundedRectProjectionLocation, activeProjection);
         device.Enable(RenderCapability.Blend);
-        device.BlendFunc(BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha);
+        ApplyBlendFunc();
 
         device.BindVertexArray(roundedRectVao);
         device.BindBuffer(BufferTarget.ArrayBuffer, roundedRectVbo);

--- a/src/KeenEyes.Particles/ParticleEffects.cs
+++ b/src/KeenEyes.Particles/ParticleEffects.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Particles.Components;
 using KeenEyes.Particles.Data;
 
@@ -107,7 +108,7 @@ public static class ParticleEffects
             StartRotationMin = 0f,
             StartRotationMax = MathF.PI * 2f,
             StartColor = new Vector4(0.4f, 0.4f, 0.4f, 0.6f), // Gray
-            BlendMode = BlendMode.Transparent,
+            BlendMode = BlendMode.Alpha,
             Shape = EmissionShape.Cone(MathF.PI / 4f, 8f, new Vector2(0, -1)), // Wide upward cone
             IsPlaying = true
         };
@@ -324,7 +325,7 @@ public static class ParticleEffects
             StartRotationMin = 0f,
             StartRotationMax = MathF.PI * 2f,
             StartColor = new Vector4(0.6f, 0f, 0f, 1f), // Dark red
-            BlendMode = BlendMode.Transparent,
+            BlendMode = BlendMode.Alpha,
             Shape = EmissionShape.Cone(MathF.PI / 3f, 5f, new Vector2(0, -1)), // Upward spray
             IsPlaying = true
         };
@@ -380,7 +381,7 @@ public static class ParticleEffects
             StartRotationMin = 0f,
             StartRotationMax = 0f, // No rotation - rain falls straight
             StartColor = new Vector4(0.7f, 0.8f, 0.9f, 0.6f), // Light blue-gray
-            BlendMode = BlendMode.Transparent,
+            BlendMode = BlendMode.Alpha,
             Shape = EmissionShape.Box(400f, 10f), // Wide emission area
             IsPlaying = true
         };
@@ -425,7 +426,7 @@ public static class ParticleEffects
             StartRotationMin = 0f,
             StartRotationMax = MathF.PI * 2f,
             StartColor = new Vector4(1f, 1f, 1f, 0.9f), // White
-            BlendMode = BlendMode.Transparent,
+            BlendMode = BlendMode.Alpha,
             Shape = EmissionShape.Box(400f, 10f), // Wide emission area
             IsPlaying = true
         };

--- a/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
+++ b/src/KeenEyes.Particles/Systems/ParticleRenderSystem.cs
@@ -65,8 +65,8 @@ public sealed class ParticleRenderSystem : SystemBase
         }
 
         // Group emitters by blend mode for efficient batching
-        // We'll render transparent first, then additive (so glow effects overlay)
-        var transparentEmitters = new List<RenderEntry>();
+        // We'll render alpha-blended first, then additive (so glow effects overlay)
+        var alphaEmitters = new List<RenderEntry>();
         var additiveEmitters = new List<RenderEntry>();
         var multiplyEmitters = new List<RenderEntry>();
         var premultipliedEmitters = new List<RenderEntry>();
@@ -90,8 +90,8 @@ public sealed class ParticleRenderSystem : SystemBase
 
             switch (emitter.BlendMode)
             {
-                case BlendMode.Transparent:
-                    transparentEmitters.Add(entry);
+                case BlendMode.Alpha:
+                    alphaEmitters.Add(entry);
                     break;
                 case BlendMode.Additive:
                     additiveEmitters.Add(entry);
@@ -105,15 +105,15 @@ public sealed class ParticleRenderSystem : SystemBase
             }
         }
 
-        // Render in order: multiply -> transparent -> premultiplied -> additive
+        // Render in order: multiply -> alpha -> premultiplied -> additive
         // (This is a common ordering but can be adjusted based on desired visual results)
-        RenderBatch(r, multiplyEmitters);
-        RenderBatch(r, transparentEmitters);
-        RenderBatch(r, premultipliedEmitters);
-        RenderBatch(r, additiveEmitters);
+        RenderBatch(r, multiplyEmitters, BlendMode.Multiply);
+        RenderBatch(r, alphaEmitters, BlendMode.Alpha);
+        RenderBatch(r, premultipliedEmitters, BlendMode.Premultiplied);
+        RenderBatch(r, additiveEmitters, BlendMode.Additive);
     }
 
-    private static void RenderBatch(I2DRenderer renderer, List<RenderEntry> emitters)
+    private static void RenderBatch(I2DRenderer renderer, List<RenderEntry> emitters, BlendMode blendMode)
     {
         if (emitters.Count == 0)
         {
@@ -128,6 +128,7 @@ public sealed class ParticleRenderSystem : SystemBase
         }
 
         renderer.Begin();
+        renderer.SetBlendMode(blendMode);
         renderer.SetBatchHint(totalParticles);
 
         foreach (var entry in emitters)
@@ -136,6 +137,12 @@ public sealed class ParticleRenderSystem : SystemBase
         }
 
         renderer.End();
+
+        // Leave the renderer in the default state for whoever draws next.
+        if (blendMode != BlendMode.Alpha)
+        {
+            renderer.SetBlendMode(BlendMode.Alpha);
+        }
     }
 
     private static void RenderPool(I2DRenderer renderer, ParticlePool pool, in ParticleEmitter emitter, Vector2 offset)

--- a/src/KeenEyes.Testing/Graphics/Mock2DRenderer.cs
+++ b/src/KeenEyes.Testing/Graphics/Mock2DRenderer.cs
@@ -80,6 +80,9 @@ public sealed class Mock2DRenderer : I2DRenderer
     /// </summary>
     public int? BatchHint { get; private set; }
 
+    /// <inheritdoc />
+    public BlendMode CurrentBlendMode { get; private set; } = BlendMode.Alpha;
+
     #endregion
 
     #region Clipping
@@ -115,6 +118,7 @@ public sealed class Mock2DRenderer : I2DRenderer
         isInBatch = true;
         currentProjection = projection;
         CurrentBatchSize = 0;
+        CurrentBlendMode = BlendMode.Alpha;
         BeginCount++;
     }
 
@@ -134,6 +138,20 @@ public sealed class Mock2DRenderer : I2DRenderer
     public void Flush()
     {
         FlushCount++;
+    }
+
+    /// <inheritdoc />
+    public void SetBlendMode(BlendMode mode)
+    {
+        if (mode == CurrentBlendMode)
+        {
+            return;
+        }
+
+        // Match the real renderer contract: switching modes flushes queued geometry.
+        FlushCount++;
+        CurrentBlendMode = mode;
+        RecordCommand(new SetBlendModeCommand(mode));
     }
 
     #endregion
@@ -324,6 +342,7 @@ public sealed class Mock2DRenderer : I2DRenderer
         EndCount = 0;
         FlushCount = 0;
         CurrentBatchSize = 0;
+        CurrentBlendMode = BlendMode.Alpha;
         BatchHint = null;
     }
 
@@ -514,5 +533,11 @@ public sealed record PopClipCommand : Draw2DCommand;
 /// A clear clip command.
 /// </summary>
 public sealed record ClearClipCommand : Draw2DCommand;
+
+/// <summary>
+/// A blend mode change command.
+/// </summary>
+/// <param name="Mode">The blend mode applied to subsequent draws.</param>
+public sealed record SetBlendModeCommand(BlendMode Mode) : Draw2DCommand;
 
 #endregion

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
@@ -735,7 +735,9 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
             BoundProgram,
             BoundVAO,
             BoundTextures.Values.ToList(),
-            InstanceCount: 1));
+            InstanceCount: 1,
+            RenderState.BlendSrcFactor,
+            RenderState.BlendDstFactor));
     }
 
     /// <inheritdoc />
@@ -748,7 +750,9 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
             BoundProgram,
             BoundVAO,
             BoundTextures.Values.ToList(),
-            InstanceCount: 1));
+            InstanceCount: 1,
+            RenderState.BlendSrcFactor,
+            RenderState.BlendDstFactor));
     }
 
     /// <inheritdoc />
@@ -761,7 +765,9 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
             BoundProgram,
             BoundVAO,
             BoundTextures.Values.ToList(),
-            instanceCount));
+            instanceCount,
+            RenderState.BlendSrcFactor,
+            RenderState.BlendDstFactor));
     }
 
     /// <inheritdoc />
@@ -774,7 +780,9 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
             BoundProgram,
             BoundVAO,
             BoundTextures.Values.ToList(),
-            instanceCount));
+            instanceCount,
+            RenderState.BlendSrcFactor,
+            RenderState.BlendDstFactor));
     }
 
     /// <inheritdoc />
@@ -1030,6 +1038,8 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
 /// <param name="VAO">The VAO used, if any.</param>
 /// <param name="Textures">The textures bound during the draw.</param>
 /// <param name="InstanceCount">The number of instances drawn (1 for non-instanced).</param>
+/// <param name="BlendSrcFactor">The source blend factor active when the draw was issued.</param>
+/// <param name="BlendDstFactor">The destination blend factor active when the draw was issued.</param>
 public sealed record DrawCall(
     PrimitiveType PrimitiveType,
     int VertexCount,
@@ -1037,7 +1047,9 @@ public sealed record DrawCall(
     uint? Program,
     uint? VAO,
     List<uint> Textures,
-    uint InstanceCount = 1);
+    uint InstanceCount = 1,
+    BlendFactor BlendSrcFactor = BlendFactor.Zero,
+    BlendFactor BlendDstFactor = BlendFactor.Zero);
 
 /// <summary>
 /// Tracks buffer state.

--- a/tests/KeenEyes.Editor.Tests/Application/EditorFrameCompositionTests.cs
+++ b/tests/KeenEyes.Editor.Tests/Application/EditorFrameCompositionTests.cs
@@ -257,6 +257,10 @@ public sealed class EditorFrameCompositionTests
         {
         }
 
+        public BlendMode CurrentBlendMode { get; private set; } = BlendMode.Alpha;
+
+        public void SetBlendMode(BlendMode mode) => CurrentBlendMode = mode;
+
         public void FillRect(float x, float y, float width, float height, Vector4 color)
             => callLog.Add("UI:FillRect");
 

--- a/tests/KeenEyes.Graphics.Tests/BlendModeExtensionsTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/BlendModeExtensionsTests.cs
@@ -1,17 +1,16 @@
 using KeenEyes.Graphics.Abstractions;
-using KeenEyes.Particles.Data;
 
-namespace KeenEyes.Particles.Tests;
+namespace KeenEyes.Graphics.Tests;
 
 /// <summary>
-/// Tests for the BlendModeExtensions class.
+/// Tests for the <see cref="BlendModeExtensions"/> class.
 /// </summary>
 public class BlendModeExtensionsTests
 {
     [Fact]
-    public void ToBlendFactors_Transparent_ReturnsSrcAlphaAndOneMinusSrcAlpha()
+    public void ToBlendFactors_Alpha_ReturnsSrcAlphaAndOneMinusSrcAlpha()
     {
-        var (src, dst) = BlendMode.Transparent.ToBlendFactors();
+        var (src, dst) = BlendMode.Alpha.ToBlendFactors();
 
         Assert.Equal(BlendFactor.SrcAlpha, src);
         Assert.Equal(BlendFactor.OneMinusSrcAlpha, dst);
@@ -27,12 +26,12 @@ public class BlendModeExtensionsTests
     }
 
     [Fact]
-    public void ToBlendFactors_Multiply_ReturnsDstColorAndZero()
+    public void ToBlendFactors_Multiply_ReturnsDstColorAndOneMinusSrcAlpha()
     {
         var (src, dst) = BlendMode.Multiply.ToBlendFactors();
 
         Assert.Equal(BlendFactor.DstColor, src);
-        Assert.Equal(BlendFactor.Zero, dst);
+        Assert.Equal(BlendFactor.OneMinusSrcAlpha, dst);
     }
 
     [Fact]
@@ -45,20 +44,20 @@ public class BlendModeExtensionsTests
     }
 
     [Fact]
-    public void ToBlendFactors_UnknownValue_ReturnsDefaultTransparent()
+    public void ToBlendFactors_UnknownValue_ReturnsDefaultAlpha()
     {
         // Cast an invalid value to BlendMode
         var invalidMode = (BlendMode)999;
 
         var (src, dst) = invalidMode.ToBlendFactors();
 
-        // Should default to Transparent
+        // Should default to standard alpha blending
         Assert.Equal(BlendFactor.SrcAlpha, src);
         Assert.Equal(BlendFactor.OneMinusSrcAlpha, dst);
     }
 
     [Theory]
-    [InlineData(BlendMode.Transparent)]
+    [InlineData(BlendMode.Alpha)]
     [InlineData(BlendMode.Additive)]
     [InlineData(BlendMode.Multiply)]
     [InlineData(BlendMode.Premultiplied)]

--- a/tests/KeenEyes.Graphics.Tests/Silk2DRendererTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/Silk2DRendererTests.cs
@@ -136,6 +136,118 @@ public class Silk2DRendererTests : IDisposable
 
     #endregion
 
+    #region Blend modes
+
+    /// <summary>
+    /// Switching the blend mode mid-batch must flush exactly at the boundary: geometry queued
+    /// before the switch draws with the old factors, geometry queued after draws with the new ones.
+    /// </summary>
+    [Fact]
+    public void SetBlendMode_MidBatch_FlushesAtBoundaryAndSecondDrawUsesNewFactors()
+    {
+        renderer.Begin();
+        renderer.FillRect(0f, 0f, 10f, 10f, new Vector4(1f, 0f, 0f, 1f));
+
+        Assert.Empty(device.DrawCalls);
+
+        renderer.SetBlendMode(BlendMode.Additive);
+
+        // The pending quad must have been flushed exactly at the mode switch.
+        Assert.Single(device.DrawCalls);
+
+        renderer.FillRect(20f, 0f, 10f, 10f, new Vector4(0f, 1f, 0f, 1f));
+        renderer.End();
+
+        Assert.Equal(2, device.DrawCalls.Count);
+
+        // First batch drew with alpha blending, second with additive.
+        Assert.Equal(BlendFactor.SrcAlpha, device.DrawCalls[0].BlendSrcFactor);
+        Assert.Equal(BlendFactor.OneMinusSrcAlpha, device.DrawCalls[0].BlendDstFactor);
+        Assert.Equal(BlendFactor.SrcAlpha, device.DrawCalls[1].BlendSrcFactor);
+        Assert.Equal(BlendFactor.One, device.DrawCalls[1].BlendDstFactor);
+    }
+
+    /// <summary>
+    /// Setting the mode that is already active must not flush the batch.
+    /// </summary>
+    [Fact]
+    public void SetBlendMode_SameMode_DoesNotFlush()
+    {
+        renderer.Begin();
+        renderer.FillRect(0f, 0f, 10f, 10f, new Vector4(1f, 0f, 0f, 1f));
+
+        renderer.SetBlendMode(BlendMode.Alpha);
+
+        Assert.Empty(device.DrawCalls);
+        renderer.End();
+        Assert.Single(device.DrawCalls);
+    }
+
+    /// <summary>
+    /// <c>Begin()</c> must reset the blend mode to <see cref="BlendMode.Alpha"/> even if a
+    /// previous batch left a different mode active.
+    /// </summary>
+    [Fact]
+    public void Begin_AfterAdditiveBatch_ResetsBlendModeToAlpha()
+    {
+        renderer.Begin();
+        renderer.SetBlendMode(BlendMode.Additive);
+        renderer.FillRect(0f, 0f, 10f, 10f, new Vector4(1f, 1f, 1f, 1f));
+        renderer.End();
+
+        Assert.Equal(BlendMode.Additive, renderer.CurrentBlendMode);
+
+        renderer.Begin();
+        Assert.Equal(BlendMode.Alpha, renderer.CurrentBlendMode);
+
+        renderer.FillRect(0f, 0f, 10f, 10f, new Vector4(1f, 1f, 1f, 1f));
+        renderer.End();
+
+        var lastDraw = device.DrawCalls[^1];
+        Assert.Equal(BlendFactor.SrcAlpha, lastDraw.BlendSrcFactor);
+        Assert.Equal(BlendFactor.OneMinusSrcAlpha, lastDraw.BlendDstFactor);
+    }
+
+    /// <summary>
+    /// Every blend mode must map to its documented GL blend factor pair at draw time.
+    /// </summary>
+    [Theory]
+    [InlineData(BlendMode.Alpha, BlendFactor.SrcAlpha, BlendFactor.OneMinusSrcAlpha)]
+    [InlineData(BlendMode.Additive, BlendFactor.SrcAlpha, BlendFactor.One)]
+    [InlineData(BlendMode.Multiply, BlendFactor.DstColor, BlendFactor.OneMinusSrcAlpha)]
+    [InlineData(BlendMode.Premultiplied, BlendFactor.One, BlendFactor.OneMinusSrcAlpha)]
+    public void SetBlendMode_Mode_DrawsWithMappedFactors(BlendMode mode, BlendFactor expectedSrc, BlendFactor expectedDst)
+    {
+        renderer.Begin();
+        renderer.SetBlendMode(mode);
+        renderer.FillRect(0f, 0f, 10f, 10f, new Vector4(1f, 1f, 1f, 1f));
+        renderer.End();
+
+        Assert.Equal(mode, renderer.CurrentBlendMode);
+
+        var draw = Assert.Single(device.DrawCalls);
+        Assert.Equal(expectedSrc, draw.BlendSrcFactor);
+        Assert.Equal(expectedDst, draw.BlendDstFactor);
+    }
+
+    /// <summary>
+    /// The rounded-rect flush path must honor the active blend mode too.
+    /// </summary>
+    [Fact]
+    public void FillRoundedRect_WithAdditiveBlendMode_DrawsWithAdditiveFactors()
+    {
+        renderer.Begin();
+        renderer.SetBlendMode(BlendMode.Additive);
+        renderer.FillRoundedRect(0f, 0f, 40f, 40f, 8f, new Vector4(1f, 1f, 1f, 1f));
+        renderer.End();
+
+        var roundedDraw = device.DrawCalls[0];
+        Assert.Equal(BlendFactor.SrcAlpha, roundedDraw.BlendSrcFactor);
+        Assert.Equal(BlendFactor.One, roundedDraw.BlendDstFactor);
+    }
+
+    #endregion
+
     #region Helpers
 
     /// <summary>

--- a/tests/KeenEyes.Particles.Tests/ParticleEffectsTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleEffectsTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Particles.Components;
 using KeenEyes.Particles.Data;
 
@@ -72,7 +73,7 @@ public class ParticleEffectsTests
 
         Assert.True(emitter.EmissionRate > 0);
         Assert.True(emitter.LifetimeMin > 0);
-        Assert.Equal(BlendMode.Transparent, emitter.BlendMode);
+        Assert.Equal(BlendMode.Alpha, emitter.BlendMode);
         Assert.True(emitter.IsPlaying);
     }
 

--- a/tests/KeenEyes.Particles.Tests/ParticleRenderSystemTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleRenderSystemTests.cs
@@ -39,7 +39,7 @@ public class ParticleRenderSystemTests : IDisposable
 
         var emitter = ParticleEmitter.Burst(5, 1f) with
         {
-            BlendMode = BlendMode.Transparent
+            BlendMode = BlendMode.Alpha
         };
         world!.Spawn()
             .With(new Transform2D(Vector2.Zero, 0f, Vector2.One))
@@ -125,13 +125,13 @@ public class ParticleRenderSystemTests : IDisposable
     #region Blend Mode Tests
 
     [Fact]
-    public void RenderSystem_TransparentBlend_DrawsParticles()
+    public void RenderSystem_AlphaBlend_DrawsParticles()
     {
         SetupWorldWithMockRenderer();
 
         var emitter = ParticleEmitter.Burst(5, 1f) with
         {
-            BlendMode = BlendMode.Transparent
+            BlendMode = BlendMode.Alpha
         };
         world!.Spawn()
             .With(new Transform2D(Vector2.Zero, 0f, Vector2.One))
@@ -208,7 +208,7 @@ public class ParticleRenderSystemTests : IDisposable
         // Create emitters with different blend modes
         world!.Spawn()
             .With(new Transform2D(new Vector2(0, 0), 0f, Vector2.One))
-            .With(ParticleEmitter.Burst(2, 1f) with { BlendMode = BlendMode.Transparent })
+            .With(ParticleEmitter.Burst(2, 1f) with { BlendMode = BlendMode.Alpha })
             .Build();
 
         world.Spawn()
@@ -262,9 +262,68 @@ public class ParticleRenderSystemTests : IDisposable
         Assert.Equal(2, circles.Count);
 
         // Multiply (red) should be rendered before Additive (blue)
-        // Order: Multiply -> Transparent -> Premultiplied -> Additive
+        // Order: Multiply -> Alpha -> Premultiplied -> Additive
         Assert.Equal(1f, circles[0].Color.X); // First is red (Multiply)
         Assert.Equal(1f, circles[1].Color.Z); // Second is blue (Additive)
+    }
+
+    [Fact]
+    public void RenderSystem_MixedBlendModes_SetsAdditiveForAdditiveGroupAndRestoresAlpha()
+    {
+        SetupWorldWithMockRenderer();
+
+        world!.Spawn()
+            .With(new Transform2D(Vector2.Zero, 0f, Vector2.One))
+            .With(ParticleEmitter.Burst(2, 1f) with
+            {
+                BlendMode = BlendMode.Alpha,
+                StartColor = new Vector4(1, 0, 0, 1) // Red = Alpha group
+            })
+            .Build();
+
+        world.Spawn()
+            .With(new Transform2D(new Vector2(100, 0), 0f, Vector2.One))
+            .With(ParticleEmitter.Burst(3, 1f) with
+            {
+                BlendMode = BlendMode.Additive,
+                StartColor = new Vector4(0, 0, 1, 1) // Blue = Additive group
+            })
+            .Build();
+
+        world.Update(1f / 60f);
+
+        var commands = mockRenderer!.Commands;
+
+        // The additive group must be preceded by an explicit switch to Additive.
+        var additiveSwitch = Assert.Single(
+            commands.OfType<SetBlendModeCommand>(), c => c.Mode == BlendMode.Additive);
+        var additiveSwitchIndex = commands.IndexOf(additiveSwitch);
+
+        for (var i = 0; i < commands.Count; i++)
+        {
+            if (commands[i] is not FillCircleCommand circle)
+            {
+                continue;
+            }
+
+            if (circle.Color.Z > 0.5f)
+            {
+                // Blue (additive) particles draw only after the Additive switch.
+                Assert.True(i > additiveSwitchIndex,
+                    "Additive particle drawn before SetBlendMode(Additive)");
+            }
+            else
+            {
+                // Red (alpha) particles draw before the Additive switch.
+                Assert.True(i < additiveSwitchIndex,
+                    "Alpha particle drawn after SetBlendMode(Additive)");
+            }
+        }
+
+        // After rendering, the blend mode must be restored to Alpha.
+        var lastSwitch = commands.OfType<SetBlendModeCommand>().Last();
+        Assert.Equal(BlendMode.Alpha, lastSwitch.Mode);
+        Assert.Equal(BlendMode.Alpha, mockRenderer.CurrentBlendMode);
     }
 
     #endregion

--- a/tests/KeenEyes.Particles.Tests/ParticleSystemIntegrationTests.cs
+++ b/tests/KeenEyes.Particles.Tests/ParticleSystemIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Particles.Components;
 using KeenEyes.Particles.Data;
 using KeenEyes.Particles.Systems;
@@ -684,7 +685,7 @@ public class ParticleSystemIntegrationTests : IDisposable
                 Shape = EmissionShape.Point,
                 Texture = default,
                 StartColor = new Vector4(1f, 1f, 1f, 1f),
-                BlendMode = BlendMode.Transparent,
+                BlendMode = BlendMode.Alpha,
                 IsPlaying = true
             })
             .Build();


### PR DESCRIPTION
## Summary
Prerequisite for the NOVAFALL flagship 2D sample (tracked on the KeenEyes tarot board): the 2D renderer hardcoded `SrcAlpha/OneMinusSrcAlpha` in every flush path, and `ParticleRenderSystem` grouped particles by a `BlendMode` that was silently ignored at the GL level.

- New public `BlendMode` enum (Alpha/Additive/Multiply/Premultiplied) + `ToBlendFactors()` in `KeenEyes.Graphics.Abstractions`; the private Particles copy deleted and migrated (no shims, per no-backwards-compat policy).
- `I2DRenderer` gains `CurrentBlendMode` + `SetBlendMode(mode)` — switching modes flushes the pending batch; same-mode is a no-op; `Begin()` resets to Alpha.
- `Silk2DRenderer` applies the active mode's factors on every flush; no `IGraphicsDevice` change needed (existing `BlendFactor` enum already had all four factors).
- `ParticleRenderSystem` now actually sets the blend mode per group and restores Alpha after.
- All implementers updated (`Mock2DRenderer` + editor test recorder); `Mock2DRenderer` records `SetBlendModeCommand` for assertions.

## Test plan
- [x] Mid-batch flush-at-boundary, `Begin()` reset, per-mode factor mapping, particle group set/restore — all fail-on-old proven via source revert (old code never emits Additive)
- [x] Graphics.Tests 579, Particles.Tests 285; full suite 14,741, 0 failed; 0 warnings; format clean