### PR TITLE
fix(ai,testbridge): Inspect blackboard values through a typed accessor instead of private-field reflection

### DIFF
--- a/editor/KeenEyes.Editor/AI/AIDebugPanel.cs
+++ b/editor/KeenEyes.Editor/AI/AIDebugPanel.cs
@@ -285,8 +285,9 @@ public sealed class AIDebugPanel : IEditorPanel
             return null;
         }
 
-        // Note: Blackboard doesn't expose enumeration, so we return a placeholder
-        // A real implementation would need to extend Blackboard to support this
+        // Only the entry count is surfaced today because nothing in the panel renders
+        // individual entries yet. When it does, enumerate Blackboard.Entries - that inspection
+        // API returns unwrapped values, so no reflection over Blackboard is needed.
         return new BlackboardDebugInfo
         {
             EntryCount = blackboard.Count

--- a/src/KeenEyes.AI/Core/Blackboard.cs
+++ b/src/KeenEyes.AI/Core/Blackboard.cs
@@ -124,6 +124,35 @@ public sealed class Blackboard
     /// </summary>
     public int Count => data.Count;
 
+    /// <summary>
+    /// Enumerates every entry as a key and its boxed value, for inspection by debug and
+    /// editor tooling.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a read-only inspection surface, not a storage view: value-type entries are
+    /// returned as their real boxed value with their real runtime type, so a caller sees
+    /// <c>Single</c> / <c>1.5</c> rather than any internal storage representation. It is the
+    /// enumeration counterpart to <see cref="TryGet{T}"/> and performs no mutation.
+    /// </para>
+    /// <para>
+    /// Intended for diagnostics (debug panels, the test bridge, AI inspectors) rather than
+    /// gameplay code: enumerating boxes every value-type entry, so prefer the typed
+    /// <see cref="Get{T}(string)"/> / <see cref="TryGet{T}"/> accessors on hot paths.
+    /// Enumerating while the blackboard is being modified throws, as with any dictionary.
+    /// </para>
+    /// </remarks>
+    public IEnumerable<KeyValuePair<string, object>> Entries
+    {
+        get
+        {
+            foreach (var kvp in data)
+            {
+                yield return new KeyValuePair<string, object>(kvp.Key, Unwrap(kvp.Value));
+            }
+        }
+    }
+
     // Resolves a stored value to the requested type, matching the semantics of the original
     // `stored is T` check. Values written through the value-type fast path live inside a
     // ValueCell; the exact-type branch unwraps them without boxing, while the IValueCell branch
@@ -158,6 +187,10 @@ public sealed class Blackboard
         typed = default;
         return false;
     }
+
+    // Recovers the value a caller stored, undoing the value-type cell wrapper so no storage
+    // detail escapes through the inspection surface.
+    private static object Unwrap(object stored) => stored is IValueCell cell ? cell.BoxedValue : stored;
 
     // Non-generic view over a typed value cell, used to recover the boxed value on the rare
     // cross-type lookup path.

--- a/src/KeenEyes.TestBridge/AIImpl/AIControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/AIImpl/AIControllerImpl.cs
@@ -52,7 +52,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
     /// <inheritdoc />
     public Task<BehaviorTreeSnapshot?> GetBehaviorTreeStateAsync(int entityId, CancellationToken cancellationToken = default)
     {
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity) || !world.Has<BehaviorTreeComponent>(entity))
         {
             return Task.FromResult<BehaviorTreeSnapshot?>(null);
@@ -81,7 +81,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -108,7 +108,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
     /// <inheritdoc />
     public Task<StateMachineSnapshot?> GetStateMachineStateAsync(int entityId, CancellationToken cancellationToken = default)
     {
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity) || !world.Has<StateMachineComponent>(entity))
         {
             return Task.FromResult<StateMachineSnapshot?>(null);
@@ -168,7 +168,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -180,7 +180,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
     /// <inheritdoc />
     public Task<bool> ForceStateTransitionByNameAsync(int entityId, string stateName, CancellationToken cancellationToken = default)
     {
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity) || !world.Has<StateMachineComponent>(entity))
         {
             return Task.FromResult(false);
@@ -235,7 +235,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
     /// <inheritdoc />
     public Task<UtilityAISnapshot?> GetUtilityAIStateAsync(int entityId, CancellationToken cancellationToken = default)
     {
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity) || !world.Has<UtilityComponent>(entity))
         {
             return Task.FromResult<UtilityAISnapshot?>(null);
@@ -268,7 +268,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity) || !world.Has<UtilityComponent>(entity))
         {
             return Task.FromResult<IReadOnlyList<UtilityScoreSnapshot>>([]);
@@ -302,7 +302,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -323,7 +323,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult<IReadOnlyList<BlackboardEntrySnapshot>>([]);
@@ -347,7 +347,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult<BlackboardEntrySnapshot?>(null);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult<BlackboardEntrySnapshot?>(null);
@@ -377,7 +377,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -408,7 +408,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -431,7 +431,7 @@ internal sealed class AIControllerImpl(World world) : IAIController
             return Task.FromResult(false);
         }
 
