### PR TITLE
fix(audio,core,graphics): Ship native OpenAL, uninstall plugins in reverse order, make GPU teardown non-throwing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,10 @@
   </ItemGroup>
   <ItemGroup Label="Audio">
     <PackageVersion Include="Silk.NET.OpenAL" Version="2.23.0" />
+    <!-- Native OpenAL Soft runtime (soft_oal.dll / libopenal.so / libopenal.dylib).
+         Silk.NET.OpenAL ships bindings only; without this package there is no OpenAL
+         implementation to load on Windows, which no longer ships one in the OS. -->
+    <PackageVersion Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
   </ItemGroup>
   <ItemGroup Label="Assets">
     <PackageVersion Include="StbImageSharp" Version="2.30.15" />

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -52,6 +52,43 @@ Installing `SilkAudioPlugin` registers:
 
 If the window plugin was not installed first, `Install` throws an `InvalidOperationException`.
 
+### The Native OpenAL Runtime
+
+`Silk.NET.OpenAL` provides bindings only - the actual implementation is a native library
+(`soft_oal.dll` on Windows, `libopenal.so` on Linux, `libopenal.dylib` on macOS). Windows ships no
+system OpenAL at all, so `KeenEyes.Audio.Silk` references
+[`Silk.NET.OpenAL.Soft.Native`](https://www.nuget.org/packages/Silk.NET.OpenAL.Soft.Native), which
+publishes the OpenAL Soft runtime for every supported RID into `runtimes/<rid>/native/` next to the
+application. Games that reference `KeenEyes.Audio.Silk` get this automatically and need no manual
+OpenAL install.
+
+### Audio Is Optional Hardware
+
+Audio can be unavailable for reasons outside the application's control: no output device, no audio
+backend the runtime can drive, or a native runtime that was stripped from the deployment. That must
+never stop a game from starting, so the backend degrades instead of failing:
+
+- The device is opened when the window loads, not when the plugin is installed. `Install` therefore
+  never fails because of missing audio hardware.
+- If the device cannot be opened, the context stays uninitialized rather than aborting the window
+  loop: `IAudioContext.IsInitialized` is `false` and `IAudioContext.InitializationError` holds a
+  typed `AudioInitializationException` naming the cause and the remedy.
+- Calling `LoadClip`, `CreateClip`, `Play`, or `PlayAt` on an uninitialized context throws. Check
+  `IsInitialized` first:
+
+```csharp
+var audio = world.GetExtension<IAudioContext>();
+
+if (!audio.IsInitialized)
+{
+    Console.WriteLine($"Audio unavailable: {audio.InitializationError?.Message}");
+    return;     // Play on in silence.
+}
+```
+
+The `AudioSource`/`AudioListener` systems already no-op when no device is present, so ECS-driven
+sound needs no extra guard - only direct `IAudioContext` calls do.
+
 ### Playing a One-Shot Sound
 
 ```csharp

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -157,6 +157,12 @@ world.InstallPlugin(new SilkInputPlugin(inputConfig));
 GameSetup.InstallSimulationPlugins(world);
 world.InstallPlugin(new ParticlesPlugin());
 world.InstallPlugin(new AnimationPlugin());
+
+// Audio is optional hardware. Installing the plugin only registers systems and the
+// context - the OpenAL device is opened when the window loads, so a machine with no
+// audio runtime or no output device cannot fail here, and does not fail the window
+// loop either: the context reports IsInitialized == false and NovaFallAudioSystem
+// prints one warning and plays the game silently.
 world.InstallPlugin(new SilkAudioPlugin());
 world.InstallPlugin(new UIPlugin());
 
@@ -254,8 +260,14 @@ catch (Exception ex)
     // surface a wide range of platform exceptions (missing display, driver, or GL
     // context errors). A demo recovers by reporting the failure and exiting rather
     // than crashing, so a catch-all is appropriate here.
-    Console.WriteLine($"Error: {ex.Message}");
-    Console.WriteLine("Windowed mode requires a display. Try --simulate 600 for the headless check.");
+    //
+    // Report WHAT failed rather than guessing WHY: a blanket "requires a display"
+    // is actively misleading on a machine that has one, and it hides the real
+    // exception type behind a wrong diagnosis. The headless hint is worth printing
+    // either way, but as a suggestion, not as a cause.
+    Console.WriteLine($"Startup failed: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine("The windowed mode needs a display, a GPU driver, and OpenGL 3.3. "
+        + "For a check that needs none of them, run with --simulate 600.");
 }
 finally
 {

--- a/samples/KeenEyes.Sample.NovaFall/Systems/NovaFallAudioSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/NovaFallAudioSystem.cs
@@ -26,8 +26,11 @@ namespace KeenEyes.Sample.NovaFall;
 /// graze, and the smash crunch scales with impact speed.
 /// </para>
 /// <para>
-/// All fades use real delta time. Missing asset files or a missing audio
-/// context disable the system gracefully (one console warning, then silence).
+/// All fades use real delta time. Missing asset files, a missing audio context,
+/// or an audio device the machine cannot provide (no OpenAL runtime, no output
+/// device) disable the system gracefully: one console warning, then silence, and
+/// the game keeps playing. This is the pattern to copy - audio is optional
+/// hardware, so a game must never require it to start.
 /// </para>
 /// </remarks>
 public sealed class NovaFallAudioSystem : SystemBase
@@ -61,6 +64,7 @@ public sealed class NovaFallAudioSystem : SystemBase
 
     private bool loadAttempted;
     private bool loaded;
+    private bool unavailableReported;
     private bool loopsActive;
     private bool deathImpactPlayed;
     private bool silenced;
@@ -72,6 +76,16 @@ public sealed class NovaFallAudioSystem : SystemBase
         if (!juice.PresentationAvailable
             || !World.TryGetExtension<IAudioContext>(out var context) || context is null)
         {
+            return;
+        }
+
+        // The extension exists as soon as the audio plugin is installed, but the device is
+        // opened later, when the window loads - and it can fail (no OpenAL runtime installed,
+        // no output device). Playing into an uninitialized context throws, so check first and
+        // fall silent instead.
+        if (!context.IsInitialized)
+        {
+            ReportAudioUnavailable(context.InitializationError);
             return;
         }
 
@@ -106,6 +120,23 @@ public sealed class NovaFallAudioSystem : SystemBase
         UpdateStemMix(deltaTime, juice.Enabled);
         UpdateWindAndRumble(juice.Enabled);
         PlayEventOneShots(juice.Enabled);
+    }
+
+    /// <summary>
+    /// Warns once that the game is running without sound, naming the reason the backend gave.
+    /// </summary>
+    /// <param name="error">The backend failure, or null when audio simply never initialized.</param>
+    private void ReportAudioUnavailable(AudioException? error)
+    {
+        if (unavailableReported)
+        {
+            return;
+        }
+
+        unavailableReported = true;
+        Console.WriteLine(error is null
+            ? "Audio unavailable - continuing without sound."
+            : $"Audio unavailable: {error.Message} Continuing without sound.");
     }
 
     private bool EnsureClipsLoaded()

--- a/samples/KeenEyes.Sample.NovaFall/packages.lock.json
+++ b/samples/KeenEyes.Sample.NovaFall/packages.lock.json
@@ -157,7 +157,8 @@
           "KeenEyes.Audio": "[1.0.0, )",
           "KeenEyes.Audio.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.OpenAL": "[2.23.0, )"
+          "Silk.NET.OpenAL": "[2.23.0, )",
+          "Silk.NET.OpenAL.Soft.Native": "[1.23.1, )"
         }
       },
       "keeneyes.common": {
@@ -444,6 +445,12 @@
         "dependencies": {
           "Silk.NET.Core": "2.23.0"
         }
+      },
+      "Silk.NET.OpenAL.Soft.Native": {
+        "type": "CentralTransitive",
+        "requested": "[1.23.1, )",
+        "resolved": "1.23.1",
+        "contentHash": "gZIbksInoiXbJZmepYnTs5O6Edg5O5k86c1+Uus0zSaVnQx5WRbInGz2VTlvudbs0qAqXs/asL1YvJzco/nfAQ=="
       },
       "Silk.NET.OpenGL": {
         "type": "CentralTransitive",

--- a/src/KeenEyes.Audio.Abstractions/Exceptions.cs
+++ b/src/KeenEyes.Audio.Abstractions/Exceptions.cs
@@ -26,8 +26,31 @@ public class AudioException : Exception
 /// <summary>
 /// Thrown when audio device initialization fails.
 /// </summary>
-/// <param name="message">The error message.</param>
-public class AudioInitializationException(string message) : AudioException(message);
+/// <remarks>
+/// Typical causes are a missing native OpenAL runtime and a machine with no usable
+/// audio output device. Audio is optional hardware, so callers should treat this as a
+/// recoverable loss of capability rather than a fatal error.
+/// </remarks>
+public class AudioInitializationException : AudioException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioInitializationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public AudioInitializationException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioInitializationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The backend exception that caused the failure.</param>
+    public AudioInitializationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
 
 /// <summary>
 /// Thrown when loading an audio file fails.

--- a/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
+++ b/src/KeenEyes.Audio.Abstractions/IAudioContext.cs
@@ -44,6 +44,35 @@ public interface IAudioContext : IDisposable
     bool IsInitialized { get; }
 
     /// <summary>
+    /// Gets the failure that prevented the audio backend from initializing, or
+    /// <see langword="null"/> if initialization has not failed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Audio is optional hardware: a machine may have no output device, or no native
+    /// audio runtime installed at all. A backend that cannot open a device leaves
+    /// <see cref="IsInitialized"/> <see langword="false"/> and records the reason here
+    /// instead of tearing down the host application, so a game can report the loss of
+    /// capability and keep running silently.
+    /// </para>
+    /// <para>
+    /// This is <see langword="null"/> while the backend simply has not initialized yet
+    /// (for example before the window has loaded). Use <see cref="IsInitialized"/> to
+    /// decide whether audio may be used, and this property to explain why it may not.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// if (!audio.IsInitialized)
+    /// {
+    ///     Console.WriteLine($"Audio unavailable: {audio.InitializationError?.Message}");
+    ///     return;
+    /// }
+    /// </code>
+    /// </example>
+    AudioException? InitializationError { get; }
+
+    /// <summary>
     /// Gets or sets the master volume (0.0 to 1.0).
     /// </summary>
     /// <remarks>

--- a/src/KeenEyes.Audio.Silk/Backend/OpenALDevice.cs
+++ b/src/KeenEyes.Audio.Silk/Backend/OpenALDevice.cs
@@ -24,20 +24,46 @@ internal sealed unsafe class OpenALDevice : IAudioDevice
 
     internal OpenALDevice(string? deviceName = null)
     {
-        alc = ALContext.GetApi(soft: true);
-        al = AL.GetApi(soft: true);
+        // Loading the native OpenAL library is the first thing that can fail, and Silk.NET
+        // reports it as a bare Exception ("Could not load from any of the possible library
+        // names!") that says nothing about audio. Translate it into a typed, actionable
+        // failure: the caller cannot fix the load, but it can degrade to silence.
+        ALContext? loadedContextApi = null;
+        try
+        {
+            loadedContextApi = ALContext.GetApi(soft: true);
+            al = AL.GetApi(soft: true);
+            alc = loadedContextApi;
+        }
+        catch (Exception ex)
+        {
+            loadedContextApi?.Dispose();
+            throw new AudioInitializationException(
+                "The native OpenAL runtime could not be loaded (soft_oal.dll on Windows, " +
+                "libopenal.so on Linux, libopenal.dylib on macOS). Reference the " +
+                "Silk.NET.OpenAL.Soft.Native package so the runtime is published next to the " +
+                "application, or install a system OpenAL implementation.",
+                ex);
+        }
 
         device = alc.OpenDevice(deviceName);
         if (device == null)
         {
-            throw new AudioInitializationException("Failed to open OpenAL device");
+            throw new AudioInitializationException(
+                deviceName is null
+                    ? "OpenAL could not open the default audio output device. The machine may " +
+                      "have no audio output, or no audio backend the OpenAL runtime can drive."
+                    : $"OpenAL could not open the audio output device '{deviceName}'. Check the " +
+                      "device name, or leave it unset to use the system default device.");
         }
 
         context = alc.CreateContext(device, null);
         if (context == null)
         {
             alc.CloseDevice(device);
-            throw new AudioInitializationException("Failed to create OpenAL context");
+            throw new AudioInitializationException(
+                $"OpenAL opened the audio output device '{deviceName ?? "default"}' but could not " +
+                "create a playback context on it.");
         }
 
         alc.MakeContextCurrent(context);

--- a/src/KeenEyes.Audio.Silk/KeenEyes.Audio.Silk.csproj
+++ b/src/KeenEyes.Audio.Silk/KeenEyes.Audio.Silk.csproj
@@ -23,6 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="Silk.NET.OpenAL" />
+    <!-- Silk.NET.OpenAL is bindings only. This package carries the OpenAL Soft native
+         runtime for every supported RID, so a consuming game gets working audio without
+         asking the user to install OpenAL by hand (Windows has no system OpenAL at all). -->
+    <PackageReference Include="Silk.NET.OpenAL.Soft.Native" />
   </ItemGroup>
 
 </Project>

--- a/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Numerics;
 using KeenEyes.Audio.Abstractions;
 using KeenEyes.Audio.Silk.Backend;
@@ -18,6 +19,14 @@ namespace KeenEyes.Audio.Silk;
 /// The audio context uses a shared <see cref="ISilkWindowProvider"/> to coordinate
 /// lifecycle with the window, initializing OpenAL when the window loads and
 /// cleaning up when it closes.
+/// </para>
+/// <para>
+/// If OpenAL cannot be initialized - no native OpenAL runtime, or no usable output
+/// device - the context stays uninitialized instead of failing the window load:
+/// <see cref="IsInitialized"/> is <see langword="false"/> and
+/// <see cref="InitializationError"/> holds the typed reason. Applications should check
+/// <see cref="IsInitialized"/> before loading clips or playing sounds so that a machine
+/// without audio still runs.
 /// </para>
 /// </remarks>
 [PluginExtension("SilkAudio")]
@@ -53,6 +62,9 @@ public sealed class SilkAudioContext : IAudioContext
     public bool IsInitialized => initialized;
 
     /// <inheritdoc />
+    public AudioException? InitializationError { get; private set; }
+
+    /// <inheritdoc />
     public float MasterVolume
     {
         get => masterVolume;
@@ -75,11 +87,28 @@ public sealed class SilkAudioContext : IAudioContext
 
     private void HandleWindowLoad()
     {
-        device = new OpenALDevice(config.DeviceName);
-        sourcePool = new SourcePool(device, config.MaxOneShotSources);
-        device.SetListenerGain(config.InitialMasterVolume);
-        masterVolume = config.InitialMasterVolume;
-        initialized = true;
+        // This runs inside the window's Load event, so throwing here would abort the whole
+        // window loop and take the application down with it. Audio is optional hardware:
+        // record the failure, stay uninitialized, and let the application decide (see
+        // IAudioContext.InitializationError). The loss of capability is never silent - it is
+        // observable on the context and written to the debug log.
+        try
+        {
+            device = new OpenALDevice(config.DeviceName);
+            sourcePool = new SourcePool(device, config.MaxOneShotSources);
+            device.SetListenerGain(config.InitialMasterVolume);
+            masterVolume = config.InitialMasterVolume;
+            initialized = true;
+        }
+        catch (AudioException ex)
+        {
+            device?.Dispose();
+            device = null;
+            sourcePool = null;
+            initialized = false;
+            InitializationError = ex;
+            Debug.WriteLine($"Audio unavailable: {ex.Message}");
+        }
     }
 
     private void HandleWindowClosing()
@@ -491,11 +520,23 @@ public sealed class SilkAudioContext : IAudioContext
 
     private void ThrowIfNotInitialized()
     {
-        if (!initialized)
+        if (initialized)
+        {
+            return;
+        }
+
+        // Name the real cause when the device failed: "wait for the window to load" would be
+        // actively misleading on a machine where audio is simply unavailable.
+        if (InitializationError is not null)
         {
             throw new InvalidOperationException(
-                "Audio not initialized. Wait for window to load.");
+                $"Audio is unavailable: {InitializationError.Message} " +
+                "Check IAudioContext.IsInitialized before using audio.",
+                InitializationError);
         }
+
+        throw new InvalidOperationException(
+            "Audio not initialized. Wait for window to load.");
     }
 
     private void DisposeAudioResources()

--- a/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
+++ b/src/KeenEyes.Audio.Silk/SilkAudioPlugin.cs
@@ -19,6 +19,14 @@ namespace KeenEyes.Audio.Silk;
 /// ECS components <see cref="AudioSource"/> and <see cref="AudioListener"/> are registered
 /// automatically, along with systems to synchronize them with the OpenAL backend.
 /// </para>
+/// <para>
+/// Installing the plugin does not touch the audio hardware: OpenAL is opened when the
+/// window loads. A machine with no OpenAL runtime or no output device therefore does not
+/// fail installation and does not fail the window loop - the context reports
+/// <see cref="IAudioContext.IsInitialized"/> <see langword="false"/> and explains why
+/// through <see cref="IAudioContext.InitializationError"/>. Check
+/// <see cref="IAudioContext.IsInitialized"/> before loading clips.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/KeenEyes.Audio.Silk/packages.lock.json
+++ b/src/KeenEyes.Audio.Silk/packages.lock.json
@@ -17,6 +17,12 @@
           "Silk.NET.Core": "2.23.0"
         }
       },
+      "Silk.NET.OpenAL.Soft.Native": {
+        "type": "Direct",
+        "requested": "[1.23.1, )",
+        "resolved": "1.23.1",
+        "contentHash": "gZIbksInoiXbJZmepYnTs5O6Edg5O5k86c1+Uus0zSaVnQx5WRbInGz2VTlvudbs0qAqXs/asL1YvJzco/nfAQ=="
+      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[10.29.0.143774, )",

--- a/src/KeenEyes.Core/PluginManager.cs
+++ b/src/KeenEyes.Core/PluginManager.cs
@@ -21,6 +21,13 @@ internal sealed class PluginManager
 {
     private readonly Lock syncRoot = new();
     private readonly Dictionary<string, PluginEntry> plugins = [];
+
+    /// <summary>
+    /// Plugin names in installation order, so <see cref="UninstallAll"/> can tear down
+    /// dependents before their dependencies. Dictionary enumeration order is an
+    /// implementation detail, so the order is tracked explicitly.
+    /// </summary>
+    private readonly List<string> installOrder = [];
     private readonly World world;
     private readonly SystemManager systemManager;
 
@@ -67,6 +74,7 @@ internal sealed class PluginManager
 
             context = new PluginContext(world, plugin);
             plugins[plugin.Name] = new PluginEntry(plugin, context);
+            installOrder.Add(plugin.Name);
         }
 
         // Call Install outside lock to allow plugins to use world APIs
@@ -83,6 +91,7 @@ internal sealed class PluginManager
             lock (syncRoot)
             {
                 plugins.Remove(plugin.Name);
+                installOrder.Remove(plugin.Name);
             }
             throw;
         }
@@ -193,17 +202,24 @@ internal sealed class PluginManager
     /// <summary>
     /// Uninstalls all plugins, disposing their registered systems.
     /// </summary>
+    /// <remarks>
+    /// Plugins are uninstalled in reverse installation order. Plugins declare their
+    /// dependencies by requiring an extension to already exist at install time (a graphics
+    /// plugin requires a window plugin, for example), so a dependent must tear down while its
+    /// dependency is still alive - tearing the window down first would leave the graphics
+    /// plugin releasing GPU resources against a destroyed context.
+    /// </remarks>
     internal void UninstallAll()
     {
         string[] names;
         lock (syncRoot)
         {
-            names = [.. plugins.Keys];
+            names = [.. installOrder];
         }
 
-        foreach (var name in names)
+        for (var i = names.Length - 1; i >= 0; i--)
         {
-            UninstallPluginInternal(name);
+            UninstallPluginInternal(names[i]);
         }
     }
 
@@ -216,6 +232,7 @@ internal sealed class PluginManager
         lock (syncRoot)
         {
             plugins.Clear();
+            installOrder.Clear();
         }
     }
 
@@ -232,6 +249,7 @@ internal sealed class PluginManager
                 return false;
             }
             plugins.Remove(name);
+            installOrder.Remove(name);
         }
 
         // Call the plugin's uninstall hook (outside lock to allow plugins to use world APIs).

--- a/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Numerics;
 using KeenEyes.Graphics.Abstractions;
 using KeenEyes.Graphics.Silk.Rendering2D;
@@ -217,7 +218,20 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
         window = new SilkWindow(windowProvider.Window, isAlreadyLoaded: true);
 
         // Create device from window
-        device = window.CreateDevice();
+        InitializeResources(window.CreateDevice());
+    }
+
+    /// <summary>
+    /// Binds the context to a graphics device and creates the built-in GPU resources.
+    /// </summary>
+    /// <param name="graphicsDevice">The device to render through.</param>
+    /// <remarks>
+    /// Separated from <see cref="HandleWindowLoad"/> so that resource setup is independent
+    /// of window and device acquisition, which keeps the GPU lifecycle testable headlessly.
+    /// </remarks>
+    internal void InitializeResources(IGraphicsDevice graphicsDevice)
+    {
+        device = graphicsDevice;
 
         // Initialize resource managers with the device
         meshManager.Device = device;
@@ -924,6 +938,22 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
     #endregion
 
+    /// <summary>
+    /// Releases every GPU-backed resource this context owns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called from the window's Closing event, while the OpenGL context is still valid, and
+    /// again from <see cref="Dispose"/> as a backstop.
+    /// </para>
+    /// <para>
+    /// The backstop path can run after the OpenGL context is gone - a window whose load
+    /// aborted never raises Closing, and a destroyed window takes its context with it. Deleting
+    /// a GPU object without a current context throws from the driver binding, so each
+    /// disposal is isolated: <see cref="Dispose"/> must not throw, or teardown failures escape
+    /// <c>World.Dispose()</c> and crash an application that already handled the real error.
+    /// </para>
+    /// </remarks>
     private void DisposeGpuResources()
     {
         if (gpuResourcesDisposed)
@@ -933,14 +963,45 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
         gpuResourcesDisposed = true;
 
-        renderTargetManager?.Dispose();
-        renderer2D?.Dispose();
-        textRenderer?.Dispose();
-        fontManager?.Dispose();
-        meshManager.Dispose();
-        textureManager.Dispose();
-        shaderManager.Dispose();
-        instanceBufferManager.Dispose();
+        TryDispose(renderTargetManager, nameof(renderTargetManager));
+        TryDispose(renderer2D, nameof(renderer2D));
+        TryDispose(textRenderer, nameof(textRenderer));
+        TryDispose(fontManager, nameof(fontManager));
+        TryDispose(meshManager, nameof(meshManager));
+        TryDispose(textureManager, nameof(textureManager));
+        TryDispose(shaderManager, nameof(shaderManager));
+        TryDispose(instanceBufferManager, nameof(instanceBufferManager));
+    }
+
+    /// <summary>
+    /// Disposes one GPU resource owner, reporting rather than propagating failures.
+    /// </summary>
+    /// <param name="resource">The resource owner to dispose; ignored when null.</param>
+    /// <param name="description">The field name, used in the diagnostic message.</param>
+    /// <remarks>
+    /// The catch is deliberately broad because the failure it exists for comes from the
+    /// graphics driver binding: Silk.NET surfaces a lost or non-current OpenGL context as
+    /// whatever the underlying loader throws (for example <c>GlfwException</c> from the GLFW
+    /// error callback), and there is no exception type to filter on. Nothing else can be
+    /// done about a failed GPU delete during shutdown, so it is logged and skipped.
+    /// </remarks>
+    private static void TryDispose(IDisposable? resource, string description)
+    {
+        if (resource is null)
+        {
+            return;
+        }
+
+        try
+        {
+            resource.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(
+                $"Graphics teardown: disposing {description} failed " +
+                $"({ex.GetType().Name}: {ex.Message}). The OpenGL context is most likely already gone.");
+        }
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
@@ -155,6 +155,30 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     public int SimulatedErrorCode { get; set; }
 
     /// <summary>
+    /// Gets or sets whether every delete operation throws, simulating a lost graphics context.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A real backend cannot delete GPU objects once its context has been destroyed or is no
+    /// longer current: the driver binding throws instead. Setting this after resources have
+    /// been created reproduces that state, which is how teardown paths are tested for the
+    /// rule that disposal must never throw.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var device = new MockGraphicsDevice();
+    /// var program = device.CreateProgram();
+    ///
+    /// // The window died and took the context with it.
+    /// device.ThrowOnDelete = true;
+    ///
+    /// Assert.Null(Record.Exception(() =&gt; renderer.Dispose()));
+    /// </code>
+    /// </example>
+    public bool ThrowOnDelete { get; set; }
+
+    /// <summary>
     /// Gets or sets the simulated framebuffer data returned by <see cref="ReadFramebuffer"/>.
     /// </summary>
     /// <remarks>
@@ -176,6 +200,20 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     #endregion
 
     #region Test Control
+
+    /// <summary>
+    /// Throws when <see cref="ThrowOnDelete"/> is set, mimicking a driver binding that cannot
+    /// service a GPU delete because no context is current.
+    /// </summary>
+    /// <param name="operation">The delete operation being simulated.</param>
+    private void ThrowIfContextLost(string operation)
+    {
+        if (ThrowOnDelete)
+        {
+            throw new InvalidOperationException(
+                $"{operation} was called with no usable graphics context.");
+        }
+    }
 
     /// <summary>
     /// Resets all tracking state and counters.
@@ -282,6 +320,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteVertexArray(uint vao)
     {
+        ThrowIfContextLost(nameof(DeleteVertexArray));
         VAOs.Remove(vao);
         if (BoundVAO == vao)
         {
@@ -292,6 +331,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteBuffer(uint buffer)
     {
+        ThrowIfContextLost(nameof(DeleteBuffer));
         Buffers.Remove(buffer);
         foreach (var target in BoundBuffers.Where(kv => kv.Value == buffer).Select(kv => kv.Key).ToList())
         {
@@ -464,6 +504,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteTexture(uint texture)
     {
+        ThrowIfContextLost(nameof(DeleteTexture));
         Textures.Remove(texture);
         foreach (var unit in BoundTextures.Where(kv => kv.Value == texture).Select(kv => kv.Key).ToList())
         {
@@ -585,12 +626,14 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteShader(uint shader)
     {
+        ThrowIfContextLost(nameof(DeleteShader));
         Shaders.Remove(shader);
     }
 
     /// <inheritdoc />
     public void DeleteProgram(uint program)
     {
+        ThrowIfContextLost(nameof(DeleteProgram));
         Programs.Remove(program);
         if (BoundProgram == program)
         {
@@ -855,6 +898,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteFramebuffer(uint framebuffer)
     {
+        ThrowIfContextLost(nameof(DeleteFramebuffer));
         Framebuffers.Remove(framebuffer);
         if (BoundFramebuffer == framebuffer)
         {
@@ -894,6 +938,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// <inheritdoc />
     public void DeleteRenderbuffer(uint renderbuffer)
     {
+        ThrowIfContextLost(nameof(DeleteRenderbuffer));
         Renderbuffers.Remove(renderbuffer);
         if (BoundRenderbuffer == renderbuffer)
         {

--- a/tests/KeenEyes.Assets.Tests/AudioLoaderTests.cs
+++ b/tests/KeenEyes.Assets.Tests/AudioLoaderTests.cs
@@ -70,6 +70,7 @@ file sealed class MockAudioContext : IAudioContext
 
     public IAudioDevice? Device => null;
     public bool IsInitialized => true;
+    public AudioException? InitializationError => null;
     public float MasterVolume { get; set; } = 1f;
 
     public AudioClipHandle LoadClip(string path)

--- a/tests/KeenEyes.Audio.Silk.Tests/OpenALDeviceTests.cs
+++ b/tests/KeenEyes.Audio.Silk.Tests/OpenALDeviceTests.cs
@@ -1,0 +1,51 @@
+using KeenEyes.Audio.Abstractions;
+using KeenEyes.Audio.Silk.Backend;
+
+namespace KeenEyes.Audio.Silk.Tests;
+
+/// <summary>
+/// Tests that an unavailable audio device is reported as a typed, actionable failure.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1256. Opening the backend can fail two ways - the native OpenAL
+/// runtime is missing, or no output device can be opened - and both used to surface as
+/// something the caller could not act on: a bare Silk.NET <see cref="Exception"/> reading
+/// "Could not load from any of the possible library names!", or a message that named neither
+/// the cause nor a remedy. Both now arrive as <see cref="AudioInitializationException"/> with a
+/// message that says what is missing.
+/// </remarks>
+public class OpenALDeviceTests
+{
+    [Fact]
+    public void Constructor_WithUnknownDeviceName_ThrowsAudioInitializationException()
+    {
+        var exception = Assert.Throws<AudioInitializationException>(
+            () => new OpenALDevice("KeenEyes.Tests.NoSuchAudioDevice"));
+
+        // Whichever way the backend is unavailable on the test machine, the message has to
+        // name the failure and point at the fix rather than leaking a loader detail.
+        Assert.Contains("OpenAL", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Could not load from any of the possible library names",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Constructor_WhenBackendUnavailable_ExplainsHowToFixIt()
+    {
+        var exception = Assert.Throws<AudioInitializationException>(
+            () => new OpenALDevice("KeenEyes.Tests.NoSuchAudioDevice"));
+
+        // A missing native runtime names the package that ships it; a missing device names the
+        // device instead. Either way the message is actionable.
+        var namesTheRuntime = exception.Message.Contains(
+            "Silk.NET.OpenAL.Soft.Native", StringComparison.Ordinal);
+        var namesTheDevice = exception.Message.Contains(
+            "KeenEyes.Tests.NoSuchAudioDevice", StringComparison.Ordinal);
+
+        Assert.True(
+            namesTheRuntime || namesTheDevice,
+            $"Message explained neither the missing runtime nor the missing device: {exception.Message}");
+    }
+}

--- a/tests/KeenEyes.Audio.Silk.Tests/packages.lock.json
+++ b/tests/KeenEyes.Audio.Silk.Tests/packages.lock.json
@@ -277,7 +277,8 @@
           "KeenEyes.Audio": "[1.0.0, )",
           "KeenEyes.Audio.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.OpenAL": "[2.23.0, )"
+          "Silk.NET.OpenAL": "[2.23.0, )",
+          "Silk.NET.OpenAL.Soft.Native": "[1.23.1, )"
         }
       },
       "keeneyes.common": {
@@ -317,6 +318,12 @@
         "dependencies": {
           "Silk.NET.Core": "2.23.0"
         }
+      },
+      "Silk.NET.OpenAL.Soft.Native": {
+        "type": "CentralTransitive",
+        "requested": "[1.23.1, )",
+        "resolved": "1.23.1",
+        "contentHash": "gZIbksInoiXbJZmepYnTs5O6Edg5O5k86c1+Uus0zSaVnQx5WRbInGz2VTlvudbs0qAqXs/asL1YvJzco/nfAQ=="
       },
       "Silk.NET.Windowing": {
         "type": "CentralTransitive",

--- a/tests/KeenEyes.Audio.Tests/AudioSourceSystemTests.cs
+++ b/tests/KeenEyes.Audio.Tests/AudioSourceSystemTests.cs
@@ -227,6 +227,8 @@ public sealed class AudioSourceSystemTests : IDisposable
 
         public bool IsInitialized => true;
 
+        public AudioException? InitializationError => null;
+
         public float MasterVolume { get; set; } = 1f;
 
         public uint GetBufferId(AudioClipHandle handle) => handle.IsValid ? 1u : 0u;

--- a/tests/KeenEyes.Core.Tests/PluginUninstallOrderTests.cs
+++ b/tests/KeenEyes.Core.Tests/PluginUninstallOrderTests.cs
@@ -1,0 +1,126 @@
+namespace KeenEyes.Tests;
+
+/// <summary>
+/// Tests for the order in which plugins are torn down.
+/// </summary>
+/// <remarks>
+/// Plugins declare dependencies by requiring an extension to exist at install time, so a
+/// dependent must be uninstalled while its dependency is still alive. Regression coverage for
+/// #1256, where the window plugin was uninstalled before the graphics plugin that renders
+/// through it and the graphics teardown then ran against a destroyed OpenGL context.
+/// </remarks>
+public class PluginUninstallOrderTests
+{
+    /// <summary>
+    /// A dependency plugin: publishes a service other plugins build on.
+    /// </summary>
+    private sealed class HostPlugin(List<string> log) : IWorldPlugin
+    {
+        public string Name => "Host";
+
+        public void Install(IPluginContext context)
+        {
+            context.SetExtension(new HostService());
+        }
+
+        public void Uninstall(IPluginContext context)
+        {
+            log.Add("Host");
+            context.RemoveExtension<HostService>();
+        }
+    }
+
+    /// <summary>
+    /// A dependent plugin: requires the host service at install time and needs it again to
+    /// release its own resources, exactly like a graphics plugin releasing GPU objects
+    /// through the window that owns the context.
+    /// </summary>
+    private sealed class DependentPlugin(List<string> log) : IWorldPlugin
+    {
+        public string Name => "Dependent";
+
+        public void Install(IPluginContext context)
+        {
+            if (!context.TryGetExtension<HostService>(out _))
+            {
+                throw new InvalidOperationException("DependentPlugin requires HostPlugin.");
+            }
+        }
+
+        public void Uninstall(IPluginContext context)
+        {
+            log.Add("Dependent");
+
+            if (!context.TryGetExtension<HostService>(out var host) || host is null)
+            {
+                throw new InvalidOperationException(
+                    "DependentPlugin was uninstalled after HostPlugin, so its resources leaked.");
+            }
+
+            host.ReleaseResources();
+        }
+    }
+
+    private sealed class HostService
+    {
+        public int ReleaseCount { get; private set; }
+
+        public void ReleaseResources() => ReleaseCount++;
+    }
+
+    [Fact]
+    public void Dispose_WithDependentPlugins_UninstallsInReverseInstallationOrder()
+    {
+        var log = new List<string>();
+        var world = new World();
+        world.InstallPlugin(new HostPlugin(log));
+        world.InstallPlugin(new DependentPlugin(log));
+
+        world.Dispose();
+
+        Assert.Equal(["Dependent", "Host"], log);
+    }
+
+    [Fact]
+    public void Dispose_WithDependentPlugins_DoesNotThrowFromTeardown()
+    {
+        var log = new List<string>();
+        var world = new World();
+        world.InstallPlugin(new HostPlugin(log));
+        world.InstallPlugin(new DependentPlugin(log));
+
+        var exception = Record.Exception(world.Dispose);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_WithDependentPlugins_LetsDependentReleaseThroughItsDependency()
+    {
+        var log = new List<string>();
+        var world = new World();
+        world.InstallPlugin(new HostPlugin(log));
+        world.InstallPlugin(new DependentPlugin(log));
+        var host = world.GetExtension<HostService>();
+
+        world.Dispose();
+
+        Assert.Equal(1, host.ReleaseCount);
+    }
+
+    [Fact]
+    public void UninstallPlugin_ThenDispose_UninstallsRemainingPluginsOnce()
+    {
+        var log = new List<string>();
+        using var world = new World();
+        world.InstallPlugin(new HostPlugin(log));
+        world.InstallPlugin(new DependentPlugin(log));
+
+        // Explicitly uninstalling the dependent first is the caller doing the ordering by
+        // hand; the automatic teardown must not try to uninstall it a second time.
+        world.UninstallPlugin<DependentPlugin>();
+        world.Dispose();
+
+        Assert.Equal(["Dependent", "Host"], log);
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/SilkGraphicsContextTeardownTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/SilkGraphicsContextTeardownTests.cs
@@ -1,0 +1,113 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+// This project carries a local mock of the same name; the shared testing double is the one
+// that can simulate a lost context.
+using MockGraphicsDevice = KeenEyes.Testing.Graphics.MockGraphicsDevice;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests that graphics teardown never throws, even when the underlying graphics context is
+/// already gone.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1256. A window whose load aborted never raises Closing, so the GPU
+/// resources are still alive when the world is disposed - and by then the OpenGL context may be
+/// destroyed, which makes every GPU delete throw from the driver binding. Those exceptions
+/// escaped <c>World.Dispose()</c> and crashed the process after the application had already
+/// reported and handled the original failure.
+/// </remarks>
+public class SilkGraphicsContextTeardownTests
+{
+    /// <summary>
+    /// Builds a world with the graphics plugin installed and its GPU resources created against
+    /// a mock device, which is the state a real game reaches once its window has loaded.
+    /// </summary>
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device) CreateLoadedGraphics()
+    {
+        var world = new World();
+        world.SetExtension<ISilkWindowProvider>(new MockSilkWindowProvider());
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        var context = world.GetExtension<SilkGraphicsContext>();
+        var device = new MockGraphicsDevice();
+        context.InitializeResources(device);
+
+        return (world, context, device);
+    }
+
+    [Fact]
+    public void Dispose_WhenGraphicsContextIsLost_DoesNotThrow()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            // The window died and took the OpenGL context with it.
+            device.ThrowOnDelete = true;
+
+            var exception = Record.Exception(context.Dispose);
+
+            Assert.Null(exception);
+        }
+    }
+
+    [Fact]
+    public void UninstallPlugin_WhenGraphicsContextIsLost_DoesNotThrow()
+    {
+        var (world, _, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            device.ThrowOnDelete = true;
+
+            var exception = Record.Exception(() => world.UninstallPlugin<SilkGraphicsPlugin>());
+
+            Assert.Null(exception);
+        }
+    }
+
+    [Fact]
+    public void WorldDispose_WhenGraphicsContextIsLost_DoesNotThrow()
+    {
+        var (world, _, device) = CreateLoadedGraphics();
+        device.ThrowOnDelete = true;
+
+        var exception = Record.Exception(world.Dispose);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_WhenGraphicsContextIsLost_StillRemovesExtensions()
+    {
+        var (world, _, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            device.ThrowOnDelete = true;
+
+            world.UninstallPlugin<SilkGraphicsPlugin>();
+
+            // A failed GPU delete must not abort the rest of the teardown.
+            Assert.False(world.TryGetExtension<IGraphicsContext>(out _));
+            Assert.False(world.TryGetExtension<SilkGraphicsContext>(out _));
+        }
+    }
+
+    [Fact]
+    public void Dispose_WithUsableGraphicsContext_DeletesGpuResources()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            Assert.NotEmpty(device.Programs);
+
+            context.Dispose();
+
+            // Tolerating failures must not turn into skipping the work: with a live context
+            // every shader program the context created is deleted.
+            Assert.Empty(device.Programs);
+        }
+    }
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/AudioAvailabilityTests.cs
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/AudioAvailabilityTests.cs
@@ -1,0 +1,150 @@
+using System.Numerics;
+using KeenEyes.Audio.Abstractions;
+
+namespace KeenEyes.Sample.NovaFall.Tests;
+
+/// <summary>
+/// Pins down that the game plays without sound: no audio plugin at all, and an audio backend
+/// that is installed but could not open a device.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1256, where a machine with no native OpenAL runtime could not run
+/// the sample at all. Audio is optional hardware, so <see cref="NovaFallAudioSystem"/> must
+/// no-op in both cases rather than throwing into the frame loop.
+/// </remarks>
+public class AudioAvailabilityTests
+{
+    [Fact]
+    public void Update_WithNoAudioExtension_DoesNothing()
+    {
+        using var world = CreatePresentationWorld();
+        var system = new NovaFallAudioSystem();
+        system.Initialize(world);
+
+        var exception = Record.Exception(() => system.Update(1f / 60f));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Update_WithUninitializedAudioContext_DoesNotTouchTheBackend()
+    {
+        using var world = CreatePresentationWorld();
+        var audio = new UnavailableAudioContext();
+        world.SetExtension<IAudioContext>(audio, owned: false);
+
+        var system = new NovaFallAudioSystem();
+        system.Initialize(world);
+
+        // Several frames, including a frame of play: the system must never reach the backend.
+        var exception = Record.Exception(() =>
+        {
+            system.Update(1f / 60f);
+            world.GetSingleton<GameState>().Phase = GamePhase.Playing;
+            system.Update(1f / 60f);
+            system.Update(1f / 60f);
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(0, audio.CallCount);
+    }
+
+    private static World CreatePresentationWorld()
+    {
+        var world = new World();
+
+        // presentation: true is the windowed path - the juice systems believe they may render
+        // and play sound, which is exactly when a missing audio device has to be survivable.
+        GameSetup.InitializeSingletons(world, seed: 1234, pinSeed: true, presentation: true);
+        GameSetup.StartRun(world, seed: 1234);
+
+        return world;
+    }
+
+    /// <summary>
+    /// An <see cref="IAudioContext"/> whose device never opened, matching what the Silk backend
+    /// reports on a machine with no OpenAL runtime: uninitialized, with a typed reason, and
+    /// throwing on any playback call.
+    /// </summary>
+    private sealed class UnavailableAudioContext : IAudioContext
+    {
+        public int CallCount { get; private set; }
+
+        public IAudioDevice? Device => null;
+
+        public bool IsInitialized => false;
+
+        public AudioException? InitializationError { get; } =
+            new AudioInitializationException("The native OpenAL runtime could not be loaded.");
+
+        public float MasterVolume
+        {
+            get => Fail<float>();
+            set => Fail<float>();
+        }
+
+        public AudioClipHandle LoadClip(string path) => Fail<AudioClipHandle>();
+
+        public AudioClipHandle CreateClip(ReadOnlySpan<byte> data, AudioFormat format, int sampleRate) =>
+            Fail<AudioClipHandle>();
+
+        public AudioClipInfo? GetClipInfo(AudioClipHandle handle) => Fail<AudioClipInfo?>();
+
+        public void UnloadClip(AudioClipHandle handle) => Fail<bool>();
+
+        public uint GetBufferId(AudioClipHandle handle) => Fail<uint>();
+
+        public SoundHandle Play(AudioClipHandle clip, float volume = 1f) => Fail<SoundHandle>();
+
+        public SoundHandle Play(AudioClipHandle clip, PlaybackOptions options) => Fail<SoundHandle>();
+
+        public SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, float volume = 1f) =>
+            Fail<SoundHandle>();
+
+        public SoundHandle PlayAt(AudioClipHandle clip, Vector3 position, PlaybackOptions options) =>
+            Fail<SoundHandle>();
+
+        public void Stop(SoundHandle sound) => Fail<bool>();
+
+        public void Pause(SoundHandle sound) => Fail<bool>();
+
+        public void Resume(SoundHandle sound) => Fail<bool>();
+
+        public void SetVolume(SoundHandle sound, float volume) => Fail<bool>();
+
+        public void SetPitch(SoundHandle sound, float pitch) => Fail<bool>();
+
+        public void SetPosition(SoundHandle sound, Vector3 position) => Fail<bool>();
+
+        public bool IsPlaying(SoundHandle sound) => Fail<bool>();
+
+        public void StopAll() => Fail<bool>();
+
+        public void PauseAll() => Fail<bool>();
+
+        public void ResumeAll() => Fail<bool>();
+
+        public float GetChannelVolume(AudioChannel channel) => Fail<float>();
+
+        public void SetChannelVolume(AudioChannel channel, float volume) => Fail<bool>();
+
+        public void SetListenerPosition(Vector3 position) => Fail<bool>();
+
+        public void SetListenerOrientation(Vector3 forward, Vector3 up) => Fail<bool>();
+
+        public void SetListenerVelocity(Vector3 velocity) => Fail<bool>();
+
+        public void Update() => Fail<bool>();
+
+        public void Dispose()
+        {
+        }
+
+        private T Fail<T>()
+        {
+            CallCount++;
+            throw new InvalidOperationException(
+                "Audio is unavailable: the caller must check IAudioContext.IsInitialized first.");
+        }
+    }
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/packages.lock.json
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/packages.lock.json
@@ -335,7 +335,8 @@
           "KeenEyes.Audio": "[1.0.0, )",
           "KeenEyes.Audio.Abstractions": "[1.0.0, )",
           "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
-          "Silk.NET.OpenAL": "[2.23.0, )"
+          "Silk.NET.OpenAL": "[2.23.0, )",
+          "Silk.NET.OpenAL.Soft.Native": "[1.23.1, )"
         }
       },
       "keeneyes.common": {
@@ -649,6 +650,12 @@
         "dependencies": {
           "Silk.NET.Core": "2.23.0"
         }
+      },
+      "Silk.NET.OpenAL.Soft.Native": {
+        "type": "CentralTransitive",
+        "requested": "[1.23.1, )",
+        "resolved": "1.23.1",
+        "contentHash": "gZIbksInoiXbJZmepYnTs5O6Edg5O5k86c1+Uus0zSaVnQx5WRbInGz2VTlvudbs0qAqXs/asL1YvJzco/nfAQ=="
       },
       "Silk.NET.OpenGL": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary
Fixes #1256 (NOVAFALL failing on Windows). The reported "fails to load" was three separate defects; investigation corrected the initial diagnosis in two places.

### Root cause chain
1. **Missing native OpenAL.** `Silk.NET.OpenAL` is bindings-only and nothing in the repo shipped a native runtime. `OpenALDevice` calls `ALContext.GetApi(soft: true)` (i.e. `soft_oal.dll`), which stock Windows does not have → `Could not load from any of the possible library names!`. It surfaced *inside* `.Run()` because the device opens from the window `Load` event, not at plugin install — **not** a display problem (GL had fully initialized, hence a live shader program at teardown).
2. **`PluginManager.UninstallAll` tore down in installation order** — so `SilkWindowPlugin` (installed first) destroyed the window *before* `SilkGraphicsPlugin` deleted its GPU objects, producing `GlfwException: NoContext`. This is a Core bug affecting any dependency-ordered plugin teardown, not just this crash.
3. **Unguarded GPU teardown** let one failing resource owner abort the rest and escape `World.Dispose()`.

### Fixes
- **`Silk.NET.OpenAL.Soft.Native` 1.23.1** added centrally (+ `KeenEyes.Audio.Silk`). Ships `soft_oal.dll` (win-x64/x86/arm64), `libopenal.so`, `libopenal.dylib` — matching the `soft: true` probe. Verified deployed: `bin/Release/net10.0/runtimes/win-x64/native/soft_oal.dll` (1,113,088 bytes), same deps.json path as the `glfw3.dll` that already works on the reporter's machine.
- **Audio failure is now typed and non-fatal.** `OpenALDevice` throws `AudioInitializationException` naming the missing runtime and the package that provides it; `SilkAudioContext.HandleWindowLoad` catches `AudioException` and degrades (rethrowing would kill the window loop — the app cannot recover, which *was* the reported cascade). Not a silent swallow: exposed via the new `IAudioContext.InitializationError`, `IsInitialized` stays false, logged, and `ThrowIfNotInitialized` now quotes the real cause.
- **`PluginManager.UninstallAll` uninstalls in reverse installation order** (explicit `installOrder` list — dictionary order is not contractual), so dependents release while their dependencies are still alive.
- **`SilkGraphicsContext.DisposeGpuResources` isolates each resource owner** (`TryDispose` + `Debug.WriteLine`, matching the existing convention in `SilkLoopProvider`/`SaveFileFormat`/`IpcBridgeServer`), so teardown never throws out of `World.Dispose()`.
- **NOVAFALL diagnostics are honest** — prints `Startup failed: <Type>: <message>` and offers the headless hint as a suggestion, not a diagnosis; `NovaFallAudioSystem` checks `IsInitialized`, warns once, and no-ops so the game plays silently.
- **`docs/audio.md`** documents the native runtime requirement and the degradation contract.

### Deliberate non-change
No GL-context-validity probe: `IWindow`/`GLContext.IsCurrent` answers go through GLFW — the thing that throws once the window is destroyed — so probing adds a failure mode instead of removing one. Correct ordering + isolated disposal are the reliable guarantees.

## Test plan
- [x] `PluginUninstallOrderTests` (4) — 3 fail on old code
- [x] `SilkGraphicsContextTeardownTests` (5) — 4 fail on old; includes a **positive** test that a live context still deletes every program, so "swallow and skip" cannot pass. Enabled by new documented `MockGraphicsDevice.ThrowOnDelete`.
- [x] `OpenALDeviceTests` (2) / NOVAFALL `AudioAvailabilityTests` (2) — 1 fail on old each
- [x] Full suite **14,781, 0 failed**; 0 warnings; format clean; `--simulate 600` double-run byte-identical

## Needs confirmation on Windows (cannot be verified from Linux)
1. That `soft_oal.dll` actually loads and opens a device on Windows 11 — deployment and the Linux twin are proven here; the Windows load is not.
2. The exact GLFW teardown state — the reconstruction matches the stack trace and install order, but GLFW-on-Windows was not observable. **Either fix alone prevents the crash.**
3. `HandleWindowLoad`'s catch is verified by inspection only (constructing it needs a real `IWindow` + display); the typed exception it catches and the consumer behavior it enables are both covered by tests.

Expected new behavior if OpenAL still fails for any other reason: one `Audio unavailable: …` line and the game runs silently — no misleading display message, no unhandled exception at exit.

Closes #1256
