### PR TITLE
feat(graphics): Detect and report OpenGL capability, failing fast below the 3.3 minimum

### DIFF
--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -18,6 +18,31 @@ This separation allows:
 - Writing backend-agnostic plugins and systems
 - Testing graphics logic without GPU dependencies
 
+## Requirements and capability detection
+
+The Silk.NET backend requires **OpenGL 3.3 or newer**. Every built-in shader declares
+`#version 330 core`, so this is a hard floor, not a recommendation.
+
+When the window loads, the backend asks the device for its identity via
+`IGraphicsDevice.GetDeviceInfo()`, which returns a `GraphicsDeviceInfo` carrying the driver's
+vendor, renderer, version, and shading language version strings plus the parsed major/minor
+version. It then:
+
+1. **Rejects a driver below 3.3** by throwing `UnsupportedGraphicsDeviceException` before any
+   shader or renderer is created. The message states the detected version, the driver's renderer
+   and vendor strings, the required version, and the likely remedy - installing the GPU vendor's
+   driver. The exception also exposes the `GraphicsDeviceInfo` for callers that want to present it
+   themselves.
+2. **Logs one line** naming the driver it did get (`Debug.WriteLine`), so a session's OpenGL and
+   shading language versions appear in diagnostic output even when everything works.
+
+Shader compilation and linking failures also append the driver's OpenGL and shading language
+versions to the info log, so a version mismatch is self-evident in the error text.
+
+The classic cause of a below-minimum driver on Windows is that no vendor GPU driver is installed,
+which leaves the Microsoft Basic Display Adapter software fallback in place; it reports OpenGL
+1.1, as do remote-desktop sessions.
+
 ## Quick Start
 
 ```csharp

--- a/src/KeenEyes.Graphics.Abstractions/GraphicsDeviceInfo.cs
+++ b/src/KeenEyes.Graphics.Abstractions/GraphicsDeviceInfo.cs
@@ -1,0 +1,52 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Identity and API version of the graphics driver behind an <see cref="IGraphicsDevice"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Returned by <see cref="IGraphicsDevice.GetDeviceInfo"/>. The strings are the driver's own,
+/// reported verbatim so that a log line or bug report carries what the machine actually has;
+/// the parsed <see cref="MajorVersion"/> and <see cref="MinorVersion"/> are what capability
+/// checks compare.
+/// </para>
+/// <para>
+/// A string is empty when the driver does not report it. The classic case is
+/// <see cref="ShadingLanguageVersion"/> on an OpenGL 1.1 software fallback, which predates
+/// shaders entirely.
+/// </para>
+/// </remarks>
+/// <param name="Vendor">The driver vendor, for example <c>NVIDIA Corporation</c>.</param>
+/// <param name="Renderer">The renderer, usually the GPU model, for example <c>GeForce RTX 4070</c>.</param>
+/// <param name="Version">The driver's API version string, for example <c>4.6.0 NVIDIA 551.86</c>.</param>
+/// <param name="ShadingLanguageVersion">The driver's shading language version string, for example <c>4.60</c>.</param>
+/// <param name="MajorVersion">The major API version, or 0 when it could not be determined.</param>
+/// <param name="MinorVersion">The minor API version, or 0 when it could not be determined.</param>
+public readonly record struct GraphicsDeviceInfo(
+    string Vendor,
+    string Renderer,
+    string Version,
+    string ShadingLanguageVersion,
+    int MajorVersion,
+    int MinorVersion)
+{
+    /// <summary>
+    /// Determines whether the device's API version is at least the specified version.
+    /// </summary>
+    /// <param name="major">The required major version.</param>
+    /// <param name="minor">The required minor version.</param>
+    /// <returns>True when the device reports <paramref name="major"/>.<paramref name="minor"/> or newer.</returns>
+    public bool IsAtLeast(int major, int minor)
+        => MajorVersion > major || (MajorVersion == major && MinorVersion >= minor);
+
+    /// <summary>
+    /// Returns a single-line summary suitable for logs and error messages.
+    /// </summary>
+    /// <returns>The driver's version, shading language version, renderer, and vendor.</returns>
+    public override string ToString()
+        => $"{Describe(Version)} | shading language {Describe(ShadingLanguageVersion)} " +
+           $"| renderer: {Describe(Renderer)} | vendor: {Describe(Vendor)}";
+
+    private static string Describe(string value)
+        => string.IsNullOrWhiteSpace(value) ? "unreported" : value;
+}

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsDevice.cs
@@ -21,6 +21,21 @@ namespace KeenEyes.Graphics.Abstractions;
 /// </remarks>
 public interface IGraphicsDevice : IDisposable
 {
+    #region Capability
+
+    /// <summary>
+    /// Queries the driver for its identity and API version.
+    /// </summary>
+    /// <returns>The driver's vendor, renderer, version strings, and parsed API version.</returns>
+    /// <remarks>
+    /// Used to log which driver a session actually got, and to reject drivers below the engine's
+    /// minimum before any shader is compiled. Implementations query the driver on each call
+    /// rather than caching, so callers should hold the result if they need it repeatedly.
+    /// </remarks>
+    GraphicsDeviceInfo GetDeviceInfo();
+
+    #endregion
+
     #region Buffer Operations
 
     /// <summary>

--- a/src/KeenEyes.Graphics.Abstractions/UnsupportedGraphicsDeviceException.cs
+++ b/src/KeenEyes.Graphics.Abstractions/UnsupportedGraphicsDeviceException.cs
@@ -1,0 +1,24 @@
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Thrown when the graphics driver on the machine cannot support the engine's rendering
+/// requirements, most commonly because its API version is too old.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The backend raises this during graphics initialization, before it creates any shader or
+/// renderer, so the failure names the real cause instead of surfacing later as an opaque shader
+/// compilation error. <see cref="DeviceInfo"/> carries the driver's reported identity for
+/// callers that want to present it themselves; the message already contains it.
+/// </para>
+/// </remarks>
+/// <param name="message">A message stating what was detected, what is required, and how to fix it.</param>
+/// <param name="deviceInfo">The driver identity and version that failed the check.</param>
+public sealed class UnsupportedGraphicsDeviceException(string message, GraphicsDeviceInfo deviceInfo)
+    : InvalidOperationException(message)
+{
+    /// <summary>
+    /// Gets the driver identity and version that failed the check.
+    /// </summary>
+    public GraphicsDeviceInfo DeviceInfo { get; } = deviceInfo;
+}

--- a/src/KeenEyes.Graphics.Silk/Backend/GlCapabilities.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/GlCapabilities.cs
@@ -1,0 +1,52 @@
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graphics.Silk.Backend;
+
+/// <summary>
+/// The OpenGL feature level this backend requires, and the check that enforces it.
+/// </summary>
+internal static class GlCapabilities
+{
+    /// <summary>
+    /// The minimum OpenGL major version this backend runs on.
+    /// </summary>
+    /// <remarks>
+    /// Every built-in shader declares <c>#version 330 core</c> - see
+    /// <see cref="Rendering2D.Shaders2D"/> and <see cref="Shaders.DefaultShaders"/> - so OpenGL
+    /// 3.3 is a hard requirement, not a preference. Raising the shaders raises this constant.
+    /// </remarks>
+    internal const int MinimumMajorVersion = 3;
+
+    /// <summary>
+    /// The minimum OpenGL minor version this backend runs on.
+    /// </summary>
+    /// <remarks>See <see cref="MinimumMajorVersion"/>.</remarks>
+    internal const int MinimumMinorVersion = 3;
+
+    /// <summary>
+    /// Throws when the device's OpenGL version is below the engine's minimum.
+    /// </summary>
+    /// <param name="deviceInfo">The driver identity and version reported by the device.</param>
+    /// <exception cref="UnsupportedGraphicsDeviceException">
+    /// Thrown when the driver reports a version below
+    /// <see cref="MinimumMajorVersion"/>.<see cref="MinimumMinorVersion"/>.
+    /// </exception>
+    internal static void EnsureMinimumVersion(GraphicsDeviceInfo deviceInfo)
+    {
+        if (deviceInfo.IsAtLeast(MinimumMajorVersion, MinimumMinorVersion))
+        {
+            return;
+        }
+
+        throw new UnsupportedGraphicsDeviceException(
+            $"This machine's OpenGL driver is too old to run KeenEyes: detected " +
+            $"{deviceInfo.MajorVersion}.{deviceInfo.MinorVersion}, but " +
+            $"{MinimumMajorVersion}.{MinimumMinorVersion} or newer is required " +
+            $"(every built-in shader is '#version 330 core'). " +
+            $"Driver reports {deviceInfo}. " +
+            "Install the graphics driver from your GPU vendor (NVIDIA, AMD, or Intel): the " +
+            "Microsoft Basic Display Adapter software fallback, used when no vendor driver is " +
+            "installed, reports OpenGL 1.1 - as do remote-desktop sessions.",
+            deviceInfo);
+    }
+}

--- a/src/KeenEyes.Graphics.Silk/Backend/GlVersionString.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/GlVersionString.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+
+namespace KeenEyes.Graphics.Silk.Backend;
+
+/// <summary>
+/// Parses the version number out of an OpenGL <c>GL_VERSION</c> string.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GL_MAJOR_VERSION</c> and <c>GL_MINOR_VERSION</c> only exist on OpenGL 3.0 and newer, so the
+/// version string is the only source available on exactly the old drivers a capability check
+/// needs to detect. The spec guarantees it begins with <c>major.minor</c>, optionally prefixed
+/// (<c>OpenGL ES 3.2 ...</c>) and always allowed a vendor suffix (<c>4.6.0 NVIDIA 551.86</c>).
+/// </para>
+/// </remarks>
+internal static class GlVersionString
+{
+    /// <summary>
+    /// Extracts the major and minor version from a <c>GL_VERSION</c> string.
+    /// </summary>
+    /// <param name="versionString">The driver's version string, which may be null or malformed.</param>
+    /// <returns>
+    /// The first <c>major.minor</c> pair in the string, or <c>(0, 0)</c> when the string contains
+    /// none - a value no real driver reports, so it fails every minimum-version check.
+    /// </returns>
+    internal static (int Major, int Minor) Parse(string? versionString)
+    {
+        if (string.IsNullOrWhiteSpace(versionString))
+        {
+            return (0, 0);
+        }
+
+        var text = versionString.AsSpan();
+
+        int index = 0;
+        while (index < text.Length)
+        {
+            if (!char.IsAsciiDigit(text[index]))
+            {
+                index++;
+                continue;
+            }
+
+            int majorEnd = index;
+            while (majorEnd < text.Length && char.IsAsciiDigit(text[majorEnd]))
+            {
+                majorEnd++;
+            }
+
+            // A digit run not followed by ".<digit>" cannot be a version (for example the "2" in
+            // "WebGL2 ..."). Skip past it and keep looking; the first real pair wins, which is
+            // the leading one the spec mandates.
+            if (majorEnd >= text.Length || text[majorEnd] != '.')
+            {
+                index = majorEnd;
+                continue;
+            }
+
+            int minorStart = majorEnd + 1;
+            int minorEnd = minorStart;
+            while (minorEnd < text.Length && char.IsAsciiDigit(text[minorEnd]))
+            {
+                minorEnd++;
+            }
+
+            if (minorEnd == minorStart)
+            {
+                index = minorEnd;
+                continue;
+            }
+
+            return int.TryParse(text[index..majorEnd], CultureInfo.InvariantCulture, out int major)
+                   && int.TryParse(text[minorStart..minorEnd], CultureInfo.InvariantCulture, out int minor)
+                ? (major, minor)
+                : (0, 0);
+        }
+
+        return (0, 0);
+    }
+}

--- a/src/KeenEyes.Graphics.Silk/Backend/GraphicsDeviceDiagnostics.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/GraphicsDeviceDiagnostics.cs
@@ -1,0 +1,23 @@
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graphics.Silk.Backend;
+
+/// <summary>
+/// Diagnostic formatting shared by the backend's shader failure paths.
+/// </summary>
+internal static class GraphicsDeviceDiagnostics
+{
+    /// <summary>
+    /// Combines a driver info log with the driver's identity and version strings.
+    /// </summary>
+    /// <param name="device">The device whose shader compilation or linking failed.</param>
+    /// <param name="infoLog">The info log the driver returned for the failure.</param>
+    /// <returns>The info log followed by the driver's version, renderer, and vendor.</returns>
+    /// <remarks>
+    /// A GLSL version mismatch surfaces as an ordinary compile error whose text varies by
+    /// vendor, so the info log alone rarely identifies the cause. Reporting the driver's
+    /// OpenGL and shading language versions alongside it makes that case self-evident.
+    /// </remarks>
+    internal static string DescribeShaderFailure(this IGraphicsDevice device, string infoLog)
+        => $"{infoLog} (driver: OpenGL {device.GetDeviceInfo()})";
+}

--- a/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
+++ b/src/KeenEyes.Graphics.Silk/Backend/OpenGLDevice.cs
@@ -17,6 +17,33 @@ public sealed class OpenGLDevice(GL gl) : IGraphicsDevice
     private readonly GL gl = gl ?? throw new ArgumentNullException(nameof(gl));
     private bool disposed;
 
+    #region Capability
+
+    /// <inheritdoc />
+    public GraphicsDeviceInfo GetDeviceInfo()
+    {
+        string version = gl.GetStringS(StringName.Version) ?? string.Empty;
+        string renderer = gl.GetStringS(StringName.Renderer) ?? string.Empty;
+        string vendor = gl.GetStringS(StringName.Vendor) ?? string.Empty;
+        string shadingLanguage = gl.GetStringS(StringName.ShadingLanguageVersion) ?? string.Empty;
+
+        int major = gl.GetInteger(GetPName.MajorVersion);
+        int minor = gl.GetInteger(GetPName.MinorVersion);
+
+        if (major <= 0)
+        {
+            // GL_MAJOR_VERSION and GL_MINOR_VERSION were added in OpenGL 3.0. An older driver
+            // raises GL_INVALID_ENUM and leaves the value untouched, so drain that error and fall
+            // back to the version string, which every OpenGL version reports.
+            gl.GetError();
+            (major, minor) = GlVersionString.Parse(version);
+        }
+
+        return new GraphicsDeviceInfo(vendor, renderer, version, shadingLanguage, major, minor);
+    }
+
+    #endregion
+
     #region Buffer Operations
 
     /// <inheritdoc />

--- a/src/KeenEyes.Graphics.Silk/Ibl/IblManager.cs
+++ b/src/KeenEyes.Graphics.Silk/Ibl/IblManager.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Backend;
 using KeenEyes.Graphics.Silk.Shaders;
 
 namespace KeenEyes.Graphics.Silk.Ibl;
@@ -299,7 +300,7 @@ public sealed class IblManager(IGraphicsContext graphics, IGraphicsDevice device
         {
             string log = device.GetShaderInfoLog(vertexShader);
             device.DeleteShader(vertexShader);
-            throw new InvalidOperationException($"Vertex shader compilation failed: {log}");
+            throw new InvalidOperationException($"Vertex shader compilation failed: {device.DescribeShaderFailure(log)}");
         }
 
         uint fragmentShader = device.CreateShader(ShaderType.Fragment);
@@ -311,7 +312,7 @@ public sealed class IblManager(IGraphicsContext graphics, IGraphicsDevice device
             string log = device.GetShaderInfoLog(fragmentShader);
             device.DeleteShader(vertexShader);
             device.DeleteShader(fragmentShader);
-            throw new InvalidOperationException($"Fragment shader compilation failed: {log}");
+            throw new InvalidOperationException($"Fragment shader compilation failed: {device.DescribeShaderFailure(log)}");
         }
 
         uint program = device.CreateProgram();
@@ -325,7 +326,7 @@ public sealed class IblManager(IGraphicsContext graphics, IGraphicsDevice device
             device.DeleteProgram(program);
             device.DeleteShader(vertexShader);
             device.DeleteShader(fragmentShader);
-            throw new InvalidOperationException($"Shader program linking failed: {log}");
+            throw new InvalidOperationException($"Shader program linking failed: {device.DescribeShaderFailure(log)}");
         }
 
         device.DetachShader(program, vertexShader);

--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 
 using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Backend;
 using KeenEyes.Graphics.Silk.Resources;
 
 namespace KeenEyes.Graphics.Silk.Rendering2D;
@@ -163,7 +164,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetShaderCompileStatus(vertexShader))
         {
             var log = device.GetShaderInfoLog(vertexShader);
-            throw new InvalidOperationException($"Failed to compile 2D vertex shader: {log}");
+            throw new InvalidOperationException($"Failed to compile 2D vertex shader: {device.DescribeShaderFailure(log)}");
         }
 
         var fragmentShader = device.CreateShader(Abstractions.ShaderType.Fragment);
@@ -173,7 +174,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetShaderCompileStatus(fragmentShader))
         {
             var log = device.GetShaderInfoLog(fragmentShader);
-            throw new InvalidOperationException($"Failed to compile 2D fragment shader: {log}");
+            throw new InvalidOperationException($"Failed to compile 2D fragment shader: {device.DescribeShaderFailure(log)}");
         }
 
         shaderProgram = device.CreateProgram();
@@ -184,7 +185,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetProgramLinkStatus(shaderProgram))
         {
             var log = device.GetProgramInfoLog(shaderProgram);
-            throw new InvalidOperationException($"Failed to link 2D shader program: {log}");
+            throw new InvalidOperationException($"Failed to link 2D shader program: {device.DescribeShaderFailure(log)}");
         }
 
         device.DetachShader(shaderProgram, vertexShader);
@@ -257,7 +258,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetShaderCompileStatus(vertexShader))
         {
             var log = device.GetShaderInfoLog(vertexShader);
-            throw new InvalidOperationException($"Failed to compile rounded rect vertex shader: {log}");
+            throw new InvalidOperationException($"Failed to compile rounded rect vertex shader: {device.DescribeShaderFailure(log)}");
         }
 
         var fragmentShader = device.CreateShader(Abstractions.ShaderType.Fragment);
@@ -267,7 +268,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetShaderCompileStatus(fragmentShader))
         {
             var log = device.GetShaderInfoLog(fragmentShader);
-            throw new InvalidOperationException($"Failed to compile rounded rect fragment shader: {log}");
+            throw new InvalidOperationException($"Failed to compile rounded rect fragment shader: {device.DescribeShaderFailure(log)}");
         }
 
         roundedRectShaderProgram = device.CreateProgram();
@@ -278,7 +279,7 @@ public sealed class Silk2DRenderer : I2DRenderer
         if (!device.GetProgramLinkStatus(roundedRectShaderProgram))
         {
             var log = device.GetProgramInfoLog(roundedRectShaderProgram);
-            throw new InvalidOperationException($"Failed to link rounded rect shader program: {log}");
+            throw new InvalidOperationException($"Failed to link rounded rect shader program: {device.DescribeShaderFailure(log)}");
         }
 
         device.DetachShader(roundedRectShaderProgram, vertexShader);

--- a/src/KeenEyes.Graphics.Silk/Resources/ShaderData.cs
+++ b/src/KeenEyes.Graphics.Silk/Resources/ShaderData.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 
 using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Backend;
 
 namespace KeenEyes.Graphics.Silk.Resources;
 
@@ -78,11 +79,11 @@ internal sealed class ShaderManager : IDisposable
         // Check for linking errors
         if (!Device.GetProgramLinkStatus(program))
         {
-            string infoLog = Device.GetProgramInfoLog(program);
+            string detail = Device.DescribeShaderFailure(Device.GetProgramInfoLog(program));
             Device.DeleteProgram(program);
             Device.DeleteShader(vertexShader);
             Device.DeleteShader(fragmentShader);
-            throw new InvalidOperationException($"Shader program linking failed: {infoLog}");
+            throw new InvalidOperationException($"Shader program linking failed: {detail}");
         }
 
         // Clean up shader objects (they're now part of the program)
@@ -113,9 +114,9 @@ internal sealed class ShaderManager : IDisposable
 
         if (!Device.GetShaderCompileStatus(shader))
         {
-            string infoLog = Device.GetShaderInfoLog(shader);
+            string detail = Device.DescribeShaderFailure(Device.GetShaderInfoLog(shader));
             Device.DeleteShader(shader);
-            throw new InvalidOperationException($"Shader compilation failed ({type}): {infoLog}");
+            throw new InvalidOperationException($"Shader compilation failed ({type}): {detail}");
         }
 
         return shader;

--- a/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Backend;
 using KeenEyes.Graphics.Silk.Rendering2D;
 using KeenEyes.Graphics.Silk.Resources;
 using KeenEyes.Graphics.Silk.Shaders;
@@ -229,8 +230,17 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     /// Separated from <see cref="HandleWindowLoad"/> so that resource setup is independent
     /// of window and device acquisition, which keeps the GPU lifecycle testable headlessly.
     /// </remarks>
+    /// <exception cref="UnsupportedGraphicsDeviceException">
+    /// Thrown when the driver's OpenGL version is below the engine's minimum. Checked here,
+    /// before any shader exists, so an unsupported driver reports itself instead of failing
+    /// later as an unexplained shader compilation error.
+    /// </exception>
     internal void InitializeResources(IGraphicsDevice graphicsDevice)
     {
+        var deviceInfo = graphicsDevice.GetDeviceInfo();
+        GlCapabilities.EnsureMinimumVersion(deviceInfo);
+        Debug.WriteLine($"Graphics device: OpenGL {deviceInfo}");
+
         device = graphicsDevice;
 
         // Initialize resource managers with the device

--- a/src/KeenEyes.Graphics.Silk/Text/FontStashRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Text/FontStashRenderer.cs
@@ -6,6 +6,7 @@ using FontStashSharp;
 using FontStashSharp.Interfaces;
 
 using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Backend;
 
 namespace KeenEyes.Graphics.Silk.Text;
 
@@ -266,7 +267,7 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
         if (!device.GetShaderCompileStatus(vertexShader))
         {
             var log = device.GetShaderInfoLog(vertexShader);
-            throw new InvalidOperationException($"Failed to compile text vertex shader: {log}");
+            throw new InvalidOperationException($"Failed to compile text vertex shader: {device.DescribeShaderFailure(log)}");
         }
 
         var fragmentShader = device.CreateShader(Abstractions.ShaderType.Fragment);
@@ -276,7 +277,7 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
         if (!device.GetShaderCompileStatus(fragmentShader))
         {
             var log = device.GetShaderInfoLog(fragmentShader);
-            throw new InvalidOperationException($"Failed to compile text fragment shader: {log}");
+            throw new InvalidOperationException($"Failed to compile text fragment shader: {device.DescribeShaderFailure(log)}");
         }
 
         shaderProgram = device.CreateProgram();
@@ -287,7 +288,7 @@ internal sealed class FontStashRenderer : IFontStashRenderer2, IDisposable
         if (!device.GetProgramLinkStatus(shaderProgram))
         {
             var log = device.GetProgramInfoLog(shaderProgram);
-            throw new InvalidOperationException($"Failed to link text shader program: {log}");
+            throw new InvalidOperationException($"Failed to link text shader program: {device.DescribeShaderFailure(log)}");
         }
 
         device.DetachShader(shaderProgram, vertexShader);

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsDevice.cs
@@ -36,6 +36,18 @@ namespace KeenEyes.Testing.Graphics;
 /// </example>
 public sealed class MockGraphicsDevice : IGraphicsDevice
 {
+    /// <summary>
+    /// The driver identity a freshly created or reset mock reports: a modern OpenGL 4.6 device,
+    /// so tests that do not care about capability checks always pass them.
+    /// </summary>
+    private static readonly GraphicsDeviceInfo defaultDeviceInfo = new(
+        Vendor: "KeenEyes",
+        Renderer: "MockGraphicsDevice",
+        Version: "4.6.0 KeenEyes Mock",
+        ShadingLanguageVersion: "4.60",
+        MajorVersion: 4,
+        MinorVersion: 6);
+
     private uint nextHandle = 1;
     private bool disposed;
 
@@ -179,6 +191,24 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     public bool ThrowOnDelete { get; set; }
 
     /// <summary>
+    /// Gets or sets the driver identity and version returned by <see cref="GetDeviceInfo"/>.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to a modern OpenGL 4.6 device so that capability checks pass. Set it to an old
+    /// version to exercise the paths that reject a driver the engine cannot run on.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var device = new MockGraphicsDevice
+    /// {
+    ///     DeviceInfo = new GraphicsDeviceInfo(
+    ///         "Microsoft Corporation", "Microsoft Basic Render Driver", "1.1.0", "", 1, 1)
+    /// };
+    /// </code>
+    /// </example>
+    public GraphicsDeviceInfo DeviceInfo { get; set; } = defaultDeviceInfo;
+
+    /// <summary>
     /// Gets or sets the simulated framebuffer data returned by <see cref="ReadFramebuffer"/>.
     /// </summary>
     /// <remarks>
@@ -241,6 +271,7 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
         ShouldFailShaderCompile = false;
         ShouldFailProgramLink = false;
         SimulatedErrorCode = 0;
+        DeviceInfo = defaultDeviceInfo;
         SimulatedFramebufferData = null;
         SimulatedFramebufferWidth = 0;
         SimulatedFramebufferHeight = 0;
@@ -254,6 +285,13 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     {
         DrawCalls.Clear();
     }
+
+    #endregion
+
+    #region Capability
+
+    /// <inheritdoc />
+    public GraphicsDeviceInfo GetDeviceInfo() => DeviceInfo;
 
     #endregion
 

--- a/tests/KeenEyes.Graphics.Tests/GlVersionStringTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/GlVersionStringTests.cs
@@ -1,0 +1,58 @@
+using KeenEyes.Graphics.Silk.Backend;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests for <see cref="GlVersionString"/>, the fallback that reads the OpenGL version out of
+/// the driver's <c>GL_VERSION</c> string.
+/// </summary>
+/// <remarks>
+/// This parser is the only version source available on drivers older than OpenGL 3.0, which are
+/// exactly the ones the capability check exists to reject, so it has to cope with every shape
+/// real drivers emit: bare numbers, vendor suffixes, build tags, and API-name prefixes.
+/// </remarks>
+public class GlVersionStringTests
+{
+    [Theory]
+    // Desktop OpenGL with a vendor suffix.
+    [InlineData("4.6.0 NVIDIA 551.86", 4, 6)]
+    [InlineData("4.6.0 Compatibility Profile Context 23.20.15017.4003", 4, 6)]
+    [InlineData("2.1 Mesa 20.0.8", 2, 1)]
+    [InlineData("4.6 (Core Profile) Mesa 24.0.3", 4, 6)]
+    // The software fallback this whole feature exists to diagnose.
+    [InlineData("1.1.0", 1, 1)]
+    // Intel drivers append a build tag whose numbers must not win over the leading version.
+    [InlineData("3.3.0 - Build 31.0.101.2111", 3, 3)]
+    // OpenGL ES prefixes the numbers with the API name.
+    [InlineData("OpenGL ES 3.2 NVIDIA 551.86", 3, 2)]
+    [InlineData("OpenGL ES 2.0 (WebGL 1.0)", 2, 0)]
+    // Two-digit components must not be truncated.
+    [InlineData("10.12.0 Some Future Driver", 10, 12)]
+    // A digit run with no ".<digit>" after it is skipped rather than mistaken for a version.
+    [InlineData("WebGL2 3.1 Emulated", 3, 1)]
+    public void Parse_WithRealWorldVersionString_ReturnsLeadingVersion(string versionString, int expectedMajor, int expectedMinor)
+    {
+        var (major, minor) = GlVersionString.Parse(versionString);
+
+        Assert.Equal(expectedMajor, major);
+        Assert.Equal(expectedMinor, minor);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("no digits at all")]
+    [InlineData("4")]
+    [InlineData("4.")]
+    [InlineData(".6")]
+    // Larger than int.MaxValue: unparseable rather than silently wrapped.
+    [InlineData("99999999999999.1")]
+    public void Parse_WithUnusableVersionString_ReturnsZeroSoEveryCheckFails(string? versionString)
+    {
+        var (major, minor) = GlVersionString.Parse(versionString);
+
+        Assert.Equal(0, major);
+        Assert.Equal(0, minor);
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/GraphicsCapabilityDetectionTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/GraphicsCapabilityDetectionTests.cs
@@ -1,0 +1,207 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Silk.Backend;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+// This project carries a local mock of the same name; the shared testing double is the one
+// whose reported driver version can be spoofed.
+using MockGraphicsDevice = KeenEyes.Testing.Graphics.MockGraphicsDevice;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests that graphics initialization detects the driver's OpenGL version and refuses to run on
+/// one below the engine's minimum.
+/// </summary>
+/// <remarks>
+/// A machine with no vendor GPU driver installed falls back to the Microsoft Basic Display
+/// Adapter, which reports OpenGL 1.1. Every built-in shader is <c>#version 330 core</c>, so such
+/// a driver cannot work - but before this check the failure surfaced as an opaque shader
+/// compilation error deep inside initialization, with the actual OpenGL version never reported
+/// anywhere.
+/// </remarks>
+public class GraphicsCapabilityDetectionTests
+{
+    /// <summary>
+    /// The driver a Windows machine with no vendor GPU driver installed reports.
+    /// </summary>
+    private static GraphicsDeviceInfo BasicRenderDriver => new(
+        Vendor: "Microsoft Corporation",
+        Renderer: "Microsoft Basic Render Driver",
+        Version: "1.1.0",
+        ShadingLanguageVersion: "",
+        MajorVersion: 1,
+        MinorVersion: 1);
+
+    /// <summary>
+    /// Builds a world with the graphics plugin installed but its device not yet bound, which is
+    /// the state a real game is in the instant its window finishes loading.
+    /// </summary>
+    private static (World World, SilkGraphicsContext Context) CreateUnboundGraphics()
+    {
+        var world = new World();
+        world.SetExtension<ISilkWindowProvider>(new MockSilkWindowProvider());
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        return (world, world.GetExtension<SilkGraphicsContext>());
+    }
+
+    #region Minimum version gate
+
+    [Fact]
+    public void InitializeResources_WithDriverBelowMinimum_ThrowsUnsupportedGraphicsDeviceException()
+    {
+        var (world, context) = CreateUnboundGraphics();
+        using (world)
+        {
+            using var device = new MockGraphicsDevice { DeviceInfo = BasicRenderDriver };
+
+            var exception = Assert.Throws<UnsupportedGraphicsDeviceException>(
+                () => context.InitializeResources(device));
+
+            Assert.Equal(BasicRenderDriver, exception.DeviceInfo);
+        }
+    }
+
+    [Fact]
+    public void InitializeResources_WithDriverBelowMinimum_MessageNamesDetectedAndRequiredVersions()
+    {
+        var (world, context) = CreateUnboundGraphics();
+        using (world)
+        {
+            using var device = new MockGraphicsDevice { DeviceInfo = BasicRenderDriver };
+
+            var exception = Assert.Throws<UnsupportedGraphicsDeviceException>(
+                () => context.InitializeResources(device));
+
+            // What the machine has, verbatim and parsed.
+            Assert.Contains("1.1", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Microsoft Basic Render Driver", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Microsoft Corporation", exception.Message, StringComparison.Ordinal);
+
+            // What it needs, and why.
+            Assert.Contains("3.3", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("#version 330 core", exception.Message, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void InitializeResources_WithDriverBelowMinimum_MessageNamesTheLikelyRemediation()
+    {
+        var (world, context) = CreateUnboundGraphics();
+        using (world)
+        {
+            using var device = new MockGraphicsDevice { DeviceInfo = BasicRenderDriver };
+
+            var exception = Assert.Throws<UnsupportedGraphicsDeviceException>(
+                () => context.InitializeResources(device));
+
+            Assert.Contains("Install the graphics driver", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Microsoft Basic Display Adapter", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("remote-desktop", exception.Message, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void InitializeResources_WithDriverBelowMinimum_FailsBeforeCreatingAnyShader()
+    {
+        var (world, context) = CreateUnboundGraphics();
+        using (world)
+        {
+            using var device = new MockGraphicsDevice { DeviceInfo = BasicRenderDriver };
+
+            Assert.Throws<UnsupportedGraphicsDeviceException>(() => context.InitializeResources(device));
+
+            // The whole point of the check: the driver is rejected by name instead of failing
+            // later as an unexplained shader compilation error.
+            Assert.Empty(device.Shaders);
+            Assert.Empty(device.Programs);
+            Assert.False(context.IsInitialized);
+        }
+    }
+
+    [Fact]
+    public void InitializeResources_WithModernDriver_InitializesNormally()
+    {
+        var (world, context) = CreateUnboundGraphics();
+        using (world)
+        {
+            // The mock defaults to OpenGL 4.6, so this is the ordinary path - the guard must not
+            // pass by rejecting everything.
+            using var device = new MockGraphicsDevice();
+
+            context.InitializeResources(device);
+
+            Assert.True(context.IsInitialized);
+            Assert.NotEmpty(device.Programs);
+        }
+    }
+
+    [Theory]
+    [InlineData(3, 3)]
+    [InlineData(3, 4)]
+    [InlineData(4, 6)]
+    public void EnsureMinimumVersion_AtOrAboveMinimum_DoesNotThrow(int major, int minor)
+    {
+        var info = new GraphicsDeviceInfo("Vendor", "Renderer", $"{major}.{minor}.0", "3.30", major, minor);
+
+        Assert.Null(Record.Exception(() => GlCapabilities.EnsureMinimumVersion(info)));
+    }
+
+    [Theory]
+    [InlineData(3, 2)]
+    [InlineData(3, 0)]
+    [InlineData(2, 1)]
+    [InlineData(1, 1)]
+    // An unparseable version string leaves 0.0, which must fail rather than pass by accident.
+    [InlineData(0, 0)]
+    public void EnsureMinimumVersion_BelowMinimum_Throws(int major, int minor)
+    {
+        var info = new GraphicsDeviceInfo("Vendor", "Renderer", $"{major}.{minor}.0", "", major, minor);
+
+        Assert.Throws<UnsupportedGraphicsDeviceException>(() => GlCapabilities.EnsureMinimumVersion(info));
+    }
+
+    #endregion
+
+    #region GraphicsDeviceInfo
+
+    [Theory]
+    [InlineData(4, 6, 3, 3, true)]
+    [InlineData(3, 3, 3, 3, true)]
+    [InlineData(3, 2, 3, 3, false)]
+    [InlineData(2, 9, 3, 3, false)]
+    [InlineData(4, 0, 3, 3, true)]
+    public void IsAtLeast_ComparesMajorBeforeMinor(int major, int minor, int requiredMajor, int requiredMinor, bool expected)
+    {
+        var info = new GraphicsDeviceInfo("Vendor", "Renderer", "irrelevant", "irrelevant", major, minor);
+
+        Assert.Equal(expected, info.IsAtLeast(requiredMajor, requiredMinor));
+    }
+
+    [Fact]
+    public void ToString_ReportsEveryDriverStringForLogsAndBugReports()
+    {
+        var info = new GraphicsDeviceInfo(
+            "NVIDIA Corporation", "NVIDIA GeForce RTX 4070", "4.6.0 NVIDIA 551.86", "4.60", 4, 6);
+
+        var summary = info.ToString();
+
+        Assert.Contains("4.6.0 NVIDIA 551.86", summary, StringComparison.Ordinal);
+        Assert.Contains("4.60", summary, StringComparison.Ordinal);
+        Assert.Contains("NVIDIA GeForce RTX 4070", summary, StringComparison.Ordinal);
+        Assert.Contains("NVIDIA Corporation", summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToString_WithStringTheDriverDoesNotReport_SaysSoRatherThanShowingABlank()
+    {
+        // A pre-shader driver reports no shading language version at all.
+        var summary = BasicRenderDriver.ToString();
+
+        Assert.Contains("shading language unreported", summary, StringComparison.Ordinal);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
+++ b/tests/KeenEyes.Graphics.Tests/Mocks/MockGraphicsDevice.cs
@@ -95,6 +95,28 @@ public sealed class MockGraphicsDevice : IGraphicsDevice
     /// </summary>
     public Dictionary<string, int> UniformLocations { get; } = [];
 
+    /// <summary>
+    /// Driver identity and version to report. Defaults to a modern OpenGL 4.6 device so that
+    /// capability checks pass.
+    /// </summary>
+    public GraphicsDeviceInfo DeviceInfo { get; set; } = new(
+        Vendor: "KeenEyes",
+        Renderer: "MockGraphicsDevice",
+        Version: "4.6.0 KeenEyes Mock",
+        ShadingLanguageVersion: "4.60",
+        MajorVersion: 4,
+        MinorVersion: 6);
+
+    #region Capability
+
+    public GraphicsDeviceInfo GetDeviceInfo()
+    {
+        Calls.Add($"GetDeviceInfo() => {DeviceInfo}");
+        return DeviceInfo;
+    }
+
+    #endregion
+
     #region Buffer Operations
 
     public uint GenVertexArray()

--- a/tests/KeenEyes.Graphics.Tests/ShaderFailureDiagnosticsTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/ShaderFailureDiagnosticsTests.cs
@@ -1,0 +1,123 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk.Rendering2D;
+using KeenEyes.Graphics.Silk.Resources;
+using KeenEyes.Graphics.Silk.Text;
+using KeenEyes.Testing.Graphics;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests that shader compilation and linking failures report the driver's OpenGL and shading
+/// language versions alongside the info log.
+/// </summary>
+/// <remarks>
+/// A driver too old for the engine's <c>#version 330 core</c> shaders fails with an ordinary
+/// compile error whose wording varies by vendor, so the info log alone rarely identifies the
+/// cause. Naming the versions in the message makes a version mismatch self-evident even when the
+/// minimum-version check has been bypassed - for example by a renderer constructed directly.
+/// </remarks>
+public class ShaderFailureDiagnosticsTests
+{
+    /// <summary>
+    /// A driver whose OpenGL version predates GLSL 3.30: old enough that every built-in shader
+    /// fails to compile, new enough to reach the compiler at all.
+    /// </summary>
+    private static MockGraphicsDevice CreateDeviceReportingGlsl130() => new()
+    {
+        DeviceInfo = new GraphicsDeviceInfo(
+            Vendor: "Intel",
+            Renderer: "Intel HD Graphics 3000",
+            Version: "3.0.0 - Build 9.17.10.4459",
+            ShadingLanguageVersion: "1.30",
+            MajorVersion: 3,
+            MinorVersion: 0)
+    };
+
+    private static void AssertNamesDriverVersions(string message)
+    {
+        Assert.Contains("3.0.0 - Build 9.17.10.4459", message, StringComparison.Ordinal);
+        Assert.Contains("1.30", message, StringComparison.Ordinal);
+        Assert.Contains("Intel HD Graphics 3000", message, StringComparison.Ordinal);
+    }
+
+    #region ShaderManager
+
+    [Fact]
+    public void CreateShader_WhenCompilationFails_MessageNamesDriverVersions()
+    {
+        using var device = CreateDeviceReportingGlsl130();
+        device.ShouldFailShaderCompile = true;
+        using var manager = new ShaderManager { Device = device };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateShader("#version 330 core\nvoid main() {}", "#version 330 core\nvoid main() {}"));
+
+        Assert.Contains("Shader compilation failed", exception.Message, StringComparison.Ordinal);
+        AssertNamesDriverVersions(exception.Message);
+    }
+
+    [Fact]
+    public void CreateShader_WhenLinkingFails_MessageNamesDriverVersions()
+    {
+        using var device = CreateDeviceReportingGlsl130();
+        device.ShouldFailProgramLink = true;
+        using var manager = new ShaderManager { Device = device };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateShader("#version 330 core\nvoid main() {}", "#version 330 core\nvoid main() {}"));
+
+        Assert.Contains("linking failed", exception.Message, StringComparison.Ordinal);
+        AssertNamesDriverVersions(exception.Message);
+    }
+
+    #endregion
+
+    #region Silk2DRenderer
+
+    [Fact]
+    public void Silk2DRenderer_WhenShaderCompilationFails_MessageNamesDriverVersions()
+    {
+        using var device = CreateDeviceReportingGlsl130();
+        device.ShouldFailShaderCompile = true;
+        using var textureManager = new TextureManager { Device = device };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => new Silk2DRenderer(device, textureManager, 800f, 600f));
+
+        Assert.Contains("2D vertex shader", exception.Message, StringComparison.Ordinal);
+        AssertNamesDriverVersions(exception.Message);
+    }
+
+    [Fact]
+    public void Silk2DRenderer_WhenShaderLinkingFails_MessageNamesDriverVersions()
+    {
+        using var device = CreateDeviceReportingGlsl130();
+        device.ShouldFailProgramLink = true;
+        using var textureManager = new TextureManager { Device = device };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => new Silk2DRenderer(device, textureManager, 800f, 600f));
+
+        Assert.Contains("link 2D shader program", exception.Message, StringComparison.Ordinal);
+        AssertNamesDriverVersions(exception.Message);
+    }
+
+    #endregion
+
+    #region FontStashRenderer
+
+    [Fact]
+    public void FontStashRenderer_WhenShaderCompilationFails_MessageNamesDriverVersions()
+    {
+        using var device = CreateDeviceReportingGlsl130();
+        device.ShouldFailShaderCompile = true;
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => new FontStashRenderer(device, new FontStashTextureManager(device), 800f, 600f));
+
+        Assert.Contains("text vertex shader", exception.Message, StringComparison.Ordinal);
+        AssertNamesDriverVersions(exception.Message);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
The engine never queried `GL_VERSION`, `GL_RENDERER`, `GL_VENDOR` or the GLSL version anywhere — so a machine whose driver is below our real minimum failed deep inside shader compilation with no indication of the cause, and neither the log nor the user learned what the driver actually offers. Every built-in shader is `#version 330 core`, making OpenGL 3.3 a hard requirement that was previously undocumented and unchecked.

