### PR TITLE
fix(input,samples): Distinguish absent input devices from uninitialized input, and play NOVAFALL without a gamepad

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -114,6 +114,7 @@
     <Project Path="tests/KeenEyes.Graph.Tests/KeenEyes.Graph.Tests.csproj" />
     <Project Path="tests/KeenEyes.Graphics.Tests/KeenEyes.Graphics.Tests.csproj" />
     <Project Path="tests/KeenEyes.Input.Abstractions.Tests/KeenEyes.Input.Abstractions.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Input.Silk.Tests/KeenEyes.Input.Silk.Tests.csproj" />
     <Project Path="tests/KeenEyes.Localization.Tests/KeenEyes.Localization.Tests.csproj" />
     <Project Path="tests/KeenEyes.Logging.Tests/KeenEyes.Logging.Tests.csproj" />
     <Project Path="tests/KeenEyes.Mcp.TestBridge.Tests/KeenEyes.Mcp.TestBridge.Tests.csproj" />

--- a/docs/input.md
+++ b/docs/input.md
@@ -70,7 +70,11 @@ var input = world.GetExtension<IInputContext>();
 // Primary devices (most common use case)
 IKeyboard keyboard = input.Keyboard;
 IMouse mouse = input.Mouse;
-IGamepad gamepad = input.Gamepad;
+
+// A gamepad is optional hardware: `input.Gamepad` THROWS when no controller is
+// plugged in, which is the normal state of most machines. Ask first, and keep the
+// game playable when the answer is "none".
+IGamepad? gamepad = input.ConnectedGamepadCount > 0 ? input.Gamepad : null;
 
 // All connected devices (multi-device support)
 ImmutableArray<IKeyboard> keyboards = input.Keyboards;
@@ -231,10 +235,23 @@ mouse.SetPosition(new Vector2(400, 300));  // Center cursor
 
 ### Connection Status
 
