### PR TITLE
docs: Warn that misplaced test flags run zero tests while reporting failed: 0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,18 @@ dotnet test tests/KeenEyes.Core.Tests -- --filter-namespace "KeenEyes.Core.Tests
 
 `--filter-not-method`, `--filter-not-class`, etc. negate. Each test project lives in `tests/KeenEyes.<Area>.Tests` mirroring `src/`.
 
+**Flag placement matters, and getting it wrong looks like success.** Only *test-platform* options go after `--`. Options belonging to `dotnet test` itself — notably `--max-parallel-test-modules` — must come **before** it:
+
+```bash
+# CORRECT: driver option before --
+dotnet test tests/KeenEyes.Core.Tests --max-parallel-test-modules 1
+
+# WRONG: runs ZERO tests and exits 5
+dotnet test tests/KeenEyes.Core.Tests -- --max-parallel-test-modules 1
+```
+
+The wrong form does not error usefully — it prints `failed: 0, succeeded: 0` and exits 5. **`failed: 0` is therefore not evidence a test ran**; always check `succeeded`/`total` (or the exit code) before treating a targeted run as proof. MTP exit code 5 means "zero tests ran".
+
 ## Key Design Decisions
 
 1. **Components are structs** - Cache-friendly, value semantics


### PR DESCRIPTION
## Summary
Several agent runs this week reported "Zero tests ran" after appending `--max-parallel-test-modules` to a targeted test command. Verified empirically on this checkout:

| Command | Result |
|---|---|
| `dotnet test tests/KeenEyes.Core.Tests -- --max-parallel-test-modules 1` | **succeeded: 0, exit 5** |
| `dotnet test tests/KeenEyes.Core.Tests --max-parallel-test-modules 1` | succeeded: 2351, exit 0 |

The flag belongs to `dotnet test`, not the test platform, so it must precede the `--` separator. MTP **filter** options after `--` are correct exactly as documented — `--filter-method "*Spawn_CreatesEntity*"` verified to run 1 test with exit 0, so that guidance is unchanged.

**The failure mode is why this is worth documenting:** the wrong form doesn't error usefully. It prints `failed: 0` alongside `succeeded: 0` and exits 5. Anyone verifying with "0 failed" reads a run that executed nothing as a pass — which quietly invalidates a verification claim rather than surfacing a mistake.

CLAUDE.md now shows the correct placement and states that `succeeded`/`total` or the exit code must be checked before trusting a targeted run.

## Test plan
- [x] Both forms run and their output/exit codes captured (table above)
- [x] Documented filter syntax re-verified as correct
- [x] Docs-only change; no code touched