### PR TITLE
feat(samples): Add NOVAFALL Phase A — playable core of the Fall Down reimagining

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -21,6 +21,7 @@
     <Project Path="samples/KeenEyes.Sample.MassSimulation/KeenEyes.Sample.MassSimulation.csproj" />
     <Project Path="samples/KeenEyes.Sample.Messaging/KeenEyes.Sample.Messaging.csproj" />
     <Project Path="samples/KeenEyes.Sample.Multiplayer/KeenEyes.Sample.Multiplayer.csproj" />
+    <Project Path="samples/KeenEyes.Sample.NovaFall/KeenEyes.Sample.NovaFall.csproj" />
     <Project Path="samples/KeenEyes.Sample.Physics/KeenEyes.Sample.Physics.csproj" />
     <Project Path="samples/KeenEyes.Sample.Prefabs/KeenEyes.Sample.Prefabs.csproj" />
     <Project Path="samples/KeenEyes.Sample.Racing/KeenEyes.Sample.Racing.csproj" />

--- a/samples/KeenEyes.Sample.NovaFall/Components.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Components.cs
@@ -1,0 +1,202 @@
+namespace KeenEyes.Sample.NovaFall;
+
+// ============================================================================
+// Entity components — pure data attached to entities.
+// ============================================================================
+
+/// <summary>
+/// Marks the player-controlled ball and stores its collision radius.
+/// </summary>
+[Component]
+public partial struct Ball
+{
+    /// <summary>Collision radius in design units.</summary>
+    public float Radius;
+}
+
+/// <summary>
+/// 2D position in design-space units. (0,0) is the top-left of the shaft,
+/// Y increases downward.
+/// </summary>
+[Component]
+public partial struct Position2D
+{
+    /// <summary>Horizontal position.</summary>
+    public float X;
+
+    /// <summary>Vertical position.</summary>
+    public float Y;
+}
+
+/// <summary>
+/// 2D velocity in design-space units per second.
+/// </summary>
+[Component]
+public partial struct Velocity2D
+{
+    /// <summary>Horizontal velocity.</summary>
+    public float X;
+
+    /// <summary>Vertical velocity (positive is downward).</summary>
+    public float Y;
+}
+
+/// <summary>
+/// Steering input for the ball, written by <see cref="InputSteerSystem"/> and
+/// consumed by <see cref="BallMovementSystem"/>.
+/// </summary>
+/// <remarks>
+/// Storing the input on the entity (instead of having the movement system poll
+/// devices directly) keeps device access in exactly one system, so the rest of the
+/// simulation stays headless-friendly and deterministic.
+/// </remarks>
+[Component]
+public partial struct SteerInput
+{
+    /// <summary>Steering axis in [-1, 1]; negative steers left, positive steers right.</summary>
+    public float Axis;
+}
+
+/// <summary>
+/// A horizontal floor spanning the shaft, with a single gap the ball can fall through.
+/// </summary>
+[Component]
+public partial struct Floor
+{
+    /// <summary>Sequential index of this floor within the run (0 = first floor).</summary>
+    public int Index;
+
+    /// <summary>X position of the gap's center.</summary>
+    public float GapCenterX;
+
+    /// <summary>Width of the gap.</summary>
+    public float GapWidth;
+
+    /// <summary>Vertical thickness of the floor slab.</summary>
+    public float Thickness;
+
+    /// <summary>
+    /// True once the ball has passed below this floor. Prevents a single floor
+    /// from stoking heat more than once.
+    /// </summary>
+    public bool Cleared;
+}
+
+/// <summary>
+/// Present on the ball while it rests on a floor; the floor carries it upward.
+/// </summary>
+[Component]
+public partial struct RestingOn
+{
+    /// <summary>The floor entity the ball is resting on.</summary>
+    public Entity FloorEntity;
+}
+
+// ============================================================================
+// Singletons — world-wide state accessed via the World singleton API.
+// ============================================================================
+
+/// <summary>
+/// Immutable-per-run configuration for the current run.
+/// </summary>
+public struct RunConfig
+{
+    /// <summary>Seed driving all floor generation for this run.</summary>
+    public ulong Seed;
+
+    /// <summary>
+    /// When true, restarts reuse <see cref="Seed"/> instead of deriving a new one.
+    /// Useful for practicing a specific layout and for deterministic testing.
+    /// </summary>
+    public bool PinSeed;
+}
+
+/// <summary>
+/// State of the upward-scrolling shaft.
+/// </summary>
+public struct ScrollState
+{
+    /// <summary>Current upward scroll speed in design units per second.</summary>
+    public float Speed;
+
+    /// <summary>Total depth fallen this run, in meters.</summary>
+    public float Depth;
+
+    /// <summary>Index of the next floor to spawn (also the count of floors spawned).</summary>
+    public int NextFloorIndex;
+}
+
+/// <summary>
+/// The Heat resource stoked by clean gap-throughs.
+/// </summary>
+public struct HeatState
+{
+    /// <summary>Current heat in [0, <see cref="Tuning.MaxHeat"/>].</summary>
+    public float Heat;
+
+    /// <summary>Current tier: 0 = Ember, 1 = Flame, 2 = Plasma, 3 = Nova.</summary>
+    public int Tier;
+}
+
+/// <summary>
+/// Score accumulation for the current run and the best score across runs.
+/// </summary>
+public struct ScoreState
+{
+    /// <summary>Score for the current run (meters fallen x heat multiplier, integrated).</summary>
+    public double Score;
+
+    /// <summary>Best final score across all runs this session.</summary>
+    public int Best;
+
+    /// <summary>Depth already converted into score, used to integrate per-frame deltas.</summary>
+    public float LastDepth;
+}
+
+/// <summary>
+/// The high-level phase of the game.
+/// </summary>
+public enum GamePhase
+{
+    /// <summary>Waiting for the player to start.</summary>
+    Ready,
+
+    /// <summary>The run is live.</summary>
+    Playing,
+
+    /// <summary>The ball touched the Furnace ceiling.</summary>
+    Dead,
+}
+
+/// <summary>
+/// Current <see cref="GamePhase"/> of the game.
+/// </summary>
+public struct GameState
+{
+    /// <summary>The active phase.</summary>
+    public GamePhase Phase;
+}
+
+/// <summary>
+/// Global simulation time multiplier. Every simulation system multiplies its delta
+/// time by <see cref="Value"/>, providing the hook for hitstop and slow-motion
+/// effects in later phases.
+/// </summary>
+public struct TimeScale
+{
+    /// <summary>Multiplier applied to simulation delta time (1 = normal speed).</summary>
+    public float Value;
+}
+
+/// <summary>
+/// Per-frame collision events published by <see cref="CollisionSystem"/> and
+/// consumed (then cleared) by <see cref="HeatSystem"/>.
+/// </summary>
+public struct FrameEvents
+{
+    /// <summary>Number of floors the ball passed cleanly through this frame.</summary>
+    public int GapsPassed;
+
+    /// <summary>True if the ball landed on a floor this frame.</summary>
+    public bool Landed;
+}