-        var entity = new Entity(entityId, 0);
+        var entity = FindEntityById(entityId);
         if (!world.IsAlive(entity))
         {
             return Task.FromResult(false);
@@ -451,25 +451,32 @@ internal sealed class AIControllerImpl(World world) : IAIController
 
     #region Helper Methods
 
-#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields - Acceptable for debug tooling
     private static List<BlackboardEntrySnapshot> GetBlackboardEntries(Blackboard blackboard)
     {
-        // Blackboard doesn't expose its keys directly, so we need to use reflection
-        // This is acceptable for debug tooling
-        var entries = new List<BlackboardEntrySnapshot>();
+        var entries = new List<BlackboardEntrySnapshot>(blackboard.Count);
 
-        var dataField = typeof(Blackboard).GetField("data", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        if (dataField?.GetValue(blackboard) is Dictionary<string, object> data)
+        foreach (var (key, value) in blackboard.Entries)
         {
-            foreach (var kvp in data)
-            {
-                entries.Add(CreateBlackboardEntry(kvp.Key, kvp.Value));
-            }
+            entries.Add(CreateBlackboardEntry(key, value));
         }
 
         return entries;
     }
-#pragma warning restore S3011
+
+    // TestBridge callers address entities by id alone, so the current version has to be
+    // recovered from the world before the entity handle can be used.
+    private Entity FindEntityById(int entityId)
+    {
+        foreach (var entity in world.GetAllEntities())
+        {
+            if (entity.Id == entityId)
+            {
+                return entity;
+            }
+        }
+
+        return Entity.Null;
+    }
 
 #pragma warning disable IL2026, IL3050 // AOT compatibility - Acceptable for debug tooling which uses dynamic serialization
     private static BlackboardEntrySnapshot CreateBlackboardEntry(string key, object value)

--- a/tests/KeenEyes.AI.Tests/BlackboardTests.cs
+++ b/tests/KeenEyes.AI.Tests/BlackboardTests.cs
@@ -192,6 +192,112 @@ public class BlackboardTests
 
     #endregion
 
+    #region Entries Tests
+
+    [Fact]
+    public void Entries_WithEmptyBlackboard_YieldsNothing()
+    {
+        var blackboard = new Blackboard();
+
+        blackboard.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Entries_WithValueTypeEntry_YieldsBoxedValueWithRealRuntimeType()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("speed", 1.5f);
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+
+        entry.Key.ShouldBe("speed");
+        entry.Value.GetType().ShouldBe(typeof(float));
+        entry.Value.ShouldBe(1.5f);
+    }
+
+    [Fact]
+    public void Entries_WithStructEntry_YieldsBoxedStructNotStorageWrapper()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("target", new Vector3(1, 2, 3));
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+
+        entry.Value.GetType().ShouldBe(typeof(Vector3));
+        entry.Value.ShouldBe(new Vector3(1, 2, 3));
+    }
+
+    [Fact]
+    public void Entries_WithReferenceTypeEntry_YieldsSameInstance()
+    {
+        var blackboard = new Blackboard();
+        var waypoints = new List<Vector3> { new(1, 0, 0) };
+        blackboard.Set("waypoints", waypoints);
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+
+        entry.Value.ShouldBeSameAs(waypoints);
+    }
+
+    [Fact]
+    public void Entries_AfterRepeatedSetOfSameKeyAndType_YieldsLatestValueOnce()
+    {
+        var blackboard = new Blackboard();
+
+        // The same-type write path mutates the existing cell in place rather than replacing it.
+        blackboard.Set("speed", 1.5f);
+        blackboard.Set("speed", 9.25f);
+        blackboard.Set("speed", 4.5f);
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+
+        entry.Value.GetType().ShouldBe(typeof(float));
+        entry.Value.ShouldBe(4.5f);
+    }
+
+    [Fact]
+    public void Entries_WithMixedEntries_YieldsEveryKeyWithItsRealType()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("speed", 1.5f);
+        blackboard.Set("ticks", 7);
+        blackboard.Set("name", "goblin");
+
+        var entries = blackboard.Entries.ToDictionary(e => e.Key, e => e.Value);
+
+        entries.Count.ShouldBe(3);
+        entries["speed"].ShouldBe(1.5f);
+        entries["ticks"].ShouldBe(7);
+        entries["name"].ShouldBe("goblin");
+    }
+
+    [Fact]
+    public void Entries_AfterRemove_DoesNotYieldRemovedKey()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("speed", 1.5f);
+        blackboard.Set("ticks", 7);
+
+        blackboard.Remove("speed");
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+        entry.Key.ShouldBe("ticks");
+    }
+
+    [Fact]
+    public void Entries_AfterOverwritingValueTypeWithReferenceType_YieldsReferenceValue()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("k", 7);
+        blackboard.Set("k", "hello");
+
+        var entry = blackboard.Entries.ShouldHaveSingleItem();
+
+        entry.Value.ShouldBe("hello");
+    }
+
+    #endregion
+
     #region BBKeys Tests
 
     [Fact]