-```csharp
-var gamepad = input.Gamepad;
+`input.Gamepad` throws when there is no gamepad to return, so it can never be the
+thing you use to *test* for a gamepad. Go through the collection instead — it is
+always safe to enumerate, empty or not:
 
-if (!gamepad.IsConnected)
+```csharp
+// Find the first connected gamepad, or nothing.
+IGamepad? gamepad = null;
+foreach (var candidate in input.Gamepads)
+{
+    if (candidate.IsConnected)
+    {
+        gamepad = candidate;
+        break;
+    }
+}
+
+if (gamepad is null)
 {
     Console.WriteLine("No gamepad connected");
     return;
@@ -337,7 +354,6 @@ public class PlayerMovementSystem : ISystem
         if (input is null) return;
 
         var keyboard = input.Keyboard;
-        var gamepad = input.Gamepad;
 
         // Calculate movement from keyboard
         var moveDir = Vector2.Zero;
@@ -346,9 +362,9 @@ public class PlayerMovementSystem : ISystem
         if (keyboard.IsKeyDown(Key.A)) moveDir.X -= 1;
         if (keyboard.IsKeyDown(Key.D)) moveDir.X += 1;
 
-        // Or from gamepad
-        if (gamepad.IsConnected)
-            moveDir = gamepad.LeftStick;
+        // Or from gamepad, if one is actually plugged in
+        if (input.ConnectedGamepadCount > 0)
+            moveDir = input.Gamepad.LeftStick;
 
         // Apply to player entities
         foreach (var entity in world!.Query<Transform3D, PlayerTag>())
@@ -775,7 +791,10 @@ public class UnifiedInputSystem : ISystem
         var input = World.GetExtension<IInputContext>();
         var kb = input.Keyboard;
         var mouse = input.Mouse;
-        var gamepad = input.Gamepad;
+
+        // Null when no controller is attached — reading input.Gamepad directly would
+        // throw, and every gamepad branch below is written to be skippable.
+        var gamepad = input.ConnectedGamepadCount > 0 ? input.Gamepad : null;
 
         // Movement: keyboard OR gamepad
         var moveDir = Vector2.Zero;
@@ -787,7 +806,7 @@ public class UnifiedInputSystem : ISystem
         if (kb.IsKeyDown(Key.D)) moveDir.X += 1;
 
         // Gamepad overrides if connected and active
-        if (gamepad.IsConnected)
+        if (gamepad is not null)
         {
             var stick = gamepad.LeftStick;
             if (stick.LengthSquared() > 0.01f)
@@ -801,7 +820,7 @@ public class UnifiedInputSystem : ISystem
         // Aim: mouse OR right stick
         var aimDir = Vector2.Zero;
 
-        if (gamepad.IsConnected &&
+        if (gamepad is not null &&
             gamepad.RightStick.LengthSquared() > 0.01f)
         {
             aimDir = Vector2.Normalize(gamepad.RightStick);
@@ -852,7 +871,7 @@ public class InputDeviceTracker : ISystem
         }
 
         // Check for gamepad activity
-        if (input.Gamepad.IsConnected)
+        if (input.ConnectedGamepadCount > 0)
         {
             var gp = input.Gamepad;
             if (gp.LeftStick.LengthSquared() > 0.1f ||

--- a/samples/KeenEyes.Sample.NovaFall/InputDevices.cs
+++ b/samples/KeenEyes.Sample.NovaFall/InputDevices.cs
@@ -1,0 +1,65 @@
+using KeenEyes.Input.Abstractions;
+
+namespace KeenEyes.Sample.NovaFall;
+
+/// <summary>
+/// Device lookups that survive absent hardware, so NOVAFALL is fully playable on a
+/// keyboard with no controller plugged in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IInputContext.Gamepad"/> and <see cref="IInputContext.Keyboard"/> return the
+/// primary device and throw when there is none. A gamepad is optional hardware that most
+/// machines do not have, so reading <c>input.Gamepad</c> in a per-frame system is a crash
+/// waiting for its first player without a controller — and checking
+/// <c>input.Gamepad.IsConnected</c> does not help, because the getter has already thrown.
+/// </para>
+/// <para>
+/// The plural collections (<see cref="IInputContext.Gamepads"/>,
+/// <see cref="IInputContext.Keyboards"/>) are always safe to enumerate, so "first connected
+/// device, or none" is the pattern every game should use for optional input. Both helpers
+/// return <see langword="null"/> instead of throwing, which lets each caller decide what
+/// missing hardware means for it.
+/// </para>
+/// </remarks>
+public static class InputDevices
+{
+    /// <summary>
+    /// Gets the first connected gamepad, or <see langword="null"/> when no controller is attached.
+    /// </summary>
+    /// <param name="input">The input context to search.</param>
+    /// <returns>The first connected gamepad, or <see langword="null"/> if there is none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is null.</exception>
+    public static IGamepad? FirstConnectedGamepad(IInputContext input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        foreach (var gamepad in input.Gamepads)
+        {
+            if (gamepad.IsConnected)
+            {
+                return gamepad;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the first keyboard, or <see langword="null"/> when the input backend reports none.
+    /// </summary>
+    /// <param name="input">The input context to search.</param>
+    /// <returns>The first keyboard, or <see langword="null"/> if there is none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is null.</exception>
+    /// <remarks>
+    /// A keyboard is nearly always present, but it does not exist before the window has
+    /// loaded. Going through the collection keeps the systems below free of ordering
+    /// assumptions about when they first run.
+    /// </remarks>
+    public static IKeyboard? FirstKeyboard(IInputContext input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return input.Keyboards.Length > 0 ? input.Keyboards[0] : null;
+    }
+}

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -243,14 +243,27 @@ try
         .OnReady(() =>
         {
             var input = world.GetExtension<IInputContext>();
-            input.Keyboard.OnKeyDown += eventArgs =>
+            var keyboard = InputDevices.FirstKeyboard(input);
+            if (keyboard is not null)
             {
-                if (eventArgs.Key == Key.Escape)
+                keyboard.OnKeyDown += eventArgs =>
                 {
-                    Console.WriteLine("Escape pressed - exiting...");
-                    System.Environment.Exit(0);
-                }
-            };
+                    if (eventArgs.Key == Key.Escape)
+                    {
+                        Console.WriteLine("Escape pressed - exiting...");
+                        System.Environment.Exit(0);
+                    }
+                };
+            }
+            else
+            {
+                Console.WriteLine("No keyboard detected — close the window to exit.");
+            }
+
+            if (input.ConnectedGamepadCount == 0)
+            {
+                Console.WriteLine("No gamepad detected — keyboard controls cover everything.");
+            }
 
             // The UI layout system needs to know the pixel canvas size.
             if (world.TryGetExtension<KeenEyes.Graphics.Abstractions.IGraphicsContext>(out var graphics)
@@ -272,11 +285,12 @@ try
 }
 catch (Exception ex)
 {
-    // Top-level demo entry point: initializing the windowing/graphics stack can
-    // surface a wide range of platform exceptions (missing display, driver, or GL
-    // context errors). A demo recovers by reporting the failure and exiting rather
-    // than crashing, so a catch-all is appropriate here.
-    ReportStartupFailure(ex);
+    // Top-level demo entry point: Run() covers BOTH startup (window/graphics/GL
+    // creation, which can surface a wide range of platform exceptions) and the frame
+    // loop itself, so anything escaping here may have come from either. A demo
+    // recovers by reporting the failure and exiting rather than crashing, so a
+    // catch-all is appropriate here.
+    ReportRunFailure(ex);
 }
 finally
 {
@@ -291,17 +305,30 @@ finally
 
 Console.WriteLine("Sample complete!");
 
-// Reports a startup failure the honest way: WHAT failed comes first, because a
-// blanket "requires a display" is actively misleading on a machine that has one
-// and hides the real exception type behind a wrong diagnosis. The requirement
-// list follows as a suggestion, never as the stated cause.
+// Reports a failure the honest way: WHAT failed comes first, because a blanket
+// "requires a display" is actively misleading on a machine that has one and hides
+// the real exception type behind a wrong diagnosis. The requirement list follows as
+// a suggestion, never as the stated cause.
 static void ReportStartupFailure(Exception ex)
 {
     Console.WriteLine($"Startup failed: {ex.GetType().Name}: {ex.Message}");
-    Console.WriteLine("Windowed mode needs a display, a GPU driver, and OpenGL 3.3; "
-        + "the line above says which of those actually failed. "
-        + "For a check that needs none of them, run with --simulate 600.");
+    Console.WriteLine(PlatformHint());
 }
+
+// Same idea for the loop, minus the false claim of "startup": Run() returns only
+// once the frame loop ends, so a throw from frame 1 lands here too, and labelling
+// that a startup failure sends readers hunting in entirely the wrong place.
+static void ReportRunFailure(Exception ex)
+{
+    Console.WriteLine($"NOVAFALL stopped: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine("Run() covers both startup and the frame loop, so this may be a fault from the "
+        + "first frames rather than from starting up.");
+    Console.WriteLine(PlatformHint());
+}
+
+static string PlatformHint()
+    => "Windowed mode needs a display, a GPU driver, and OpenGL 3.3; the line above says which of those "
+        + "actually failed. For a check that needs none of them, run with --simulate 600.";
 
 // Headless determinism harness: builds the world with no window, graphics,
 // audio, particle, animation, or UI plugins (every juice system no-ops), steps

--- a/samples/KeenEyes.Sample.NovaFall/Systems/GameFlowSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/GameFlowSystem.cs
@@ -19,7 +19,9 @@ namespace KeenEyes.Sample.NovaFall;
 /// <para>
 /// Without an input context (headless <c>--simulate</c> mode) the menu takes no
 /// actions; the harness drives <see cref="GameState"/> directly. The time limit,
-/// being a pure music-clock comparison, applies identically in both.
+/// being a pure music-clock comparison, applies identically in both. Devices are
+/// resolved through <see cref="InputDevices"/>, so the loop runs on keyboard alone
+/// when no controller is attached.
 /// </para>
 /// </remarks>
 public sealed class GameFlowSystem : SystemBase
@@ -113,7 +115,12 @@ public sealed class GameFlowSystem : SystemBase
             return;
         }
 
-        var keyboard = input.Keyboard;
+        var keyboard = InputDevices.FirstKeyboard(input);
+        if (keyboard is null)
+        {
+            return;
+        }
+
         var leftDown = keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.Left);
         var rightDown = keyboard.IsKeyDown(Key.D) || keyboard.IsKeyDown(Key.Right);
         var tabDown = keyboard.IsKeyDown(Key.Tab);
@@ -244,14 +251,16 @@ public sealed class GameFlowSystem : SystemBase
             return false;
         }
 
-        var keyboard = input.Keyboard;
-        if (keyboard.IsKeyDown(Key.Space) || keyboard.IsKeyDown(Key.Enter))
+        var keyboard = InputDevices.FirstKeyboard(input);
+        if (keyboard is not null && (keyboard.IsKeyDown(Key.Space) || keyboard.IsKeyDown(Key.Enter)))
         {
             return true;
         }
 
-        var gamepad = input.Gamepad;
-        return gamepad.IsConnected && gamepad.IsButtonDown(GamepadButton.South);
+        // Space/Enter is the whole control scheme; the South button is a bonus for
+        // whoever brought a controller, so its absence must not block the dive.
+        var gamepad = InputDevices.FirstConnectedGamepad(input);
+        return gamepad is not null && gamepad.IsButtonDown(GamepadButton.South);
     }
 
     private bool IsSteerPressed()
@@ -261,9 +270,10 @@ public sealed class GameFlowSystem : SystemBase
             return false;
         }
 
-        var keyboard = input.Keyboard;
-        return keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.D)
-            || keyboard.IsKeyDown(Key.Left) || keyboard.IsKeyDown(Key.Right);
+        var keyboard = InputDevices.FirstKeyboard(input);
+        return keyboard is not null
+            && (keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.D)
+                || keyboard.IsKeyDown(Key.Left) || keyboard.IsKeyDown(Key.Right));
     }
 
     /// <summary>

--- a/samples/KeenEyes.Sample.NovaFall/Systems/InputSteerSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/InputSteerSystem.cs
@@ -10,7 +10,8 @@ namespace KeenEyes.Sample.NovaFall;
 /// <remarks>
 /// This is the only simulation system that touches input devices. When no input
 /// context is available (headless <c>--simulate</c> mode), it does nothing and the
-/// steering axis stays at zero.
+/// steering axis stays at zero. Device lookups go through <see cref="InputDevices"/>
+/// so a missing gamepad — the normal case — costs nothing but the gamepad branch.
 /// </remarks>
 public sealed class InputSteerSystem : SystemBase
 {
@@ -24,21 +25,25 @@ public sealed class InputSteerSystem : SystemBase
 
         var axis = 0f;
 
-        var keyboard = input.Keyboard;
-        if (keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.Left))
+        var keyboard = InputDevices.FirstKeyboard(input);
+        if (keyboard is not null)
         {
-            axis -= 1f;
-        }
+            if (keyboard.IsKeyDown(Key.A) || keyboard.IsKeyDown(Key.Left))
+            {
+                axis -= 1f;
+            }
 
-        if (keyboard.IsKeyDown(Key.D) || keyboard.IsKeyDown(Key.Right))
-        {
-            axis += 1f;
+            if (keyboard.IsKeyDown(Key.D) || keyboard.IsKeyDown(Key.Right))
+            {
+                axis += 1f;
+            }
         }
 
         // Gamepad left stick only contributes when the keyboard is idle, so the
-        // two devices never fight over the ball.
-        var gamepad = input.Gamepad;
-        if (axis.IsApproximatelyZero() && gamepad.IsConnected)
+        // two devices never fight over the ball. No controller attached is the
+        // common case, not an error: the stick simply never contributes.
+        var gamepad = InputDevices.FirstConnectedGamepad(input);
+        if (gamepad is not null && axis.IsApproximatelyZero())
         {
             axis = Math.Clamp(gamepad.LeftStick.X, -1f, 1f);
         }

--- a/samples/KeenEyes.Sample.NovaFall/Systems/JuiceToggleSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/JuiceToggleSystem.cs
@@ -23,7 +23,13 @@ public sealed class JuiceToggleSystem : SystemBase
             return;
         }
 