--- a/samples/KeenEyes.Sample.NovaFall/FloorLayout.cs
+++ b/samples/KeenEyes.Sample.NovaFall/FloorLayout.cs
@@ -1,0 +1,33 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Pure functions describing the procedural floor layout of a run.
+/// </summary>
+/// <remarks>
+/// Both <see cref="FloorScrollSystem"/> (spawning floors during play) and the
+/// headless <c>--simulate</c> mode (verifying determinism) call the same function,
+/// guaranteeing that what the test asserts is exactly what the game spawns.
+/// </remarks>
+public static class FloorLayout
+{
+    /// <summary>
+    /// Computes the gap for a given floor of a run.
+    /// </summary>
+    /// <param name="seed">The run seed from <see cref="RunConfig"/>.</param>
+    /// <param name="floorIndex">The sequential index of the floor (0 = first floor).</param>
+    /// <returns>The gap center X and gap width in design units.</returns>
+    public static (float GapCenterX, float GapWidth) GapForFloor(ulong seed, int floorIndex)
+    {
+        var rng = SeededGenerator.ForFloor(seed, floorIndex);
+
+        var gapWidth = rng.NextRange(Tuning.GapWidthMin, Tuning.GapWidthMax);
+
+        // Keep the whole gap away from the walls so every gap is reachable.
+        var halfGap = gapWidth / 2f;
+        var minCenter = Tuning.GapWallMargin + halfGap;
+        var maxCenter = Tuning.ShaftWidth - Tuning.GapWallMargin - halfGap;
+        var gapCenterX = rng.NextRange(minCenter, maxCenter);
+
+        return (gapCenterX, gapWidth);
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/GameSetup.cs
+++ b/samples/KeenEyes.Sample.NovaFall/GameSetup.cs
@@ -1,0 +1,73 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Shared world setup used by both the windowed game and the headless
+/// <c>--simulate</c> mode.
+/// </summary>
+public static class GameSetup
+{
+    /// <summary>
+    /// Installs all game singletons with their initial values. Call once per world,
+    /// before the first <see cref="StartRun"/>.
+    /// </summary>
+    /// <param name="world">The world to initialize.</param>
+    /// <param name="seed">The seed for the first run.</param>
+    /// <param name="pinSeed">When true, every restart reuses <paramref name="seed"/>.</param>
+    public static void InitializeSingletons(IWorld world, ulong seed, bool pinSeed)
+    {
+        world.SetSingleton(new RunConfig { Seed = seed, PinSeed = pinSeed });
+        world.SetSingleton(new ScrollState { Speed = Tuning.BaseScrollSpeed });
+        world.SetSingleton(new HeatState());
+        world.SetSingleton(new ScoreState());
+        world.SetSingleton(new GameState { Phase = GamePhase.Ready });
+        world.SetSingleton(new TimeScale { Value = 1f });
+        world.SetSingleton(new FrameEvents());
+    }
+
+    /// <summary>
+    /// Resets the world for a fresh run: despawns the previous ball and floors,
+    /// resets per-run singletons (preserving the session best score), and spawns a
+    /// new ball. Floors are populated lazily by <see cref="FloorScrollSystem"/> on
+    /// the next update.
+    /// </summary>
+    /// <param name="world">The world to reset.</param>
+    /// <param name="seed">The seed for the new run.</param>
+    public static void StartRun(IWorld world, ulong seed)
+    {
+        // Collect first, despawn after: never structurally modify the world while
+        // a query enumerator is live.
+        var stale = new List<Entity>();
+        foreach (var entity in world.Query<Ball>())
+        {
+            stale.Add(entity);
+        }
+
+        foreach (var entity in world.Query<Floor>())
+        {
+            stale.Add(entity);
+        }
+
+        foreach (var entity in stale)
+        {
+            world.Despawn(entity);
+        }
+
+        ref var runConfig = ref world.GetSingleton<RunConfig>();
+        runConfig.Seed = seed;
+
+        world.SetSingleton(new ScrollState { Speed = Tuning.BaseScrollSpeed });
+        world.SetSingleton(new HeatState());
+        world.SetSingleton(new FrameEvents());
+
+        ref var score = ref world.GetSingleton<ScoreState>();
+        score.Score = 0;
+        score.LastDepth = 0;
+
+        world.Spawn("Ball")
+            .With(new Ball { Radius = Tuning.BallRadius })
+            .With(new Position2D { X = Tuning.BallSpawnX, Y = Tuning.BallSpawnY })
+            .With(new Velocity2D())
+            .With(new SteerInput())
+            .Build();
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/KeenEyes.Sample.NovaFall.csproj
+++ b/samples/KeenEyes.Sample.NovaFall/KeenEyes.Sample.NovaFall.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Common\KeenEyes.Common.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Core\KeenEyes.Core.csproj" />
+    <ProjectReference Include="..\..\editor\KeenEyes.Generators\KeenEyes.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Abstractions\KeenEyes.Graphics.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics.Silk\KeenEyes.Graphics.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Graphics\KeenEyes.Graphics.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Abstractions\KeenEyes.Input.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Silk\KeenEyes.Input.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Input\KeenEyes.Input.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk\KeenEyes.Platform.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Runtime\KeenEyes.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Spatial\KeenEyes.Spatial.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -1,0 +1,241 @@
+// NOVAFALL — a modern reinterpretation of the TI-83 classic "Fall Down".
+//
+// A ball falls down an endless shaft of scrolling floors. Steer LEFT/RIGHT — the
+// only inputs — to drop through the gaps. Floors scroll upward and carry anything
+// resting on them toward the Furnace ceiling at the top; touch it and die.
+//
+// The NOVAFALL twist: consecutive clean gap-throughs stoke a Heat resource through
+// four tiers — Ember → Flame → Plasma → Nova — which gate the score multiplier
+// (x1/x2/x4/x8). Landing on a floor halves heat; resting bleeds it slowly; only
+// death resets it. Score is meters fallen times the current multiplier, ticking
+// continuously.
+//
+// Controls:
+//   A / Left Arrow / Left Stick   - Steer left
+//   D / Right Arrow / Left Stick  - Steer right
+//   Any steer key                 - Start / restart
+//   Escape                        - Exit
+//
+// Command line:
+//   --seed <n>        Pin the run seed (same layout every run)
+//   --simulate <n>    Headless determinism check: run n frames without a window
+//                     and print the procedural layout and final depth
+//
+// NOTE: The windowed mode requires a display; --simulate does not.
+
+using System.Globalization;
+using System.Numerics;
+using KeenEyes;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Input.Silk;
+using KeenEyes.Platform.Silk;
+using KeenEyes.Runtime;
+using KeenEyes.Sample.NovaFall;
+
+// --- Parse arguments ---
+
+var pinnedSeed = default(ulong?);
+var simulateFrames = default(int?);
+
+for (var i = 0; i < args.Length - 1; i++)
+{
+    if (args[i] == "--seed" && ulong.TryParse(args[i + 1], CultureInfo.InvariantCulture, out var parsedSeed))
+    {
+        pinnedSeed = parsedSeed;
+    }
+    else if (args[i] == "--simulate" && int.TryParse(args[i + 1], CultureInfo.InvariantCulture, out var parsedFrames))
+    {
+        simulateFrames = parsedFrames;
+    }
+}
+
+// --- Headless determinism mode ---
+
+if (simulateFrames is int frames)
+{
+    RunHeadlessSimulation(frames, pinnedSeed ?? 0x5EEDF00DUL);
+    return;
+}
+
+// --- Windowed game ---
+
+Console.WriteLine("NOVAFALL");
+Console.WriteLine("========");
+Console.WriteLine();
+Console.WriteLine("Steer into the gaps. Do not touch the Furnace.");
+Console.WriteLine();
+Console.WriteLine("Controls:");
+Console.WriteLine("  A / Left Arrow / Left Stick   - Steer left");
+Console.WriteLine("  D / Right Arrow / Left Stick  - Steer right");
+Console.WriteLine("  Any steer key                 - Start / restart");
+Console.WriteLine("  Escape                        - Exit");
+Console.WriteLine();
+
+var fontPath = FindSystemFont();
+if (fontPath is null)
+{
+    Console.WriteLine("Warning: no system font found; the score will show in the window title.");
+}
+
+var windowConfig = new WindowConfig
+{
+    Title = "NOVAFALL",
+    Width = 720,
+    Height = 1080,
+    VSync = true
+};
+
+var graphicsConfig = new SilkGraphicsConfig
+{
+    ClearColor = new Vector4(0.03f, 0.05f, 0.12f, 1f), // dark navy shaft
+    EnableDepthTest = false,
+    EnableCulling = false
+};
+
+var inputConfig = new SilkInputConfig
+{
+    EnableGamepads = true,
+    MaxGamepads = 1,
+    GamepadDeadzone = 0.15f,
+    CaptureMouseOnClick = false
+};
+
+using var world = new World();
+
+// Install plugins (order matters: window first, then graphics and input).
+world.InstallPlugin(new SilkWindowPlugin(windowConfig));
+world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
+world.InstallPlugin(new SilkInputPlugin(inputConfig));
+
+// A new seed per run unless one is pinned on the command line.
+var seed = pinnedSeed ?? (ulong)Environment.TickCount64;
+
+GameSetup.InitializeSingletons(world, seed, pinSeed: pinnedSeed is not null);
+RegisterSystems(world, fontPath);
+GameSetup.StartRun(world, seed);
+
+Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Run seed: {seed}"));
+Console.WriteLine("Starting...");
+
+try
+{
+    world.CreateRunner()
+        .OnReady(() =>
+        {
+            var input = world.GetExtension<IInputContext>();
+            input.Keyboard.OnKeyDown += eventArgs =>
+            {
+                if (eventArgs.Key == Key.Escape)
+                {
+                    Console.WriteLine("Escape pressed - exiting...");
+                    System.Environment.Exit(0);
+                }
+            };
+
+            Console.WriteLine("Ready. Press A/D to dive.");
+        })
+        .OnResize((width, height) =>
+        {
+            // Gameplay lives in a fixed design space; the render system rescales
+            // automatically, so a resize only needs acknowledging, not handling.
+            Console.WriteLine($"Window resized to {width}x{height}");
+        })
+        .Run();
+}
+catch (Exception ex)
+{
+    // Top-level demo entry point: initializing the windowing/graphics stack can
+    // surface a wide range of platform exceptions (missing display, driver, or GL
+    // context errors). A demo recovers by reporting the failure and exiting rather
+    // than crashing, so a catch-all is appropriate here.
+    Console.WriteLine($"Error: {ex.Message}");
+    Console.WriteLine("Windowed mode requires a display. Try --simulate 600 for the headless check.");
+}
+
+Console.WriteLine("Sample complete!");
+
+// Registers every game system with explicit phases and orders. Shared by the
+// windowed game and the headless simulation so both run the same pipeline.
+static void RegisterSystems(World world, string? fontPath)
+{
+    world.AddSystem<InputSteerSystem>(SystemPhase.Update, order: 0);
+    world.AddSystem<BallMovementSystem>(SystemPhase.Update, order: 10);
+    world.AddSystem<FloorScrollSystem>(SystemPhase.Update, order: 20);
+    world.AddSystem<CollisionSystem>(SystemPhase.Update, order: 30);
+    world.AddSystem<HeatSystem>(SystemPhase.Update, order: 40);
+    world.AddSystem<ScoreSystem>(SystemPhase.Update, order: 50);
+    world.AddSystem<CrushSystem>(SystemPhase.Update, order: 60);
+    world.AddSystem<GameFlowSystem>(SystemPhase.Update, order: 70);
+    world.AddSystem(new NovaFallRenderSystem(fontPath), SystemPhase.Render, order: 0, runsBefore: [], runsAfter: []);
+}
+
+// Headless determinism harness: builds the world with no window, graphics, or
+// input plugins (every system that needs one no-ops), steps a fixed number of
+// frames at a fixed timestep, and prints the procedural layout plus final state.
+// Running this twice with the same seed must produce byte-identical output — the
+// CI-safe determinism hook for a later phase's replay tests.
+static void RunHeadlessSimulation(int frames, ulong seed)
+{
+    using var world = new World();
+
+    GameSetup.InitializeSingletons(world, seed, pinSeed: true);
+    RegisterSystems(world, fontPath: null);
+    GameSetup.StartRun(world, seed);
+
+    // No input exists to press a start key, so the harness starts the run itself.
+    world.GetSingleton<GameState>().Phase = GamePhase.Playing;
+
+    const float fixedDeltaTime = 1f / 60f;
+    for (var i = 0; i < frames; i++)
+    {
+        world.Update(fixedDeltaTime);
+    }
+
+    Console.WriteLine(string.Create(
+        CultureInfo.InvariantCulture, $"NOVAFALL simulation: seed={seed} frames={frames}"));
+
+    for (var i = 0; i < 10; i++)
+    {
+        var (gapCenterX, gapWidth) = FloorLayout.GapForFloor(seed, i);
+        Console.WriteLine(string.Create(
+            CultureInfo.InvariantCulture,
+            $"floor {i}: gapCenter={gapCenterX:F3} gapWidth={gapWidth:F3}"));
+    }
+
+    var scroll = world.GetSingleton<ScrollState>();
+    var score = world.GetSingleton<ScoreState>();
+    var heat = world.GetSingleton<HeatState>();
+    var phase = world.GetSingleton<GameState>().Phase;
+
+    Console.WriteLine(string.Create(
+        CultureInfo.InvariantCulture,
+        $"final: depth={scroll.Depth:F3}m speed={scroll.Speed:F3} floorsSpawned={scroll.NextFloorIndex} " +
+        $"score={score.Score:F3} heat={heat.Heat:F3} tier={heat.Tier} phase={phase}"));
+}
+
+// Finds a usable system font for the HUD, or null if none exists.
+static string? FindSystemFont()
+{
+    string[] candidates =
+    [
+        @"C:\Windows\Fonts\segoeui.ttf",
+        @"C:\Windows\Fonts\arial.ttf",
+        @"C:\Windows\Fonts\calibri.ttf",
+        @"C:\Windows\Fonts\verdana.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/TTF/DejaVuSans.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf"
+    ];
+
+    foreach (var path in candidates)
+    {
+        if (File.Exists(path))
+        {
+            return path;
+        }
+    }
+
+    return null;
+}

--- a/samples/KeenEyes.Sample.NovaFall/Rendering/NovaFallRenderSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Rendering/NovaFallRenderSystem.cs
@@ -1,0 +1,269 @@
+using System.Globalization;
+using System.Numerics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Renders the shaft with flat SDF shapes via <see cref="I2DRenderer"/>: a faked
+/// background gradient, the Furnace ceiling, floors as outlined rounded rects, and
+/// the ball as an ellipse subtly squashed by its velocity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The renderer is resolved lazily through <c>World.TryGetExtension</c> (it only
+/// exists once the window has loaded), following the same pattern as
+/// <c>KeenEyes.UI.UIRenderSystem</c>. In headless mode no renderer ever appears and
+/// the system is a no-op.
+/// </para>
+/// <para>
+/// The simulation runs in a fixed design space (see <see cref="Tuning"/>); this
+/// system scales design units to the current window size, so resizing the window
+/// never affects gameplay.
+/// </para>
+/// </remarks>
+/// <param name="fontPath">
+/// Path to a TTF font for the HUD, or null to fall back to showing the score in
+/// the window title.
+/// </param>
+public sealed class NovaFallRenderSystem(string? fontPath) : SystemBase
+{
+    private static readonly Vector4[] tierColors =
+    [
+        new(0.95f, 0.55f, 0.20f, 1f),  // Ember — warm orange
+        new(1.00f, 0.35f, 0.10f, 1f),  // Flame — hot orange-red
+        new(0.75f, 0.40f, 1.00f, 1f),  // Plasma — violet
+        new(0.85f, 0.95f, 1.00f, 1f),  // Nova — white-blue
+    ];
+
+    private static readonly Vector4 floorFill = new(0.16f, 0.20f, 0.32f, 1f);
+    private static readonly Vector4 floorOutline = new(0.45f, 0.56f, 0.80f, 1f);
+    private static readonly Vector4 hudColor = new(0.92f, 0.94f, 1.00f, 1f);
+
+    private I2DRenderer? renderer;
+    private ITextRenderer? textRenderer;
+    private FontHandle font;
+    private bool fontLoaded;
+    private bool fontLoadAttempted;
+    private int framesSinceTitleUpdate;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        // Lazy init: the renderer only exists after the window has loaded, and it
+        // never exists in headless simulation mode.
+        if (renderer is null && !TryInitializeRenderers())
+        {
+            return;
+        }
+
+        var scaleX = 1f;
+        var scaleY = 1f;
+        if (World.TryGetExtension<IGraphicsContext>(out var graphics) && graphics.Width > 0 && graphics.Height > 0)
+        {
+            scaleX = graphics.Width / Tuning.ShaftWidth;
+            scaleY = graphics.Height / Tuning.ShaftHeight;
+        }
+
+        renderer!.Begin();
+        try
+        {
+            DrawBackground(scaleX, scaleY);
+            DrawFloors(scaleX, scaleY);
+            DrawBall(scaleX, scaleY);
+        }
+        finally
+        {
+            renderer.End();
+        }
+
+        DrawHud(scaleX, scaleY);
+    }
+
+    private bool TryInitializeRenderers()
+    {
+        if (!World.TryGetExtension<I2DRenderer>(out renderer)
+            && World.TryGetExtension<I2DRendererProvider>(out var provider))
+        {
+            renderer = provider.Get2DRenderer();
+        }
+
+        if (renderer is null)
+        {
+            return false;
+        }
+
+        if (!World.TryGetExtension<ITextRenderer>(out textRenderer)
+            && World.TryGetExtension<ITextRendererProvider>(out var textProvider))
+        {
+            textRenderer = textProvider.GetTextRenderer();
+        }
+
+        return true;
+    }
+
+    private void DrawBackground(float scaleX, float scaleY)
+    {
+        var width = Tuning.ShaftWidth * scaleX;
+        var height = Tuning.ShaftHeight * scaleY;
+
+        // Faked vertical gradient: a few stacked translucent rects over the clear
+        // color — warm near the Furnace above, darkening toward the depths below.
+        renderer!.FillRect(0f, 0f, width, height * 0.30f, new Vector4(0.55f, 0.16f, 0.05f, 0.10f));
+        renderer.FillRect(0f, 0f, width, height * 0.12f, new Vector4(0.90f, 0.30f, 0.08f, 0.16f));
+        renderer.FillRect(0f, height * 0.62f, width, height * 0.38f, new Vector4(0.00f, 0.01f, 0.06f, 0.28f));
+
+        // The Furnace ceiling: a glowing band with a hard edge. Touch it and die.
+        var ceilingY = Tuning.CeilingY * scaleY;
+        renderer.FillRect(0f, 0f, width, ceilingY, new Vector4(0.95f, 0.42f, 0.10f, 0.35f));
+        renderer.DrawLine(0f, ceilingY, width, ceilingY, new Vector4(1.00f, 0.55f, 0.15f, 1f), 3f);
+    }
+
+    private void DrawFloors(float scaleX, float scaleY)
+    {
+        const float cornerRadius = 6f;
+        const float outlineThickness = 2f;
+
+        foreach (var entity in World.Query<Floor, Position2D>())
+        {
+            ref readonly var floor = ref World.Get<Floor>(entity);
+            ref readonly var position = ref World.Get<Position2D>(entity);
+
+            var y = position.Y * scaleY;
+            var thickness = floor.Thickness * scaleY;
+            var gapLeft = (floor.GapCenterX - floor.GapWidth / 2f) * scaleX;
+            var gapRight = (floor.GapCenterX + floor.GapWidth / 2f) * scaleX;
+            var shaftRight = Tuning.ShaftWidth * scaleX;
+
+            // Each floor is two slabs: wall → gap-left and gap-right → wall.
+            DrawSlab(0f, y, gapLeft, thickness, cornerRadius, outlineThickness);
+            DrawSlab(gapRight, y, shaftRight - gapRight, thickness, cornerRadius, outlineThickness);
+        }
+    }
+
+    private void DrawSlab(float x, float y, float width, float height, float cornerRadius, float outlineThickness)
+    {
+        if (width < 1f)
+        {
+            return;
+        }
+
+        renderer!.FillRoundedRect(x, y, width, height, cornerRadius, floorFill);
+        renderer.DrawRoundedRect(x, y, width, height, cornerRadius, floorOutline, outlineThickness);
+    }
+
+    private void DrawBall(float scaleX, float scaleY)
+    {
+        var tier = World.GetSingleton<HeatState>().Tier;
+        var color = tierColors[Math.Clamp(tier, 0, tierColors.Length - 1)];
+
+        foreach (var entity in World.Query<Ball, Position2D, Velocity2D>())
+        {
+            ref readonly var ball = ref World.Get<Ball>(entity);
+            ref readonly var position = ref World.Get<Position2D>(entity);
+            ref readonly var velocity = ref World.Get<Velocity2D>(entity);
+
+            // Velocity-driven aspect: elongate along the dominant motion axis.
+            // (The full squash/stretch tween is a later phase; this is the cheap
+            // teaser that already makes the ball feel alive.)
+            var verticalStretch = MathF.Min(MathF.Abs(velocity.Y) / 2800f, 0.35f);
+            var horizontalStretch = MathF.Min(MathF.Abs(velocity.X) / 2400f, 0.25f);
+            var radiusX = ball.Radius * (1f + horizontalStretch - verticalStretch) * scaleX;
+            var radiusY = ball.Radius * (1f + verticalStretch - horizontalStretch) * scaleY;
+
+            renderer!.FillEllipse(position.X * scaleX, position.Y * scaleY, radiusX, radiusY, color);
+            renderer.DrawEllipse(
+                position.X * scaleX, position.Y * scaleY, radiusX, radiusY,
+                new Vector4(1f, 1f, 1f, 0.35f), 2f);
+        }
+    }
+
+    private void DrawHud(float scaleX, float scaleY)
+    {
+        var score = World.GetSingleton<ScoreState>();
+        var heat = World.GetSingleton<HeatState>();
+        var depth = World.GetSingleton<ScrollState>().Depth;
+        var phase = World.GetSingleton<GameState>().Phase;
+
+        var hudLine = string.Create(
+            CultureInfo.InvariantCulture,
+            $"SCORE {score.Score:F0}  x{HeatSystem.MultiplierForTier(heat.Tier)} {HeatSystem.NameForTier(heat.Tier)}  {depth:F0}m");
+
+        EnsureFontLoaded();
+        if (fontLoaded && textRenderer is not null)
+        {
+            textRenderer.Begin();
+            try
+            {
+                textRenderer.DrawText(
+                    font, hudLine.AsSpan(),
+                    16f * scaleX, (Tuning.CeilingY + 14f) * scaleY,
+                    hudColor);
+
+                var prompt = phase switch
+                {
+                    GamePhase.Ready => "Press A/D or LEFT/RIGHT to dive",
+                    GamePhase.Dead => $"BEST {score.Best} — press A/D to dive again",
+                    _ => null,
+                };
+
+                if (prompt is not null)
+                {
+                    textRenderer.DrawText(
+                        font, prompt.AsSpan(),
+                        (Tuning.ShaftWidth / 2f) * scaleX, (Tuning.ShaftHeight / 2f) * scaleY,
+                        hudColor, TextAlignH.Center, TextAlignV.Middle);
+                }
+            }
+            finally
+            {
+                textRenderer.End();
+            }
+        }
+        else
+        {
+            // Graceful degradation: no usable font, so surface the score through
+            // the window title instead (throttled — title updates are not free).
+            framesSinceTitleUpdate++;
+            if (framesSinceTitleUpdate >= 30 && phase == GamePhase.Playing
+                && World.TryGetExtension<ISilkWindowProvider>(out var windowProvider))
+            {
+                windowProvider.Window.Title = $"NOVAFALL — {hudLine}";
+                framesSinceTitleUpdate = 0;
+            }
+        }
+    }
+
+    private void EnsureFontLoaded()
+    {
+        if (fontLoadAttempted)
+        {
+            return;
+        }
+
+        fontLoadAttempted = true;
+
+        if (fontPath is null
+            || !World.TryGetExtension<IFontManagerProvider>(out var fontManagerProvider))
+        {
+            return;
+        }
+
+        var fontManager = fontManagerProvider.GetFontManager();
+        if (fontManager is null)
+        {
+            return;
+        }
+
+        try
+        {
+            font = fontManager.LoadFont(fontPath, 20f);
+            fontLoaded = true;
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentException)
+        {
+            Console.WriteLine($"Failed to load font '{fontPath}': {ex.Message}");
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/SeededGenerator.cs
+++ b/samples/KeenEyes.Sample.NovaFall/SeededGenerator.cs
@@ -1,0 +1,78 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// A tiny deterministic pseudo-random generator based on SplitMix64.
+/// </summary>
+/// <remarks>
+/// <para>
+/// NOVAFALL derives all of its procedural content (floor gap positions and widths)
+/// from this generator so that a run is a pure function of its seed: the same seed
+/// always produces the same shaft, on any machine, with or without a window. That
+/// property powers the headless <c>--simulate</c> determinism check and, in a later
+/// phase, replay verification.
+/// </para>
+/// <para>
+/// The repo analyzer (KEEN030) forbids <c>System.Random</c> outside of
+/// <c>World.Next*</c>; a self-contained SplitMix64 struct is the established pattern
+/// for content generation that must be replayable from an explicit seed.
+/// </para>
+/// </remarks>
+/// <param name="seed">The seed value. Equal seeds produce identical sequences.</param>
+public struct SeededGenerator(ulong seed)
+{
+    private const ulong Gamma = 0x9E3779B97F4A7C15UL;
+
+    private ulong state = seed;
+
+    /// <summary>
+    /// Creates a generator for a specific floor of a run.
+    /// </summary>
+    /// <remarks>
+    /// The stream depends only on the run seed and the floor index, never on spawn
+    /// order or elapsed time, which is what makes floor generation window-independent.
+    /// </remarks>
+    /// <param name="seed">The run seed from <see cref="RunConfig"/>.</param>
+    /// <param name="floorIndex">The sequential index of the floor.</param>
+    /// <returns>A generator whose sequence is unique to (seed, floorIndex).</returns>
+    public static SeededGenerator ForFloor(ulong seed, int floorIndex)
+        => new(Mix(seed + ((ulong)floorIndex + 1) * Gamma));
+
+    /// <summary>
+    /// Derives the seed for the next run from the current one, so successive runs
+    /// get fresh layouts without any wall-clock or <c>System.Random</c> dependency.
+    /// </summary>
+    /// <param name="seed">The current run seed.</param>
+    /// <returns>A well-mixed successor seed.</returns>
+    public static ulong NextSeed(ulong seed) => Mix(seed + Gamma);
+
+    /// <summary>
+    /// Returns the next value in the sequence as a float in [0, 1).
+    /// </summary>
+    /// <returns>A uniformly distributed float in [0, 1).</returns>
+    public float NextFloat()
+    {
+        // Take the top 24 bits so the value fits a float mantissa exactly.
+        return (NextUInt64() >> 40) * (1f / (1 << 24));
+    }
+
+    /// <summary>
+    /// Returns the next value in the sequence as a float in [min, max).
+    /// </summary>
+    /// <param name="min">Inclusive lower bound.</param>
+    /// <param name="max">Exclusive upper bound.</param>
+    /// <returns>A uniformly distributed float in [min, max).</returns>
+    public float NextRange(float min, float max) => min + NextFloat() * (max - min);
+
+    private ulong NextUInt64()
+    {
+        state += Gamma;
+        return Mix(state);
+    }
+
+    private static ulong Mix(ulong value)
+    {
+        value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9UL;
+        value = (value ^ (value >> 27)) * 0x94D049BB133111EBUL;
+        return value ^ (value >> 31);
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/BallMovementSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/BallMovementSystem.cs
@@ -1,0 +1,73 @@
+using KeenEyes.Common;
+
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Integrates ball motion: gravity, steering acceleration, horizontal speed clamp,
+/// and wall clamping at the shaft edges.
+/// </summary>
+/// <remarks>
+/// Vertical integration is skipped while the ball rests on a floor —
+/// <see cref="CollisionSystem"/> keeps the resting ball glued to the floor that
+/// carries it upward. Horizontal steering always applies, which is how the player
+/// slides a resting ball toward the gap.
+/// </remarks>
+public sealed class BallMovementSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (World.GetSingleton<GameState>().Phase != GamePhase.Playing)
+        {
+            return;
+        }
+
+        var dt = deltaTime * World.GetSingleton<TimeScale>().Value;
+
+        foreach (var entity in World.Query<Ball, Position2D, Velocity2D, SteerInput>())
+        {
+            ref readonly var ball = ref World.Get<Ball>(entity);
+            ref readonly var steer = ref World.Get<SteerInput>(entity);
+            ref var position = ref World.Get<Position2D>(entity);
+            ref var velocity = ref World.Get<Velocity2D>(entity);
+
+            var resting = World.Has<RestingOn>(entity);
+
+            // Horizontal: accelerate with input, damp toward zero without it.
+            // Tolerance-based comparison — never == on floats.
+            if (!steer.Axis.IsApproximatelyZero())
+            {
+                velocity.X += steer.Axis * Tuning.SteerAcceleration * dt;
+            }
+            else
+            {
+                var damping = resting ? Tuning.GroundFriction : Tuning.AirDrag;
+                velocity.X -= velocity.X * Math.Min(damping * dt, 1f);
+            }
+
+            velocity.X = Math.Clamp(velocity.X, -Tuning.MaxHorizontalSpeed, Tuning.MaxHorizontalSpeed);
+            position.X += velocity.X * dt;
+
+            // Wall clamp: the shaft has hard edges.
+            var minX = ball.Radius;
+            var maxX = Tuning.ShaftWidth - ball.Radius;
+            if (position.X < minX)
+            {
+                position.X = minX;
+                velocity.X = 0f;
+            }
+            else if (position.X > maxX)
+            {
+                position.X = maxX;
+                velocity.X = 0f;
+            }
+
+            // Vertical: gravity only while airborne.
+            if (!resting)
+            {
+                velocity.Y = Math.Min(velocity.Y + Tuning.Gravity * dt, Tuning.MaxFallSpeed);
+                position.Y += velocity.Y * dt;
+            }
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/CollisionSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/CollisionSystem.cs
@@ -1,0 +1,139 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Resolves ball-versus-floor collisions: landing, resting (being carried upward),
+/// slipping into a gap, and clean gap-through detection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// TEACHING NOTE — why a simple row scan instead of a spatial index?
+/// </para>
+/// <para>
+/// NOVAFALL keeps roughly 10-15 live floors and exactly one ball, so a collision
+/// test is ~15 AABB checks per frame — trivially cheap and, more importantly,
+/// trivially correct. A quadtree (see <c>KeenEyes.Spatial</c>) would add tree
+/// maintenance every frame (floors move every frame, so the tree churns
+/// constantly) just to answer a query the flat scan answers faster. Spatial
+/// partitioning earns its keep when BOTH sides of the test are numerous — hundreds
+/// of projectiles against hundreds of colliders — because it turns an O(n*m)
+/// pairing into O(n log m). With m = 15, the constant factors dominate and the
+/// simplest code wins. Measure before you partition.
+/// </para>
+/// <para>
+/// The system publishes landing and gap-through events into the
+/// <see cref="FrameEvents"/> singleton, which <see cref="HeatSystem"/> consumes.
+/// </para>
+/// </remarks>
+public sealed class CollisionSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (World.GetSingleton<GameState>().Phase != GamePhase.Playing)
+        {
+            return;
+        }
+
+        // There is exactly one ball; grab it without structural changes mid-query.
+        var ballEntity = default(Entity);
+        var ballFound = false;
+        foreach (var entity in World.Query<Ball, Position2D, Velocity2D>())
+        {
+            ballEntity = entity;
+            ballFound = true;
+            break;
+        }
+
+        if (!ballFound)
+        {
+            return;
+        }
+
+        var radius = World.Get<Ball>(ballEntity).Radius;
+        ref var position = ref World.Get<Position2D>(ballEntity);
+        ref var velocity = ref World.Get<Velocity2D>(ballEntity);
+        ref var events = ref World.GetSingleton<FrameEvents>();
+
+        if (World.Has<RestingOn>(ballEntity))
+        {
+            UpdateResting(ballEntity, radius, ref position, ref velocity);
+            return;
+        }
+
+        // Airborne: row-scan the floors for landings and clean gap-throughs.
+        var landedOn = default(Entity);
+        var landed = false;
+
+        foreach (var floorEntity in World.Query<Floor, Position2D>())
+        {
+            ref var floor = ref World.Get<Floor>(floorEntity);
+            var floorTop = World.Get<Position2D>(floorEntity).Y;
+            var ballBottom = position.Y + radius;
+
+            // Landing: the ball's bottom is within the floor slab (plus a small
+            // tolerance for fast frames) while falling, and not over the gap.
+            if (!landed
+                && velocity.Y >= 0f
+                && ballBottom >= floorTop
+                && ballBottom <= floorTop + floor.Thickness + Tuning.LandingTolerance
+                && !IsOverGap(position.X, radius, in floor))
+            {
+                position.Y = floorTop - radius;
+                velocity.Y = 0f;
+                landedOn = floorEntity;
+                landed = true;
+                events.Landed = true;
+                continue;
+            }
+
+            // Clean gap-through: the ball's center has passed below a floor it
+            // never rested on top of at this moment — the only way down is
+            // through the gap.
+            if (!floor.Cleared && position.Y > floorTop + floor.Thickness)
+            {
+                floor.Cleared = true;
+                events.GapsPassed++;
+            }
+        }
+
+        // Structural change (component add) deferred until iteration is done.
+        if (landed)
+        {
+            World.Add(ballEntity, new RestingOn { FloorEntity = landedOn });
+        }
+    }
+
+    private void UpdateResting(Entity ballEntity, float radius, ref Position2D position, ref Velocity2D velocity)
+    {
+        var restingOn = World.Get<RestingOn>(ballEntity);
+        var floorEntity = restingOn.FloorEntity;
+
+        if (!World.IsAlive(floorEntity) || !World.Has<Floor>(floorEntity))
+        {
+            // The floor scrolled away and was despawned out from under us.
+            World.Remove<RestingOn>(ballEntity);
+            return;
+        }
+
+        ref readonly var floor = ref World.Get<Floor>(floorEntity);
+        var floorTop = World.Get<Position2D>(floorEntity).Y;
+
+        // The floor carries the resting ball upward, toward the Furnace.
+        position.Y = floorTop - radius;
+        velocity.Y = 0f;
+
+        // Steered over the gap? Let go and fall.
+        if (IsOverGap(position.X, radius, in floor))
+        {
+            World.Remove<RestingOn>(ballEntity);
+        }
+    }
+
+    private static bool IsOverGap(float ballX, float radius, in Floor floor)
+    {
+        // The ball only fits through when it is fully inside the gap.
+        var gapLeft = floor.GapCenterX - floor.GapWidth / 2f;
+        var gapRight = floor.GapCenterX + floor.GapWidth / 2f;
+        return ballX > gapLeft + radius && ballX < gapRight - radius;
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/CrushSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/CrushSystem.cs
@@ -1,0 +1,42 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Ends the run when the ball touches the Furnace ceiling.
+/// </summary>
+public sealed class CrushSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        ref var state = ref World.GetSingleton<GameState>();
+        if (state.Phase != GamePhase.Playing)
+        {
+            return;
+        }
+
+        foreach (var entity in World.Query<Ball, Position2D>())
+        {
+            ref readonly var ball = ref World.Get<Ball>(entity);
+            ref readonly var position = ref World.Get<Position2D>(entity);
+
+            if (position.Y - ball.Radius <= Tuning.CeilingY)
+            {
+                state.Phase = GamePhase.Dead;
+
+                ref var score = ref World.GetSingleton<ScoreState>();
+                score.Best = Math.Max(score.Best, (int)score.Score);
+
+                // Only death resets heat.
+                ResetHeat();
+                break;
+            }
+        }
+    }
+
+    private void ResetHeat()
+    {
+        ref var heat = ref World.GetSingleton<HeatState>();
+        heat.Heat = 0f;
+        heat.Tier = 0;
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/FloorScrollSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/FloorScrollSystem.cs
@@ -1,0 +1,102 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Scrolls floors upward, escalates scroll speed with depth, spawns new floors
+/// below the view, and despawns floors that scroll past the Furnace ceiling.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Floors form a ring-buffer style window over an infinite procedural shaft: only
+/// the ~10 floors near the view exist as entities at any time. Each floor's gap is
+/// a pure function of the run seed and the floor index (see <see cref="FloorLayout"/>),
+/// so the layout is identical for every replay of a seed regardless of frame rate
+/// or window size.
+/// </para>
+/// <para>
+/// Spawning and despawning run in every phase so the shaft is already populated on
+/// the Ready screen; scrolling and depth accumulation only happen while Playing.
+/// </para>
+/// </remarks>
+public sealed class FloorScrollSystem : SystemBase
+{
+    private readonly List<Entity> despawnList = [];
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        ref var scroll = ref World.GetSingleton<ScrollState>();
+        var seed = World.GetSingleton<RunConfig>().Seed;
+        var playing = World.GetSingleton<GameState>().Phase == GamePhase.Playing;
+
+        if (playing)
+        {
+            var dt = deltaTime * World.GetSingleton<TimeScale>().Value;
+
+            // Scroll speed escalates with depth: the deeper you are, the faster
+            // the Furnace chases you.
+            scroll.Speed = Math.Min(
+                Tuning.BaseScrollSpeed + scroll.Depth * Tuning.ScrollSpeedPerMeter,
+                Tuning.MaxScrollSpeed);
+
+            var rise = scroll.Speed * dt;
+            scroll.Depth += rise / Tuning.UnitsPerMeter;
+
+            foreach (var entity in World.Query<Floor, Position2D>())
+            {
+                ref var position = ref World.Get<Position2D>(entity);
+                position.Y -= rise;
+            }
+        }
+
+        // Despawn floors that scrolled above the ceiling. Collect first, despawn
+        // after: never structurally modify the world during query iteration.
+        despawnList.Clear();
+        var lowestY = float.MinValue;
+        var anyFloors = false;
+
+        foreach (var entity in World.Query<Floor, Position2D>())
+        {
+            var y = World.Get<Position2D>(entity).Y;
+            if (y < Tuning.CeilingY - Tuning.FloorDespawnMargin)
+            {
+                despawnList.Add(entity);
+            }
+            else
+            {
+                anyFloors = true;
+                lowestY = Math.Max(lowestY, y);
+            }
+        }
+
+        foreach (var entity in despawnList)
+        {
+            World.Despawn(entity);
+        }
+
+        // Keep the shaft filled one floor beyond the bottom of the view.
+        while (!anyFloors || lowestY < Tuning.ShaftHeight + Tuning.FloorSpacing)
+        {
+            var y = anyFloors ? lowestY + Tuning.FloorSpacing : Tuning.FirstFloorY;
+            SpawnFloor(seed, scroll.NextFloorIndex, y);
+            scroll.NextFloorIndex++;
+            lowestY = y;
+            anyFloors = true;
+        }
+    }
+
+    private void SpawnFloor(ulong seed, int floorIndex, float y)
+    {
+        var (gapCenterX, gapWidth) = FloorLayout.GapForFloor(seed, floorIndex);
+
+        World.Spawn()
+            .With(new Floor
+            {
+                Index = floorIndex,
+                GapCenterX = gapCenterX,
+                GapWidth = gapWidth,
+                Thickness = Tuning.FloorThickness,
+            })
+            .With(new Position2D { X = 0f, Y = y })
+            .Build();
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/GameFlowSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/GameFlowSystem.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Drives the Ready → Playing → Dead → Playing loop: starts the run on any steer
+/// key, announces the final score on death, and restarts with a fresh seed
+/// (unless <see cref="RunConfig.PinSeed"/> pins one).
+/// </summary>
+/// <remarks>
+/// Without an input context (headless <c>--simulate</c> mode) this system takes no
+/// actions; the harness drives <see cref="GameState"/> directly.
+/// </remarks>
+public sealed class GameFlowSystem : SystemBase
+{
+    private bool deathAnnounced;
+    private float restartCooldown;
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        ref var state = ref World.GetSingleton<GameState>();
+
+        switch (state.Phase)
+        {
+            case GamePhase.Ready:
+                if (IsStartPressed())
+                {
+                    state.Phase = GamePhase.Playing;
+                }
+
+                break;
+
+            case GamePhase.Dead:
+                if (!deathAnnounced)
+                {
+                    AnnounceDeath();
+                    deathAnnounced = true;
+                    restartCooldown = Tuning.RestartCooldown;
+                }
+
+                // Brief cooldown so the key that killed you cannot instantly
+                // skip the death screen.
+                restartCooldown -= deltaTime;
+                if (restartCooldown <= 0f && IsStartPressed())
+                {
+                    var runConfig = World.GetSingleton<RunConfig>();
+                    var seed = runConfig.PinSeed
+                        ? runConfig.Seed
+                        : SeededGenerator.NextSeed(runConfig.Seed);
+
+                    GameSetup.StartRun(World, seed);
+                    state.Phase = GamePhase.Playing;
+                    deathAnnounced = false;
+                }
+
+                break;
+
+            case GamePhase.Playing:
+            default:
+                break;
+        }
+    }
+
+    private bool IsStartPressed()
+    {
+        if (!World.TryGetExtension<IInputContext>(out var input))
+        {
+            return false;
+        }
+
+        var keyboard = input.Keyboard;
+        if (keyboard.IsKeyDown(Key.Space) || keyboard.IsKeyDown(Key.Enter)
+            || keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.D)
+            || keyboard.IsKeyDown(Key.Left) || keyboard.IsKeyDown(Key.Right))
+        {
+            return true;
+        }
+
+        var gamepad = input.Gamepad;
+        return gamepad.IsConnected && gamepad.IsButtonDown(GamepadButton.South);
+    }
+
+    private void AnnounceDeath()
+    {
+        var score = World.GetSingleton<ScoreState>();
+        var depth = World.GetSingleton<ScrollState>().Depth;
+
+        var summary = string.Create(
+            CultureInfo.InvariantCulture,
+            $"The Furnace claims you. Score {score.Score:F0} at {depth:F0}m (best {score.Best}). Press A/D to dive again.");
+        Console.WriteLine(summary);
+
+        if (World.TryGetExtension<ISilkWindowProvider>(out var windowProvider))
+        {
+            windowProvider.Window.Title = $"NOVAFALL — {summary}";
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/HeatSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/HeatSystem.cs
@@ -1,0 +1,84 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Manages the Heat resource: clean gap-throughs stoke it, landings halve it,
+/// resting bleeds it slowly, and thresholds map it to the four tiers that gate
+/// the score multiplier.
+/// </summary>
+/// <remarks>
+/// Tier progression: Ember (x1) → Flame (x2) → Plasma (x4) → Nova (x8).
+/// A full-stop landing HALVES heat but never zeroes it; only death resets heat.
+/// </remarks>
+public sealed class HeatSystem : SystemBase
+{
+    /// <summary>
+    /// Gets the score multiplier for a heat tier (1, 2, 4, or 8).
+    /// </summary>
+    /// <param name="tier">The tier index from <see cref="HeatState.Tier"/>.</param>
+    /// <returns>The score multiplier for the tier.</returns>
+    public static int MultiplierForTier(int tier) => 1 << tier;
+
+    /// <summary>
+    /// Gets the display name of a heat tier.
+    /// </summary>
+    /// <param name="tier">The tier index from <see cref="HeatState.Tier"/>.</param>
+    /// <returns>The tier's display name.</returns>
+    public static string NameForTier(int tier) => tier switch
+    {
+        3 => "NOVA",
+        2 => "PLASMA",
+        1 => "FLAME",
+        _ => "EMBER",
+    };
+
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (World.GetSingleton<GameState>().Phase != GamePhase.Playing)
+        {
+            return;
+        }
+
+        var dt = deltaTime * World.GetSingleton<TimeScale>().Value;
+        ref var heat = ref World.GetSingleton<HeatState>();
+        ref var events = ref World.GetSingleton<FrameEvents>();
+
+        // Stoke: every clean gap-through adds heat.
+        if (events.GapsPassed > 0)
+        {
+            heat.Heat = Math.Min(heat.Heat + events.GapsPassed * Tuning.HeatPerGap, Tuning.MaxHeat);
+        }
+
+        // A full-stop landing halves heat — punishing, but never back to zero.
+        if (events.Landed)
+        {
+            heat.Heat *= 0.5f;
+        }
+
+        // Resting on a floor slowly bleeds heat away.
+        var resting = false;
+        foreach (var _ in World.Query<Ball, RestingOn>())
+        {
+            resting = true;
+            break;
+        }
+
+        if (resting)
+        {
+            heat.Heat = Math.Max(heat.Heat - Tuning.HeatDecayPerSecond * dt, 0f);
+        }
+
+        heat.Tier = TierForHeat(heat.Heat);
+
+        // Events are consumed once per frame.
+        events = default;
+    }
+
+    private static int TierForHeat(float heat) => heat switch
+    {
+        >= Tuning.NovaThreshold => 3,
+        >= Tuning.PlasmaThreshold => 2,
+        >= Tuning.FlameThreshold => 1,
+        _ => 0,
+    };
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/InputSteerSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/InputSteerSystem.cs
@@ -1,0 +1,52 @@
+using KeenEyes.Common;
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Reads steering input (keyboard and gamepad) and writes it to the ball's
+/// <see cref="SteerInput"/> component. NOVAFALL's only inputs are LEFT and RIGHT.
+/// </summary>
+/// <remarks>
+/// This is the only simulation system that touches input devices. When no input
+/// context is available (headless <c>--simulate</c> mode), it does nothing and the
+/// steering axis stays at zero.
+/// </remarks>
+public sealed class InputSteerSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (!World.TryGetExtension<IInputContext>(out var input))
+        {
+            return;
+        }
+
+        var axis = 0f;
+
+        var keyboard = input.Keyboard;
+        if (keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.Left))
+        {
+            axis -= 1f;
+        }
+
+        if (keyboard.IsKeyDown(Key.D) || keyboard.IsKeyDown(Key.Right))
+        {
+            axis += 1f;
+        }
+
+        // Gamepad left stick only contributes when the keyboard is idle, so the
+        // two devices never fight over the ball.
+        var gamepad = input.Gamepad;
+        if (axis.IsApproximatelyZero() && gamepad.IsConnected)
+        {
+            axis = Math.Clamp(gamepad.LeftStick.X, -1f, 1f);
+        }
+
+        foreach (var entity in World.Query<Ball, SteerInput>())
+        {
+            ref var steer = ref World.Get<SteerInput>(entity);
+            steer.Axis = axis;
+        }
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Systems/ScoreSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/ScoreSystem.cs
@@ -1,0 +1,34 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Accumulates score continuously: meters fallen multiplied by the current heat
+/// tier's multiplier.
+/// </summary>
+/// <remarks>
+/// Score integrates per frame from the depth delta, so the multiplier active
+/// <em>while</em> each meter is fallen is what counts — stoking heat early
+/// compounds for the whole run.
+/// </remarks>
+public sealed class ScoreSystem : SystemBase
+{
+    /// <inheritdoc />
+    public override void Update(float deltaTime)
+    {
+        if (World.GetSingleton<GameState>().Phase != GamePhase.Playing)
+        {
+            return;
+        }
+
+        ref var score = ref World.GetSingleton<ScoreState>();
+        var depth = World.GetSingleton<ScrollState>().Depth;
+        var tier = World.GetSingleton<HeatState>().Tier;
+
+        var metersThisFrame = depth - score.LastDepth;
+        if (metersThisFrame > 0f)
+        {
+            score.Score += metersThisFrame * HeatSystem.MultiplierForTier(tier);
+        }
+
+        score.LastDepth = depth;
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Tuning.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Tuning.cs
@@ -1,0 +1,125 @@
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Central gameplay tuning constants for NOVAFALL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All simulation values are expressed in a fixed <em>design space</em> of
+/// <see cref="ShaftWidth"/> x <see cref="ShaftHeight"/> units, independent of the
+/// actual window size. The render system scales design units to pixels, which keeps
+/// the simulation fully deterministic and lets the headless <c>--simulate</c> mode
+/// replay a run without any window at all.
+/// </para>
+/// <para>
+/// Keeping every knob in one file makes the game feel easy to iterate on and gives
+/// readers a single map of the mechanics.
+/// </para>
+/// </remarks>
+public static class Tuning
+{
+    // --- Shaft geometry (design units) ---
+
+    /// <summary>Width of the playfield shaft in design units.</summary>
+    public const float ShaftWidth = 720f;
+
+    /// <summary>Height of the playfield shaft in design units.</summary>
+    public const float ShaftHeight = 1080f;
+
+    /// <summary>Y position of the Furnace ceiling. Touching it is death.</summary>
+    public const float CeilingY = 80f;
+
+    /// <summary>Design units per scored meter of descent.</summary>
+    public const float UnitsPerMeter = 100f;
+
+    // --- Ball ---
+
+    /// <summary>Radius of the ball in design units.</summary>
+    public const float BallRadius = 16f;
+
+    /// <summary>Ball spawn X at the start of a run (shaft center).</summary>
+    public const float BallSpawnX = ShaftWidth / 2f;
+
+    /// <summary>Ball spawn Y at the start of a run.</summary>
+    public const float BallSpawnY = 240f;
+
+    /// <summary>Downward gravity in design units per second squared.</summary>
+    public const float Gravity = 1500f;
+
+    /// <summary>Terminal fall speed in design units per second.</summary>
+    public const float MaxFallSpeed = 1100f;
+
+    /// <summary>Horizontal steering acceleration in design units per second squared.</summary>
+    public const float SteerAcceleration = 2800f;
+
+    /// <summary>Maximum horizontal speed in design units per second.</summary>
+    public const float MaxHorizontalSpeed = 420f;
+
+    /// <summary>Horizontal damping factor per second while resting on a floor with no input.</summary>
+    public const float GroundFriction = 8f;
+
+    /// <summary>Horizontal damping factor per second while airborne with no input.</summary>
+    public const float AirDrag = 1.5f;
+
+    // --- Floors ---
+
+    /// <summary>Vertical thickness of each floor in design units.</summary>
+    public const float FloorThickness = 24f;
+
+    /// <summary>Vertical distance between consecutive floors in design units.</summary>
+    public const float FloorSpacing = 170f;
+
+    /// <summary>Y position of the first floor of a run.</summary>
+    public const float FirstFloorY = 430f;
+
+    /// <summary>Minimum gap width in design units (comfortably wider than the ball).</summary>
+    public const float GapWidthMin = 96f;
+
+    /// <summary>Maximum gap width in design units.</summary>
+    public const float GapWidthMax = 150f;
+
+    /// <summary>Minimum distance from a gap edge to a shaft wall.</summary>
+    public const float GapWallMargin = 40f;
+
+    /// <summary>How far above the ceiling a floor may scroll before it is despawned.</summary>
+    public const float FloorDespawnMargin = 60f;
+
+    /// <summary>Extra tolerance below a floor top that still counts as a landing.</summary>
+    public const float LandingTolerance = 14f;
+
+    // --- Scrolling ---
+
+    /// <summary>Upward scroll speed at depth zero, in design units per second.</summary>
+    public const float BaseScrollSpeed = 70f;
+
+    /// <summary>Additional scroll speed per meter of depth.</summary>
+    public const float ScrollSpeedPerMeter = 1.1f;
+
+    /// <summary>Upper bound on scroll speed in design units per second.</summary>
+    public const float MaxScrollSpeed = 340f;
+
+    // --- Heat ---
+
+    /// <summary>Heat gained for each clean gap-through.</summary>
+    public const float HeatPerGap = 12f;
+
+    /// <summary>Heat lost per second while resting on a floor.</summary>
+    public const float HeatDecayPerSecond = 3f;
+
+    /// <summary>Maximum heat value.</summary>
+    public const float MaxHeat = 200f;
+
+    /// <summary>Heat required for the Flame tier (x2 multiplier).</summary>
+    public const float FlameThreshold = 30f;
+
+    /// <summary>Heat required for the Plasma tier (x4 multiplier).</summary>
+    public const float PlasmaThreshold = 70f;
+
+    /// <summary>Heat required for the Nova tier (x8 multiplier).</summary>
+    public const float NovaThreshold = 120f;
+
+    // --- Flow ---
+
+    /// <summary>Seconds after death before a restart key press is accepted.</summary>
+    public const float RestartCooldown = 0.75f;
+}

--- a/samples/KeenEyes.Sample.NovaFall/packages.lock.json
+++ b/samples/KeenEyes.Sample.NovaFall/packages.lock.json
@@ -1,0 +1,252 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+      },
+      "Cyotek.Drawing.BitmapFont": {
+        "type": "Transitive",
+        "resolved": "2.0.4",
+        "contentHash": "iA6WehGVdMUuNbfsQQDq/Bt+mMd/OqHjiMUtKFLIQd/0pyYh4ehT7FEjTxN9/4OXNKQZsp9bAJgltP2nnswUJg=="
+      },
+      "FontStashSharp.Base": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "kw8ovakGHz8jCah+H5M7qI8aOvtESF0jQRpcpubXUMsSid86dRO6DoDPlh+Tk/XAW5a3XgzGDgsHfeZTfZTr+Q=="
+      },
+      "FontStashSharp.Rasterizers.StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.2.3",
+        "contentHash": "xjzgWeiaODbW7DR/kI05V7C3CVtDvtB+4TrgX4EKNpRGzxb42vsvXKWrXORQWU2LCLnPPqdBNNSgtRujnpK2ww==",
+        "dependencies": {
+          "FontStashSharp.Base": "1.2.3",
+          "StbTrueTypeSharp": "1.26.12"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "fNGvKct2De8ghm0Bpfq0iWthtzIWabgOTi+gJhNOPhNJIowXNEUE2eZNW/zNCzrHVA3PXg2yZ+3cWZndC2IqYA=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "StbTrueTypeSharp": {
+        "type": "Transitive",
+        "resolved": "1.26.12",
+        "contentHash": "hCc6/OsfcPa5VsLECcEU2m78WOshBrKwK42nAodSm9Z5wH68f7n66SoiRLCdGCkDaqbWz2TlX4zYHIjogj1HJA=="
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.common": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.core": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "keeneyes.graphics.silk": {
+        "type": "Project",
+        "dependencies": {
+          "FontStashSharp.PlatformAgnostic": "[1.5.6, )",
+          "KeenEyes.Common": "[1.0.0, )",
+          "KeenEyes.Graphics.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Maths": "[2.23.0, )",
+          "Silk.NET.OpenGL": "[2.23.0, )",
+          "StbImageSharp": "[2.30.15, )"
+        }
+      },
+      "keeneyes.input": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.runtime": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.spatial": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Common": "[1.0.0, )"
+        }
+      },
+      "FontStashSharp.PlatformAgnostic": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.6, )",
+        "resolved": "1.5.6",
+        "contentHash": "aIuRgPeucC3zkCZvY8Y8E8JyrvukUX8MfKCUO31HWOg3yuYniHUA/3kjpNJE2apRGQzmreYhWFMatKv8cgGRxw==",
+        "dependencies": {
+          "Cyotek.Drawing.BitmapFont": "2.0.4",
+          "FontStashSharp.Base": "1.2.3",
+          "FontStashSharp.Rasterizers.StbTrueTypeSharp": "1.2.3",
+          "StbImageSharp": "2.30.15"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.OpenGL": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "CIakUoUqiAyRPykMk54tr1M1XpbJrT/iw12T85HDQcuRCFlBa1cxbX7v3FmtznKO5eM89esfmGNCgqDaKBiWfg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "StbImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.30.15, )",
+        "resolved": "2.30.15",
+        "contentHash": "7QqbupVhz2kcFUPTgMw4iHR9rYDHGundzzee19Mwmd1typ2Lnv8EVJcLJxlkeBM2+4ex0NwsMtdbGSJctp1XCQ=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Phase A of **NOVAFALL**, the flagship 2D arcade sample (modern reinterpretation of the TI-83 classic Fall Down; design chosen via ultracode judge panel, tracked on the KeenEyes tarot board). First sample to drive `I2DRenderer` directly.

- **Core loop:** gravity ball, left/right-only input (A/D + arrows + gamepad stick X); floors with gaps scroll upward; resting carries you toward the Furnace ceiling (death); steer into gaps to fall. Heat tiers Ember→Flame→Plasma→Nova gate the x1/x2/x4/x8 score multiplier; a landing **halves** heat (never zeroes); resting decays it; only death resets.
- **Architecture (teaching code):** pure-data components + 8 one-concern systems with explicit orders (InputSteer→BallMovement→FloorScroll→Collision→Heat→Score→Crush→GameFlow) + a Render-phase `NovaFallRenderSystem` (SDF shapes, outlined floors, velocity-squashed ball, font-discovery HUD with window-title fallback). `TimeScale` singleton multiplied into every sim dt (Phase B hitstop hook). Includes the quadtree-is-overkill-here teaching comment in `CollisionSystem`.
- **Determinism as configuration:** SplitMix64 `SeededGenerator` (KEEN030-compliant) + pure `FloorLayout.GapForFloor(seed, index)`; `--seed <n>` pins a run.
- **Headless `--simulate <frames>` mode:** windowless world, prints the floor script + final state — CI-safe determinism hook. Verified byte-identical across repeated runs (SHA-256 matched, incl. `--simulate 1800 --seed 42`).

## Test plan
- [x] Sample + full slnx build 0 warnings; full suite 14,732, 0 failed; format clean
- [x] Determinism: two `--simulate` runs byte-identical
- [x] No `src/**` changes (blend-mode PR #1252 is independent/parallel)
- [ ] Windowed feel-check deferred to a display machine (this box is headless)

Phase B (juice: additive comet trail via #1252, particles, camera shake, audio stems, HUD) and Phase C (modes/meta) follow as separate PRs.