### PR TITLE
fix(samples): Report NOVAFALL window-creation failures instead of crashing

### DIFF
--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -151,9 +151,25 @@ using var world = new World();
 
 // Install plugins (order matters: window first, then graphics and input, then
 // the gameplay/juice plugins that build on them).
-world.InstallPlugin(new SilkWindowPlugin(windowConfig));
-world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
-world.InstallPlugin(new SilkInputPlugin(inputConfig));
+//
+// The window, graphics and input plugins are the hard requirements, and they are
+// the ones that touch the platform: SilkWindowPlugin.Install creates the window
+// (and therefore initializes GLFW) right here, so on a machine with no display
+// this is where startup fails - before the game loop is ever reached. Guarding
+// only the loop would let that surface as an unhandled crash, so the same
+// diagnostic covers the installation.
+try
+{
+    world.InstallPlugin(new SilkWindowPlugin(windowConfig));
+    world.InstallPlugin(new SilkGraphicsPlugin(graphicsConfig));
+    world.InstallPlugin(new SilkInputPlugin(inputConfig));
+}
+catch (Exception ex)
+{
+    ReportStartupFailure(ex);
+    return;
+}
+
 GameSetup.InstallSimulationPlugins(world);
 world.InstallPlugin(new ParticlesPlugin());
 world.InstallPlugin(new AnimationPlugin());
@@ -260,14 +276,7 @@ catch (Exception ex)
     // surface a wide range of platform exceptions (missing display, driver, or GL
     // context errors). A demo recovers by reporting the failure and exiting rather
     // than crashing, so a catch-all is appropriate here.
-    //
-    // Report WHAT failed rather than guessing WHY: a blanket "requires a display"
-    // is actively misleading on a machine that has one, and it hides the real
-    // exception type behind a wrong diagnosis. The headless hint is worth printing
-    // either way, but as a suggestion, not as a cause.
-    Console.WriteLine($"Startup failed: {ex.GetType().Name}: {ex.Message}");
-    Console.WriteLine("The windowed mode needs a display, a GPU driver, and OpenGL 3.3. "
-        + "For a check that needs none of them, run with --simulate 600.");
+    ReportStartupFailure(ex);
 }
 finally
 {
@@ -281,6 +290,18 @@ finally
 }
 
 Console.WriteLine("Sample complete!");
+
+// Reports a startup failure the honest way: WHAT failed comes first, because a
+// blanket "requires a display" is actively misleading on a machine that has one
+// and hides the real exception type behind a wrong diagnosis. The requirement
+// list follows as a suggestion, never as the stated cause.
+static void ReportStartupFailure(Exception ex)
+{
+    Console.WriteLine($"Startup failed: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine("Windowed mode needs a display, a GPU driver, and OpenGL 3.3; "
+        + "the line above says which of those actually failed. "
+        + "For a check that needs none of them, run with --simulate 600.");
+}
 
 // Headless determinism harness: builds the world with no window, graphics,
 // audio, particle, animation, or UI plugins (every juice system no-ops), steps


### PR DESCRIPTION
## Summary
Follow-up to #1258, found by running the sample on a headless host. The startup guard added there covered only the game loop — but `SilkWindowPlugin.Install` creates the window (and initializes GLFW) during **plugin installation**, several statements earlier. So the most common startup failure escaped as an unhandled exception rather than the intended diagnostic.

**Before** (headless host, reproduced locally):
```
Unhandled exception. Silk.NET.GLFW.GlfwException: GLFW Init failed, 65550: Failed to detect any supported platform
   at KeenEyes.Platform.Silk.SilkWindowProvider..ctor(...)
   at Program.<Main>$(String[] args) in .../Program.cs:line 154
```

**After** (same host):
```
Startup failed: GlfwException: GLFW Init failed, 65550: Failed to detect any supported platform
Windowed mode needs a display, a GPU driver, and OpenGL 3.3; the line above says which of those actually failed. For a check that needs none of them, run with --simulate 600.
```

- The presentation-plugin installs (window/graphics/input — the hard requirements, and the ones that touch the platform) are now inside the guard, sharing one `ReportStartupFailure` helper with the loop's handler.
- The requirement hint is reworded to **point at** the diagnostic line rather than compete with it. Motivation: a user reported only the hint text, which is a guess-list — the actual exception line above it is what identifies the cause.

## Test plan
- [x] Reproduced the unhandled crash on this headless host, then confirmed the clean diagnostic after the fix
- [x] Sample + `KeenEyes.slnx` build 0 warnings; full suite **14,781, 0 failed**; format clean
- [x] `--simulate 600` double-run byte-identical (determinism unaffected)