-        var isDown = input.Keyboard.IsKeyDown(Key.J);
+        var keyboard = InputDevices.FirstKeyboard(input);
+        if (keyboard is null)
+        {
+            return;
+        }
+
+        var isDown = keyboard.IsKeyDown(Key.J);
         if (isDown && !wasDown)
         {
             ref var juice = ref World.GetSingleton<JuiceConfig>();

--- a/src/KeenEyes.Input.Abstractions/IInputContext.cs
+++ b/src/KeenEyes.Input.Abstractions/IInputContext.cs
@@ -47,6 +47,11 @@ public interface IInputContext : IDisposable
     /// Returns the first available keyboard. For systems with multiple keyboards,
     /// use <see cref="Keyboards"/> to access all connected devices.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when there is no keyboard to return, either because input has not
+    /// initialized yet or because the machine has none. Test <see cref="Keyboards"/>
+    /// first if either case is possible.
+    /// </exception>
     IKeyboard Keyboard { get; }
 
     /// <summary>
@@ -56,15 +61,31 @@ public interface IInputContext : IDisposable
     /// Returns the first available mouse. For systems with multiple mice,
     /// use <see cref="Mice"/> to access all connected devices.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when there is no mouse to return, either because input has not
+    /// initialized yet or because the machine has none. Test <see cref="Mice"/>
+    /// first if either case is possible.
+    /// </exception>
     IMouse Mouse { get; }
 
     /// <summary>
     /// Gets the primary gamepad device.
     /// </summary>
     /// <remarks>
-    /// Returns the first connected gamepad (index 0), or a disconnected placeholder
-    /// if no gamepad is connected. Check <see cref="IGamepad.IsConnected"/> before use.
+    /// <para>
+    /// Returns the first gamepad the backend knows about. A gamepad is optional
+    /// hardware and is absent on most machines, so treat this property as unsafe by
+    /// default: query <see cref="ConnectedGamepadCount"/> or <see cref="Gamepads"/>
+    /// and keep the game playable when the answer is "none".
+    /// </para>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when there is no gamepad to return — the normal state of a machine with
+    /// no controller plugged in. Check <see cref="ConnectedGamepadCount"/> or
+    /// <see cref="Gamepads"/> before reading this property, and
+    /// <see cref="IGamepad.IsConnected"/> on the result, since a backend may expose a
+    /// fixed slot with nothing plugged into it.
+    /// </exception>
     IGamepad Gamepad { get; }
 
     /// <summary>

--- a/src/KeenEyes.Input.Silk/SilkInputContext.cs
+++ b/src/KeenEyes.Input.Silk/SilkInputContext.cs
@@ -35,13 +35,15 @@ public sealed class SilkInputContext : IInputContext
     private bool disposed;
 
     /// <inheritdoc />
-    public IKeyboard Keyboard => primaryKeyboard ?? throw new InvalidOperationException("Input not initialized. Wait for window to load.");
+    public IKeyboard Keyboard => primaryKeyboard
+        ?? throw DeviceUnavailable(nameof(Keyboard), "keyboard", nameof(Keyboards));
 
     /// <inheritdoc />
-    public IMouse Mouse => primaryMouse ?? throw new InvalidOperationException("Input not initialized. Wait for window to load.");
+    public IMouse Mouse => primaryMouse
+        ?? throw DeviceUnavailable(nameof(Mouse), "mouse", nameof(Mice));
 
     /// <inheritdoc />
-    public IGamepad Gamepad => primaryGamepad ?? throw new InvalidOperationException("Input not initialized. Wait for window to load.");
+    public IGamepad Gamepad => primaryGamepad ?? throw GamepadUnavailable();
 
     /// <inheritdoc />
     public ImmutableArray<IKeyboard> Keyboards => keyboards;
@@ -58,6 +60,13 @@ public sealed class SilkInputContext : IInputContext
     /// <summary>
     /// Gets whether the input context has been initialized.
     /// </summary>
+    /// <remarks>
+    /// This becomes <see langword="true"/> only once the window has loaded AND the shared
+    /// Silk.NET input context was actually obtained from it. While it is <see langword="false"/>
+    /// no devices exist at all; once it is <see langword="true"/>, the device collections
+    /// (<see cref="Keyboards"/>, <see cref="Mice"/>, <see cref="Gamepads"/>) report what the
+    /// machine really has, which for gamepads is frequently nothing.
+    /// </remarks>
     public bool IsInitialized => initialized;
 
     #region Global Events
@@ -102,31 +111,68 @@ public sealed class SilkInputContext : IInputContext
         this.windowProvider = windowProvider;
         this.config = config;
 
-        // Hook into window load to initialize input
-        windowProvider.Window.Load += OnWindowLoad;
+        // Hook into the provider's load event rather than the window's: the provider
+        // creates the Silk.NET input context inside its own window-load handler and
+        // then raises this, so InputContext is guaranteed to exist by the time we run.
+        windowProvider.OnLoad += OnWindowLoad;
     }
 
     private void OnWindowLoad()
     {
         // Get the input context from the shared window provider
-        silkInput = windowProvider.InputContext;
+        var silkInputContext = windowProvider.InputContext;
+        if (silkInputContext is null)
+        {
+            // Nothing to wrap, so stay uninitialized: claiming otherwise would make
+            // IsInitialized report success while every device getter fails, which is
+            // exactly the lie that makes "no gamepad" look like "window not loaded".
+            return;
+        }
+
+        silkInput = silkInputContext;
 
         // Wrap Silk.NET devices in our abstractions
-        InitializeDevices();
+        InitializeDevices(silkInputContext);
 
         initialized = true;
     }
 