Motivated by a real report (#1256 follow-up): a Windows 11 laptop at the physical console created the window fine, then failed during graphics init with no usable diagnostic.

- **`IGraphicsDevice.GetDeviceInfo()`** → new `GraphicsDeviceInfo` record (vendor, renderer, version, GLSL version, major/minor) with `IsAtLeast(major, minor)`. `OpenGLDevice` reads the GL strings plus `MajorVersion`/`MinorVersion`, and when those integers are unavailable (they only exist on GL 3.0+) it drains the `GL_INVALID_ENUM` a pre-3.0 driver raises and falls back to parsing the version string.
- **Fail fast below 3.3** — `SilkGraphicsContext.InitializeResources` validates before creating any shader and throws the new `UnsupportedGraphicsDeviceException` (carrying the `DeviceInfo`).
- **Log once on success** — `Debug.WriteLine("Graphics device: OpenGL <version> | shading language <glsl> | renderer: … | vendor: …")`, matching the file's existing convention.
- **Enriched shader failures** — all 14 compile/link throw sites now include the driver's GL + GLSL version via one shared `DescribeShaderFailure` helper, so a version mismatch is self-evident.
- `docs/graphics.md` gains a Requirements / capability-detection note.

### The message a user with no GPU driver now sees
> This machine's OpenGL driver is too old to run KeenEyes: detected 1.1, but 3.3 or newer is required (every built-in shader is '#version 330 core'). Driver reports 1.1.0 | shading language unreported | renderer: Microsoft Basic Render Driver | vendor: Microsoft Corporation. Install the graphics driver from your GPU vendor (NVIDIA, AMD, or Intel): the Microsoft Basic Display Adapter software fallback, used when no vendor driver is installed, reports OpenGL 1.1 - as do remote-desktop sessions.

## Test plan
- [x] 43 new tests. Version-string parser is table-driven over real-world forms: `4.6.0 NVIDIA 551.86`, `4.6.0 Compatibility Profile Context …`, `2.1 Mesa 20.0.8`, `4.6 (Core Profile) Mesa 24.0.3`, `1.1.0`, `3.3.0 - Build 31.0.101.2111` (build tag must not win), `OpenGL ES 3.2 …`, `10.12.0`, plus malformed/overflow inputs → 0.0 (fails every check).
- [x] Fail-on-old proven by source revert: 4 capability tests + 5 shader-diagnostic tests fail on old code. Includes a **positive** test (modern driver initializes normally) and a boundary theory (3.3/3.4/4.6 pass; 3.2/3.0/2.1/1.1 throw) so the guard can't pass by rejecting everything.
- [x] Graphics.Tests 627; full suite **14,824, 0 failed**; 0 warnings; format clean; NOVAFALL `--simulate 600` double-run byte-identical.

## Not verifiable here (no display on this host)
- The below-3.3 path is **unit-tested only** — never observed against real sub-3.3 hardware. `OpenGLDevice.GetDeviceInfo()`'s actual GL calls, the `GL_INVALID_ENUM` drain, and the string-fallback trigger are unexercised; the parser, the gate, the message, and the shader-message enrichment are covered.
- 9 of the 14 enriched shader throw sites aren't individually tested (the shared mock can't fail selectively; IblManager needs HDR env-map plumbing) — all 14 route through the one covered helper.
