### PR TITLE
docs: Align docs with current engine state (blend modes, scene tooling, TestBridge client, NOVAFALL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,7 @@ World (facade)
 ├── ComponentValidationManager - Component constraint enforcement
 ├── SaveManager                - World persistence orchestration
 ├── SnapshotManager            - World state serialization (static utility class)
-├── SceneManager               - Scene loading and management
+├── SceneManager               - In-memory scene lifecycle (spawn/unload/transition of tagged entity groups; no file I/O)
 ├── StatisticsManager          - Memory and performance stats
 └── ComponentArrayPoolManager  - Component array pooling
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1293,39 +1293,45 @@ Beyond these, the server exposes nine more tool categories — `mutation_*`, `sy
 
 ### Integrating TestBridge in Your Application
 
-To add TestBridge support to a KeenEyes game/application:
+To add TestBridge support to a KeenEyes game/application, install `TestBridgePlugin`
+(which registers the `ITestBridge` extension) and host an `IpcBridgeServer` on a named
+pipe. Note that `TestBridgeManager` shown in the editor section above is **editor-internal**
+and not available to games — games compose the same two pieces directly:
 
 ```csharp
-using KeenEyes.TestBridge;
-using KeenEyes.TestBridge.Ipc;
+using KeenEyes.TestBridge;      // TestBridgePlugin, TestBridgeOptions, IpcOptions, ITestBridge
+using KeenEyes.TestBridge.Ipc;  // IpcBridgeServer
 
-public class Game
-{
-    private TestBridgeManager? testBridge;
+using var world = new World();
 
-    public void Initialize(World world)
-    {
-        // Create the bridge manager
-        testBridge = new TestBridgeManager(world);
+// The plugin exposes the in-process bridge as an ITestBridge extension.
+world.InstallPlugin(new TestBridgePlugin(new TestBridgeOptions { EnableIpc = true }));
 
-        // Start IPC server (optional - for external tool connections)
-        _ = testBridge.StartIpcServerAsync("MyGame.TestBridge");
-    }
+// The IPC server makes it reachable by external tools (the MCP server).
+using var bridge = new IpcBridgeServer(
+    world.GetExtension<ITestBridge>(),
+    new IpcOptions { PipeName = "MyGame.TestBridge" });
 
-    public void Shutdown()
-    {
-        testBridge?.Dispose();
-    }
-}
+await bridge.StartAsync();
+
+// ... run the game loop ...
+
+await bridge.StopAsync();
 ```
+
+Follow the `<AppName>.TestBridge` pipe-naming convention. For a complete working example,
+see `samples/KeenEyes.Sample.NovaFall/Program.cs`, which starts the bridge in windowed mode
+only and treats failure as non-fatal.
 
 For headless/CI testing, use the in-process bridge directly:
 
 ```csharp
-using KeenEyes.TestBridge;
+using KeenEyes.Input.Abstractions;    // Key
+using KeenEyes.TestBridge;            // InProcessBridge
+using KeenEyes.TestBridge.State;      // EntityQuery
 
-var world = new World();
-var bridge = new InProcessBridge(world, inputContext, captureContext);
+using var world = new World();
+var bridge = new InProcessBridge(world);
 
 // Inject input
 await bridge.Input.KeyPressAsync(Key.Space);

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,6 +1,6 @@
 # Editor
 
-The KeenEyes Editor (`KeenEyes.Editor`) is a desktop application for authoring KeenEyes games — a scene view, entity hierarchy, component inspector, console, and asset browser built on the same ECS, UI, graphics, and input libraries the runtime uses. It is itself extensible: editor features are delivered as plugins, and game-specific plugins are installed from NuGet via the [`keeneyes` CLI](cli.md).
+The KeenEyes Editor (`KeenEyes.Editor`) is a desktop application for authoring KeenEyes games — a scene view, entity hierarchy, component inspector, console, and asset browser built on the same ECS, UI, graphics, and input libraries the runtime uses. It also defines a plugin model (`IEditorPlugin`, below); today the built-in panels are wired directly into the editor application, and the two built-in gizmo plugins (navigation, animation) are the only plugins installed at startup.
 
 > The editor is distinct from the ECS plugin system in [Plugins](plugins.md). `IWorldPlugin` extends a `World`; `IEditorPlugin` (below) extends the *editor application*.
 
@@ -10,7 +10,15 @@ The KeenEyes Editor (`KeenEyes.Editor`) is a desktop application for authoring K
 dotnet run --project editor/KeenEyes.Editor -c Release
 ```
 
-On start the editor opens its window, initializes graphics/input/UI, and builds the default panel layout. It also starts a [TestBridge](testbridge.md) IPC server (`KeenEyes.Editor.TestBridge`) so external tools can inspect and drive the editor world.
+On start the editor opens its window, initializes graphics/input/UI, and builds the default panel layout. It also starts a [TestBridge](testbridge.md) IPC server (`KeenEyes.Editor.TestBridge`) so external tools can inspect and drive the editor world (a second server, `KeenEyes.Editor.Scene.TestBridge`, starts for the scene world once a scene is opened).
+
+There is no project system yet: the editor treats its **current working directory** as the project root, building an `AssetDatabase` that recursively indexes `.kescene`, `.keprefab`, and `.keworld` files under it. Launch the editor from your game's directory to work on that game's assets. The **File ▸ New Project** and **File ▸ Open Project** menu items are declared but not yet implemented — clicking them does nothing.
+
+## Opening scenes
+
+**File ▸ Open Scene** (Ctrl+O) does not show a file dialog. If the asset database contains exactly one `.kescene`, it opens that scene directly; with none it logs "No scene files found"; with several it logs the candidates and defers to the Project panel, where double-clicking a `.kescene` opens it. **Save Scene As** prompts for a file name (resolved against the working directory, appending `.kescene` if missing) rather than opening a file browser.
+
+Opening (or creating) a scene is also what activates the scene-dependent features: play mode, hot reload, replay playback, and the scene TestBridge server are initialized when a scene is opened, not at launch.
 
 ## Panels & tools
 
@@ -22,12 +30,14 @@ The editor's default layout is composed of dockable panels:
 | Hierarchy | The entity tree — select, rename, reparent, create, and delete entities |
 | Inspector | Edit the components of the selected entity via per-type property drawers |
 | Console | Editor and game log output (backed by the logging query layer) |
-| Project | Browse project assets through the `AssetDatabase` |
+| Project | Browse the working directory's `.kescene`/`.keprefab`/`.keworld` assets (the `AssetDatabase`); double-click a scene to open it |
 | Frame Inspector | Step through recorded frames during replay playback |
 
 Editing actions run through an `UndoRedoManager` (every mutation is an `IEditorCommand`, e.g. create/delete/reparent/rename/set-component), a `SelectionManager` tracks the active entity, and an `EntityClipboard` supports copy/cut/paste. Layouts are saved and restored by the `LayoutManager`.
 
 ## Play mode & hot reload
+
+Both features become available once a scene is opened (see [Opening scenes](#opening-scenes) above).
 
 - **Play mode** (`PlayModeManager`) runs the game world inside the editor and returns to the authoring state when stopped.
 - **Hot reload** (`HotReloadService`) rebuilds and swaps the game assembly while the editor stays open, so component and system changes take effect without a full restart. See the [Editor Plugin Hot Reload](editor-plugin-hot-reload.md) guide for details and constraints.
@@ -45,10 +55,11 @@ public sealed class MyEditorPlugin : EditorPluginBase
 
     public override void Initialize(IEditorContext context)
     {
-        // Request the capabilities this plugin needs
-        var panels = context.GetCapability<IPanelCapability>();
-        var menus = context.GetCapability<IMenuCapability>();
-        // ...register panels, menu items, tools, inspectors, etc.
+        // Probe for the capabilities this plugin needs
+        if (context.TryGetCapability<IPanelCapability>(out var panels) && panels is not null)
+        {
+            // ...register panels, menu items, tools, inspectors, etc.
+        }
     }
 
     public override void Shutdown()
@@ -58,7 +69,7 @@ public sealed class MyEditorPlugin : EditorPluginBase
 }
 ```
 
-Available capabilities (from `KeenEyes.Editor.Abstractions`) include `IPanelCapability`, `IInspectorCapability`, `IMenuCapability`, `IShortcutCapability`, `IToolCapability`, `IViewportCapability`, `IAssetCapability`, and `INotificationCapability`. Common extension points:
+The capability interfaces defined in `KeenEyes.Editor.Abstractions` are `IPanelCapability`, `IInspectorCapability`, `IMenuCapability`, `IShortcutCapability`, `IToolCapability`, `IViewportCapability`, `IAssetCapability`, and `INotificationCapability`. Note that the shipped editor currently registers only `IViewportCapability` with the plugin manager — `GetCapability<T>()` throws `InvalidOperationException` for the others, so use `TryGetCapability<T>(out var cap)` to probe for what is available. Common extension points:
 
 - **Panels** — implement `IEditorPanel` and register via `IPanelCapability`.
 - **Tools** — derive from `EditorToolBase` (viewport tools with activate/update hooks).
@@ -67,7 +78,7 @@ Available capabilities (from `KeenEyes.Editor.Abstractions`) include `IPanelCapa
 
 ## Installing plugins (marketplace)
 
-Game and third-party editor plugins are distributed as NuGet packages and installed with the CLI, which shares its configuration with the editor:
+Game and third-party editor plugins are distributed as NuGet packages and installed with the CLI, which shares its configuration with the editor. Note that the running editor does not yet discover and load CLI-installed plugins at startup — the install/search tooling below works, but the loading step is not wired up yet:
 
 ```bash
 keeneyes sources add studio-feed https://nuget.example.com/v3/index.json --default

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -637,6 +637,35 @@ world.Spawn()
     .Build();
 ```
 
+### Blend Modes
+
+The 2D batch renderer (`I2DRenderer` in `KeenEyes.Graphics.Abstractions`) exposes a blend mode that applies to subsequent draw calls:
+
+```csharp
+renderer.Begin();
+renderer.FillRect(0, 0, 100, 100, backgroundColor);   // Alpha (default)
+
+renderer.SetBlendMode(BlendMode.Additive);            // Flushes the queued alpha draws
+renderer.FillCircle(50, 50, 20, glowColor);           // Drawn additively
+
+renderer.End();
+```
+
+The contract:
+
+- `SetBlendMode(mode)` - setting a mode different from `CurrentBlendMode` flushes the current batch so already-queued geometry is drawn with the previous mode; draws issued afterwards use the new mode. Setting the same mode is a no-op.
+- `CurrentBlendMode` - the mode applied to subsequent draw calls.
+- `Begin()` resets the blend mode to `BlendMode.Alpha`.
+
+| `BlendMode` | Source Factor | Destination Factor | Typical Use |
+|-------------|---------------|--------------------|-------------|
+| `Alpha` | `SrcAlpha` | `OneMinusSrcAlpha` | Standard alpha blending (default) |
+| `Additive` | `SrcAlpha` | `One` | Glow, fire, light effects |
+| `Multiply` | `DstColor` | `OneMinusSrcAlpha` | Darkening, shadows, tinting |
+| `Premultiplied` | `One` | `OneMinusSrcAlpha` | Textures with premultiplied alpha |
+
+`BlendModeExtensions.ToBlendFactors()` converts a `BlendMode` to its `(BlendFactor Src, BlendFactor Dst)` pair for custom renderer implementations. The particle system's `ParticleRenderSystem` is the canonical consumer: it groups emitters by blend mode and issues one batch per mode (see [Particles](particles.md)).
+
 ### Sprite Animation
 
 Animate sprites by updating texture source rectangles or swapping textures:

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,12 @@ Jump straight to practical examples:
 | [Input Handling](cookbook/input-handling.md) | Keyboard, mouse, gamepad, action mapping |
 | [Scene Management](cookbook/scene-management.md) | Load, unload, and transition between scenes |
 
+## Samples
+
+Runnable example projects live in the repository's `samples/` directory, ranging from focused single-feature demos (e.g. `KeenEyes.Sample.Replay`, `KeenEyes.Sample.InputDebugger`) to complete games. Highlight:
+
+- **NOVAFALL** (`samples/KeenEyes.Sample.NovaFall`) - the flagship 2D arcade sample, a reimagining of *Fall Down*. Its 26 systems exercise the 2D batch renderer (`I2DRenderer`), particles, animation, UI, spatial partitioning, and audio together. It exposes a TestBridge named pipe (`KeenEyes.NovaFall.TestBridge`) that can be registered in `.mcp.json` for MCP-driven inspection, and offers a headless deterministic simulation mode (`--simulate <frames>`, plus `--seed` and `--mode`) whose output is byte-identical for the same seed and mode - handy for CI.
+
 ## Design Philosophy
 
 KeenEyes makes deliberate choices that differ from many game engines:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -579,22 +579,33 @@ To enable TestBridge in your KeenEyes game, add the TestBridge plugin:
 
 ```csharp
 using KeenEyes.TestBridge;
+using KeenEyes.TestBridge.Ipc;
 
 // In your game initialization
 var world = new World();
 world.InstallPlugin(new TestBridgePlugin(new TestBridgeOptions
 {
-    PipeName = "KeenEyes.TestBridge",
-    EnableCapture = true,
-    EnableInput = true
+    EnableIpc = true,
+    EnableCapture = true
 }));
+
+// Start the IPC server the MCP server connects to
+var bridgeServer = new IpcBridgeServer(
+    world.GetExtension<ITestBridge>(),
+    new IpcOptions { PipeName = "MyGame.TestBridge" });
+await bridgeServer.StartAsync();
 ```
 
 See [TestBridge Architecture Guide](testbridge.md) for detailed setup instructions.
 
+For a .NET process that wants to drive a running game directly (without going through MCP),
+use `TestBridgeClient` from the `KeenEyes.TestBridge.Client` package - see
+[Connecting from an External .NET Process](testbridge.md#connecting-from-an-external-net-process).
+
 ## Related Documentation
 
 - [TestBridge Architecture Guide](testbridge.md) - Complete architecture, IPC protocol, command reference
+- [C# Remote Client](testbridge.md#connecting-from-an-external-net-process) - `TestBridgeClient`, the reference IPC client for external tools and IDE plugins
 - [Testing Guide](testing.md) - Unit testing with mocks
 - [ECS Fundamentals](getting-started.md) - Understanding entities and components
 - [Plugin Development](plugins.md) - Creating custom game plugins

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -43,8 +43,8 @@ It also exposes a `ParticleManager` as a world extension, retrievable with `worl
 ```csharp
 using System.Numerics;
 using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Particles.Components;
-using KeenEyes.Particles.Data;
 
 var fire = world.Spawn()
     .With(new Transform2D(new Vector2(400, 300), 0, Vector2.One))
@@ -71,7 +71,7 @@ Adding a `ParticleEmitter` component fires `World.OnComponentAdded<ParticleEmitt
 - **Spawn ranges** - `LifetimeMin`/`LifetimeMax`, `StartSizeMin`/`StartSizeMax`, `StartSpeedMin`/`StartSpeedMax`, `StartRotationMin`/`StartRotationMax` are all sampled uniformly at random per particle.
 - **Shape** - `Shape` (an `EmissionShape`) controls where particles spawn and their initial direction.
 - **Space** - `Space` (a `ParticleSpace`) selects world- or local-space simulation (see [Simulation Space](#simulation-space-world-vs-local) below); defaults to `ParticleSpace.World`.
-- **Visuals** - `Texture` (a `TextureHandle`; particles render as filled circles when it's not valid), `StartColor`, `BlendMode`, and `TextureSheetColumns`/`TextureSheetRows` for sprite-sheet animation (see [Texture Sheet Animation](#texture-sheet-animation) below).
+- **Visuals** - `Texture` (a `TextureHandle`; particles render as filled circles when it's not valid), `StartColor`, `BlendMode` (the renderer's `BlendMode` enum from `KeenEyes.Graphics.Abstractions` - see [Graphics Guide](graphics.md#blend-modes)), and `TextureSheetColumns`/`TextureSheetRows` for sprite-sheet animation (see [Texture Sheet Animation](#texture-sheet-animation) below).
 - **Playback** - `IsPlaying` toggles emission on and off without removing the component.
 
 `ParticleEmitter.Default` provides sensible starting values, and `ParticleEmitter.Burst(count, lifetime)` / `ParticleEmitter.Continuous(rate, lifetime)` are convenience factories for the two emission modes.
@@ -178,7 +178,7 @@ int totalActive = particles.TotalActiveParticles;
 
 - Particles live in `ParticlePool`'s parallel arrays (`PositionsX`/`PositionsY`, `VelocitiesX`/`VelocitiesY`, `ColorsR/G/B/A`, `Sizes`, `Rotations`, `Ages`, `Lifetimes`, etc.), not as ECS entities, so spawning and updating thousands of particles avoids archetype moves and per-particle component lookups entirely.
 - Allocation and release use an O(1) free list (`ParticlePool.Allocate`/`Release`); pools grow by doubling capacity on demand rather than reallocating per particle.
-- `ParticleRenderSystem` groups active emitters by `BlendMode` before rendering, issuing one `I2DRenderer.Begin()`/`End()` batch per blend mode (rendered in multiply → transparent → premultiplied → additive order) instead of one draw call per particle.
+- `ParticleRenderSystem` groups active emitters by `BlendMode` before rendering, issuing one `I2DRenderer.Begin()`/`End()` batch per blend mode (rendered in multiply → alpha → premultiplied → additive order) instead of one draw call per particle.
 - `ParticleCurve` and `ParticleGradient` pre-sample 64 points at construction, so evaluating them during `ParticleUpdateSystem` is a constant-time lookup and lerp with no per-frame allocation.
 
 ## Next Steps

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -139,6 +139,8 @@ Add additional KeenEyes packages as needed:
 
 The SDK defines item types for game assets and editor integration.
 
+A note on what these do at build time today: code generation for `.kescene`, `.keprefab`, and `.keworld` files is driven by `AdditionalFiles` — the SDK auto-detects files with those extensions and registers each one as both an `AdditionalFiles` entry (consumed by the source generators, which emit `Spawn<Name>` methods for scenes/prefabs and `Configure<Name>`/`Apply<Name>` methods for world configs) and the corresponding item type. The `<KeenEyesScene>`/`<KeenEyesPrefab>`/`<KeenEyesWorld>` items themselves only feed build-log messages and are bookkeeping for future editor integration. `<KeenEyesAsset>` is the one item type with build-time behavior of its own: matching files are copied to the output directory.
+
 ### Scenes
 
 Scene files define world configuration and entity setup:
@@ -241,7 +243,7 @@ The SDK generates `keeneyes.project.json` in the output directory:
 }
 ```
 
-This file enables tooling to detect and introspect KeenEyes projects.
+The file is emitted on every build so external tooling can detect and introspect KeenEyes projects. No tooling consumes it yet — the planned consumers (editor project detection, VS Code extension project discovery) are tracked in [issue #386](https://github.com/orion-ecs/keen-eye/issues/386).
 
 ## Comparison: SDK vs Manual Setup
 

--- a/docs/testbridge.md
+++ b/docs/testbridge.md
@@ -1255,6 +1255,17 @@ Pre-built prompts for common workflows:
 - Security is a concern
 - Performance is critical
 
+**Pipe names used in this repository:**
+
+| Pipe name | Host |
+|-----------|------|
+| `KeenEyes.TestBridge` | Library default (`IpcOptions.PipeName`) |
+| `KeenEyes.Editor.TestBridge` | Editor UI world |
+| `KeenEyes.Editor.Scene.TestBridge` | Editor's currently loaded scene world |
+| `KeenEyes.Sample.UI.TestBridge` | `samples/KeenEyes.Sample.UI` |
+| `KeenEyes.InputDebugger.TestBridge` | `samples/KeenEyes.Sample.InputDebugger` |
+| `KeenEyes.NovaFall.TestBridge` | `samples/KeenEyes.Sample.NovaFall` |
+
 ### TCP
 
 **Advantages:**
@@ -1369,7 +1380,9 @@ without hand-rolling the IPC protocol, add the `KeenEyes.TestBridge.Client` pack
 
 `TestBridgeClient` implements `ITestBridge` over the same named-pipe/TCP transport used by
 the MCP server, so the exact same calling code (`client.Input`, `client.State`, etc.) works
-whether you're in-process or out-of-process.
+whether you're in-process or out-of-process. It is the reference client implementation of
+the IPC protocol, and the intended building block for external tooling such as IDE plugins
+that need to talk to a running KeenEyes application.
 
 ```csharp
 using KeenEyes.TestBridge;

--- a/editor/KeenEyes.Sdk/README.md
+++ b/editor/KeenEyes.Sdk/README.md
@@ -110,7 +110,9 @@ The SDK exposes version information for tooling:
 During build, the SDK generates:
 
 - `obj/keeneyes.version.json` - Version compatibility info
-- `bin/keeneyes.project.json` - Project metadata for editor
+- `bin/keeneyes.project.json` - Project metadata for external tooling
+
+Nothing consumes `keeneyes.project.json` yet; the planned consumers (editor project detection, VS Code extension project discovery) are tracked in [issue #386](https://github.com/orion-ecs/keen-eye/issues/386).
 
 ## SDK Flavors
 

--- a/schemas/keprefab.schema.json
+++ b/schemas/keprefab.schema.json
@@ -23,7 +23,7 @@
     },
     "base": {
       "type": ["string", "null"],
-      "description": "Base prefab name for inheritance (null if no base)"
+      "description": "Base prefab name for inheritance (null if no base). Parsed but not yet implemented - the generator ignores it and reports diagnostic KEEN064."
     },
     "root": {
       "$ref": "#/$defs/prefabEntity",

--- a/schemas/kescene.schema.json
+++ b/schemas/kescene.schema.json
@@ -12,7 +12,7 @@
     },
     "name": {
       "type": "string",
-      "description": "Scene name used for generated method naming (e.g., LoadMain)",
+      "description": "Scene name used for generated method naming (e.g., SpawnMain)",
       "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
     },
     "version": {


### PR DESCRIPTION
## Summary
Docs drifted from the engine — partly from this week's changes (#1252 blend modes, NOVAFALL), partly pre-existing. Every correction was verified against the source it describes; smallest-diff edits only. Docs/schemas/CLAUDE.md one-liner only — no code changes.

- **Blend modes (#1252)** — `docs/particles.md` corrected (`BlendMode` moved to `KeenEyes.Graphics.Abstractions`; `Transparent`→`Alpha` in the documented render order) and a new **Blend Modes** section added to `docs/graphics.md` (flush-on-switch contract, same-mode no-op, `Begin()` resets to Alpha, factor table).
- **Schemas** — `kescene` "LoadMain"→"SpawnMain" (the generator emits `Spawn<Name>` for scenes *and* prefabs); `keprefab` `base` now states it's parsed but unimplemented (reports KEEN064). `keworld`'s "ConfigureDefault" was already correct and left alone.
- **CLAUDE.md** — `SceneManager` described honestly as in-memory scene lifecycle, no file I/O (verified: zero File/Path/Stream usage).
- **SDK docs** — `keeneyes.project.json` is emitted but read by nothing today; planned consumers cross-referenced to #386. Item-type table clarified: codegen is `AdditionalFiles`-driven; Scene/Prefab/World items are build-message bookkeeping; only `KeenEyesAsset`'s copy is real. **ADR-006 untouched** (historical record).
- **docs/editor.md** — corrected to what actually works: no project system (CWD-based `AssetDatabase`), Open Scene auto-opens a single `.kescene` with no dialog, New/Open Project marked declared-but-unimplemented, capability list fixed.
- **TestBridge/MCP** — `TestBridgeClient` flagged as the reference client for IDE tooling (per revised #87/#88/#392); added a code-verified pipe-name table; **fixed a broken snippet** in `docs/mcp-server.md` that used nonexistent `TestBridgeOptions` properties.
- **NOVAFALL** — added a Samples section to `docs/index.md` (no samples index existed anywhere).

## Test plan
- [x] `dotnet build KeenEyes.slnx -c Release` 0 warnings; full suite 14,768, 0 failed; format clean
- [x] **docfx build (same as docs.yml) exit 0** — 28 warnings, all pre-existing out-of-tree links, none in touched files; all new anchors resolve

## Notes
Straggler sweep (`Playback(`, `IQuery<`, `MockWorld`, `SetLatency`, serial-test flag) found **zero** hits in docs/. Fictional `KE0##` IDs exist only in a doc explicitly headed "Status: Research / Planning" — left as proposals.

Follow-up noted: CLAUDE.md's "Integrating TestBridge" snippet uses `TestBridgeManager`, which is editor-internal — out of scope here (CLAUDE.md was limited to the one-line fix).