-    private void InitializeDevices()
-    {
-        if (silkInput is null)
-        {
-            return;
-        }
+    /// <summary>
+    /// Builds the exception thrown when a primary device is unavailable, distinguishing
+    /// "input has not initialized yet" from "this machine has no such device" — two very
+    /// different problems that used to share one misleading message.
+    /// </summary>
+    /// <param name="property">The name of the property being read.</param>
+    /// <param name="deviceName">The human-readable device name.</param>
+    /// <param name="checkHint">The property (or properties) the caller should test first.</param>
+    private InvalidOperationException DeviceUnavailable(string property, string deviceName, string checkHint)
+        => initialized
+            ? new InvalidOperationException(
+                $"No {deviceName} is connected, so {property} has no device to return. " +
+                $"Check {checkHint} first and handle the case where none is present.")
+            : new InvalidOperationException(
+                $"Input is not initialized, so {property} is unavailable. Wait for the window to load " +
+                $"(see {nameof(IsInitialized)}) before reading input devices.");
 
+    /// <summary>
+    /// Builds the exception for a missing primary gamepad, which has a third case the other
+    /// devices do not: gamepad support switched off in configuration. Reporting that as
+    /// "nothing is plugged in" would send the caller looking for a hardware problem.
+    /// </summary>
+    private InvalidOperationException GamepadUnavailable()
+        => initialized && !config.EnableGamepads
+            ? new InvalidOperationException(
+                $"Gamepad support is disabled ({nameof(SilkInputConfig)}." +
+                $"{nameof(SilkInputConfig.EnableGamepads)} is false), so {nameof(Gamepad)} has no device " +
+                $"to return, whether or not a controller is plugged in.")
+            : DeviceUnavailable(
+                nameof(Gamepad), "gamepad", $"{nameof(ConnectedGamepadCount)} or {nameof(Gamepads)}");
+
+    private void InitializeDevices(SilkInput.IInputContext silkInputContext)
+    {
         // Initialize keyboards
         var keyboardList = new List<IKeyboard>();
-        foreach (var keyboard in silkInput.Keyboards)
+        foreach (var keyboard in silkInputContext.Keyboards)
         {
             var wrapper = new SilkKeyboard(keyboard);
             keyboardList.Add(wrapper);
@@ -137,7 +183,7 @@ public sealed class SilkInputContext : IInputContext
 
         // Initialize mice
         var mouseList = new List<IMouse>();
-        foreach (var mouse in silkInput.Mice)
+        foreach (var mouse in silkInputContext.Mice)
         {
             var wrapper = new SilkMouse(mouse, config);
             mouseList.Add(wrapper);
@@ -150,7 +196,7 @@ public sealed class SilkInputContext : IInputContext
         if (config.EnableGamepads)
         {
             var gamepadList = new List<IGamepad>();
-            foreach (var gamepad in silkInput.Gamepads.Take(config.MaxGamepads))
+            foreach (var gamepad in silkInputContext.Gamepads.Take(config.MaxGamepads))
             {
                 var wrapper = new SilkGamepad(gamepad, config.GamepadDeadzone);
                 gamepadList.Add(wrapper);
@@ -160,7 +206,7 @@ public sealed class SilkInputContext : IInputContext
             primaryGamepad = gamepadList.Count > 0 ? (SilkGamepad)gamepadList[0] : null;
 
             // Subscribe to connection events
-            silkInput.ConnectionChanged += OnConnectionChanged;
+            silkInputContext.ConnectionChanged += OnConnectionChanged;
         }
     }
 
@@ -225,7 +271,7 @@ public sealed class SilkInputContext : IInputContext
 
         disposed = true;
 
-        windowProvider.Window.Load -= OnWindowLoad;
+        windowProvider.OnLoad -= OnWindowLoad;
 
         if (silkInput is not null && config.EnableGamepads)
         {

--- a/src/KeenEyes.Testing/Input/MockInputContext.cs
+++ b/src/KeenEyes.Testing/Input/MockInputContext.cs
@@ -50,7 +50,12 @@ public sealed class MockInputContext : IInputContext
     /// <summary>
     /// Creates a new mock input context with the specified number of gamepads.
     /// </summary>
-    /// <param name="gamepadCount">The number of gamepad slots to create. Defaults to 4.</param>
+    /// <param name="gamepadCount">
+    /// The number of gamepad slots to create. Defaults to 4; slot 0 starts connected.
+    /// Pass <c>0</c> to model the common real-world machine that has a keyboard and mouse
+    /// but no controller at all — that configuration makes <see cref="Gamepad"/> throw,
+    /// exactly as a hardware backend does, so tests can prove code takes the safe path.
+    /// </param>
     public MockInputContext(int gamepadCount = 4)
     {
         keyboard = new MockKeyboard();
@@ -257,7 +262,13 @@ public sealed class MockInputContext : IInputContext
     public IMouse Mouse => mouse;
 
     /// <inheritdoc />
-    public IGamepad Gamepad => gamepads.Length > 0 ? gamepads[0] : throw new InvalidOperationException("No gamepads available.");
+    public IGamepad Gamepad => gamepads.Length > 0
+        ? gamepads[0]
+        : throw new InvalidOperationException(
+            $"No gamepad is connected, so {nameof(Gamepad)} has no device to return. " +
+            $"Check {nameof(ConnectedGamepadCount)} or {nameof(Gamepads)} first and handle the case " +
+            $"where none is present. This mirrors a real backend on a machine with no controller: " +
+            $"construct {nameof(MockInputContext)} with a non-zero gamepadCount to model one.");
 
     /// <inheritdoc />
     public ImmutableArray<IKeyboard> Keyboards => [keyboard];

--- a/tests/KeenEyes.Input.Silk.Tests/KeenEyes.Input.Silk.Tests.csproj
+++ b/tests/KeenEyes.Input.Silk.Tests/KeenEyes.Input.Silk.Tests.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SilkInputContext has an internal constructor (the plugin owns creation), so these
+         tests rely on the InternalsVisibleTo already declared by KeenEyes.Input.Silk. -->
+    <ProjectReference Include="..\..\src\KeenEyes.Input.Silk\KeenEyes.Input.Silk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Input.Silk.Tests/SilkInputContextDeviceAvailabilityTests.cs
+++ b/tests/KeenEyes.Input.Silk.Tests/SilkInputContextDeviceAvailabilityTests.cs
@@ -1,0 +1,206 @@
+using KeenEyes.Input.Silk;
+using KeenEyes.Platform.Silk;
+using SilkInput = Silk.NET.Input;
+using SilkWindowing = Silk.NET.Windowing;
+
+namespace KeenEyes.Input.Silk.Tests;
+
+/// <summary>
+/// Covers what <see cref="SilkInputContext"/> says when a primary device is unavailable.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1256. All three device getters used to throw the single message
+/// "Input not initialized. Wait for window to load.", which made a perfectly initialized
+/// context with no controller plugged in indistinguishable from a window that had not loaded —
+/// and sent everyone debugging the wrong problem. The two states must now read differently.
+/// </remarks>
+public class SilkInputContextDeviceAvailabilityTests
+{
+    #region Initialized, but the device is absent
+
+    [Fact]
+    public void Gamepad_WhenInitializedWithNoGamepad_ThrowsAboutTheAbsentDevice()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = CreateLoadedContext(provider);
+
+        Assert.True(input.IsInitialized);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Gamepad);
+
+        // Assert on the distinguishing facts, not the sentence: the message must name the
+        // absent device and the safe property to test, and must NOT blame initialization.
+        Assert.Contains("gamepad", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(input.ConnectedGamepadCount), exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("wait", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Keyboard_WhenInitializedWithNoKeyboard_ThrowsAboutTheAbsentDevice()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = CreateLoadedContext(provider);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Keyboard);
+
+        Assert.Contains("keyboard", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(input.Keyboards), exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Mouse_WhenInitializedWithNoMouse_ThrowsAboutTheAbsentDevice()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = CreateLoadedContext(provider);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Mouse);
+
+        Assert.Contains("mouse", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(input.Mice), exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Gamepad_WhenGamepadsAreDisabledInConfig_ThrowsAboutTheConfiguration()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = new SilkInputContext(provider, new SilkInputConfig { EnableGamepads = false });
+        provider.RaiseLoad();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Gamepad);
+
+        // A deliberate configuration choice must not masquerade as missing hardware.
+        Assert.Contains(nameof(SilkInputConfig.EnableGamepads), exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SafeQueries_WhenInitializedWithNoDevices_ReportEmptyInsteadOfThrowing()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = CreateLoadedContext(provider);
+
+        // The properties callers are told to check must themselves be safe to read.
+        Assert.Empty(input.Gamepads);
+        Assert.Empty(input.Keyboards);
+        Assert.Empty(input.Mice);
+        Assert.Equal(0, input.ConnectedGamepadCount);
+    }
+
+    #endregion
+
+    #region Not initialized yet
+
+    [Fact]
+    public void Gamepad_WhenWindowHasNotLoaded_ThrowsAboutWaitingForTheWindow()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = new SilkInputContext(provider, new SilkInputConfig());
+
+        // No load event raised: this is the case the old message was actually written for.
+        Assert.False(input.IsInitialized);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Gamepad);
+
+        Assert.Contains("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("load", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Keyboard_WhenWindowHasNotLoaded_ThrowsAboutWaitingForTheWindow()
+    {
+        using var provider = new FakeWindowProvider(new FakeSilkInputContext());
+        using var input = new SilkInputContext(provider, new SilkInputConfig());
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Keyboard);
+
+        Assert.Contains("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("load", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsInitialized_WhenProviderYieldsNoInputContext_StaysFalse()
+    {
+        // A provider that loaded without producing an input context: the context has nothing
+        // to wrap, so it must not claim to be initialized. It used to set the flag anyway,
+        // which made IsInitialized report success while every device getter failed.
+        using var provider = new FakeWindowProvider(silkInputContext: null);
+        using var input = CreateLoadedContext(provider);
+
+        Assert.False(input.IsInitialized);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => input.Gamepad);
+        Assert.Contains("not initialized", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static SilkInputContext CreateLoadedContext(FakeWindowProvider provider)
+    {
+        var input = new SilkInputContext(provider, new SilkInputConfig());
+        provider.RaiseLoad();
+        return input;
+    }
+
+    /// <summary>
+    /// A window provider that never opens a window: it only hands out a Silk.NET input context
+    /// and raises <see cref="ISilkWindowProvider.OnLoad"/> on demand, which is all
+    /// <see cref="SilkInputContext"/> needs. That keeps these tests headless.
+    /// </summary>
+    private sealed class FakeWindowProvider(SilkInput.IInputContext? silkInputContext) : ISilkWindowProvider
+    {
+        public SilkWindowing.IWindow Window
+            => throw new NotSupportedException("These tests never open a window.");
+
+        public SilkInput.IInputContext InputContext => silkInputContext!;
+
+        public event Action? OnLoad;
+
+        // The rest of the lifecycle is irrelevant to input, so these accept subscribers
+        // and never fire.
+        public event Action<double>? OnUpdate { add { } remove { } }
+
+        public event Action<double>? OnRender { add { } remove { } }
+
+        public event Action<int, int>? OnResize { add { } remove { } }
+
+        public event Action? OnClosing { add { } remove { } }
+
+        public void RaiseLoad() => OnLoad?.Invoke();
+
+        public void Dispose() => silkInputContext?.Dispose();
+    }
+
+    /// <summary>
+    /// A Silk.NET input context for a machine with no input hardware at all: every device
+    /// list is empty, which is exactly the shape the gamepad case takes in the real world.
+    /// </summary>
+    private sealed class FakeSilkInputContext : SilkInput.IInputContext
+    {
+        public nint Handle => 0;
+
+        public IReadOnlyList<SilkInput.IGamepad> Gamepads => [];
+
+        public IReadOnlyList<SilkInput.IJoystick> Joysticks => [];
+
+        public IReadOnlyList<SilkInput.IKeyboard> Keyboards => [];
+
+        public IReadOnlyList<SilkInput.IMouse> Mice => [];
+
+        public IReadOnlyList<SilkInput.IInputDevice> OtherDevices => [];
+
+        // Nothing ever connects or disconnects in these tests.
+        public event Action<SilkInput.IInputDevice, bool>? ConnectionChanged { add { } remove { } }
+
+        public void Dispose()
+        {
+            // No native resources behind this fake.
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Input.Silk.Tests/packages.lock.json
+++ b/tests/KeenEyes.Input.Silk.Tests/packages.lock.json
@@ -1,0 +1,317 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.input": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )"
+        }
+      },
+      "keeneyes.input.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Input": "[1.0.0, )",
+          "KeenEyes.Input.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/InputDeviceAvailabilityTests.cs
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/InputDeviceAvailabilityTests.cs
@@ -1,0 +1,227 @@
+using KeenEyes.Common;
+using KeenEyes.Input.Abstractions;
+using KeenEyes.Testing.Input;
+
+namespace KeenEyes.Sample.NovaFall.Tests;
+
+/// <summary>
+/// Pins down that NOVAFALL plays on a keyboard with no controller attached, and still uses a
+/// controller when one is.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1256, where a Windows laptop with no gamepad could not run the
+/// sample at all: <see cref="InputSteerSystem"/> and <see cref="GameFlowSystem"/> read
+/// <see cref="IInputContext.Gamepad"/> unguarded, that getter throws when nothing is plugged
+/// in, and the exception escaped frame 1 of the loop. A gamepad is optional hardware, so both
+/// systems must run on keyboard alone.
+/// </remarks>
+public class InputDeviceAvailabilityTests
+{
+    private const float FixedDeltaTime = 1f / 60f;
+
+    #region Test double contract
+
+    [Fact]
+    public void MockInputContext_WithZeroGamepads_ThrowsFromPrimaryGamepad()
+    {
+        // The guard below is only meaningful if the double behaves like the hardware backend:
+        // a machine with no controller has no primary gamepad to hand out. If this ever stops
+        // throwing, the keyboard-only tests below would pass for the wrong reason.
+        using var input = new MockInputContext(gamepadCount: 0);
+
+        Assert.Equal(0, input.ConnectedGamepadCount);
+        Assert.Empty(input.Gamepads);
+        Assert.Throws<InvalidOperationException>(() => input.Gamepad);
+    }
+
+    #endregion
+
+    #region InputSteerSystem
+
+    [Theory]
+    [InlineData(Key.A, -1f)]
+    [InlineData(Key.Left, -1f)]
+    [InlineData(Key.D, 1f)]
+    [InlineData(Key.Right, 1f)]
+    public void InputSteer_WithNoGamepadConnected_SteersFromKeyboard(Key key, float expectedAxis)
+    {
+        using var world = CreateWorld(gamepadCount: 0, out var input);
+        input.SetKeyDown(key);
+
+        var system = new InputSteerSystem();
+        system.Initialize(world);
+
+        var exception = Record.Exception(() => system.Update(FixedDeltaTime));
+
+        Assert.Null(exception);
+        Assert.True(
+            SteerAxis(world).ApproximatelyEquals(expectedAxis),
+            $"Expected steer axis {expectedAxis} but got {SteerAxis(world)}.");
+    }
+
+    [Fact]
+    public void InputSteer_WithNoGamepadConnectedAndNoKeysHeld_LeavesAxisAtZero()
+    {
+        using var world = CreateWorld(gamepadCount: 0, out _);
+
+        var system = new InputSteerSystem();
+        system.Initialize(world);
+
+        var exception = Record.Exception(() => system.Update(FixedDeltaTime));
+
+        Assert.Null(exception);
+        Assert.True(SteerAxis(world).IsApproximatelyZero());
+    }
+
+    [Fact]
+    public void InputSteer_WithGamepadConnected_SteersFromLeftStick()
+    {
+        using var world = CreateWorld(gamepadCount: 1, out var input);
+        input.SetGamepadStick(0, isLeft: true, 1f, 0f);
+
+        var system = new InputSteerSystem();
+        system.Initialize(world);
+        system.Update(FixedDeltaTime);
+
+        Assert.True(SteerAxis(world).ApproximatelyEquals(1f));
+    }
+
+    [Fact]
+    public void InputSteer_WithGamepadConnectedAndKeyHeld_PrefersTheKeyboard()
+    {
+        using var world = CreateWorld(gamepadCount: 1, out var input);
+        input.SetGamepadStick(0, isLeft: true, 1f, 0f);
+        input.SetKeyDown(Key.A);
+
+        var system = new InputSteerSystem();
+        system.Initialize(world);
+        system.Update(FixedDeltaTime);
+
+        Assert.True(SteerAxis(world).ApproximatelyEquals(-1f));
+    }
+
+    #endregion
+
+    #region GameFlowSystem
+
+    [Fact]
+    public void GameFlow_WithNoGamepadConnected_StartsTheRunFromSpace()
+    {
+        using var world = CreateWorld(gamepadCount: 0, out var input);
+        input.SetKeyDown(Key.Space);
+
+        var system = new GameFlowSystem();
+        system.Initialize(world);
+
+        var exception = Record.Exception(() => system.Update(FixedDeltaTime));
+
+        Assert.Null(exception);
+        Assert.Equal(GamePhase.Playing, world.GetSingleton<GameState>().Phase);
+    }
+
+    [Fact]
+    public void GameFlow_WithNoGamepadConnected_CyclesTheMenuFromTheKeyboard()
+    {
+        using var world = CreateWorld(gamepadCount: 0, out var input);
+        var startingMode = world.GetSingleton<MenuState>().SelectedMode;
+
+        var system = new GameFlowSystem();
+        system.Initialize(world);
+
+        // Edge-detected input: one idle frame establishes "up", then the press registers.
+        system.Update(FixedDeltaTime);
+        input.SetKeyDown(Key.D);
+        var exception = Record.Exception(() => system.Update(FixedDeltaTime));
+
+        Assert.Null(exception);
+        Assert.NotEqual(startingMode, world.GetSingleton<MenuState>().SelectedMode);
+        Assert.Equal(GamePhase.Ready, world.GetSingleton<GameState>().Phase);
+    }
+
+    [Fact]
+    public void GameFlow_WithNoGamepadConnectedAndNothingPressed_StaysOnTheReadyScreen()
+    {
+        using var world = CreateWorld(gamepadCount: 0, out _);
+
+        var system = new GameFlowSystem();
+        system.Initialize(world);
+
+        var exception = Record.Exception(() =>
+        {
+            for (var frame = 0; frame < 5; frame++)
+            {
+                system.Update(FixedDeltaTime);
+            }
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(GamePhase.Ready, world.GetSingleton<GameState>().Phase);
+    }
+
+    [Fact]
+    public void GameFlow_WithGamepadConnected_StartsTheRunFromTheSouthButton()
+    {
+        using var world = CreateWorld(gamepadCount: 1, out var input);
+        input.SetGamepadButton(0, GamepadButton.South, isDown: true);
+
+        var system = new GameFlowSystem();
+        system.Initialize(world);
+        system.Update(FixedDeltaTime);
+
+        Assert.Equal(GamePhase.Playing, world.GetSingleton<GameState>().Phase);
+    }
+
+    #endregion
+
+    #region JuiceToggleSystem
+
+    [Fact]
+    public void JuiceToggle_WithNoGamepadConnected_TogglesFromTheKeyboard()
+    {
+        using var world = CreateWorld(gamepadCount: 0, out var input);
+        var system = new JuiceToggleSystem();
+        system.Initialize(world);
+
+        input.SetKeyDown(Key.J);
+        var exception = Record.Exception(() => system.Update(FixedDeltaTime));
+
+        Assert.Null(exception);
+        Assert.False(world.GetSingleton<JuiceConfig>().Enabled);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Builds a Ready-screen world whose only input device set is a keyboard, a mouse, and
+    /// <paramref name="gamepadCount"/> gamepad slots — zero models the reported machine.
+    /// </summary>
+    private static World CreateWorld(int gamepadCount, out MockInputContext input)
+    {
+        var world = new World();
+
+        // presentation: true is the windowed path, the one that reads real input devices.
+        GameSetup.InitializeSingletons(world, seed: 1319914546, pinSeed: true, presentation: true);
+        GameSetup.StartRun(world, seed: 1319914546);
+
+        input = new MockInputContext(gamepadCount);
+
+        // owned: false - the context outlives nothing here; the test disposes the world only.
+        world.SetExtension<IInputContext>(input, owned: false);
+
+        return world;
+    }
+
+    private static float SteerAxis(World world)
+    {
+        foreach (var entity in world.Query<Ball, SteerInput>())
+        {
+            return world.Get<SteerInput>(entity).Axis;
+        }
+
+        throw new InvalidOperationException("The run has no ball to steer.");
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
@@ -12,6 +12,9 @@
          deterministic core (floor script, heat ladder, mode schedules) that
          the headless simulation and future replay support depend on. -->
     <ProjectReference Include="..\..\samples\KeenEyes.Sample.NovaFall\KeenEyes.Sample.NovaFall.csproj" />
+    <!-- MockInputContext: models a machine whose gamepad slot count is zero, which is what
+         made the sample crash for a player with no controller (#1256). -->
+    <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Fixes the third crash reported on #1256: `InvalidOperationException: Input not initialized. Wait for window to load.` on a Windows laptop with a working display and driver — the real cause was **no gamepad connected**.

`SilkInputContext` threw the *identical* message from `Keyboard`, `Mouse` and `Gamepad`, so "this device type is absent" was indistinguishable from "the window hasn't loaded". With no controller, `primaryGamepad` stays null while the context is fully initialized, and NOVAFALL read `input.Gamepad` unguarded in two per-frame systems — so frame 1 threw. `Sample.UI` was unaffected because it only touches keyboard/mouse.

**The docs were generating the bug.** `IInputContext.Gamepad`'s XML doc claimed it "returns a disconnected placeholder if no gamepad is connected. Check `IGamepad.IsConnected`" — and `docs/input.md` taught exactly that idiom in all five gamepad snippets. `input.Gamepad.IsConnected` cannot work: the getter throws before `IsConnected` is ever evaluated. Both are corrected.

### Engine
- Messages now branch on initialization state: absent-device messages name the device *and* the safe property to test; the uninitialized case keeps "wait for window to load". A third case — gamepads switched off via `SilkInputConfig.EnableGamepads` — now says so instead of posing as missing hardware.
- `IInputContext` docs gained `<exception>` tags naming the property to check first.
- Fixed a silent lie: `initialized = true` was set even when the Silk input context was never obtained, so `IsInitialized` reported success while every getter failed.
- Subscription moved from `windowProvider.Window.Load` to `windowProvider.OnLoad`, matching `SilkGraphicsContext`/`SilkLoopProvider` — the provider creates the input context before raising `OnLoad`, so it is strictly safer and makes the type headlessly testable. Ordering verified unchanged: `Run()` fires `OnReady` after `Window.Initialize()` returns.

### Sample
- New `InputDevices` helper (`FirstConnectedGamepad`/`FirstKeyboard`) over the safe plural collections, documenting why `input.Gamepad.IsConnected` is a trap. All gamepad and keyboard reads route through it; gamepad support is retained when one is attached. `OnReady` logs "No gamepad detected — keyboard controls cover everything."
- Catch-all split into `ReportStartupFailure` (plugin install) and `ReportRunFailure` ("NOVAFALL stopped: …"), because `Run()` covers both startup *and* the frame loop — the previous wording reported a first-frame crash as a startup failure.

### Sweep
Zero singular `.Gamepad` reads remain in production code. The two fixed sites were the only high-risk ones in the repo; existing `Gamepads`-loop/`GetConnectedGamepad` call sites were already safe. ~25 `.Keyboard`/`.Mouse` sites are reported in the agent notes but deliberately left unchanged (a keyboard/mouse is not legitimately absent on a real machine, and the engine message is now honest). One indirect hazard worth knowing: `CompositeInputContext.EnsureInitialized` dereferences `real.Keyboard`/`real.Mouse`, so any Composite property can throw if the real context has neither yet.

## Test plan
- [x] `InputDeviceAvailabilityTests` (13) drives the real systems against `MockInputContext(gamepadCount: 0)` — **7 fail on old code** with the exact reported exception at the exact reported lines; keyboard steering and gamepad stick/button both asserted on new code.
- [x] New `tests/KeenEyes.Input.Silk.Tests` (8) — headless via a fake `ISilkWindowProvider`; asserts on distinguishing substrings only. Fail-on-old isolated in two steps (whole-file revert fails all 8 — the old type couldn't even be constructed without a real window, which is why it was never covered; message-only revert fails exactly the 3 absent-device tests).
- [x] Full suite **14,845, 0 failed**; 0 warnings; format clean; `--simulate 600` double-run byte-identical.

## Not verifiable here (no display)
The windowed launch on that laptop now reaching the Ready screen; the `OnLoad` subscription change against a live GLFW window; controller hot-plug.

**Pre-existing limitation found, not fixed:** `gamepads` is snapshotted at window load, so a controller plugged in *mid-session* still won't populate `primaryGamepad`. Worth a follow-up issue.

Refs #1256