--- a/tests/KeenEyes.TestBridge.Tests/AI/AIControllerBlackboardTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/AI/AIControllerBlackboardTests.cs
@@ -1,0 +1,240 @@
+using System.Numerics;
+using KeenEyes.AI;
+using KeenEyes.AI.FSM;
+
+namespace KeenEyes.TestBridge.Tests.AI;
+
+/// <summary>
+/// Tests for blackboard inspection through the TestBridge AI controller (issue #1306).
+/// Blackboard stores value types inside an internal reusable cell to avoid re-boxing on hot
+/// writes; inspection must report the real value and its real type, never the storage wrapper.
+/// </summary>
+public class AIControllerBlackboardTests
+{
+    #region Helpers
+
+    private static Entity SpawnAIEntity(World world, Action<Blackboard> populate)
+    {
+        world.InstallPlugin(new AIPlugin());
+
+        var entity = world.Spawn()
+            .With(new StateMachineComponent { Enabled = true })
+            .Build();
+
+        ref var fsm = ref world.Get<StateMachineComponent>(entity);
+        populate(fsm.GetOrCreateBlackboard());
+
+        return entity;
+    }
+
+    #endregion
+
+    #region GetBlackboardAsync value-type reporting
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithFloatValue_ReportsRealTypeAndValue()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Speed", 1.5f));
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        var entry = entries.ShouldHaveSingleItem();
+        entry.Key.ShouldBe("Speed");
+        entry.ValueType.ShouldBe("Single");
+        entry.Value.ShouldNotBeNull();
+        entry.Value!.Value.GetSingle().ShouldBe(1.5f);
+        entry.ValueString.ShouldBe("1.5");
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithVector3Value_ReportsRealType()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Target", new Vector3(1, 2, 3)));
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        // Vector3 exposes its components as fields, which the default serializer options omit,
+        // so only the reported type is meaningful here - it must be the stored type.
+        var entry = entries.ShouldHaveSingleItem();
+        entry.Key.ShouldBe("Target");
+        entry.ValueType.ShouldBe("Vector3");
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithValueTypeEntry_DoesNotLeakStorageWrapper()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Ticks", 7));
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        var entry = entries.ShouldHaveSingleItem();
+        entry.ValueType.ShouldNotContain("Cell");
+        entry.ValueType.ShouldBe("Int32");
+        entry.Value.ShouldNotBeNull();
+        entry.Value!.Value.GetInt32().ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithReferenceTypeValue_ReportsValueUnchanged()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Name", "goblin"));
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        var entry = entries.ShouldHaveSingleItem();
+        entry.ValueType.ShouldBe("String");
+        entry.ValueString.ShouldBe("goblin");
+        entry.Value.ShouldNotBeNull();
+        entry.Value!.Value.GetString().ShouldBe("goblin");
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithMixedEntries_ReportsEveryEntryWithItsRealType()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard =>
+        {
+            blackboard.Set("Speed", 1.5f);
+            blackboard.Set("Target", new Vector3(4, 5, 6));
+            blackboard.Set("Name", "goblin");
+        });
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        entries.Count.ShouldBe(3);
+        entries.Single(e => e.Key == "Speed").ValueType.ShouldBe("Single");
+        entries.Single(e => e.Key == "Target").ValueType.ShouldBe("Vector3");
+        entries.Single(e => e.Key == "Name").ValueType.ShouldBe("String");
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_AfterRepeatedSetOfSameKey_ReportsLatestValue()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard =>
+        {
+            blackboard.Set("Speed", 1.5f);
+            blackboard.Set("Speed", 9.25f);
+        });
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        var entry = entries.ShouldHaveSingleItem();
+        entry.ValueType.ShouldBe("Single");
+        entry.Value.ShouldNotBeNull();
+        entry.Value!.Value.GetSingle().ShouldBe(9.25f);
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithEmptyBlackboard_ReturnsNoEntries()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, _ => { });
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_AgreesWithGetBlackboardValueAsync_ForValueTypes()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Speed", 1.5f));
+        using var bridge = new InProcessBridge(world);
+
+        var listed = (await bridge.AI.GetBlackboardAsync(entity.Id, TestContext.Current.CancellationToken)).ShouldHaveSingleItem();
+        var single = await bridge.AI.GetBlackboardValueAsync(entity.Id, "Speed", TestContext.Current.CancellationToken);
+
+        single.ShouldNotBeNull();
+        listed.ValueType.ShouldBe(single!.ValueType);
+        listed.ValueString.ShouldBe(single.ValueString);
+    }
+
+    [Fact]
+    public async Task GetBlackboardAsync_WithUnknownEntityId_ReturnsNoEntries()
+    {
+        using var world = new World();
+        SpawnAIEntity(world, blackboard => blackboard.Set("Speed", 1.5f));
+        using var bridge = new InProcessBridge(world);
+
+        var entries = await bridge.AI.GetBlackboardAsync(9999, TestContext.Current.CancellationToken);
+
+        entries.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region Entity resolution
+
+    [Fact]
+    public async Task GetStateMachineStateAsync_WithLiveEntity_ResolvesEntityAndReturnsSnapshot()
+    {
+        using var world = new World();
+        var entity = SpawnAIEntity(world, blackboard => blackboard.Set("Speed", 1.5f));
+        using var bridge = new InProcessBridge(world);
+
+        // Entity versions start at 1, so an id-addressed lookup has to recover the live version.
+        var snapshot = await bridge.AI.GetStateMachineStateAsync(entity.Id, TestContext.Current.CancellationToken);
+
+        snapshot.ShouldNotBeNull();
+        snapshot!.EntityId.ShouldBe(entity.Id);
+        snapshot.Enabled.ShouldBeTrue();
+        snapshot.BlackboardEntryCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetStateMachineStateAsync_WithUnknownEntityId_ReturnsNull()
+    {
+        using var world = new World();
+        SpawnAIEntity(world, _ => { });
+        using var bridge = new InProcessBridge(world);
+
+        var snapshot = await bridge.AI.GetStateMachineStateAsync(9999, TestContext.Current.CancellationToken);
+
+        snapshot.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region Reflection regression guard
+
+    [Fact]
+    public void AIControllerImplSource_DoesNotUseReflection()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "KeenEyes.TestBridge",
+            "AIImpl",
+            "AIControllerImpl.cs"));
+
+        source.ShouldNotContain("BindingFlags");
+        source.ShouldNotContain("GetField");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "KeenEyes.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.ShouldNotBeNull("Could not locate the repository root (KeenEyes.slnx) from the test output directory.");
+        return directory!.FullName;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Closes #1306. Filed as a refactor (replace private-field reflection with a typed accessor) — scoping it uncovered **two live bugs the reflection was hiding**, so this is a bug fix.

### Bug 1: blackboard inspection reported wrapper types, not values
`Blackboard.Set<T>` stores value types in a private `ValueCell<T>` to avoid re-boxing on hot writes (added by the allocation work in #1238). `AIControllerImpl.GetBlackboardEntries` read the private `data` dictionary by reflection and passed entries straight through, so the wrapper leaked. Measured through `InProcessBridge.AI.GetBlackboardAsync`:

| Key | Before | After |
|---|---|---|
| `Speed` (float 1.5) | type `ValueCell\`1`, json `{"BoxedValue":1.5}` | type `Single`, json `1.5` |
| `Target` (Vector3) | type `ValueCell\`1` | type `Vector3` |
| `Name` (string) | type `String`, json `"goblin"` | unchanged |

A performance PR silently broke a debug feature *through* the reflection — no compile-time signal, and no test could catch it because none existed. Note `GetBlackboardValueAsync` (single key) was already correct, since `TryGet<object>` unwraps via `IValueCell.BoxedValue`; only the enumerate-all path was wrong. A test now asserts the two paths agree.

### Bug 2: the entire AI inspection/control surface was dead
All **13** id-addressed methods in `AIControllerImpl` constructed `new Entity(entityId, 0)`. `EntityPool.Acquire` assigns version **1** to a fresh id and increments on recycle (`EntityPool.cs:90`) — **version 0 never exists** — so every one failed its `IsAlive` guard and returned `null`/`false`/`[]` for live entities. Fixed with a `FindEntityById` helper mirroring the one `MutationControllerImpl` already had. This is why the #1306 regression test couldn't even reach the buggy code on the first attempt: it got `[]`, not a wrapper.

### The fix
- **`Blackboard.Entries`** → `IEnumerable<KeyValuePair<string, object>>`, unwrapping through the existing `IValueCell.BoxedValue`. No reflection; `ValueCell` stays invisible to callers. Documented as a read-only diagnostics surface that points at `Get<T>`/`TryGet<T>` for hot paths.
- **Public rather than `internal` + `InternalsVisibleTo`**: the editor's `AIDebugPanel` is a third assembly with exactly this need (it carried a TODO claiming enumeration was impossible), and a game's own debug HUD wants it too. That TODO comment is corrected; no speculative panel rendering added.
- **`AIControllerImpl.GetBlackboardEntries`** rewritten onto it; the reflection, the `"data"` string literal and the `#pragma warning disable S3011` are gone. The neighbouring `IL2026/IL3050` pragma is retained — it covers `JsonSerializer`, not reflection.

## Test plan
- [x] 11 tests in `AIControllerBlackboardTests` (float/Vector3/int/string, mixed, repeated-`Set`, empty, unknown id, agreement with the single-key path, entity resolution) + 8 in `BlackboardTests` for `Entries`.
- [x] **Fail-on-old proven in two stages**: all 8 bridge tests fail pre-fix; with entity resolution fixed but the reflection restored, 7 fail specifically on `should be "Single" but was "ValueCell\`1"` — isolating bug 1 from bug 2.
- [x] A guard asserts `AIControllerImpl.cs` no longer contains `BindingFlags`/`GetField` (locates the repo root by walking up to `KeenEyes.slnx`, so it survives CI's deterministic source paths).
- [x] AI.Tests 258, TestBridge.Tests 261 + 1 pre-existing skip; full suite **14,865, 0 failed**; 0 warnings; format clean.

## Left alone deliberately
`Vector3` serializes as `{}` both before and after — `CreateBlackboardEntry` uses default `JsonSerializerOptions`, which omit *fields*, and `Vector3.X/Y/Z` are fields. Pre-existing and out of scope; the test asserts only the type name there and says why. Worth its own issue if blackboard JSON matters.

## Note for reviewers
This surface has never been reachable from MCP: per #1265, `AITools` is one of the nine tool classes that is documented but never registered. Fixing that registration would have turned both of these into visible bugs rather than dormant ones.
