### PR TITLE
docs(adr): Convert ADRs to living documents with revision headers and changelogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -418,6 +418,20 @@ dotnet test tests/KeenEyes.Core.Tests -- --filter-namespace "KeenEyes.Core.Tests
 4. **Systems are explicit** - User registers what they need per-world
 5. **Builders are generated** - `WithPosition(x, y)` instead of `With(new Position{...})`
 
+## Architecture Decision Records (ADRs)
+
+ADRs in `docs/adr/` are **living documents, not immutable records**. Each describes present-tense reality and carries a current-state header (`Status`, `Revision: vN`, `Implementation`, `First accepted` / `Last amended`, `Relates to`) plus a newest-first `## Changelog`. Full policy: [docs/adr/index.md](docs/adr/index.md).
+
+**Rules for agents:**
+
+1. **If your code change invalidates something an ADR says, amend the ADR in the same PR.** Don't leave the record stale, and don't write "Update:" notes — edit the body in place.
+2. **Amending in place** = edit the living sections to present-tense reality, bump `Revision`, update `Last amended`, and add exactly one Changelog line stating *what changed and why* (format: `- **vN — YYYY-MM-DD (#issue/PR):** ...`). The Revision must always equal the number of Changelog entries, and the top entry's `vN` must match it.
+3. **Section semantics:** `Context` and `Alternatives Considered` are **frozen** history — never rewrite them to match later reality. `Decision`, `Consequences`, and implementation/phase sections are **living** — keep them true. Planned-but-unshipped items get labeled ("Not yet implemented: …"), never silently deleted.
+4. **New decision area** → new ADR: copy [docs/adr/TEMPLATE.md](docs/adr/TEMPLATE.md), take the next number, add it to the `docs/toc.yml` "Architecture Decisions" node and the index table in `docs/adr/index.md`.
+5. **Reversal** → a new ADR that supersedes the old one; the old ADR's Status flips to `Superseded by ADR-NNN` with links both ways. Never delete an ADR.
+6. **Status ≠ Implementation.** `Status` is about the decision (`Proposed`/`Accepted`/`Amended`/`Superseded by ADR-NNN`/`Deprecated`); `Implementation` is about the code (`Not started`/`Partial`/`Shipped`). Only claim `Shipped` from verified code, and reserve `Amended` for real post-acceptance decision changes — fixing a stale field is a correction, recorded in the Changelog.
+7. **Keep the index in sync:** any change to an ADR's `Status` or `Implementation` must be mirrored in the table in `docs/adr/index.md`.
+
 ## World Manager Architecture
 
 The `World` class uses a **facade pattern** with specialized internal managers. This keeps `World` as a thin coordinator (~300-400 lines) while delegating to focused managers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,18 +352,15 @@ public void GetThrows()
 
 ## Architecture Decisions
 
-Major architectural decisions are documented as ADRs (Architecture Decision Records) in `docs/adr/`.
+Major architectural decisions are documented as ADRs (Architecture Decision Records) in `docs/adr/`. The full index and policy live in [docs/adr/index.md](docs/adr/index.md).
 
-Before making significant changes, check if an ADR exists. If proposing a new architectural direction, consider writing an ADR.
+**ADRs are living documents, not immutable records.** Each carries a current-state header (`Status`, `Revision`, `Implementation`, dates) and a newest-first Changelog. When a decision evolves:
 
-### Key ADRs
+- **Refinement of an existing decision** → amend the ADR in place: edit the body to present-tense reality, bump `Revision`, add one Changelog line. Don't mint a near-duplicate ADR.
+- **Genuinely new decision area** → a new ADR, copied from [docs/adr/TEMPLATE.md](docs/adr/TEMPLATE.md).
+- **Reversal** → a new ADR that supersedes the old one; the old ADR's Status flips to `Superseded by ADR-NNN` with links both ways. ADRs are never deleted.
 
-| ADR | Topic |
-|-----|-------|
-| [ADR-001](docs/adr/001-world-manager-architecture.md) | World Manager facade pattern |
-| [ADR-004](docs/adr/004-reflection-elimination.md) | Native AOT and reflection elimination |
-| [ADR-006](docs/adr/006-custom-msbuild-sdk.md) | Custom MSBuild SDK |
-| [ADR-007](docs/adr/007-capability-based-plugin-architecture.md) | Plugin architecture |
+Before making significant changes, check if an ADR exists — and if you change what an ADR describes, amend the ADR in the same PR. If proposing a new architectural direction, write an ADR.
 
 ---
 

--- a/docs/adr/001-world-manager-architecture.md
+++ b/docs/adr/001-world-manager-architecture.md
@@ -1,8 +1,10 @@
 # ADR-001: World Manager Architecture
 
-**Status:** Accepted
-**Date:** 2025-12-07
-**Issue:** [#82](https://github.com/orion-ecs/keen-eye/issues/82)
+**Status:** Amended
+**Revision:** v4
+**Implementation:** Shipped
+**First accepted:** 2025-12-07 · **Last amended:** 2026-07-26
+**Relates to:** [#82](https://github.com/orion-ecs/keen-eye/issues/82) · [#332](https://github.com/orion-ecs/keen-eye/issues/332)
 
 ## Context
 
@@ -29,21 +31,30 @@ This violates the Single Responsibility Principle. The class is difficult to:
 
 ## Decision
 
-Refactor `World` into a **facade pattern** with specialized internal managers:
+Refactor `World` into a **facade pattern** with specialized internal managers. The original decision named 11 managers (8 to extract plus 3 pre-existing); the pattern has since absorbed every new World concern, and the shipped architecture is:
 
 ```
-World (facade, target ~300-400 lines)
-├── HierarchyManager      - Parent-child entity relationships
-├── SystemManager         - System registration, ordering, execution
-├── PluginManager         - Plugin lifecycle
-├── SingletonManager      - Global resource storage
-├── ExtensionManager      - Plugin-provided APIs
-├── EntityNamingManager   - Entity name registration and lookup
-├── EventManager          - Component and entity lifecycle events
-├── ChangeTracker         - Dirty flag tracking (enhanced with EntityPool)
-├── ArchetypeManager      - (existing) Component storage
-├── QueryManager          - (existing) Query caching
-└── ComponentRegistry     - (existing) Component type registry
+World (facade)
+├── HierarchyManager           - Parent-child entity relationships
+├── SystemManager              - System registration, ordering, execution
+├── SystemHookManager          - Before/after system execution hooks
+├── PluginManager              - Plugin lifecycle
+├── SingletonManager           - Global resource storage
+├── ExtensionManager           - Plugin-provided APIs
+├── EntityNamingManager        - Entity name registration and lookup
+├── EventManager               - Component and entity lifecycle events
+├── MessageManager             - Inter-system messaging
+├── TagManager                 - String-based entity tagging
+├── ChangeTracker              - Dirty flag tracking with entity reconstruction
+├── ArchetypeManager           - (pre-existing) Component storage
+├── QueryManager               - (pre-existing) Query caching
+├── ComponentRegistry          - (pre-existing) Component type registry
+├── ComponentValidationManager - Component constraint enforcement
+├── SaveManager                - World persistence orchestration
+├── SnapshotManager            - World state serialization (static utility class)
+├── SceneManager               - In-memory scene lifecycle (spawn/unload/transition of tagged entity groups)
+├── StatisticsManager          - Memory and performance stats
+└── ComponentArrayPoolManager  - Component array pooling
 ```
 
 ### Implementation Order
@@ -59,11 +70,11 @@ Extract managers in order of size and isolation (largest/cleanest first):
 7. ✅ **EventManager** (~140 lines) - Consolidates EventBus, ComponentEventHandlers, EntityEventHandlers
 8. ✅ **ChangeTracker** (enhanced) - Added EntityPool dependency for entity reconstruction
 
-**Current Status:** World.cs reduced from 3,073 to ~2,272 lines (~26% reduction)
+**Current Status:** Extraction is complete. `World.cs` proper is 235 lines (core fields, constructor, Dispose), meeting the ~300-400 line facade target. The facade's public surface is organized as partial-class files (`World.Entities.cs`, `World.Systems.cs`, etc.) containing thin one-line delegations to managers — the partial split rejected as Option 1 proved useful as file organization *on top of*, not instead of, manager extraction.
 
 ### Design Constraints
 
-- Managers are `internal` (not public API)
+- Managers default to `internal` (not public API); all eight managers extracted under this ADR are internal. A minority are deliberately public where users need direct access (`ArchetypeManager`, `QueryManager`, `ComponentRegistry`, `ComponentValidationManager`, `ComponentArrayPoolManager`, `SceneManager`), exposed as properties on `World`
 - `World` remains the single entry point (facade pattern)
 - Public API unchanged - **no breaking changes**
 - Each manager takes minimal dependencies
@@ -152,3 +163,12 @@ This exception does not violate per-world isolation principles because worlds ca
 
 - Public API unchanged
 - Performance impact negligible (one extra method call)
+
+---
+
+## Changelog
+
+- **v4 — 2026-07-26 (living-ADR conversion):** Status set to Amended (decision shipped 2025-12-07 and twice amended in place); Implementation: Shipped with no gaps — all eight planned extractions exist as internal managers. Decision diagram expanded from the original 11 managers to the 20 shipped today; obsolete "~2,272 lines" status replaced with the as-built result (World.cs is a 235-line facade with its delegation surface split across partial files); "managers are `internal`" constraint amended to record the deliberately public managers (ArchetypeManager, QueryManager, ComponentRegistry, ComponentValidationManager, ComponentArrayPoolManager, SceneManager).
+- **v3 — 2026-01-04 (49db2cc4 / issue #332):** Added 'Explicit Static State Exceptions' section documenting the ComponentArrayPoolManager static delegate cache (rentDelegates/returnDelegates/lockObj) as an accepted exception to the no-static-state principle, with six justifications.
+- **v2 — 2025-12-07 (fdcfc15a):** Progress update: marked all eight extraction phases complete, added EntityNamingManager, EventManager, and enhanced ChangeTracker to the architecture diagram, and recorded World.cs reduction from 3,073 to ~2,272 lines.
+- **v1 — 2025-12-07 (b25913ab / issue #82):** Accepted — refactor the 3,073-line World class into a facade over specialized internal managers to restore single responsibility, testability, and maintainability.

--- a/docs/adr/002-iworld-entity-lifecycle-events.md
+++ b/docs/adr/002-iworld-entity-lifecycle-events.md
@@ -1,8 +1,10 @@
 # ADR-002: Complete IWorld Event System
 
 **Status:** Accepted
-**Date:** 2025-12-10
-**Issue:** [#206](https://github.com/tyevco/keen-eye/issues/206) (Phase 1: Grid-Based Spatial Partitioning)
+**Revision:** v3
+**Implementation:** Shipped
+**First accepted:** 2025-12-10 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-001](001-world-manager-architecture.md) (World managers) · [ADR-003](003-command-buffer-abstraction.md) (CommandBuffer) · [#206](https://github.com/orion-ecs/keen-eye/issues/206)
 
 ## Context
 
@@ -169,7 +171,7 @@ public EventSubscription OnEntityDestroyed(Action<Entity> handler)
     => eventManager.OnEntityDestroyed(handler);
 ```
 
-3. **Fire component events during entity creation** using delegate-per-component-type pattern (see ADR-003 for details):
+3. **Fire component events during entity creation** using a delegate-per-component-type pattern (this ADR is the authoritative record of the pattern; [ADR-003](003-command-buffer-abstraction.md) and [ADR-004](004-reflection-elimination.md) apply the same reflection-free delegate approach elsewhere in the engine):
 ```csharp
 // In World.CreateEntity()
 foreach (var (info, data) in components)
@@ -245,7 +247,7 @@ Wait for more plugin use cases before expanding IWorld:
 - **Plugins can react to entity lifecycle** without internal World access
 - **SpatialPlugin works correctly** - entities indexed on creation, removed on destruction
 - **Consistent event model** - both entities and components have lifecycle events
-- **No reflection overhead** - component events use delegate-per-type pattern (see ADR-003)
+- **No reflection overhead** - component events use the delegate-per-type pattern described in Implementation Strategy above; [ADR-003](003-command-buffer-abstraction.md) and [ADR-004](004-reflection-elimination.md) apply the same reflection-free approach elsewhere
 - **Symmetric API** - creation and destruction both have events
 - **Cleaner abstractions** - All IWorld signature types now in Abstractions package
 
@@ -308,12 +310,13 @@ All 2114 tests passing with 0 warnings.
 
 ## Related Decisions
 
-- **ADR-003** (TBD): Reflection-Free Component Event Dispatching - Details the delegate-per-type pattern used to fire component events with boxed data
-- **ADR-001**: World Manager Architecture - EventManager consolidation enables this change
+- [ADR-003](003-command-buffer-abstraction.md): CommandBuffer Abstraction and Reflection Elimination - Applies the same delegate-capture approach to command execution. (A separate ADR titled "Reflection-Free Component Event Dispatching" was originally planned but never written; the delegate-per-component-type event dispatch pattern is documented in this ADR's Implementation Strategy.)
+- [ADR-004](004-reflection-elimination.md): Reflection Elimination for AOT Compatibility - The broader reflection-elimination record
+- [ADR-001](001-world-manager-architecture.md): World Manager Architecture - EventManager consolidation enables this change
 
 ## References
 
-- Issue [#206](https://github.com/tyevco/keen-eye/issues/206) - Phase 1: Grid-Based Spatial Partitioning
+- Issue [#206](https://github.com/orion-ecs/keen-eye/issues/206) - Phase 1: Grid-Based Spatial Partitioning
 - Commit: "Complete IWorld event system + fire component events during entity creation"
 - Files changed:
   - `src/KeenEyes.Abstractions/IWorld.cs` - Added `Set<T>`, `OnComponentChanged<T>`, `OnEntityCreated`, `OnEntityDestroyed`
@@ -323,7 +326,7 @@ All 2114 tests passing with 0 warnings.
   - `src/KeenEyes.Abstractions/IQueryBuilder.cs` - New (IWorld.Query() return types)
   - `src/KeenEyes.Core/World.Entities.cs` - Fire component/entity events during creation
   - `src/KeenEyes.Core/EventManager.cs` - Expose entity event subscriptions
-  - `src/KeenEyes.Core/ComponentRegistry.cs` - Add IComponent constraint, setup event dispatchers
+  - `src/KeenEyes.Core/Components/ComponentRegistry.cs` - Add IComponent constraint, setup event dispatchers
   - `src/KeenEyes.Spatial/Systems/SpatialUpdateSystem.cs` - Subscribe to entity destroyed
 
 ### IWorld Evolution
@@ -340,3 +343,11 @@ All 2114 tests passing with 0 warnings.
 - Added: `OnEntityDestroyed` - React to entity destruction
 
 This evolution reflects the lesson that plugin isolation requires **complete** lifecycle coverage, not minimal surface area. Incomplete interfaces force workarounds (casting, fragile event ordering) that defeat the purpose of abstraction.
+
+---
+
+## Changelog
+
+- **v3 — 2026-07-26 (living-ADR conversion):** Converted to living-document header; status stays Accepted, Implementation: Shipped — every specified API verified in code (IWorld.Set/OnComponentChanged/OnEntityCreated/OnEntityDestroyed, Abstractions type moves, FireAddedBoxed dispatch, SpatialUpdateSystem wiring). Body amended to correct the forward reference to a planned "ADR-003: Reflection-Free Component Event Dispatching" that was never written under that scope — the shipped ADR-003 is the CommandBuffer abstraction record, and this ADR remains the authoritative documentation of the delegate-per-component-type event dispatch pattern (ADR-004 covers broader reflection elimination). Fixed wrong-org issue links (tyevco → orion-ecs) and the moved ComponentRegistry.cs path.
+- **v2 — 2025-12-10 (1a875176):** Added 'Supporting Architecture Changes' section documenting the moves of EventSubscription, IEntityBuilder, SystemBase into KeenEyes.Abstractions and the new IQueryBuilder interfaces, plus the corresponding Consequences bullets and Files-changed entries.
+- **v1 — 2025-12-10 (#206, f04b516c):** Accepted — Complete the IWorld interface with full lifecycle coverage (Set<T>, OnComponentChanged<T>, OnEntityCreated, OnEntityDestroyed) and fire component events during entity creation via a delegate-per-component-type pattern, so stateful plugins like SpatialPlugin can index entities correctly.

--- a/docs/adr/003-command-buffer-abstraction.md
+++ b/docs/adr/003-command-buffer-abstraction.md
@@ -1,8 +1,10 @@
 # ADR-003: CommandBuffer Abstraction and Reflection Elimination
 
 **Status:** Accepted
-**Date:** 2025-12-10
-**Related Work:** Plugin Architecture, Performance Optimization
+**Revision:** v3
+**Implementation:** Shipped
+**First accepted:** 2025-12-10 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-001](001-world-manager-architecture.md) (World managers) · [ADR-002](002-iworld-entity-lifecycle-events.md) (IWorld events)
 
 ## Context
 
@@ -81,8 +83,11 @@ KeenEyes.Abstractions/
     ├── AddComponentCommand.cs   (delegate-based, no reflection)
     ├── DespawnCommand.cs
     ├── RemoveComponentCommand.cs
-    └── SetComponentCommand.cs
+    ├── SetComponentCommand.cs
+    └── PlaceholderResolvingCommand.cs  (base class: resolves same-buffer placeholder entities at flush time)
 ```
+
+Spawn commands return negative placeholder IDs, which later commands in the same buffer can target; `PlaceholderResolvingCommand` (added after the initial move) resolves these placeholders to real entities at flush time.
 
 **Key Changes:**
 
@@ -320,20 +325,19 @@ All 2,172 tests passing, zero warnings.
 
 ## Future Considerations
 
-- **Command Pooling** - Reuse command objects to reduce GC pressure
+- ✅ **Command Pooling** - Shipped as `CommandBufferPool` (`src/KeenEyes.Core/Parallelism/CommandBufferPool.cs`): per-system isolated buffers for parallel system execution, with thread-safe rent/return and deterministic ordered merging against a shared placeholder-to-entity map
 - **Batch Optimization** - Process similar commands together for cache efficiency
 - **Async Commands** - Support for async/await in command execution
 - **Command Validation** - Pre-execution validation for debugging
 
 ## Related Decisions
 
-- **ADR-001**: World Manager Architecture - EventManager provides command execution infrastructure
-- **ADR-002**: Complete IWorld Event System - IWorld.Spawn() must return IEntityBuilder
+- [ADR-001](001-world-manager-architecture.md): World Manager Architecture - EventManager provides command execution infrastructure
+- [ADR-002](002-iworld-entity-lifecycle-events.md): IWorld Entity Lifecycle Events - IWorld.Spawn() must return IEntityBuilder
 
 ## References
 
-- Commit: "refactor: Enhance CommandBuffer and generator for plugin architecture"
-- Commit: "refactor: Move CommandBuffer implementation to Abstractions"
+- Commit: dd4e5bf0 ("refactor: Enhance CommandBuffer and generator for plugin architecture") - the entire move and reflection elimination landed in this single commit
 - Files changed:
   - `src/KeenEyes.Abstractions/ICommandBuffer.cs` - New interface
   - `src/KeenEyes.Abstractions/CommandBuffer.cs` - Moved from Core
@@ -360,3 +364,11 @@ All 2,172 tests passing, zero warnings.
 - Generated methods work with interfaces and concrete types
 
 This evolution reflects the principle that **performance and isolation should not be opposing goals**. By combining the delegate capture pattern with dual method generation, we achieve both zero-reflection performance and clean plugin isolation without compromise.
+
+---
+
+## Changelog
+
+- **v3 — 2026-07-26 (living-ADR conversion):** Converted to living-document format; Status remains Accepted, Implementation: Shipped (fully verified — command system in Abstractions, zero reflection, Core/Commands removed, dual generator output). Body amended to as-built reality: `PlaceholderResolvingCommand.cs` added to the Commands/ listing (same-buffer placeholder resolution at flush time), the "Command Pooling" future item marked shipped as `CommandBufferPool`; Related Decisions converted to links with the ADR-002 title corrected to "IWorld Entity Lifecycle Events", and References fixed to the single real commit dd4e5bf0 (the second cited commit never existed).
+- **v2 — 2025-12-31 (e636b5b3):** Reference path updated from src/KeenEyes.Generators/ComponentGenerator.cs to editor/KeenEyes.Generators/ComponentGenerator.cs as part of the repo-wide move of generators/SDK projects to editor/ (one-line change; otherwise mechanical).
+- **v1 — 2025-12-10 (dd4e5bf0):** Accepted — Move the entire CommandBuffer system from Core to KeenEyes.Abstractions and eliminate reflection via the delegate-capture pattern, giving plugins Core-free access and ~20-50x faster command execution; generator emits dual (generic + interface) extension methods.

--- a/docs/adr/004-reflection-elimination.md
+++ b/docs/adr/004-reflection-elimination.md
@@ -1,7 +1,10 @@
 # ADR-004: Reflection Elimination for AOT Compatibility
 
-**Status:** Proposed
-**Date:** 2025-12-11
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Shipped
+**First accepted:** 2025-12-11 · **Last amended:** 2026-07-26
+**Relates to:** [#1079](https://github.com/orion-ecs/keen-eye/issues/1079)
 
 ## Context
 
@@ -50,125 +53,131 @@ However, reflection remains as fallback paths or in areas not yet addressed by g
 
 ## Decision
 
-Eliminate all reflection from production code using these patterns:
+Eliminate all reflection from production code using these patterns (all five shipped; the code below reflects the as-built implementation):
 
 ### Pattern 1: Factory Delegate Registration (ArchetypeChunk)
 
-Store factory delegates at component registration time when the generic type is known:
+`ComponentInfo` carries a `CreateComponentArray` factory delegate, assigned at component registration time when the generic type is known:
 
 ```csharp
 // In ComponentInfo
-public Func<int, IComponentArray> ArrayFactory { get; }
+internal Func<int, IComponentArray>? CreateComponentArray { get; set; }
 
-// At registration (type is known)
-public ComponentInfo Register<T>(bool isTag = false) where T : struct, IComponent
-{
-    return new ComponentInfo
-    {
-        ArrayFactory = capacity => new FixedComponentArray<T>(capacity),
-        // ...
-    };
-}
+// Assigned in ComponentRegistry.Register<T> (type is known)
+CreateComponentArray = capacity => new FixedComponentArray<T>(capacity),
 
-// Usage - no reflection
-var array = componentInfo.ArrayFactory(capacity);
+// Usage in the ArchetypeChunk constructor - no reflection
+var array = info.CreateComponentArray!(capacity);
 ```
+
+No `Activator.CreateInstance` or `MakeGenericType` remains anywhere in `KeenEyes.Core`.
 
 ### Pattern 2: Typed Wrapper Interface (MessageManager)
 
-Replace `Dictionary<Type, object>` with typed wrappers that implement a common interface:
+`MessageManager` stores queues as `Dictionary<Type, IMessageQueueWrapper>`, where the wrapper is a private nested typed class implementing a type-erased interface:
 
 ```csharp
-internal interface IMessageQueue
+private interface IMessageQueueWrapper
 {
-    void Process(object handlers);
-    void Clear();
     int Count { get; }
+    void Clear();
+    void Process(object handlersObj);
 }
 
-internal sealed class MessageQueue<T> : IMessageQueue
+private sealed class MessageQueueWrapper<T> : IMessageQueueWrapper
 {
-    private readonly Queue<T> queue = new();
+    public Queue<T> Queue { get; } = new();
 
-    public void Process(object handlers)
+    public int Count => Queue.Count;
+
+    public void Clear() => Queue.Clear();
+
+    public void Process(object handlersObj)
     {
-        var handlerList = (List<Action<T>>)handlers;
-        while (queue.Count > 0)
+        var handlerList = (List<Action<T>>)handlersObj;
+
+        // Snapshot the handler list so a handler can safely unsubscribe mid-dispatch
+        var snapshot = handlerList.ToArray();
+
+        while (Queue.Count > 0)
         {
-            var msg = queue.Dequeue();
-            foreach (var handler in handlerList)
-                handler(msg);
+            var message = Queue.Dequeue();
+
+            for (int i = 0; i < snapshot.Length; i++)
+            {
+                snapshot[i](message);
+            }
         }
     }
-    // ...
 }
 ```
+
+Processing dispatches through the wrapper with no `MakeGenericMethod`/`Invoke`.
 
 ### Pattern 3: Stored Invokers (ComponentValidationManager)
 
-Cache typed invoker delegates at registration time:
+Validator invocation is AOT-safe via `ComponentInfo.InvokeValidator`, a typed delegate captured once at component registration (consolidated onto `ComponentInfo` rather than a separate invoker dictionary):
 
 ```csharp
-private readonly Dictionary<Type, Func<Entity, object, Delegate, bool>> validatorInvokers = [];
+// In ComponentInfo
+internal Func<World, Entity, object, Delegate, bool>? InvokeValidator { get; set; }
 
-public void RegisterValidator<T>(ComponentValidator<T> validator) where T : struct, IComponent
+// Assigned in ComponentRegistry.Register<T>
+InvokeValidator = (world, entity, data, validator) =>
 {
-    customValidators[typeof(T)] = validator;
-    validatorInvokers[typeof(T)] = (entity, data, del) =>
-    {
-        var typed = (ComponentValidator<T>)del;
-        return typed(world, entity, (T)data);
-    };
+    var typedValidator = (ComponentValidator<T>)validator;
+    var component = (T)data;
+    return typedValidator(world, entity, component);
 }
 ```
+
+`ComponentValidationManager` calls this delegate to invoke custom validators without reflection. No `GetCustomAttributes` or assembly scanning remains in `KeenEyes.Core`.
 
 ### Pattern 4: Applicator Delegates (PrefabManager)
 
-Store typed applicators in component definitions:
+The applicator-delegate pattern shipped as `ComponentInfo.ApplyToBuilder` / `ApplyTagToBuilder`, assigned at component registration:
 
 ```csharp
-public sealed class ComponentDefinition
-{
-    public Action<EntityBuilder>? Applicator { get; init; }
-}
+// In ComponentInfo
+internal Action<EntityBuilder, object>? ApplyToBuilder { get; set; }
+internal Action<EntityBuilder>? ApplyTagToBuilder { get; set; }
 
-public static ComponentDefinition Create<T>(T component) where T : struct, IComponent
-{
-    return new ComponentDefinition
-    {
-        Type = typeof(T),
-        Data = component,
-        Applicator = builder => builder.With(component)
-    };
-}
+// Assigned in ComponentRegistry.Register<T>
+ApplyToBuilder = (builder, boxedValue) => builder.With((T)boxedValue),
 ```
+
+The original consumer — the runtime prefab API (`PrefabManager`, `EntityPrefab`, `ComponentDefinition`) — was removed entirely in July 2026 ([#1079](https://github.com/orion-ecs/keen-eye/issues/1079)); prefabs are now `.keprefab` assets with source-generated spawn methods, which never used reflection. The applicator delegates remain in use for boxed component application generally.
 
 ### Pattern 5: Extended Serializer Interface (SnapshotManager)
 
-Extend `IComponentSerializer` to handle registration and singleton operations:
+`IComponentSerializer` exposes registration and singleton operations over `ISerializationCapability`:
 
 ```csharp
 public interface IComponentSerializer
 {
     // Existing...
 
-    ComponentInfo? Register(ComponentRegistry registry, string typeName, bool isTag);
-    bool SetSingleton(World world, string typeName, object value);
+    ComponentInfo? RegisterComponent(ISerializationCapability serialization, string typeName, bool isTag);
+    bool SetSingleton(ISerializationCapability serialization, string typeName, object value);
 }
 
-// Generated implementation uses switch on type names
-public ComponentInfo? Register(ComponentRegistry registry, string typeName, bool isTag)
+// SerializationGenerator emits switch-on-type-name implementations
+public ComponentInfo? RegisterComponent(ISerializationCapability serialization, string typeName, bool isTag)
 {
     return typeName switch
     {
-        "MyGame.Position" => registry.Register<Position>(isTag),
-        "MyGame.Velocity" => registry.Register<Velocity>(isTag),
+        "MyGame.Position" => serialization.Components.Register<Position>(isTag),
+        "MyGame.Velocity" => serialization.Components.Register<Velocity>(isTag),
         _ => null
     };
 }
 ```
 
+`SnapshotManager` and `DeltaRestorer` route all deserialization-time component registration and singleton restoration through these methods — no `MakeGenericMethod` or `Type.GetType`.
+
 ### Implementation Order
+
+All five refactors were implemented on 2025-12-11, the same day this ADR was written (commit e823210c eliminated the reflection, fd61ece6 removed the remaining fallback paths). The priority table below is preserved as the original plan; the `PrefabManager.cs` row is now moot since the runtime prefab API was removed entirely in [#1079](https://github.com/orion-ecs/keen-eye/issues/1079).
 
 | Priority | File | Effort | Justification |
 |----------|------|--------|---------------|
@@ -177,6 +186,8 @@ public ComponentInfo? Register(ComponentRegistry registry, string typeName, bool
 | 3 | PrefabManager.cs | Medium | Only at prefab spawn; store applicators at definition time |
 | 4 | SnapshotManager.cs | Medium | Only at save/load; extend existing `IComponentSerializer` |
 | 5 | ComponentValidationManager.cs | Low | Already has generated path; enhance with stored invokers |
+
+Compliance is continuously enforced: the [aot-compatibility workflow](../../.github/workflows/aot-compatibility.yml) gates every PR with an AOT-analyzer build, then natively publishes and runs `tests/KeenEyes.AotCompatibility.Tests` and [`samples/KeenEyes.Sample.Aot`](../../samples/KeenEyes.Sample.Aot/) on linux-x64, win-x64, and osx-arm64 with `-warnaserror`.
 
 ## Alternatives Considered
 
@@ -232,7 +243,7 @@ Keep reflection and document that Native AOT is not supported.
 
 ### Positive
 
-- **Native AOT Compatible**: All production code will work with `PublishAot=true`
+- **Native AOT Compatible**: All production code publishes and runs under `PublishAot=true`, verified on every PR by the aot-compatibility workflow (analyzer build plus native publish and execution of an AOT test project and sample on linux-x64, win-x64, and osx-arm64 with zero trimming warnings)
 - **Trimming Safe**: No runtime type discovery; IL Linker can safely trim
 - **Better Performance**: Delegate calls are ~100x faster than `MethodInfo.Invoke`
 - **Compile-Time Safety**: Type errors caught at build time, not runtime
@@ -249,7 +260,7 @@ Keep reflection and document that Native AOT is not supported.
 ### Neutral
 
 - **Public API Unchanged**: All changes are internal
-- **Fallback Preserved**: Reflection can remain for edge cases with clear documentation
+- **Fallbacks Removed**: No reflection fallbacks remain in production code — commit fd61ece6 removed them, and the repo-wide policy (CLAUDE.md "No Reflection in Production Code") plus the AOT CI gate prevent reintroduction. Test code and `#if DEBUG` diagnostics are the only sanctioned exceptions
 - **Testing Required**: Each refactored area needs additional unit tests
 
 ## References
@@ -257,3 +268,12 @@ Keep reflection and document that Native AOT is not supported.
 - [.NET Native AOT Deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/)
 - [Trimming and Native AOT Warnings](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings)
 - [Source Generators Overview](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview)
+- [AOT compatibility CI workflow](../../.github/workflows/aot-compatibility.yml)
+- [AOT sample project](../../samples/KeenEyes.Sample.Aot/)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted — all five reflection eliminations shipped 2025-12-11 (commits e823210c, fd61ece6) and Implementation is Shipped, gated by the three-OS AOT CI workflow. Decision patterns amended to as-built names and signatures (`ArrayFactory` → `ComponentInfo.CreateComponentArray`; `IMessageQueue`/`MessageQueue<T>` → private nested `IMessageQueueWrapper`/`MessageQueueWrapper<T>`; `validatorInvokers` dictionary → `ComponentInfo.InvokeValidator`; serializer `Register`/`SetSingleton` → `RegisterComponent`/`SetSingleton` over `ISerializationCapability`). Noted that the runtime prefab API targeted by Pattern 4 was deleted in #1079 (replaced by `.keprefab` assets with source-generated spawn methods, applicator delegates retained as `ComponentInfo.ApplyToBuilder`/`ApplyTagToBuilder`). Consequences amended: reflection fallbacks were removed outright rather than preserved, and AOT compatibility is now continuously CI-verified.
+- **v1 — 2025-12-11 (b714ad14):** Proposed — eliminate all reflection (~34 operations across 5 KeenEyes.Core files) via factory delegates, typed queue wrappers, stored invokers, applicator delegates, and an extended IComponentSerializer, to make the runtime Native-AOT compatible. Implementation landed in code the same day (commits e823210c, fd61ece6) without further edits to the ADR itself.

--- a/docs/adr/005-graphics-input-abstraction-layers.md
+++ b/docs/adr/005-graphics-input-abstraction-layers.md
@@ -1,7 +1,9 @@
 # ADR-005: Graphics and Input Abstraction Layers
 
 **Status:** Accepted
-**Date:** 2025-12-16
+**Revision:** v2
+**Implementation:** Shipped
+**First accepted:** 2025-12-16 · **Last amended:** 2026-07-26
 
 ## Context
 
@@ -57,19 +59,19 @@ Create a layered abstraction architecture that separates loop management from gr
 │   (Core loop contract)                                       │
 └─────────────────────────────────────────────────────────────┘
                               │
-          ┌───────────────────┴───────────────────┐
-          ▼                                       ▼
-┌─────────────────────────┐         ┌─────────────────────────┐
-│ KeenEyes.Graphics       │         │ KeenEyes.Input          │
-│ .Abstractions           │         │ .Abstractions           │
-│ IGraphicsContext        │         │ IInputContext           │
-│ (extends ILoopProvider) │         │ (extends ILoopProvider) │
-└─────────────────────────┘         └─────────────────────────┘
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│   KeenEyes.Platform.Silk (+ Platform.Silk.Abstractions)      │
+│   SilkWindowPlugin registers SilkLoopProvider                 │
+│   (Owns the window and the main loop)                         │
+└─────────────────────────────────────────────────────────────┘
           │                                       │
           ▼                                       ▼
 ┌─────────────────────────┐         ┌─────────────────────────┐
-│ KeenEyes.Graphics.Silk  │         │ KeenEyes.Input.Silk     │
-│ (Silk.NET OpenGL impl)  │         │ (Silk.NET input impl)   │
+│ KeenEyes.Graphics       │         │ KeenEyes.Input          │
+│ .Abstractions / .Silk   │         │ .Abstractions / .Silk   │
+│ IGraphicsContext        │         │ IInputContext           │
+│ (subscribes to loop)    │         │ (subscribes to loop)    │
 └─────────────────────────┘         └─────────────────────────┘
 ```
 
@@ -91,6 +93,10 @@ public interface ILoopProvider
     void Initialize();
     void Run();
     bool IsInitialized { get; }
+
+    // Render-thread marshaling for operations needing the GL context
+    Task<T> InvokeOnRenderThreadAsync<T>(Func<T> action);
+    void InvokeOnRenderThread(Action action);
 }
 ```
 
@@ -116,15 +122,15 @@ Key features:
 - **Backend-agnostic**: Works with any `ILoopProvider` implementation
 - **Consistent API**: Same pattern regardless of graphics backend or input-only mode
 
-#### IGraphicsContext Extension
+#### Loop Ownership (Platform Layer)
 
-`IGraphicsContext` now extends `ILoopProvider`:
+The loop contract sits below the graphics and input layers: neither `IGraphicsContext` nor `IInputContext` extends `ILoopProvider` — both are `IDisposable` only. A dedicated platform layer (`KeenEyes.Platform.Silk` / `KeenEyes.Platform.Silk.Abstractions`) owns windowing and the main loop: `SilkWindowPlugin` registers `SilkLoopProvider` as the world's `ILoopProvider`, and the graphics and input plugins subscribe to that shared loop.
 
 ```csharp
-public interface IGraphicsContext : ILoopProvider, IDisposable
+public interface IGraphicsContext : IDisposable
 {
     // Graphics-specific members (meshes, textures, shaders)
-    // Loop members inherited from ILoopProvider
+    // Use ILoopProvider (from SilkWindowPlugin) for the main loop
 }
 ```
 
@@ -132,25 +138,46 @@ public interface IGraphicsContext : ILoopProvider, IDisposable
 
 ```
 KeenEyes.Abstractions (IWorld, ILoopProvider)
-    ↑
-KeenEyes.Runtime (WorldRunnerBuilder)
-    ↑
-KeenEyes.Graphics.Abstractions (IGraphicsContext : ILoopProvider)
-    ↑
-KeenEyes.Graphics.Silk (SilkGraphicsContext implementation)
+    ↑                              ↑
+KeenEyes.Runtime          KeenEyes.Platform.Silk.Abstractions
+(WorldRunnerBuilder)               ↑
+                          KeenEyes.Platform.Silk
+                          (SilkWindowPlugin, SilkLoopProvider)
+                               ↑              ↑
+                 KeenEyes.Graphics.Silk   KeenEyes.Input.Silk
+                 (rendering only)         (input only)
 ```
+
+The Silk graphics and input packages depend on the platform layer for the loop; they contribute no loop implementation of their own.
 
 ### Registration
 
-Plugins register as both specific and abstract types:
+Registration is split by responsibility. `SilkWindowPlugin` (KeenEyes.Platform.Silk) registers the `ILoopProvider` extension that enables `WorldRunnerBuilder`:
 
 ```csharp
+// SilkWindowPlugin — owns window and loop
 public void Install(IPluginContext context)
 {
-    graphicsContext = new SilkGraphicsContext(config);
+    provider = new SilkWindowProvider(config);
+    var loopProvider = new SilkLoopProvider(provider);
+
+    context.SetExtension<ISilkWindowProvider>(provider);
+    context.SetExtension<ILoopProvider>(loopProvider);  // Enables WorldRunnerBuilder
+}
+```
+
+`SilkGraphicsPlugin` registers only graphics-facing extensions and requires the window plugin to be installed first:
+
+```csharp
+// SilkGraphicsPlugin — graphics-facing extensions only
+public void Install(IPluginContext context)
+{
+    graphicsContext = new SilkGraphicsContext(windowProvider, config);
 
     context.SetExtension<IGraphicsContext>(graphicsContext);
-    context.SetExtension<ILoopProvider>(graphicsContext);  // Enables WorldRunnerBuilder
+    context.SetExtension<I2DRendererProvider>(graphicsContext);
+    context.SetExtension<ITextRendererProvider>(graphicsContext);
+    context.SetExtension<IFontManagerProvider>(graphicsContext);
 }
 ```
 
@@ -206,10 +233,10 @@ world.Run();  // World contains loop logic
 |---------|-------------|
 | **Backend swapping** | Replace `SilkGraphicsPlugin` with `SDLGraphicsPlugin` without changing application code |
 | **Platform migration** | Same game code runs on different platforms with appropriate backend |
-| **Testability** | Mock `ILoopProvider` for testing loop-dependent logic |
+| **Testability** | Mock `ILoopProvider` for testing loop-dependent logic (`MockLoopProvider` ships in `KeenEyes.Testing`) |
 | **Reduced boilerplate** | Auto-update removes repetitive `world.Update()` wiring |
 | **Consistent patterns** | Follows existing builder patterns (EntityBuilder, QueryBuilder) |
-| **Future-proof** | Input, audio, and other systems can provide loops |
+| **Future-proof** | Input, audio, and other systems share the platform-provided loop |
 
 ### Negative
 
@@ -221,24 +248,32 @@ world.Run();  // World contains loop logic
 
 ### Neutral
 
-- Existing `IGraphicsContext` event wiring still works (for advanced use cases)
+- Direct event wiring against `ILoopProvider` still works (for advanced use cases)
 - No changes to component, system, or query APIs
 - Build complexity unchanged (packages already existed)
 
 ## Future Work
 
-This architecture enables planned features:
+This architecture enabled planned features; status as of the latest revision:
 
-1. **Input Abstraction** (`KeenEyes.Input.Abstractions`)
-   - `IInputContext : ILoopProvider`
+1. **Input Abstraction** (`KeenEyes.Input.Abstractions`) — ✅ Shipped
+   - `KeenEyes.Input.Abstractions` and `KeenEyes.Input.Silk` exist
+   - `IInputContext : IDisposable` — input subscribes to the platform-provided loop rather than providing one
    - Backend-agnostic input polling and events
-   - Same builder pattern
 
-2. **Headless Loop Provider**
+2. **Headless Loop Provider** — Not yet implemented
    - Simple timer-based loop for servers
    - No window or graphics dependency
-   - Enables CLI tools and dedicated servers
+   - Would enable CLI tools and dedicated servers
+   - The only `ILoopProvider` implementations today are `SilkLoopProvider` (windowed, KeenEyes.Platform.Silk) and `MockLoopProvider` (test-only, KeenEyes.Testing)
 
-3. **Multi-Backend Applications**
+3. **Multi-Backend Applications** — Not yet implemented
    - Swap backends at runtime (e.g., Vulkan fallback to OpenGL)
    - Platform-specific backend selection
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status Accepted confirmed; Implementation marked Shipped. Decision amended to as-built loop ownership: `IGraphicsContext`/`IInputContext` no longer extend `ILoopProvider` — the platform layer (`KeenEyes.Platform.Silk`) owns window and loop, with `SilkWindowPlugin` registering `SilkLoopProvider` and `SilkGraphicsPlugin` registering graphics-facing extensions only; architecture and package-dependency diagrams and the registration example updated to match. Future Work updated: input abstraction shipped (as `IInputContext : IDisposable`); headless server loop provider and runtime multi-backend swapping remain unimplemented (`MockLoopProvider` covers testing only).
+- **v1 — 2025-12-16 (e63b8c0b):** Accepted — introduce layered loop abstraction: ILoopProvider in KeenEyes.Abstractions plus WorldRunnerBuilder in KeenEyes.Runtime, separating main-loop orchestration from the Silk.NET graphics backend and paving the way for backend-agnostic input.

--- a/docs/adr/006-custom-msbuild-sdk.md
+++ b/docs/adr/006-custom-msbuild-sdk.md
@@ -1,7 +1,9 @@
 # ADR-006: Custom MSBuild SDK for KeenEyes Projects
 
 **Status:** Accepted
-**Date:** 2025-12-18
+**Revision:** v2
+**Implementation:** Shipped
+**First accepted:** 2025-12-18 · **Last amended:** 2026-07-26
 
 ## Context
 
@@ -43,8 +45,8 @@ Create custom MSBuild SDK packages that encapsulate KeenEyes conventions and dep
 
 | Package | Target Use Case | Default Dependencies |
 |---------|-----------------|---------------------|
-| `KeenEyes.Sdk` | Games and applications | Core + Generators |
-| `KeenEyes.Sdk.Plugin` | Plugin libraries | Abstractions + Generators |
+| `KeenEyes.Sdk` | Games and applications | Core + Generators + Shaders.Generator |
+| `KeenEyes.Sdk.Plugin` | Plugin libraries | Abstractions + Generators (opt-in Common) |
 | `KeenEyes.Sdk.Library` | Reusable ECS libraries | Core + Generators (private) |
 
 ### Minimal Project File
@@ -62,31 +64,41 @@ The SDK automatically:
 - Sets `OutputType=Exe` (for main SDK) or `Library` (for Plugin/Library SDKs)
 - Enables `IsAotCompatible=true`
 - References appropriate KeenEyes packages with correct attributes
-- Defines custom ItemGroup types for editor integration
+- Defines custom ItemGroup types and auto-detects KeenEyes file types for build-time processing
+
+Package references per flavor:
+
+- `KeenEyes.Sdk` references `KeenEyes.Core`, `KeenEyes.Generators` (as analyzer), and
+  `KeenEyes.Shaders.Generator` (as analyzer, for KESL shader compilation). Each is individually
+  opt-out via `IncludeKeenEyesCore`, `IncludeKeenEyesGenerators`, and `IncludeKeenEyesShaders`.
+- `KeenEyes.Sdk.Plugin` references `KeenEyes.Abstractions` (opt-out via
+  `IncludeKeenEyesAbstractions`) and `KeenEyes.Generators`, with opt-in `KeenEyes.Common`
+  (`IncludeKeenEyesCommon=true`).
+- `KeenEyes.Sdk.Library` references `KeenEyes.Core` and `KeenEyes.Generators` with
+  `PrivateAssets=all` on Generators, so the analyzer does not flow to library consumers.
 
 ### Custom ItemGroups
 
-The SDK defines item types for future editor and build pipeline integration:
+The SDK defines six item types for editor and build pipeline integration:
+
+| Item Type | File Extension | Handling |
+|-----------|----------------|----------|
+| `KeenEyesScene` | `.kescene` | Auto-detected, fed to source generators |
+| `KeenEyesPrefab` | `.keprefab` | Auto-detected, fed to source generators |
+| `KeenEyesWorld` | `.keworld` | Auto-detected, fed to source generators |
+| `KeenEyesShader` | `.kesl` | Auto-detected, fed to the KESL shader generator |
+| `KeenEyesAsset` | any | Copied to the output directory by the `CopyKeenEyesAssets` target |
+| `KeenEyesSystem` | — | ItemDefinitionGroup metadata for system declarations |
+
+Scene, prefab, world, and shader files are auto-detected by glob in `Sdk.targets` and forwarded
+as `AdditionalFiles` to the KeenEyes source generators, so consumers do not declare these
+ItemGroups manually — dropping a `.kescene` or `.kesl` file anywhere in the project is enough.
+Explicit declarations remain possible for `KeenEyesAsset` items:
 
 ```xml
-<!-- Scene definitions -->
-<ItemGroup>
-  <KeenEyesScene Include="Scenes/**/*.kescene" />
-</ItemGroup>
-
-<!-- Prefab templates -->
-<ItemGroup>
-  <KeenEyesPrefab Include="Prefabs/**/*.keprefab" />
-</ItemGroup>
-
 <!-- Game assets (auto-copied to output) -->
 <ItemGroup>
   <KeenEyesAsset Include="Assets/**/*" />
-</ItemGroup>
-
-<!-- World configuration -->
-<ItemGroup>
-  <KeenEyesWorld Include="Worlds/**/*.keworld" />
 </ItemGroup>
 ```
 
@@ -101,16 +113,23 @@ The SDK generates `keeneyes.project.json` in the output directory:
   "sdkVersion": "0.1.0",
   "coreVersion": "0.1.0",
   "targetFramework": "net10.0",
+  "outputType": "Exe",
   "isAotCompatible": true,
   "features": ["ECS", "SourceGenerators", "AOT"]
 }
 ```
+
+The Library SDK variant additionally records `isPackable`. Every build also writes
+`keeneyes.version.json` (SDK, Core, and minimum-Core versions) to the intermediate output path
+for version-compatibility checking.
 
 This enables:
 - Editor project detection without loading the full MSBuild graph
 - Version compatibility checking
 - Upgrade path recommendations
 - Feature flag queries
+
+Editor-side consumption of these files is not yet implemented (see Future Considerations).
 
 ### Version Properties
 
@@ -173,7 +192,7 @@ Create a package with `.props` and `.targets` files instead of an SDK:
 - **Version coupling** - SDK version implies compatible package versions
 - **Editor foundation** - Project detection, metadata, custom item types ready
 - **Upgrade tooling** - Version properties enable compatibility checking
-- **Asset pipeline ready** - Custom ItemGroups for future build-time processing
+- **Asset pipeline active** - Scene, prefab, world, and shader files auto-flow to source generators at build time; assets auto-copy to output
 
 ### Negative
 
@@ -225,12 +244,27 @@ Users can disable automatic references:
 <PropertyGroup>
   <IncludeKeenEyesCore>false</IncludeKeenEyesCore>
   <IncludeKeenEyesGenerators>false</IncludeKeenEyesGenerators>
+  <IncludeKeenEyesShaders>false</IncludeKeenEyesShaders>
 </PropertyGroup>
 ```
 
+The Plugin SDK additionally offers `IncludeKeenEyesAbstractions` (opt-out) and
+`IncludeKeenEyesCommon` (opt-in, default `false`).
+
 ## Future Considerations
 
-1. **Editor integration** - Read `keeneyes.project.json` for project discovery
-2. **Asset processing** - Build targets for scene/prefab compilation
-3. **Analyzers** - Include KeenEyes-specific Roslyn analyzers
-4. **Upgrade CLI** - `dotnet keeneyes upgrade` command using version metadata
+1. **Editor integration** - Read `keeneyes.project.json` for project discovery. Not yet implemented: the file is generated on every build, but no editor code consumes it.
+2. **Asset processing** - Build targets for scene/prefab compilation. Partially shipped: scene, prefab, world, and shader files are auto-detected and fed to source generators (see Custom ItemGroups); dedicated compilation targets beyond that remain future work.
+3. **Analyzers** - Include KeenEyes-specific Roslyn analyzers. Not yet implemented.
+4. **Upgrade CLI** - `dotnet keeneyes upgrade` command using version metadata. Not yet implemented: `keeneyes.version.json` carries the data, but no CLI command reads it.
+
+## Related
+
+- [ADR-009](009-kesl-shader-language.md) (KESL shader language) — the game SDK ships the KESL shader generator wiring (`KeenEyes.Shaders.Generator` auto-reference and `.kesl` auto-detection).
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** No status change (Accepted since 2025-12-18); Implementation: Shipped — all three SDK packages, convention defaults, opt-outs, version properties, and metadata generation are in place; templates and docs consume them. Decision amended to as-built reality: item types grew from four to six (`KeenEyesShader`, `KeenEyesSystem`) and are auto-detected by glob and fed to source generators as `AdditionalFiles` rather than declared manually; the game SDK also auto-references `KeenEyes.Shaders.Generator` (opt-out `IncludeKeenEyesShaders`); `keeneyes.project.json` gained `outputType` (and `isPackable` for Library) and a second `keeneyes.version.json` is written to the intermediate output path. Noted that no editor code consumes the metadata files yet; added Related link to ADR-009.
+- **v1 — 2025-12-18 (3b6053a1):** Accepted — Introduce KeenEyes.Sdk / KeenEyes.Sdk.Plugin / KeenEyes.Sdk.Library MSBuild SDKs to replace consumer boilerplate with convention defaults, automatic package references, custom item types, and keeneyes.project.json metadata; implemented in the same commit.

--- a/docs/adr/007-capability-based-plugin-architecture.md
+++ b/docs/adr/007-capability-based-plugin-architecture.md
@@ -1,7 +1,10 @@
 # ADR-007: Capability-Based Plugin Architecture
 
 **Status:** Accepted
-**Date:** 2025-12-20
+**Revision:** v2
+**Implementation:** Shipped
+**First accepted:** 2025-12-20 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-001](001-world-manager-architecture.md) (World managers) · [ADR-003](003-command-buffer-abstraction.md) (CommandBuffer)
 
 ## Context
 
@@ -48,16 +51,18 @@ Extract cohesive World features into **capability interfaces**. Plugins request 
 | `IStatisticsCapability` | Memory profiling | Abstractions |
 | `IInspectionCapability` | Entity inspection for debugging | Abstractions |
 | `ISnapshotCapability` | Basic world snapshot operations | Abstractions |
-| `ISerializationCapability` | AOT-aware serialization with ComponentRegistry | Core* |
-| `IPrefabCapability` | Entity templates | Core* |
+| `ISerializationCapability` | AOT-aware serialization via `IComponentRegistry` | Abstractions |
+| `ISaveLoadCapability` | World save/load orchestration (extends `IPersistenceCapability`) | Core* |
 
-*Core capabilities depend on Core types (`EntityPrefab`, `ComponentInfo`, etc.).
+*Core capabilities depend on Core types and therefore live in `KeenEyes.Core`.
+
+An `IPrefabCapability` (entity templates) originally shipped with this ADR but was removed along with the runtime prefab API, which was superseded by source-generated spawn methods.
 
 **Note on ISnapshotCapability vs ISerializationCapability:**
 
 `ISnapshotCapability` provides simple snapshot operations (`GetComponents`, `GetAllSingletons`, `SetSingleton`, `Clear`) without exposing Core types. This allows plugins that only need basic snapshot functionality to depend solely on Abstractions.
 
-`ISerializationCapability` extends `ISnapshotCapability` and adds `IComponentRegistry` access, which is required for AOT-compatible serialization where component registration happens at runtime. This interface lives in Core because it exposes `ComponentInfo`.
+`ISerializationCapability` extends `ISnapshotCapability` and adds `IComponentRegistry` access, which is required for AOT-compatible serialization where component registration happens at runtime. Both interfaces live in Abstractions: `ISerializationCapability` exposes the abstraction types `IComponentRegistry`/`IComponentInfo` (defined alongside it), not Core's `ComponentInfo`, so no Core dependency is required.
 
 ### New Plugin Pattern
 
@@ -65,9 +70,9 @@ Extract cohesive World features into **capability interfaces**. Plugins request 
 public void Install(IPluginContext context)
 {
     // Request specific capability
-    if (context.TryGetCapability<IPrefabCapability>(out var prefabs))
+    if (context.TryGetCapability<ITagCapability>(out var tags))
     {
-        prefabs.RegisterPrefab("Enemy", enemyPrefab);
+        tags.AddTag(entity, "Enemy");
     }
 
     // Or require it (throws if unavailable)
@@ -78,20 +83,19 @@ public void Install(IPluginContext context)
 
 ### Mock Implementations for Testing
 
-Each capability has a corresponding mock in `KeenEyes.Testing`:
+`KeenEyes.Testing` ships seven capability mocks — `MockHierarchyCapability`, `MockInspectionCapability`, `MockPersistenceCapability`, `MockStatisticsCapability`, `MockSystemHookCapability`, `MockTagCapability`, `MockValidationCapability` — and `MockPluginContext.SetCapability<T>()` wires them into a plugin context:
 
 ```csharp
 // Test plugin without real World
-var mockPrefabs = new MockPrefabCapability();
-var mockContext = new PluginContextBuilder()
-    .WithCapability<IPrefabCapability>(mockPrefabs)
-    .Build();
+var mockHooks = new MockSystemHookCapability();
+var mockContext = new MockPluginContext()
+    .SetCapability<ISystemHookCapability>(mockHooks);
 
 plugin.Install(mockContext);
 
 // Verify behavior
-Assert.Single(mockPrefabs.RegistrationOrder);
-Assert.Equal("Enemy", mockPrefabs.RegistrationOrder[0]);
+Assert.True(mockHooks.WasHookAdded);
+Assert.Equal(1, mockHooks.HookCount);
 ```
 
 ### IWorld Already Provides Core Hierarchy
@@ -128,10 +132,10 @@ UI systems (`UIRenderSystem`, `UILayoutSystem`, `UIHitTester`) were casting to `
 ## Implementation
 
 ### Phase 1: Core Capabilities ✅
-- Created `IHierarchyCapability`, `IValidationCapability`, `ITagCapability`, `IStatisticsCapability` in Abstractions
-- Created `IPrefabCapability` in Core
-- Updated `World` to implement all capability interfaces
-- Created mock implementations in `KeenEyes.Testing`
+- `IHierarchyCapability`, `IValidationCapability`, `ITagCapability`, `IStatisticsCapability` — along with `IInspectionCapability`, `IPersistenceCapability`, `ISnapshotCapability`, `ISerializationCapability`, and `ISystemHookCapability` — live in Abstractions; `ISaveLoadCapability` lives in Core
+- `World` implements all capability interfaces
+- Seven mock capabilities plus `MockPluginContext.SetCapability<T>()` ship in `KeenEyes.Testing`
+- `IPrefabCapability` shipped in this phase but was later removed with the runtime prefab API (superseded by source-generated spawn methods)
 
 ### Phase 2: UI System Cleanup ✅
 - Updated `UIRenderSystem`, `UILayoutSystem`, `UIHitTester` to use `IWorld.GetChildren()` instead of casting to `World`
@@ -143,5 +147,12 @@ UI systems (`UIRenderSystem`, `UILayoutSystem`, `UIHitTester`) were casting to `
 
 ## Related
 
-- ADR-001: World Manager Architecture (internal managers)
-- ADR-003: Command Buffer Abstraction (similar pattern for ICommandBuffer)
+- [ADR-001](001-world-manager-architecture.md): World Manager Architecture (internal managers)
+- [ADR-003](003-command-buffer-abstraction.md): Command Buffer Abstraction (similar pattern for ICommandBuffer)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Implementation marked Shipped (status was already Accepted). Capability table corrected to as-built layout: `ISerializationCapability` lives in Abstractions and exposes `IComponentRegistry`/`IComponentInfo` (not Core's `ComponentInfo`); `IPrefabCapability` removed with the runtime prefab API (superseded by source-generated spawn methods) and Core's `ISaveLoadCapability` added in its place. Code examples rewritten against shipped APIs: `ITagCapability`/`IHierarchyCapability` plugin pattern and `MockPluginContext.SetCapability<T>()` with the seven shipped mocks, replacing the never-shipped `PluginContextBuilder`/`MockPrefabCapability`.
+- **v1 — 2025-12-20 (ef18fedd):** Accepted — extract World features into capability interfaces so plugins request explicit capabilities via IPluginContext instead of casting to World; shipped with interfaces, World implementations, Testing mocks, and UI-system IWorld cleanup.

--- a/docs/adr/008-asset-management-architecture.md
+++ b/docs/adr/008-asset-management-architecture.md
@@ -1,8 +1,10 @@
 # ADR-008: Asset Management Architecture
 
-**Date:** 2024-12-21
-**Status:** Proposed
-**References:** Issue #428 (Epic), Issue #429 (Implementation)
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2025-12-21 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-007](007-capability-based-plugin-architecture.md) (plugin capabilities) · [#428](https://github.com/orion-ecs/keen-eye/issues/428) · [#429](https://github.com/orion-ecs/keen-eye/issues/429)
 
 ## Context
 
@@ -42,7 +44,7 @@ Create `KeenEyes.Assets` as a higher-level abstraction that coordinates with exi
 │                                                                          │
 │  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐             │
 │  │  AssetManager  │  │ StreamingMgr   │  │ ReloadManager  │             │
-│  │  (facade)      │  │ (async queue)  │  │ (dev mode)     │             │
+│  │  (facade)      │  │ (batch stream) │  │ (dev mode)     │             │
 │  └───────┬────────┘  └───────┬────────┘  └───────┬────────┘             │
 │          │                   │                   │                       │
 │          ▼                   ▼                   ▼                       │
@@ -133,8 +135,8 @@ public readonly struct AssetHandle<T> : IDisposable, IEquatable<AssetHandle<T>>
 #### 3. Component-Friendly AssetRef<T>
 
 ```csharp
-[Component]
-public partial struct AssetRef<T> where T : class, IDisposable
+public struct AssetRef<T> : IComponent, IEquatable<AssetRef<T>>
+    where T : class, IDisposable
 {
     /// <summary>Path to the asset for serialization.</summary>
     public string Path;
@@ -143,8 +145,16 @@ public partial struct AssetRef<T> where T : class, IDisposable
     internal int HandleId;
 
     public readonly bool IsResolved => HandleId > 0;
+    public readonly bool HasPath => !string.IsNullOrEmpty(Path);
+
+    public static AssetRef<T> FromPath(string path) => new() { Path = path };
+
+    /// <summary>Clears the resolved handle, forcing re-resolution.</summary>
+    public void Invalidate() => HandleId = 0;
 }
 ```
+
+`AssetRef<T>` is a plain struct implementing `IComponent` — the `[Component]` source generator does not apply to generic types, so no fluent builder methods are generated for it.
 
 **Usage in ECS:**
 ```csharp
@@ -156,6 +166,8 @@ world.Spawn()
 
 // AssetResolutionSystem automatically resolves paths to handles
 ```
+
+`AssetResolutionSystem` resolves the four built-in instantiations — `AssetRef<TextureAsset>`, `AssetRef<AudioClipAsset>`, `AssetRef<MeshAsset>`, and `AssetRef<RawAsset>` — rather than resolving generically over all `AssetRef<T>` types. Custom asset types are loaded through `AssetManager` directly.
 
 #### 4. Pluggable Loaders via IAssetLoader<T>
 
@@ -182,13 +194,20 @@ public readonly record struct AssetLoadContext(
 **Built-in Loaders:**
 | Loader | Asset Type | Extensions | Dependency |
 |--------|------------|------------|------------|
-| `TextureLoader` | `TextureAsset` | .png, .jpg, .bmp, .tga | StbImageSharp, IGraphicsContext |
-| `AudioClipLoader` | `AudioClipAsset` | .wav, .ogg | NVorbis, IAudioContext |
+| `TextureLoader` | `TextureAsset` | .png, .jpg/.jpeg, .bmp, .tga, .gif, .psd, .hdr | StbImageSharp, IGraphicsContext |
+| `DdsTextureLoader` | `TextureAsset` | .dds | Pfim, IGraphicsContext |
+| `SpriteAtlasLoader` | `SpriteAtlasAsset` | .atlas, .json | IGraphicsContext |
+| `AnimationLoader` | `AnimationAsset` | .keanim | IGraphicsContext |
+| `FontLoader` | `FontAsset` | .ttf, .otf | IFontManagerProvider |
+| `AudioClipLoader` | `AudioClipAsset` | .wav, .ogg, .mp3, .flac | NVorbis, NLayer, built-in FLAC decoder, IAudioContext |
 | `MeshLoader` | `MeshAsset` | .gltf, .glb | SharpGLTF |
-| `JsonLoader<T>` | `T` | .json | System.Text.Json |
-| `RawLoader` | `RawAsset` | * | None |
+| `ModelLoader` | `ModelAsset` | .gltf, .glb | SharpGLTF |
+| `SkeletalAnimationLoader` | `SkeletalAnimationAsset` | .gltf, .glb | SharpGLTF |
+| `RawLoader` | `RawAsset` | .bin, .dat, .raw, .bytes | None |
 
-#### 5. Async Loading with Priority Queue
+The originally planned `JsonLoader<T>` (System.Text.Json) was not implemented; JSON-backed formats are handled by dedicated loaders (sprite atlases, animations) instead.
+
+#### 5. Async Loading and Batch Streaming
 
 ```csharp
 public enum LoadPriority
@@ -199,38 +218,18 @@ public enum LoadPriority
     Low = 3,        // Background loading
     Streaming = 4   // Lowest priority, for level streaming
 }
-
-public sealed class StreamingManager
-{
-    private readonly PriorityQueue<LoadRequest, LoadPriority> queue;
-    private readonly SemaphoreSlim concurrencyLimit;
-    private readonly int maxConcurrentLoads;
-
-    public async Task<AssetHandle<T>> LoadAsync<T>(
-        string path,
-        LoadPriority priority = LoadPriority.Normal,
-        CancellationToken ct = default) where T : class, IDisposable
-    {
-        // Queue the request
-        var request = new LoadRequest(path, typeof(T), priority);
-        queue.Enqueue(request, priority);
-
-        // Wait for slot
-        await concurrencyLimit.WaitAsync(ct);
-        try
-        {
-            var loader = GetLoader<T>();
-            using var stream = fileSystem.Open(path);
-            var asset = await loader.LoadAsync(stream, new AssetLoadContext(path, manager), ct);
-            return cache.AddAndGetHandle<T>(path, asset);
-        }
-        finally
-        {
-            concurrencyLimit.Release();
-        }
-    }
-}
 ```
+
+Async loading is exposed directly on the `AssetManager` facade:
+
+```csharp
+public async Task<AssetHandle<T>> LoadAsync<T>(
+    string path,
+    LoadPriority priority = LoadPriority.Normal,
+    CancellationToken cancellationToken = default) where T : class, IDisposable;
+```
+
+The `LoadPriority` enum is part of the API, but requests are **not** scheduled through a priority queue — the originally sketched `PriorityQueue<LoadRequest, LoadPriority>` scheduler was not implemented. Instead, `StreamingManager` is a batch streaming utility for level loads: queue paths with `Queue<T>(path)` / `QueueMany<T>(paths)`, run them with a bounded-concurrency worker (`Start(maxConcurrent)`, capped via `SemaphoreSlim`), track `Progress` / `QueuedCount` / `IsStreaming`, subscribe to `OnAssetStreamed` / `OnStreamingComplete` / `OnStreamingError`, and await `WaitForCompletionAsync()`. All streaming loads run at `LoadPriority.Streaming`.
 
 #### 6. Reference-Counted Cache with Policies
 
@@ -317,6 +316,8 @@ public sealed class ReloadManager : IDisposable
 }
 ```
 
+The debounce delay is a constructor parameter (default 100 ms); there is no separate `ReloadConfig` type.
+
 ### Project Structure
 
 ```
@@ -329,113 +330,137 @@ src/KeenEyes.Assets/
 │   ├── AssetManager.cs                # Central facade
 │   ├── AssetHandle.cs                 # AssetHandle<T> struct
 │   ├── AssetRef.cs                    # AssetRef<T> component
-│   ├── AssetState.cs                  # State enum
-│   └── AssetMetadata.cs               # Metadata record
+│   └── AssetState.cs                  # State enum
 │
 ├── Loading/
 │   ├── IAssetLoader.cs                # Loader interface
 │   ├── AssetLoadContext.cs            # Context passed to loaders
+│   ├── AssetLoadException.cs          # Load failure exception
 │   ├── LoadPriority.cs                # Priority enum
 │   └── LoaderRegistry.cs              # Extension → Loader mapping
 │
 ├── Caching/
 │   ├── AssetCache.cs                  # Central cache
 │   ├── AssetEntry.cs                  # Cache entry
-│   ├── CachePolicy.cs                 # Policy enum
+│   ├── CachePolicy.cs                 # Policy enum (LRU, Manual, Aggressive)
 │   └── CacheStats.cs                  # Statistics record
 │
 ├── Streaming/
-│   ├── StreamingManager.cs            # Async load queue
-│   └── StreamingConfig.cs             # Configuration
+│   └── StreamingManager.cs            # Batch level streaming
 │
 ├── Loaders/
-│   ├── TextureLoader.cs               # PNG, JPG via StbImageSharp
-│   ├── AudioClipLoader.cs             # WAV, OGG via NVorbis
+│   ├── TextureLoader.cs               # PNG, JPG, BMP, TGA, ... via StbImageSharp
+│   ├── DdsTextureLoader.cs            # DDS via Pfim
+│   ├── SpriteAtlasLoader.cs           # Sprite atlas JSON
+│   ├── AnimationLoader.cs             # Sprite animation (.keanim)
+│   ├── SkeletalAnimationLoader.cs     # Skeletal animation via SharpGLTF
+│   ├── FontLoader.cs                  # TTF/OTF via IFontManagerProvider
+│   ├── AudioClipLoader.cs             # WAV, OGG, MP3, FLAC (NVorbis, NLayer)
+│   ├── FlacDecoder.cs                 # Built-in FLAC decoding
 │   ├── MeshLoader.cs                  # GLTF via SharpGLTF
-│   ├── JsonLoader.cs                  # JSON via System.Text.Json
+│   ├── ModelLoader.cs                 # Full model import via SharpGLTF
 │   └── RawLoader.cs                   # Raw binary
 │
-├── Assets/
-│   ├── TextureAsset.cs                # Wrapper for TextureHandle
-│   ├── AudioClipAsset.cs              # Wrapper for AudioClipHandle
-│   ├── MeshAsset.cs                   # Contains vertex/index data
-│   └── RawAsset.cs                    # Raw byte array
+├── Assets/                            # Wrapper asset types
+│   ├── TextureAsset.cs, TextureData.cs
+│   ├── AudioClipAsset.cs
+│   ├── MeshAsset.cs, ModelAsset.cs, MaterialData.cs
+│   ├── FontAsset.cs
+│   ├── SpriteAtlasAsset.cs
+│   ├── AnimationAsset.cs, SkeletonAsset.cs, SkeletalAnimationAsset.cs
+│   └── RawAsset.cs
+│
+├── Data/                              # Atlas & animation JSON models
+│   ├── AtlasJsonModels.cs, AtlasJsonContext.cs
+│   ├── AnimationJsonModels.cs
+│   └── SpriteRegion.cs
+│
+├── Manifest/                          # Asset manifest support
+│   ├── AssetManifest.cs
+│   ├── AssetManifestBuilder.cs
+│   ├── AssetInfo.cs
+│   └── ManifestStatistics.cs
 │
 ├── HotReload/
-│   ├── ReloadManager.cs               # FileSystemWatcher wrapper
-│   └── ReloadConfig.cs                # Configuration
+│   └── ReloadManager.cs               # FileSystemWatcher wrapper
 │
 └── Systems/
-    ├── AssetResolutionSystem.cs       # Resolves AssetRef<T> → handles
-    └── AssetUploadSystem.cs           # Processes pending GPU uploads
+    └── AssetResolutionSystem.cs       # Resolves AssetRef<T> → handles
 ```
+
+Originally planned but not built: `Core/AssetMetadata.cs`, `Streaming/StreamingConfig.cs`, `HotReload/ReloadConfig.cs`, `Loaders/JsonLoader.cs`, and `Systems/AssetUploadSystem.cs`.
 
 ### Dependencies
 
-**Required:**
+**Project references (all unconditional):**
 - `KeenEyes.Abstractions` (IWorldPlugin, IComponent, etc.)
 - `KeenEyes.Core` (World, System, Query)
+- `KeenEyes.Common` (shared utilities)
+- `KeenEyes.Animation` (animation asset types)
+- `KeenEyes.Graphics.Abstractions` (IGraphicsContext for texture/atlas/font loaders)
+- `KeenEyes.Audio.Abstractions` (IAudioContext for AudioClipLoader)
+
+**Packages:**
 - `StbImageSharp` (pure C# image loading)
 - `SharpGLTF.Core` (pure C# glTF loading)
 - `NVorbis` (pure C# Ogg Vorbis decoding)
+- `NLayer` (pure C# MP3 decoding)
+- `Pfim` (DDS texture loading)
 
-**Optional (for built-in loaders):**
-- `KeenEyes.Graphics.Abstractions` (IGraphicsContext for TextureLoader)
-- `KeenEyes.Audio.Abstractions` (IAudioContext for AudioClipLoader)
+The Graphics and Audio abstractions were originally sketched as optional dependencies; as built they are hard compile-time references. What remains conditional is loader *registration* at runtime — `AssetsPlugin` only registers the graphics- and audio-backed loaders when the corresponding subsystem extensions are present in the world.
 
 ### Plugin Integration
 
 ```csharp
-public sealed class AssetsPlugin : IWorldPlugin
+public sealed class AssetsPlugin(AssetsConfig? config = null) : IWorldPlugin
 {
-    private readonly AssetsConfig config;
+    private readonly AssetsConfig resolvedConfig = config ?? AssetsConfig.Default;
     private AssetManager? assetManager;
     private ReloadManager? reloadManager;
 
     public string Name => "Assets";
 
-    public AssetsPlugin(AssetsConfig? config = null)
-    {
-        this.config = config ?? new AssetsConfig();
-    }
-
     public void Install(IPluginContext context)
     {
         // Create asset manager
-        assetManager = new AssetManager(config);
+        assetManager = new AssetManager(resolvedConfig);
 
-        // Register built-in loaders if dependencies available
-        if (context.TryGetExtension<IGraphicsContext>(out var graphics))
+        // Graphics-dependent loaders
+        if (context.TryGetExtension<IGraphicsContext>(out var graphics) && graphics != null)
         {
             assetManager.RegisterLoader(new TextureLoader(graphics));
+            assetManager.RegisterLoader(new DdsTextureLoader(graphics));
+            assetManager.RegisterLoader(new SpriteAtlasLoader());
+            assetManager.RegisterLoader(new AnimationLoader());
+
+            // FontLoader requires an IFontManager (from IFontManagerProvider)
+            if (graphics is IFontManagerProvider fontProvider &&
+                fontProvider.GetFontManager() is { } fontManager)
+            {
+                assetManager.RegisterLoader(new FontLoader(fontManager));
+            }
         }
 
-        if (context.TryGetExtension<IAudioContext>(out var audio))
+        // Audio-dependent loader
+        if (context.TryGetExtension<IAudioContext>(out var audio) && audio != null)
         {
             assetManager.RegisterLoader(new AudioClipLoader(audio));
         }
 
         // Always register these (no external dependencies)
         assetManager.RegisterLoader(new MeshLoader());
-        assetManager.RegisterLoader(new JsonLoader<object>());
         assetManager.RegisterLoader(new RawLoader());
 
         // Register as extension
         context.SetExtension(assetManager);
 
-        // Register component types
-        context.RegisterComponent<AssetRef<TextureAsset>>();
-        context.RegisterComponent<AssetRef<AudioClipAsset>>();
-        context.RegisterComponent<AssetRef<MeshAsset>>();
+        // Register the asset resolution system
+        context.AddSystem<AssetResolutionSystem>(SystemPhase.EarlyUpdate, order: -100);
 
-        // Register systems
-        context.AddSystem<AssetResolutionSystem>(SystemPhase.PreUpdate, order: -100);
-        context.AddSystem<AssetUploadSystem>(SystemPhase.PreUpdate, order: -99);
-
-        // Hot reload (dev mode only)
-        if (config.EnableHotReload)
+        // Hot reload requires the asset root to exist
+        if (resolvedConfig.EnableHotReload && Directory.Exists(resolvedConfig.RootPath))
         {
-            reloadManager = new ReloadManager(config.RootPath, assetManager);
+            reloadManager = new ReloadManager(resolvedConfig.RootPath, assetManager);
         }
     }
 
@@ -447,6 +472,8 @@ public sealed class AssetsPlugin : IWorldPlugin
     }
 }
 ```
+
+Differences from the original sketch: no explicit `RegisterComponent<AssetRef<...>>` calls are needed, there is no `AssetUploadSystem` (GPU upload happens inside the graphics-backed loaders), and the single `AssetResolutionSystem` runs in `SystemPhase.EarlyUpdate` (order -100) rather than `PreUpdate`.
 
 ### Usage Examples
 
@@ -537,7 +564,7 @@ Adopt an existing asset management library.
 - **Unified API** - One way to load all asset types
 - **Automatic caching** - No duplicate loads
 - **Memory management** - Reference counting prevents leaks
-- **Async loading** - No frame hitches
+- **Async loading** - Task-based `LoadAsync` and `StreamingManager` batch streaming keep loads off the frame (loads are concurrency-capped, not priority-scheduled)
 - **Dev experience** - Hot reload speeds iteration
 - **Extensibility** - Custom loaders for game-specific formats
 - **ECS integration** - AssetRef<T> components work with queries
@@ -554,48 +581,57 @@ Adopt an existing asset management library.
 - Built-in loaders require corresponding subsystem plugins to be installed first
 - Hot reload only works with file-based assets (not embedded resources)
 
-## Implementation Plan
+## Implementation Status
 
-### Phase 1: Core Infrastructure
-1. Create project structure
-2. Implement `AssetHandle<T>`, `AssetRef<T>`, `AssetState`
-3. Implement `AssetCache` with reference counting
-4. Implement `AssetManager` facade
-5. Implement `LoaderRegistry`
-6. Implement `IAssetLoader<T>` interface
+The system shipped 2025-12-21 in commit `f3ab185d` — the same commit that added this ADR. Status of the original plan:
 
-### Phase 2: Built-in Loaders
-1. `RawLoader` (simplest, no dependencies)
-2. `JsonLoader<T>` (System.Text.Json)
-3. `TextureLoader` (StbImageSharp + IGraphicsContext)
-4. `AudioClipLoader` (NVorbis + IAudioContext)
-5. `MeshLoader` (SharpGLTF)
+### Phase 1: Core Infrastructure ✅
+1. ✅ Project structure
+2. ✅ `AssetHandle<T>`, `AssetRef<T>`, `AssetState`
+3. ✅ `AssetCache` with reference counting
+4. ✅ `AssetManager` facade
+5. ✅ `LoaderRegistry`
+6. ✅ `IAssetLoader<T>` interface
 
-### Phase 3: Async & Streaming
-1. Implement `StreamingManager`
-2. Implement priority queue
-3. Implement `AssetUploadSystem` for GPU uploads
-4. Add progress callbacks
+### Phase 2: Built-in Loaders ✅ (except JsonLoader)
+1. ✅ `RawLoader` (simplest, no dependencies)
+2. Not implemented: `JsonLoader<T>` (System.Text.Json)
+3. ✅ `TextureLoader` (StbImageSharp + IGraphicsContext) — plus `DdsTextureLoader`, `SpriteAtlasLoader`, `AnimationLoader`, and `FontLoader` beyond the plan
+4. ✅ `AudioClipLoader` (NVorbis + IAudioContext) — plus MP3 via NLayer and built-in FLAC decoding
+5. ✅ `MeshLoader` (SharpGLTF) — plus `ModelLoader` and `SkeletalAnimationLoader`
 
-### Phase 4: ECS Integration
-1. Implement `AssetResolutionSystem`
-2. Register component types
-3. Create `AssetsPlugin`
+### Phase 3: Async & Streaming — partial
+1. ✅ `StreamingManager` (as a batch level-streaming helper)
+2. Not implemented: priority-queue load scheduling (`LoadPriority` exists as an API parameter only)
+3. Not implemented: `AssetUploadSystem` for GPU uploads (uploads happen inside graphics-backed loaders)
+4. ✅ Progress callbacks (`StreamingManager.Progress` / `OnAssetStreamed`)
 
-### Phase 5: Hot Reload
-1. Implement `ReloadManager`
-2. Add file watching
-3. Implement reload callbacks
+### Phase 4: ECS Integration ✅
+1. ✅ `AssetResolutionSystem` (resolves the four built-in `AssetRef<T>` instantiations)
+2. Component-type registration — not needed as built (no `RegisterComponent` calls)
+3. ✅ `AssetsPlugin`
 
-### Phase 6: Polish
-1. Cache policies (LRU eviction)
-2. Cache statistics
-3. Sample application
-4. Documentation
+### Phase 5: Hot Reload ✅
+1. ✅ `ReloadManager`
+2. ✅ File watching (FileSystemWatcher, debounced)
+3. ✅ Reload callbacks (`OnAssetReloaded`)
+
+### Phase 6: Polish — partial
+1. ✅ Cache policies (LRU, Manual, Aggressive)
+2. ✅ Cache statistics (`CacheStats`, `GetCacheStats`)
+3. Not implemented: sample application (no sample currently uses `AssetsPlugin`/`AssetManager`)
+4. ✅ Documentation ([docs/assets.md](../assets.md))
 
 ## References
 
-- Issue #428: Epic: Asset Management
-- Issue #429: Create KeenEyes.Assets project
-- docs/research/asset-loading.md: Library evaluation research
-- ADR-007: Capability-based Plugin Architecture
+- [#428](https://github.com/orion-ecs/keen-eye/issues/428): Epic: Asset Management
+- [#429](https://github.com/orion-ecs/keen-eye/issues/429): Create KeenEyes.Assets project
+- [asset-loading research](../research/asset-loading.md): Library evaluation research
+- [ADR-007: Capability-based Plugin Architecture](./007-capability-based-plugin-architecture.md)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted (implemented in the same commit that added the ADR; header date corrected 2024 → 2025-12-21). Implementation marked Partial — not built: `JsonLoader<T>`, `AssetUploadSystem`, priority-queue load scheduling, and a sample application. Body amended to the as-built code: expanded loader table (DDS/atlas/animation/font/model/skeletal loaders, MP3/FLAC audio), `AssetRef<T>` as a plain `IComponent` struct resolved for four hard-coded instantiations, async loading on `AssetManager.LoadAsync` with `StreamingManager` as a batch streaming helper, plugin wiring (conditional loader registration, `EarlyUpdate` order -100, hot reload gated on the asset root existing), hard Graphics/Audio project references plus NLayer/Pfim packages, and the as-built project tree (Manifest/, Data/, no config classes).
+- **v1 — 2025-12-21 (#428/#429, f3ab185d):** Accepted — create KeenEyes.Assets as a unified asset layer (caching, refcounting, async loading, pluggable loaders, hot reload) coordinating with Graphics/Audio; implementation landed in the same commit as the ADR.

--- a/docs/adr/009-kesl-shader-language.md
+++ b/docs/adr/009-kesl-shader-language.md
@@ -1,7 +1,9 @@
 # ADR-009: KESL - KeenEyes Shader Language
 
-**Status:** Proposed
-**Date:** 2024-12-31
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2025-12-31 · **Last amended:** 2026-07-26
 
 ## Context
 
@@ -32,7 +34,7 @@ This is error-prone, verbose, and requires maintaining synchronization between s
 Implement **KESL (KeenEyes Shader Language)**, a custom shader language that:
 
 1. Provides first-class ECS query semantics
-2. Transpiles to GLSL (with future HLSL/SPIR-V support)
+2. Transpiles to GLSL and HLSL (`ShaderBackend` also reserves MSL and SPIR-V values for future backends)
 3. Generates C# binding code automatically
 4. Integrates with KeenEyes build system
 
@@ -94,27 +96,32 @@ public sealed class UpdatePhysicsShader : IGpuComputeSystem
 
 ```
 src/
-├── KeenEyes.Shaders/                    # Core abstractions
-│   ├── IGpuComputeSystem.cs             # Interface for GPU systems
-│   ├── GpuBuffer.cs                     # Buffer abstraction
-│   └── GpuQueryExtensions.cs            # World extensions
+└── KeenEyes.Shaders/                    # Runtime abstractions
+    ├── IGpuComputeSystem.cs             # Interfaces for GPU systems
+    ├── IGpuDevice.cs                    # Device abstraction
+    ├── GpuBuffer.cs                     # Buffer abstraction
+    ├── GpuCommandBuffer.cs              # Command recording
+    ├── CompiledShader.cs
+    ├── QueryDescriptor.cs               # ECS query description
+    ├── ShaderBackend.cs                 # GLSL | HLSL | MSL | SPIRV
+    └── HotReload/                       # KeslFileWatcher, ShaderRegistry
+editor/
 ├── KeenEyes.Shaders.Compiler/           # Compiler library
-│   ├── Lexer/
-│   │   ├── Token.cs
-│   │   ├── TokenKind.cs
-│   │   └── Lexer.cs
-│   ├── Parser/
-│   │   ├── Ast/                         # AST node types
-│   │   └── Parser.cs
-│   ├── Semantics/
-│   │   ├── TypeChecker.cs
-│   │   └── SymbolTable.cs
-│   └── CodeGen/
-│       ├── GlslGenerator.cs
-│       └── CSharpBindingGenerator.cs
-└── KeenEyes.Shaders.Tools/              # CLI tool (keslc)
-    └── Program.cs
+│   ├── Lexing/                          # Token, TokenKind, Lexer
+│   ├── Parsing/                         # Parser + Ast/ node types
+│   ├── Diagnostics/                     # Error codes, formatter, suggestions
+│   └── CodeGen/                         # GlslGenerator, HlslGenerator,
+│                                        #   CSharpBindingGenerator
+├── KeenEyes.Shaders.Generator/          # Roslyn source generator
+│                                        #   (fills the planned keslc CLI role)
+├── KeenEyes.Shaders.VsCode/             # TextMate grammar + snippets
+└── KeenEyes.Graph.Kesl/                 # Node-graph authoring for KESL
+tools/
+├── KeenEyes.Lsp.Kesl/                   # KESL language server
+└── vscode-kesl/                         # VSCode extension (LSP client)
 ```
+
+The compiler lives under `editor/` (build-time tooling), not `src/`; only the runtime abstractions ship as a `src/` library. The originally planned `Semantics/` directory (TypeChecker, SymbolTable) and the standalone `keslc` CLI were not built — see the pipeline notes below.
 
 ### Compilation Pipeline
 
@@ -135,23 +142,17 @@ src/
 │  Output: AST (ComputeShaderNode)               │
 └────────────────────────────────────────────────┘
                          │
-                         ▼
-┌────────────────────────────────────────────────┐
-│              Semantic Analysis                  │
-│  - Resolve component types                     │
-│  - Type check expressions                      │
-│  - Validate GPU compatibility                  │
-└────────────────────────────────────────────────┘
-                         │
             ┌────────────┴────────────┐
             ▼                         ▼
 ┌────────────────────────┐ ┌─────────────────────┐
-│    GLSL Generator      │ │  C# Binding Gen     │
+│  GLSL/HLSL Generator   │ │  C# Binding Gen     │
 └────────────────────────┘ └─────────────────────┘
             │                         │
             ▼                         ▼
       Foo.comp.glsl          FooShader.g.cs
 ```
+
+A semantic-analysis stage between parsing and code generation — resolving component types against ECS registration metadata, type-checking expressions, and validating GPU compatibility and read/write access — is designed but **not yet implemented**. `KeslCompiler.Compile` runs lexer → parser → code generators only; error codes KESL300–306 (`UndefinedComponent`, `TypeMismatch`, `UndefinedField`, ...) are reserved for it in `KeslErrorCodes.cs` but are never emitted, and component names are currently trusted as written. This is the main outstanding gap in the implementation.
 
 ### Grammar (EBNF)
 
@@ -219,7 +220,7 @@ literal        = NUMBER | "true" | "false" ;
 
 ### Component Mapping
 
-KESL references components by name. The compiler resolves these against registered component types:
+KESL references components by name. The design has the compiler resolve these against registered component types (this resolution belongs to the not-yet-implemented semantic-analysis stage; today component names are trusted as written):
 
 ```csharp
 // Component registration (source generator metadata)
@@ -313,7 +314,7 @@ public sealed partial class UpdatePhysicsShader : IGpuComputeSystem, IDisposable
 
 ### Error Handling
 
-Compiler errors include source location:
+Compiler errors include source location. The shipped diagnostics pipeline (`editor/KeenEyes.Shaders.Compiler/Diagnostics/`) provides a structured `Diagnostic` type with source spans, a KESL error-code taxonomy, caret-style formatting via `DiagnosticFormatter`, and "did you mean" suggestions via `SuggestionEngine`. Syntax-level errors (KESL1xx/2xx) are emitted today; semantic errors such as the one below require the unimplemented semantic-analysis stage (KESL3xx codes are reserved) and currently surface at GLSL compile or runtime instead:
 
 ```
 physics.kesl:12:5: error: Cannot write to read-only component 'Velocity'
@@ -325,53 +326,45 @@ Runtime errors (GPU validation) are surfaced through the graphics abstraction la
 
 ### Build Integration
 
-**MSBuild Target:**
-```xml
-<Target Name="CompileKesl" BeforeTargets="CoreCompile">
-  <ItemGroup>
-    <KeslFile Include="**/*.kesl" />
-  </ItemGroup>
-
-  <Exec Command="keslc @(KeslFile) -o $(IntermediateOutputPath)kesl/"
-        Condition="'@(KeslFile)' != ''" />
-
-  <ItemGroup>
-    <Compile Include="$(IntermediateOutputPath)kesl/*.g.cs" />
-    <EmbeddedResource Include="$(IntermediateOutputPath)kesl/*.glsl" />
-  </ItemGroup>
-</Target>
-```
+Build integration ships through the KeenEyes SDK plus a Roslyn incremental source generator — no external tool invocation (the originally planned `keslc` Exec-based MSBuild target was never built):
 
 **SDK Integration:**
 ```xml
-<!-- In KeenEyes.Sdk.targets -->
+<!-- In KeenEyes.Sdk (Sdk.targets) — .kesl files feed the source generator -->
 <ItemGroup>
   <KeenEyesShader Include="**/*.kesl" />
+  <AdditionalFiles Include="**/*.kesl" />
 </ItemGroup>
 ```
 
+`KeslSourceGenerator` (`editor/KeenEyes.Shaders.Generator`, an `IIncrementalGenerator`) compiles the `.kesl` `AdditionalFiles` during Roslyn compilation and injects the generated C# bindings directly into the compilation.
+
 ## Implementation Phases
 
-### Phase 1: Prototype (This PR)
-- [x] Research document
+### Phase 1: Prototype ✅ (shipped with the initial prototype, Dec 2025)
+- [x] Research document ([docs/research/shader-language.md](../research/shader-language.md))
 - [x] Architecture document
-- [ ] Lexer implementation
-- [ ] Parser implementation
-- [ ] GLSL code generator
-- [ ] Basic C# binding generator
-- [ ] Unit tests
+- [x] Lexer implementation (`editor/KeenEyes.Shaders.Compiler/Lexing/`)
+- [x] Parser implementation (recursive descent, `Parsing/` + `Parsing/Ast/`)
+- [x] GLSL code generator (`CodeGen/GlslGenerator.cs`)
+- [x] Basic C# binding generator (`CodeGen/CSharpBindingGenerator.cs`)
+- [x] Unit tests (`tests/KeenEyes.Shaders.Compiler.Tests`)
 
-### Phase 2: Integration
-- [ ] `KeenEyes.Shaders` abstractions
-- [ ] MSBuild targets
-- [ ] Hot-reload support
-- [ ] Error message improvements
+### Phase 2: Integration ✅
+- [x] `KeenEyes.Shaders` abstractions (`src/KeenEyes.Shaders`)
+- [x] MSBuild targets — implemented as SDK-level `.kesl` → `AdditionalFiles` wiring for the source generator, not a standalone Exec target (see Build Integration)
+- [x] Hot-reload support (`src/KeenEyes.Shaders/HotReload/` — `KeslFileWatcher`, `ShaderRegistry`, `IHotReloadable`)
+- [x] Error message improvements (structured diagnostics with error codes and "did you mean" suggestions)
 
-### Phase 3: Polish
-- [ ] Source generator integration
-- [ ] IDE support (syntax highlighting)
-- [ ] HLSL backend
-- [ ] Rendering shader support (vertex/fragment)
+### Phase 3: Polish ✅
+- [x] Source generator integration (`editor/KeenEyes.Shaders.Generator`)
+- [x] IDE support — TextMate grammar and snippets (`editor/KeenEyes.Shaders.VsCode`), an LSP server with completion, hover, go-to-definition, and diagnostics (`tools/KeenEyes.Lsp.Kesl`), and a VSCode LSP client extension (`tools/vscode-kesl`)
+- [x] HLSL backend (`CodeGen/HlslGenerator.cs`)
+- [x] Rendering shader support (vertex/fragment) — plus geometry shaders and pipeline composition
+
+The language has grown beyond the ADR's compute-only scope: vertex, fragment, and geometry shaders plus pipeline composition are supported, and `editor/KeenEyes.Graph.Kesl` adds node-graph authoring for KESL. See [docs/shaders.md](../shaders.md) for the user-facing documentation.
+
+**Not yet implemented:** the semantic-analysis stage (component resolution against ECS metadata, expression type checking, read/write access validation — error codes KESL300–306 are reserved for it), and the `keslc` CLI (superseded by the Roslyn source generator).
 
 ## Alternatives Considered
 
@@ -425,7 +418,7 @@ Adopt WGSL and generate bindings from it:
 ### Positive
 
 - **Reduced boilerplate:** 80% less code for GPU systems
-- **Type safety:** Compile-time validation of component access
+- **Type safety:** Compile-time validation of component access — partially realized: syntax-level diagnostics with source spans and suggestions ship today (KESL1xx/2xx), but compile-time component/type validation (KESL3xx) awaits the semantic-analysis stage
 - **Single source of truth:** One file defines GPU behavior and CPU bindings
 - **Better error messages:** Domain-specific errors, not generic GPU errors
 - **Future extensibility:** Foundation for advanced GPU features
@@ -442,3 +435,15 @@ Adopt WGSL and generate bindings from it:
 - Existing shader workflows remain supported (KESL is additive)
 - Performance equivalent to hand-written shaders
 - Integrates with existing graphics abstractions
+
+## References
+
+- [Shader language research document](../research/shader-language.md)
+- [KESL user documentation](../shaders.md)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted (header year fixed 2024 → 2025); Implementation marked Partial — the semantic-analysis stage (component resolution, type checking, read-only-write validation; codes KESL300–306 reserved but never emitted) and the `keslc` CLI (superseded by the Roslyn source generator) never shipped. All Phase 1–3 checklist items checked as shipped; Architecture amended to the as-built layout (compiler under `editor/`, `KeenEyes.Shaders.Generator`, LSP server + VSCode extensions, `Graph.Kesl` node authoring); Build Integration rewritten from the `keslc` Exec target to SDK `AdditionalFiles` + source generator; Decision updated to reflect the shipped HLSL backend.
+- **v1 — 2025-12-31 (c877d9e0):** Proposed — KESL, a custom ECS-aware shader language transpiling to GLSL with generated C# bindings, to replace verbose manual ECS-to-GPU marshaling; shipped alongside the prototype lexer, parser, GLSL/C# generators, and 30 unit tests.

--- a/docs/adr/010-graph-node-editor.md
+++ b/docs/adr/010-graph-node-editor.md
@@ -1,7 +1,10 @@
 # ADR-010: Graph Node Editor Architecture
 
 **Status:** Accepted
-**Date:** 2024-12-31
+**Revision:** v2
+**Implementation:** Shipped
+**First accepted:** 2025-12-31 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-009](009-kesl-shader-language.md) (KESL)
 
 ## Context
 
@@ -11,7 +14,7 @@ KeenEyes needs visual editing capabilities for:
 
 The existing UI system (ECS-based, retained mode, 40+ widgets) provides a solid foundation but lacks graph-specific primitives: nodes, connections, ports, pan/zoom canvas.
 
-With the KESL shader language prototype complete (ADR-009), we need a visual frontend that:
+With the KESL shader language prototype complete ([ADR-009](009-kesl-shader-language.md)), we need a visual frontend that:
 1. Allows non-programmers to compose compute shaders
 2. Provides real-time validation feedback
 3. Generates KESL source that compiles via existing pipeline
@@ -24,21 +27,32 @@ Implement a **generic graph node editor framework** with KESL-specific node type
 ### Architecture Overview
 
 ```
-KeenEyes.Graph.Abstractions/     # Generic graph primitives
+src/KeenEyes.Graph.Abstractions/  # Generic graph primitives
 ├── Components (GraphCanvas, GraphNode, GraphConnection)
 ├── Ports (PortDefinition, PortTypeId, PortDirection)
 └── Interfaces (INodeTypeDefinition, IGraphRenderer)
 
-KeenEyes.Graph/                  # Core editing infrastructure
-├── Systems (Input, Layout, Render)
+src/KeenEyes.Graph/               # Core editing infrastructure
+├── Systems (Input, Layout, Render, ContextMenu, Widgets)
 ├── GraphContext extension
-└── Registries (Port, NodeType)
+├── Registries (Port, NodeType)
+├── Built-in nodes (Comment, Group, Reroute)
+└── Commands (undo/redo command objects)
 
-KeenEyes.Graph.Kesl/             # KESL-specific nodes
-├── Node definitions
-├── KeslGraphCompiler (Graph → AST)
-└── KeslGraphValidator
+editor/KeenEyes.Graph.Kesl/       # KESL-specific tooling (editor tier)
+├── Nodes (Flow, Logic, Math, Shader, Vector libraries)
+├── Compiler (KeslGraphCompiler: Graph → AST)
+├── Validation (KeslGraphValidator + rules)
+├── Editing (KeslGraphParser, KeslGraphExporter, source mapping)
+└── Preview (ShaderPreviewPanel, ShaderExecutor)
 ```
+
+The KESL package lives in the editor tier (`editor/KeenEyes.Graph.Kesl`) rather than
+`src/` — it is editor tooling, not a runtime library — and grew bidirectional `.kesl`
+editing (parse/export with source mapping) and a CPU-interpreted component preview
+alongside the compiler and validator. The core `KeenEyes.Graph` package additionally
+ships built-in Comment/Group/Reroute nodes and an in-node widget system
+(`GraphWidgetSystem`, `NodeWidgets`).
 
 ### Data Model
 
@@ -50,9 +64,10 @@ public struct GraphNode : IComponent
 {
     public Vector2 Position;      // Canvas coordinates
     public float Width;
+    public float Height;          // Calculated by the layout system
     public int NodeTypeId;
-    public bool IsSelected;
     public Entity Canvas;
+    public string? DisplayName;   // Null = use the node type's name
 }
 
 // Connections are entities
@@ -80,6 +95,9 @@ public readonly record struct PortDefinition(
 - Connections need metadata, can be selected → entities
 - Ports don't have independent lifecycle, positions derived from node → registry
 
+Selection state lives in tag components (`GraphNodeSelectedTag`, `GraphConnectionSelectedTag`)
+rather than a bool field on the component, keeping selection queryable via archetypes.
+
 ### Port Type System
 
 Types support **implicit widening only**:
@@ -89,9 +107,12 @@ Types support **implicit widening only**:
 | `float` | `float2`, `float3`, `float4` |
 | `float2` | `float3`, `float4` |
 | `float3` | `float4` |
-| `int` | `float` |
+| `int` | `float`, `int2`, `int3`, `int4` |
+| `int2` | `int3`, `int4` |
+| `int3` | `int4` |
 
-No narrowing conversions (lossy). Connection validation:
+No narrowing conversions (lossy). `PortTypeId.Flow` is connectable only to `Flow` —
+execution-order ports never mix with data ports. Connection validation:
 
 ```csharp
 public static bool CanConnect(PortTypeId source, PortTypeId target)
@@ -99,12 +120,18 @@ public static bool CanConnect(PortTypeId source, PortTypeId target)
     if (source == target) return true;
     if (target == PortTypeId.Any) return true;
 
+    // Flow can only connect to flow
+    if (source == PortTypeId.Flow || target == PortTypeId.Flow) return false;
+
     return (source, target) switch
     {
         (PortTypeId.Float, PortTypeId.Float2 or PortTypeId.Float3 or PortTypeId.Float4) => true,
         (PortTypeId.Float2, PortTypeId.Float3 or PortTypeId.Float4) => true,
         (PortTypeId.Float3, PortTypeId.Float4) => true,
         (PortTypeId.Int, PortTypeId.Float) => true,
+        (PortTypeId.Int, PortTypeId.Int2 or PortTypeId.Int3 or PortTypeId.Int4) => true,
+        (PortTypeId.Int2, PortTypeId.Int3 or PortTypeId.Int4) => true,
+        (PortTypeId.Int3, PortTypeId.Int4) => true,
         _ => false
     };
 }
@@ -161,15 +188,19 @@ public interface INodeTypeDefinition
     int TypeId { get; }
     string Name { get; }
     string Category { get; }
-    PortDefinition[] Inputs { get; }
-    PortDefinition[] Outputs { get; }
+    IReadOnlyList<PortDefinition> InputPorts { get; }
+    IReadOnlyList<PortDefinition> OutputPorts { get; }
+    bool IsCollapsible { get; }
 
     void Initialize(Entity node, IWorld world);
-    void RenderBody(Entity node, IWorld world, I2DRenderer renderer);
+    float RenderBody(Entity node, IWorld world, I2DRenderer renderer, Rectangle bodyArea);
 }
 ```
 
-Source generator support (future):
+`RenderBody` receives the available body area and returns the height it actually
+consumed, letting the layout system size nodes around custom content.
+
+Source generator support (future — not yet implemented):
 
 ```csharp
 [GraphNode("Add", Category = "Math")]
@@ -223,35 +254,35 @@ Run shader on small sample (1-10 entities), display delta.
 ## Implementation Phases
 
 ### Phase 1: Foundation
-- [ ] `GraphCanvas`, `GraphNode`, `GraphConnection` components
-- [ ] `GraphContext` extension with CreateCanvas, CreateNode, Connect
-- [ ] Basic rendering (rectangles for nodes, lines for connections)
-- [ ] Pan/zoom/drag nodes
+- [x] `GraphCanvas`, `GraphNode`, `GraphConnection` components
+- [x] `GraphContext` extension with CreateCanvas, CreateNode, Connect
+- [x] Basic rendering (rectangles for nodes, lines for connections)
+- [x] Pan/zoom/drag nodes
 
 ### Phase 2: Connections
-- [ ] Bezier curve rendering
-- [ ] Port type system with validation
-- [ ] Connection creation via drag-from-port
-- [ ] Port highlighting on hover
+- [x] Bezier curve rendering
+- [x] Port type system with validation
+- [x] Connection creation via drag-from-port
+- [x] Port highlighting on hover
 
 ### Phase 3: Interaction Polish
-- [ ] Multi-select with box selection
-- [ ] Undo/redo integration via ChangeTracker
-- [ ] Context menu for node creation
-- [ ] Keyboard shortcuts (delete, duplicate, select all)
+- [x] Multi-select with box selection
+- [x] Undo/redo via explicit command objects and the `IUndoRedoManager` extension (not ChangeTracker as originally planned)
+- [x] Context menu for node creation
+- [x] Keyboard shortcuts (delete, duplicate, select all)
 
 ### Phase 4: Node System
-- [ ] `INodeTypeDefinition` interface
-- [ ] `NodeTypeRegistry`
-- [ ] Custom node body rendering
-- [ ] Source generator for `[GraphNode]` (future)
+- [x] `INodeTypeDefinition` interface
+- [x] `NodeTypeRegistry`
+- [x] Custom node body rendering
+- [ ] Source generator for `[GraphNode]` — not yet implemented; remains future work
 
 ### Phase 5: KESL Integration
-- [ ] KESL-specific node library
-- [ ] `KeslGraphCompiler` (graph → AST)
-- [ ] Real-time validation with error highlighting
-- [ ] Component preview panel
-- [ ] Bidirectional: parse .kesl files into graph
+- [x] KESL-specific node library
+- [x] `KeslGraphCompiler` (graph → AST)
+- [x] Validation — `KeslGraphValidator` ships with four rules (no-cycles, required-inputs, single-root, type-compatibility); the in-editor error-highlighting UI integration is not yet wired up
+- [x] Component preview panel
+- [x] Bidirectional: parse .kesl files into graph
 
 ## Alternatives Considered
 
@@ -314,5 +345,17 @@ Execute KESL graphs at runtime without code generation:
 ### Neutral
 
 - Graph data model is serializable via existing WorldSnapshot
-- Integrates with existing undo/redo (ChangeTracker)
+- Undo/redo uses explicit command objects (create/delete/move/duplicate node and create/delete connection) pushed to the world's `IUndoRedoManager` extension when present; `GraphContext` exposes `*Undoable` variants of each mutating operation
 - UI plugin required as dependency
+
+## References
+
+- [ADR-009](009-kesl-shader-language.md) — KESL shader language; graphs compile to its AST
+- [Graph Node Editor documentation](../graph.md) — user-facing guide, including the as-built divergences from this ADR
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Implementation marked Shipped — all five phases landed (`src/KeenEyes.Graph`, `src/KeenEyes.Graph.Abstractions`, `editor/KeenEyes.Graph.Kesl`); named gaps: `[GraphNode]` source generator (still future) and in-editor error-highlighting UI for validation. Body amended to as-built reality: selection moved from a `GraphNode.IsSelected` bool to `GraphNodeSelectedTag`/`GraphConnectionSelectedTag` tag components (and `GraphNode` gained `Height`/`DisplayName`); undo/redo uses command objects + `IUndoRedoManager` instead of ChangeTracker; `INodeTypeDefinition` updated to shipped signatures (`IReadOnlyList` ports, height-returning `RenderBody`); port widening table extended with int-vector rows and the Flow-only-to-Flow rule; architecture diagram updated to place KeenEyes.Graph.Kesl in the editor tier with its Editing/Preview subsystems. First-accepted date corrected 2024-12-31 → 2025-12-31 (git).
+- **v1 — 2025-12-31 (c8a3690a):** Accepted — generic graph node editor framework (KeenEyes.Graph + Abstractions) with KESL shader nodes as the first domain: hybrid entity/registry data model, implicit-widening port types, IGraphRenderer, and graph-to-KESL-AST compilation.

--- a/docs/adr/011-unified-scene-model.md
+++ b/docs/adr/011-unified-scene-model.md
@@ -1,8 +1,10 @@
 # ADR-011: Unified Scene Model
 
 **Status:** Accepted
-**Date:** 2026-01-01
-**Issue:** [#431](https://github.com/orion-ecs/keen-eye/issues/431)
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2026-01-01 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-001](001-world-manager-architecture.md) (World managers) · [#431](https://github.com/orion-ecs/keen-eye/issues/431) · [#1079](https://github.com/orion-ecs/keen-eye/issues/1079)
 
 ## Context
 
@@ -32,16 +34,22 @@ This mirrors Godot's elegant approach where **everything is a scene** (`.tscn`).
 
 ### Model
 
-Scenes are entity hierarchies. A scene definition produces a root entity with descendants. How you use it determines whether it behaves like a "prefab" or a "level":
+Scenes are entity hierarchies. A scene definition produces a root entity with descendants. How you use it determines whether it behaves like a "prefab" or a "level".
+
+As built, the runtime splits this across two cooperating pieces:
+
+- **Generated static spawn methods** — the unified generator turns each `.kescene`/`.keprefab` file into a `Scenes.SpawnX(world, ...)` method that instantiates the file-defined entity hierarchy.
+- **`world.Scenes` (`SceneManager`)** — manages lifecycle. `Spawn(string name)` creates a scene root entity (`SceneRootTag` + `SceneMetadata`), `AddToScene` associates spawned entities with that root, and `Unload`/`TransitionEntity`/`MarkPersistent` handle reference counting and persistence.
 
 ```csharp
-// Spawn multiple instances (prefab usage)
-var player = world.Scenes.Spawn("Player");
-var enemy1 = world.Scenes.Spawn("Enemy");
-var enemy2 = world.Scenes.Spawn("Enemy");
+// Instantiate file-defined hierarchies (prefab usage) via generated spawn methods
+var player = Scenes.SpawnPlayer(world);
+var enemy1 = Scenes.SpawnEnemy(world);
+var enemy2 = Scenes.SpawnEnemy(world);
 
-// Spawn as current level (scene usage)
+// Create a scene root for lifecycle tracking (level usage)
 var level = world.Scenes.Spawn("ForestLevel");
+world.Scenes.AddToScene(Scenes.SpawnForestLevel(world), level);
 
 // Unload when transitioning
 world.Scenes.Unload(level);
@@ -49,7 +57,7 @@ world.Scenes.Unload(level);
 
 ### Components
 
-All scene-related components live in `KeenEyes.Abstractions`:
+All scene-related components live in `KeenEyes.Abstractions` (namespace `KeenEyes.Scenes`):
 
 ```csharp
 /// <summary>
@@ -108,17 +116,22 @@ public partial class World
 }
 ```
 
-**SceneManager API:**
+**SceneManager API (as built):**
 
 | Method | Description |
 |--------|-------------|
-| `Spawn(string name)` | Spawn a scene by name, returns root entity |
-| `Spawn(string name, Vector3 position)` | Spawn with position override |
+| `Spawn(string name)` | Create an empty scene root entity (`SceneRootTag` + `SceneMetadata`) for lifecycle tracking |
+| `AddToScene(Entity entity, Entity scene)` | Associate an entity with a scene root (increments reference count) |
+| `RemoveFromScene(Entity entity, Entity scene)` | Remove an entity from a scene (decrements reference count) |
 | `Unload(Entity sceneRoot)` | Unload scene, respecting persistence and reference counts |
 | `MarkPersistent(Entity entity)` | Mark entity to survive scene unloads |
 | `TransitionEntity(Entity entity, Entity toScene)` | Move entity to another scene (increments ref count) |
 | `GetLoaded()` | Get all currently loaded scene roots |
 | `GetScene(string name)` | Get loaded scene by name |
+| `IsLoaded(string name)` | Check whether a scene with the given name is loaded |
+| `LoadedCount` | Number of currently loaded scenes |
+
+Note that `SceneManager` does not instantiate file-defined content — the generated static `Scenes.SpawnX` methods do that. There is also no `Spawn(string name, Vector3 position)` overload; per-instance overrides are typed optional parameters on the generated spawn methods, derived from each file's `overridableFields` list.
 
 ### Scene Transitions and Persistence
 
@@ -181,18 +194,21 @@ The `.kescene` format remains unchanged. The existing JSON schema works for both
 
 ### Generator
 
-One unified generator produces spawn methods:
+One unified generator — `SceneGenerator` (`editor/KeenEyes.Generators/SceneGenerator.cs`) — processes both `.kescene` and `.keprefab` AdditionalFiles and produces spawn methods. It emits a `Scenes` class with an `All` list and one spawn method per asset; each method's optional parameters come from that file's `overridableFields` list (there is no fixed position parameter):
 
 ```csharp
-// Generated code
+// Generated code — optional parameters derive from each file's overridableFields
 public static partial class Scenes
 {
     public static IReadOnlyList<string> All { get; } = ["Player", "Enemy", "ForestLevel"];
 
-    public static Entity SpawnPlayer(World world, Vector3? position = null) { ... }
-    public static Entity SpawnEnemy(World world, Vector3? position = null) { ... }
+    public static Entity SpawnPlayer(World world, /* overridable-field parameters */) { ... }
+    public static Entity SpawnEnemy(World world, /* overridable-field parameters */) { ... }
     public static Entity SpawnForestLevel(World world) { ... }
 }
+
+// Usage: overrides are typed named arguments
+var enemy = Scenes.SpawnEnemy(world, myGamePositionX: 100, myGamePositionY: 50);
 ```
 
 ### Systems Do Not Load/Unload with Scenes
@@ -207,28 +223,36 @@ Systems are registered on the World and query for matching entities. When scene 
 - **Matches Godot's proven approach** - Everything is a scene
 - **Less code duplication** - One generator, one manager
 - **Flexible usage** - Same file can be instanced many times or loaded as a level
-- **Clean API** - `world.Scenes.Spawn("Player")` for everything
+- **Clean API** - Generated `Scenes.SpawnX` methods plus `world.Scenes` lifecycle management for everything
 
 ### Negative
 
-- **Migration** - Existing `.keprefab` files need migration to `.kescene`
+- **Migration** - Superseded: the anticipated migration of existing `.keprefab` files to `.kescene` never happened and is not planned. Both extensions remain first-class inputs to the single unified `SceneGenerator` (the SDK auto-includes `**/*.keprefab`, samples still use it, and `docs/prefabs.md` documents the workflow as current).
 - **Naming** - "Scene" for a player entity may feel odd initially
 
 ### Neutral
 
-- **Deprecation path** - `PrefabManager` and `PrefabGenerator` will be deprecated in favor of the unified model
+- **Deprecation path** - Completed and exceeded: `PrefabGenerator` was merged into `SceneGenerator`, and the entire runtime prefab API (`PrefabManager`, `EntityPrefab`, `IPrefabCapability`, `World.Prefabs`) was deprecated and then removed outright in July 2026 ([#1079](https://github.com/orion-ecs/keen-eye/issues/1079)). The unified model is the only prefab/scene mechanism.
 
 ## Implementation
 
-1. Add scene components to `KeenEyes.Abstractions`
-2. Add `SceneManager` to `KeenEyes.Core` with `world.Scenes` accessor
-3. Update `SceneGenerator` to handle all use cases
-4. Deprecate `PrefabManager` and `PrefabGenerator`
-5. Update editor to use unified model
-6. Migrate existing `.keprefab` files to `.kescene`
+- [x] Add scene components to `KeenEyes.Abstractions` (`KeenEyes.Scenes` namespace)
+- [x] Add `SceneManager` to `KeenEyes.Core` with `world.Scenes` accessor
+- [x] Update `SceneGenerator` to handle all use cases — unified over `.kescene` and `.keprefab`
+- [x] Deprecate `PrefabManager` and `PrefabGenerator` — exceeded: `PrefabGenerator` merged into `SceneGenerator`, and the runtime prefab API was subsequently removed entirely ([#1079](https://github.com/orion-ecs/keen-eye/issues/1079))
+- [x] Update editor to use unified model (`EditorWorldManager`)
+- [ ] ~~Migrate existing `.keprefab` files to `.kescene`~~ — superseded: both extensions remain supported by the unified generator; no migration planned
 
 ## References
 
 - [Issue #431: Scene Management Research](https://github.com/orion-ecs/keen-eye/issues/431)
+- [Issue #1079: Remove deprecated runtime prefab API](https://github.com/orion-ecs/keen-eye/issues/1079)
 - [Godot Scene System](https://docs.godotengine.org/en/stable/getting_started/step_by_step/scenes_and_nodes.html)
-- [ADR-001: World Manager Architecture](./001-world-manager-architecture.md)
+- [ADR-001: World Manager Architecture](001-world-manager-architecture.md)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Implementation marked Partial: `SceneManager.Spawn(name)` creates only an empty scene root — file-defined hierarchies spawn via generated static `Scenes.SpawnX` methods with `overridableFields` parameters, and the documented `Spawn(name, Vector3)` overload was never built; the planned `.keprefab`→`.kescene` migration was superseded (both extensions stay first-class). Decision/Consequences/Implementation amended to the as-built split (generated spawn methods vs. `world.Scenes` lifecycle), full SceneManager API table, and the complete removal of the runtime prefab API (#1079).
+- **v1 — 2026-01-01 (#431):** Accepted — Unify prefabs and scenes into a single scene concept (one file model, one generator, one runtime lifecycle manager), resolving issue #431's scene-management questions.

--- a/docs/adr/012-editor-plugin-extension-architecture.md
+++ b/docs/adr/012-editor-plugin-extension-architecture.md
@@ -1,7 +1,10 @@
 # ADR-012: Editor Plugin Extension Architecture
 
-**Status:** Proposed
-**Date:** 2026-01-01
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2026-01-01 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-007](007-capability-based-plugin-architecture.md) (plugin capabilities) · [#600](https://github.com/orion-ecs/keen-eye/issues/600)
 
 ## Context
 
@@ -38,13 +41,13 @@ public interface IEditorPlugin
 
 public interface IEditorContext
 {
-    // Core services (read-only access)
-    EditorProject Project { get; }
-    EditorWorldManager Worlds { get; }
-    SelectionManager Selection { get; }
-    UndoRedoManager UndoRedo { get; }
-    AssetDatabase Assets { get; }
+    // Core services (read-only access, interface-typed)
+    IEditorWorldManager Worlds { get; }
+    ISelectionManager Selection { get; }
+    IUndoRedoManager UndoRedo { get; }
+    IAssetDatabase Assets { get; }
     IWorld EditorWorld { get; }
+    ILogQueryable? Log { get; }  // null when no queryable log provider is configured
 
     // Extension storage (mirrors IPluginContext)
     void SetExtension<T>(T extension) where T : class;
@@ -58,16 +61,18 @@ public interface IEditorContext
     bool HasCapability<T>() where T : class, IEditorCapability;
 
     // Event subscriptions
-    EventSubscription OnSceneOpened(Action<World> handler);
+    EventSubscription OnSceneOpened(Action<IWorld> handler);
     EventSubscription OnSceneClosed(Action handler);
     EventSubscription OnSelectionChanged(Action<IReadOnlyList<Entity>> handler);
     EventSubscription OnPlayModeChanged(Action<EditorPlayState> handler);
 }
 ```
 
+Core services are exposed through interfaces (`IEditorWorldManager`, `ISelectionManager`, `IUndoRedoManager`, `IAssetDatabase`) rather than the concrete manager types originally sketched, and an `ILogQueryable? Log` service was added. Not yet implemented: the originally proposed `EditorProject Project` service — no `EditorProject` type exists.
+
 ### Editor Capabilities
 
-Following ADR-007's pattern, define editor features as capability interfaces:
+Following ADR-007's pattern, editor features are defined as capability interfaces. Nine ship: the seven originally proposed plus two added during implementation:
 
 | Capability | Purpose |
 |------------|---------|
@@ -78,6 +83,8 @@ Following ADR-007's pattern, define editor features as capability interfaces:
 | `IAssetCapability` | Custom asset importers, thumbnails |
 | `IShortcutCapability` | Register keyboard shortcuts |
 | `IToolCapability` | Register viewport tools (select, move, etc.) |
+| `INotificationCapability` | Editor notifications/toasts (added post-proposal) |
+| `IExtendedPanelCapability` | Extended panel management (added post-proposal) |
 
 ### Capability Interface Definitions
 
@@ -105,16 +112,18 @@ public interface IViewportCapability : IEditorCapability
     void AddOverlay(string id, IViewportOverlay overlay);
     void SetOverlayVisible(string id, bool visible);
     void AddPickHandler(IPickHandler handler);
-    void RegisterCameraMode(string id, ICameraMode mode);
+    void RemovePickHandler(IPickHandler handler);
 }
 
 public interface IGizmoRenderer
 {
     int Order { get; }
     bool IsVisible { get; }
-    void Render(GizmoRenderContext context, IReadOnlyList<Entity> selection);
+    void Render(GizmoRenderContext context);
 }
 ```
+
+`IGizmoRenderer.Render` receives the current selection through `GizmoRenderContext` rather than as a separate parameter. Not yet implemented: camera-mode registration (`RegisterCameraMode(string id, ICameraMode mode)`) from the original proposal — no `ICameraMode` type exists.
 
 #### IMenuCapability
 
@@ -124,17 +133,23 @@ public interface IMenuCapability : IEditorCapability
     void AddMenuItem(MenuPath path, EditorCommand command);
     void AddContextMenuItem<T>(MenuPath path, EditorCommand<T> command);
     void AddToolbarButton(ToolbarSection section, EditorCommand command);
-    void RemoveMenuItem(MenuPath path);
+    bool RemoveMenuItem(MenuPath path);  // true if the item existed
 }
 
-public record MenuPath(string Path)
+// MenuPath is a readonly struct of path segments,
+// constructed via new MenuPath(params string[]) or parsed from a string:
+public readonly struct MenuPath
 {
-    public static MenuPath File(string item) => new($"File/{item}");
-    public static MenuPath Edit(string item) => new($"Edit/{item}");
-    public static MenuPath Entity(string item) => new($"Entity/{item}");
-    public static MenuPath Window(string item) => new($"Window/{item}");
+    public MenuPath(params string[] segments) { ... }
+    public static MenuPath Parse(string path) { ... }  // e.g. "File/Export/Scene"
+
+    public MenuPath Parent { get; }
+    public string Name { get; }
+    public bool IsRoot { get; }
 }
 ```
+
+The originally sketched per-menu static factories (`MenuPath.File(...)`, `MenuPath.Edit(...)`, etc.) were not implemented; segment construction and `Parse` cover those cases.
 
 #### IPanelCapability
 
@@ -142,26 +157,37 @@ public record MenuPath(string Path)
 public interface IPanelCapability : IEditorCapability
 {
     void RegisterPanel<T>(PanelDescriptor descriptor) where T : IEditorPanel, new();
+    void RegisterPanel(PanelDescriptor descriptor, Func<IEditorPanel> factory);
     void OpenPanel(string id);
     void ClosePanel(string id);
     bool IsPanelOpen(string id);
+    void FocusPanel(string id);
 }
 
 public interface IEditorPanel : IDisposable
 {
-    string Title { get; }
-    Entity CreateUI(IWorld editorWorld, Entity parent, FontHandle font);
+    void Initialize(PanelContext context);
     void Update(float deltaTime);
+    void Shutdown();
 }
 
-public record PanelDescriptor(
-    string Id,
-    string Title,
-    DockPosition DefaultPosition = DockPosition.Right,
-    bool ShowByDefault = false,
-    MenuPath? WindowMenuItem = null
-);
+public class PanelDescriptor
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public string? Icon { get; init; }
+    public PanelDockLocation DefaultLocation { get; init; }
+    public bool OpenByDefault { get; init; }
+    public float MinWidth { get; init; }
+    public float MinHeight { get; init; }
+    public float DefaultWidth { get; init; }
+    public float DefaultHeight { get; init; }
+    public string? Category { get; init; }
+    public ShortcutBinding? ToggleShortcut { get; init; }
+}
 ```
+
+As shipped, `PanelDescriptor` is an init-property class rather than the positional record originally sketched, and `IEditorPanel` follows an `Initialize(PanelContext)` / `Update` / `Shutdown` lifecycle instead of building UI directly via a `CreateUI(IWorld, Entity, FontHandle)` method. A factory-based `RegisterPanel(descriptor, Func<IEditorPanel>)` overload and `FocusPanel(id)` were added.
 
 ### Source-Generated Extensions
 
@@ -209,21 +235,31 @@ On shutdown:
     └── Dispose tracked resources
 ```
 
+The shipped lifecycle matches this flow and extends it beyond the original proposal:
+
+- **Dynamic discovery and loading** in collectible, isolated load contexts (`PluginLoader`, `PluginLoadContext`, `PluginRepository`)
+- **Permission-based security** — `PluginPermission` flags gate capability access via `PermissionManager` and `SecurePluginContext`, with signature verification (`PluginSignatureVerifier`) and `PermissionDeniedException` on violations
+- **Hot reload with state preservation** — plugins implementing `IStatefulPlugin` save and restore state across reloads
+- **`EditorPluginBase`** convenience base class for plugin authors
+
+See [Editor Plugin Development](../editor-plugin-development.md) for the full authoring guide.
+
 ### Built-in Plugins
 
-Core editor features are refactored as internal plugins:
+Core editor features are implemented as internal plugins:
 
-| Plugin | Provides |
-|--------|----------|
-| `CoreEditorPlugin` | Selection, undo/redo, basic commands |
-| `InspectorPlugin` | Component inspector, built-in property drawers |
-| `HierarchyPlugin` | Scene tree panel |
-| `ViewportPlugin` | 3D/2D viewport, transform gizmos, grid |
-| `ConsolePlugin` | Log panel |
-| `ProfilerPlugin` | System timing panel |
-| `ProjectPlugin` | Asset browser panel |
+| Plugin | Provides | Status |
+|--------|----------|--------|
+| `CoreEditorPlugin` | Selection, undo/redo, basic commands | ✅ Implemented |
+| `InspectorPlugin` | Component inspector, built-in property drawers | ✅ Implemented, unit-tested |
+| `HierarchyPlugin` | Scene tree panel | ✅ Implemented, unit-tested |
+| `ViewportPlugin` | 3D/2D viewport, transform gizmos, grid | ✅ Implemented |
+| `ConsolePlugin` | Log panel | ✅ Implemented |
+| `ProfilerPlugin` | System timing panel | Not implemented — frame inspection lives in the static `FrameInspectorPanel` |
+| `ProjectPlugin` | Asset browser panel | ✅ Implemented |
+| `PluginManagerPlugin` | Plugin management panel (added post-proposal) | ✅ Implemented |
 
-This serves as reference implementations for third-party plugins.
+These serve as reference implementations for third-party plugins. Note, however, that `EditorApplication` has not yet migrated to them: the shipping editor still constructs its panels through the static panel classes (`HierarchyPanel.Create`, `ViewportPanel.Create`, `InspectorPanel.Create`, etc.), and the only plugins installed at startup via `EditorPluginManager` are the gizmo plugins (`NavigationEditorPlugin`, `AnimationEditorPlugin`). Completing the panel migration remains open work.
 
 ## Consequences
 
@@ -248,33 +284,44 @@ This serves as reference implementations for third-party plugins.
 
 ## Implementation Phases
 
-### Phase 1: Core Abstractions
-- Create `IEditorPlugin`, `IEditorContext` interfaces
-- Create `IEditorCapability` marker interface
-- Create `EditorPluginManager` for lifecycle management
+### Phase 1: Core Abstractions ✅
+- [x] Create `IEditorPlugin`, `IEditorContext` interfaces
+- [x] Create `IEditorCapability` marker interface
+- [x] Create `EditorPluginManager` for lifecycle management (wired into `EditorApplication`)
 
-### Phase 2: Capability Interfaces
-- `IInspectorCapability` with PropertyDrawer registration
-- `IMenuCapability` with menu/toolbar registration
-- `IPanelCapability` with panel registration
+### Phase 2: Capability Interfaces ✅
+- [x] `IInspectorCapability` with PropertyDrawer registration
+- [x] `IMenuCapability` with menu/toolbar registration
+- [x] `IPanelCapability` with panel registration
 
-### Phase 3: Viewport Capabilities
-- `IViewportCapability` for gizmos and overlays
-- `IToolCapability` for viewport tools
-- `IShortcutCapability` for keybindings
+### Phase 3: Viewport Capabilities ✅ (except camera modes)
+- [x] `IViewportCapability` for gizmos and overlays
+- [x] `IToolCapability` for viewport tools
+- [x] `IShortcutCapability` for keybindings
+- Not yet implemented: camera-mode registration (`RegisterCameraMode`/`ICameraMode`)
 
-### Phase 4: Asset Capabilities
-- `IAssetCapability` for importers
-- Thumbnail generators
-- Drag-drop handlers
+### Phase 4: Asset Capabilities ✅
+- [x] `IAssetCapability` for importers
+- [x] Thumbnail generators
+- [x] Drag-drop handlers
 
-### Phase 5: Built-in Plugin Refactoring
-- Convert InspectorPanel to InspectorPlugin
-- Convert HierarchyPanel to HierarchyPlugin
-- Convert ViewportPanel to ViewportPlugin
+### Phase 5: Built-in Plugin Refactoring (partial)
+- [x] Convert InspectorPanel to InspectorPlugin
+- [x] Convert HierarchyPanel to HierarchyPlugin
+- [x] Convert ViewportPanel to ViewportPlugin
+- Not yet implemented: installing these plugins in `EditorApplication` — the live editor still builds panels via the static panel classes, so the plugin versions are written and tested but not yet the shipping code path
 
 ## Related
 
 - [ADR-007: Capability-Based Plugin Architecture](007-capability-based-plugin-architecture.md)
 - [Scene Editor Architecture](../research/scene-editor-architecture.md)
+- [Editor Plugin Development](../editor-plugin-development.md) — authoring guide for this architecture
+- [Editor Documentation](../editor.md)
 - [Epic #600: Scene/World Editor](https://github.com/orion-ecs/keen-eye/issues/600)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted — the architecture is implemented and documented as the editor's supported extension surface. Implementation marked Partial: `RegisterCameraMode`/`ICameraMode`, `ProfilerPlugin`, and the `EditorProject` `Project` context service were never built, and the built-in panel plugins, though implemented and unit-tested, are not yet installed by `EditorApplication` (the live editor still uses static panel classes). Body amended to as-built API shapes (interface-typed `IEditorContext` services plus `Log`, `MenuPath` as a segment struct, `PanelDescriptor`/`IEditorPanel` Initialize/Update/Shutdown lifecycle, `IGizmoRenderer.Render(GizmoRenderContext)`), the two added capabilities (`INotificationCapability`, `IExtendedPanelCapability`), and the shipped lifecycle extensions (dynamic loading, permission-based security, hot reload).
+- **v1 — 2026-01-01 (#600):** Proposed — IEditorPlugin/IEditorContext capability-based editor plugin architecture mirroring the runtime plugin pattern (ADR-007), with capability interfaces, source-generated extensions, and built-in plugin refactoring plan.

--- a/docs/adr/013-dynamic-plugin-loading.md
+++ b/docs/adr/013-dynamic-plugin-loading.md
@@ -1,7 +1,10 @@
 # ADR-013: Dynamic Plugin Loading
 
-**Status:** Proposed
-**Date:** 2026-01-02
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2026-01-02 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-012](012-editor-plugin-extension-architecture.md) (editor plugins) · [ADR-007](007-capability-based-plugin-architecture.md) (plugin capabilities)
 
 ## Context
 
@@ -35,7 +38,8 @@ KeenEyes Editor needs to support third-party plugins distributed as NuGet packag
 Implement a **tiered plugin loading system** with three levels of dynamism:
 
 ### Tier 1: Static Plugins (Default)
-- Loaded at startup, require editor restart to add/remove
+- As built, Tier 1 is on-demand loading rather than a startup scan: built-in plugins are compiled into the editor and installed in `EditorApplication`, while installed third-party plugins are recorded in the persisted `PluginRegistry` and loaded via the Plugin Manager panel (`EditorPluginManager.LoadDynamicPlugin`)
+- No automatic startup scan of plugin folders is wired (`DiscoverPlugins()` exists but has no production caller)
 - Simplest, most stable approach
 - All plugins work at this tier
 
@@ -66,7 +70,6 @@ MyPlugin.1.0.0.nupkg
 
 ```json
 {
-  "$schema": "https://keeneyes.dev/schemas/plugin-manifest-v1.json",
   "name": "My Awesome Plugin",
   "id": "com.example.myawesomeplugin",
   "version": "1.0.0",
@@ -98,13 +101,15 @@ MyPlugin.1.0.0.nupkg
 }
 ```
 
+The manifest contract is defined by `KeenEyes.Editor.Plugins.PluginManifest` (`Parse`/`TryParse`/`ToJson`) rather than a published JSON Schema — no plugin-manifest schema file exists in `schemas/`. Beyond the fields above, the shipped format also supports `security` (publicKeyToken, assemblyHash) and `permissions` (required/optional permission lists) sections, consumed by the plugin security subsystem.
+
 ### Architecture
 
 ```
-EditorPluginManager
+EditorPluginManager            # Facade: lifecycle + state transitions
 ├── PluginRepository           # Discovers installed plugins
 │   ├── Scan NuGet global cache
-│   ├── Scan local plugin folder
+│   ├── Scan local plugin folders
 │   └── Parse manifests
 │
 ├── PluginLoader               # Loads/unloads assemblies
@@ -113,16 +118,22 @@ EditorPluginManager
 │   ├── Instantiate IEditorPlugin via reflection
 │   └── Unload context (if collectible)
 │
-├── PluginRegistry             # Tracks loaded plugins
-│   ├── Plugin metadata
-│   ├── Load state (Unloaded, Loaded, Enabled, Disabled)
-│   └── Dependency graph
+├── LoadedPlugin + PluginState # Per-plugin state machine
 │
-└── PluginLifecycle            # Manages state transitions
-    ├── Load → Enable → Disable → Unload
-    ├── Dependency ordering
-    └── Error recovery
+├── Registry/PluginRegistry    # Persisted registry of installed packages
+│
+├── Dependencies/              # PluginDependencyResolver + DependencyGraph
+│   ├── Load ordering (topological sort)
+│   ├── Version constraints (NuGet VersionRange)
+│   └── Circular-dependency detection
+│
+├── Installation/              # PluginInstaller / PluginUninstaller
+├── NuGet/                     # NuGetClient (package acquisition)
+└── Security/                  # AssemblyAnalyzer, PluginSignatureVerifier,
+                               # PermissionManager, TrustedPublisherStore
 ```
+
+There is no separate `PluginLifecycle` type: state transitions and error recovery live in `EditorPluginManager` itself, with per-plugin state carried by `LoadedPlugin`. Note that `PluginRegistry` is the *persisted installed-package registry*, not an in-memory load-state tracker. The `Installation/`, `NuGet/`, and `Security/` subsystems were added after this ADR was first written.
 
 ### PluginLoadContext
 
@@ -171,30 +182,34 @@ internal sealed class PluginLoadContext : AssemblyLoadContext
 
 ### Plugin States
 
+The shipped `PluginState` enum defines six states: `Discovered`, `Loaded`, `Enabled`, `Disabled`, `Failed`, and `Unloading`. There is no terminal `Unloaded` state — after a hot-reload unload completes, the plugin reverts to `Discovered`.
+
 ```
-                    ┌──────────────┐
-         install   │  Discovered  │   scan
-            ┌──────│   (on disk)  │◄──────┐
-            │      └──────────────┘       │
-            │                             │
-            ▼                             │
-    ┌──────────────┐              ┌───────┴──────┐
-    │    Loaded    │◄────────────►│   Unloaded   │
-    │  (in memory) │   unload*    │  (assembly   │
-    └──────┬───────┘              │   released)  │
-           │                      └──────────────┘
-           │ enable                     ▲
-           ▼                            │ unload*
-    ┌──────────────┐                    │
-    │   Enabled    │────────────────────┘
+    ┌──────────────┐
+    │  Discovered  │◄───────────────────────────┐
+    │   (on disk)  │                            │
+    └──────┬───────┘                            │
+           │ load                       ┌───────┴──────┐
+           ▼                            │  Unloading   │
+    ┌──────────────┐      unload*       │ (transitional│
+    │    Loaded    │───────────────────►│  during hot  │
+    │  (in memory) │                    │   reload)    │
+    └──────┬───────┘                    └──────────────┘
+           │ enable                             ▲
+           ▼                                    │
+    ┌──────────────┐                            │
+    │   Enabled    │────────────────────────────┘
     │  (running)   │     disable + unload*
     └──────┬───────┘
-           │ disable
-           ▼
-    ┌──────────────┐
-    │   Disabled   │
-    │  (sleeping)  │
-    └──────────────┘
+           │ disable / enable
+           ▼        ▲
+    ┌───────────────┴──┐
+    │     Disabled     │
+    │    (sleeping)    │
+    └──────────────────┘
+
+    Failed — load or Initialize() threw; error isolation
+             keeps the editor running
 
     * Only for hot-reload plugins
 ```
@@ -227,40 +242,39 @@ For unloading to work, ALL references to plugin types must be released:
 3. **Cached types** - No `Type` or `MethodInfo` references retained
 4. **Static fields** - Plugin must not store in host statics
 
-The `EditorPluginContext` tracks all resources and disposes them on unload:
+The `EditorPluginContext` tracks every event subscription a plugin registers and disposes them on disable/unload; UI cleanup flows through the panel capability rather than a per-context entity list. Capability registrations (panels, drawers, tools, gizmos, shortcuts) are tracked as weak references so `UnloadDiagnostics` can report anything that fails to collect after an unload:
 
 ```csharp
-public sealed class EditorPluginContext : IEditorContext, IDisposable
+internal sealed class EditorPluginContext : IEditorContext
 {
     private readonly List<EventSubscription> subscriptions = [];
-    private readonly List<Entity> createdPanels = [];
-    private readonly WeakReference<IEditorPlugin> pluginRef;
 
-    public void Dispose()
+    // Weak-referenced capability registrations for unload diagnostics
+    private readonly List<WeakReference<object>> registeredPanels = [];
+    // ... drawers, tools, gizmos, shortcuts
+
+    internal void DisposeSubscriptions()
     {
-        // Dispose subscriptions (removes event handlers)
-        foreach (var sub in subscriptions)
-            sub.Dispose();
-
-        // Destroy created UI entities
-        foreach (var entity in createdPanels)
-            EditorWorld.Despawn(entity);
-
-        // Clear capability registrations
-        // ...
+        foreach (var subscription in subscriptions)
+        {
+            subscription.Dispose();
+        }
+        subscriptions.Clear();
     }
 }
 ```
+
+Hot reload additionally preserves plugin state across reloads via `IStatefulPlugin.SaveState`/`RestoreState` (see the [hot reload guide](../editor-plugin-hot-reload.md)).
 
 ### Error Handling
 
 Plugin failures are isolated:
 
 ```csharp
-public void EnablePlugin(string pluginId)
+public void EnableDynamicPlugin(string pluginId)
 {
     var entry = registry.Get(pluginId);
-    var context = new EditorPluginContext(this, entry.Manifest);
+    var context = new EditorPluginContext(this, entry.Plugin);
 
     try
     {
@@ -269,9 +283,9 @@ public void EnablePlugin(string pluginId)
     }
     catch (Exception ex)
     {
-        // Log error, keep plugin in Loaded state
+        // Log error, mark the plugin Failed, release its resources
         logger.Error($"Plugin {pluginId} failed to initialize: {ex}");
-        context.Dispose();
+        context.DisposeSubscriptions();
         entry.State = PluginState.Failed;
 
         // Optionally show user notification
@@ -291,31 +305,34 @@ Plugins are discovered from:
 
 ### API Surface
 
+The shipped lifecycle surface lives on `EditorPluginManager`:
+
 ```csharp
-// Plugin management
-editorPlugins.InstallFromNuGet("com.example.myplugin", "1.0.0");
-editorPlugins.InstallFromPath("/path/to/MyPlugin.dll");
-editorPlugins.UninstallPlugin("com.example.myplugin");
+// Discovery and loading
+editorPlugins.DiscoverPlugins();
+editorPlugins.LoadDynamicPlugin("com.example.myplugin");
 
 // Enable/disable
-editorPlugins.EnablePlugin("com.example.myplugin");
-editorPlugins.DisablePlugin("com.example.myplugin");
+editorPlugins.EnableDynamicPlugin("com.example.myplugin");
+editorPlugins.DisableDynamicPlugin("com.example.myplugin");
 
 // Hot reload (opt-in plugins only)
-editorPlugins.ReloadPlugin("com.example.myplugin");
+editorPlugins.UnloadDynamicPlugin("com.example.myplugin");
+editorPlugins.ReloadDynamicPlugin("com.example.myplugin");
 
 // Query
-var plugin = editorPlugins.GetPlugin("com.example.myplugin");
-var all = editorPlugins.GetAllPlugins();
-var enabled = editorPlugins.GetEnabledPlugins();
+var plugin = editorPlugins.GetDynamicPlugin("com.example.myplugin");
+var all = editorPlugins.GetDynamicPlugins();
 ```
+
+Package install, uninstall, and update do not live on the manager: they flow through `PluginInstaller` (`CreatePlanAsync`/`ExecuteAsync`) and `PluginUninstaller`, driven by the `keeneyes plugin install|uninstall|update|list|search` CLI commands and the Plugin Manager panel's Browse tab. (`InstallPlugin<T>()` exists but installs in-process built-in plugin instances, not packages.)
 
 ### User Experience
 
 1. **Plugin Manager Panel** - UI for browsing, installing, enabling plugins
 2. **Restart Indicator** - Shows when restart is needed for full changes
 3. **Error Recovery** - Disable failing plugins, offer to uninstall
-4. **Development Mode** - Auto-reload on rebuild (for plugin developers)
+4. **Development Mode** - Not yet implemented: auto-reload on rebuild. Plugin reload is manual (Plugin Manager panel Reload action / `ReloadDynamicPlugin`); the editor's `HotReloadManager` auto-reload applies to game assemblies, not editor plugins
 
 ## Consequences
 
@@ -341,30 +358,41 @@ var enabled = editorPlugins.GetEnabledPlugins();
 
 ## Implementation Phases
 
-### Phase 1: Static Loading
-- Plugin manifest schema
-- Plugin discovery from NuGet cache
-- PluginLoadContext with dependency resolution
-- Basic PluginLoader (load-only)
+### Phase 1: Static Loading — shipped, with two gaps
+- [x] Plugin manifest format (`PluginManifest` `Parse`/`TryParse`/`ToJson`)
+- [x] Plugin discovery from NuGet cache and plugin folders (`PluginRepository`)
+- [x] PluginLoadContext with dependency resolution
+- [x] Basic PluginLoader (load-only)
+- Not yet implemented: a published manifest JSON Schema (the contract lives in `PluginManifest.cs`)
+- Not yet implemented: startup auto-load of installed plugins — loading is on-demand; `DiscoverPlugins()` has no production caller
 
-### Phase 2: Enable/Disable
-- PluginRegistry with state tracking
-- Enable/Disable API
-- Plugin Manager panel UI
+### Phase 2: Enable/Disable — shipped
+- [x] Per-plugin state tracking (`LoadedPlugin` + `PluginState`)
+- [x] Enable/Disable API (`EnableDynamicPlugin` / `DisableDynamicPlugin`)
+- [x] Plugin Manager panel UI (`PluginManagerPlugin`)
 
-### Phase 3: Hot Reload
-- Collectible context support
-- Resource tracking in context
-- Unload API
-- Development mode auto-reload
+### Phase 3: Hot Reload — shipped, except auto-reload
+- [x] Collectible context support
+- [x] Resource tracking in context (`EditorPluginContext` subscription tracking, `UnloadDiagnostics` leak reporting)
+- [x] Unload/reload API (`UnloadDynamicPlugin` / `ReloadDynamicPlugin`), with `IStatefulPlugin.SaveState`/`RestoreState` state preservation
+- Not yet implemented: development mode auto-reload on rebuild
 
-### Phase 4: NuGet Integration
-- `keeneyes plugin install <package>` CLI
-- In-editor package browser
-- Version upgrade handling
+### Phase 4: NuGet Integration — shipped
+- [x] `keeneyes plugin install|uninstall|update|list|search` CLI (plus `keeneyes sources add|list|remove`)
+- [x] In-editor package browser (Plugin Manager Browse tab)
+- [x] Version upgrade handling (`PluginUpdateCommand` over `PluginInstaller`/`NuGetClient`)
 
 ## Related
 
 - [ADR-012: Editor Plugin Extension Architecture](012-editor-plugin-extension-architecture.md)
 - [ADR-007: Capability-Based Plugin Architecture](007-capability-based-plugin-architecture.md)
+- [Editor Plugin Hot Reload guide](../editor-plugin-hot-reload.md)
+- [Editor Plugin Dependencies guide](../editor-plugin-dependencies.md)
 - [.NET AssemblyLoadContext docs](https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted — the infrastructure landed in the same commit as the ADR (f678a831) and the index already listed it as Accepted. Implementation marked Partial: development-mode auto-reload of plugins, startup auto-load of installed plugins (`DiscoverPlugins()` has no callers; loading is on-demand), and a published plugin-manifest JSON Schema remain unimplemented. Body amended to as-built reality: shipped API names (`EnableDynamicPlugin`/`DisableDynamicPlugin`/`UnloadDynamicPlugin`/`ReloadDynamicPlugin`; install via `PluginInstaller` + `keeneyes plugin` CLI, not `InstallFromNuGet`), real component decomposition (no `PluginLifecycle` type; `PluginRegistry` is the persisted install registry; `Dependencies/`, `Installation/`, `NuGet/`, `Security/` subsystems), actual `PluginState` set (adds `Failed`/`Unloading`, no terminal `Unloaded`), `EditorPluginContext` subscription tracking plus `IStatefulPlugin`/`UnloadDiagnostics`, manifest contract defined by `PluginManifest.cs` (dead `$schema` URL removed; `security`/`permissions` sections documented), and the phase checklist updated to shipped status.
+- **v1 — 2026-01-02 (f678a831):** Accepted — tiered dynamic plugin loading for editor plugins (Tier 1 static, Tier 2 enable/disable, Tier 3 collectible-ALC hot reload) with NuGet-package distribution and keeneyes-plugin.json manifests; landed together with the initial infrastructure (PluginLoadContext, PluginLoader, PluginRepository, PluginManifest, LoadedPlugin, EditorPluginManager dynamic-plugin API).

--- a/docs/adr/014-replay-playback-runtime-editor-integration.md
+++ b/docs/adr/014-replay-playback-runtime-editor-integration.md
@@ -1,8 +1,10 @@
 # ADR-014: Replay Playback Runtime and Editor Integration
 
-**Status:** Proposed
-**Date:** 2026-01-02
-**Issue:** [#84](https://github.com/orion-ecs/keen-eye/issues/84)
+**Status:** Amended
+**Revision:** v3
+**Implementation:** Partial
+**First accepted:** 2026-01-02 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-001](001-world-manager-architecture.md) (World managers) · [ADR-007](007-capability-based-plugin-architecture.md) (plugin capabilities) · [#83](https://github.com/orion-ecs/keen-eye/issues/83) · [#84](https://github.com/orion-ecs/keen-eye/issues/84)
 
 ## Context
 
@@ -47,7 +49,7 @@ Implement a layered architecture with a **core `ReplayPlayer`** that both runtim
 ┌─────────────────────────────────────────────────────────────┐
 │                 ReplayPlayer (KeenEyes.Replay)               │
 │  Core playback engine - no UI, no editor dependencies       │
-│  - LoadReplay(path/data)                                    │
+│  - LoadReplay(path/stream/bytes/data)                       │
 │  - Play/Pause/Stop/Step                                     │
 │  - SeekToFrame/SeekToTime                                   │
 │  - PlaybackSpeed (0.25x - 4x)                               │
@@ -61,13 +63,14 @@ Implement a layered architecture with a **core `ReplayPlayer`** that both runtim
 │ (KeenEyes.Replay)   │           │ (KeenEyes.Editor)       │
 │                     │           │                         │
 │ ReplayPlaybackPlugin│           │ ReplayPlaybackMode      │
-│ - Installs player   │           │ - Extends PlayModeManager│
-│ - Game calls Update │           │ - Timeline panel sync   │
-│                     │           │ - Inspector integration │
+│ - Installs player   │           │ - Owns playback world   │
+│ - Game calls Update │           │ - Frame inspector sync  │
 └─────────────────────┘           └─────────────────────────┘
 ```
 
 ### Core API: ReplayPlayer
+
+The shipped `ReplayPlayer` (`src/KeenEyes.Replay/ReplayPlayer.cs`) is **world-detached**: it is constructed with no arguments and does not own or mutate a world. Consumers pull frame data via `GetCurrentFrame()`/`GetFrame(int)`; a world and serializer are optionally attached via `SetValidationContext` for checksum validation and (with `EnableStateRestoration`) snapshot restoration. This diverges from the originally proposed world-owning constructor — the sketches below reflect the as-built API. `Unload()` shipped as `UnloadReplay()`, `StepBack()` shipped as `Step(int)` accepting negative counts, and the `EventHandler`-based events shipped as `Action`-based events.
 
 ```csharp
 namespace KeenEyes.Replay;
@@ -75,29 +78,31 @@ namespace KeenEyes.Replay;
 /// <summary>
 /// Core playback engine for replaying recorded sessions.
 /// </summary>
-public sealed class ReplayPlayer
+public sealed class ReplayPlayer : IDisposable
 {
-    // Construction
-    public ReplayPlayer(IWorld world, IComponentSerializer serializer);
+    // Construction - the player is world-detached; no world required
+    public ReplayPlayer();
 
     // Loading
-    public void LoadReplay(string path);
-    public void LoadReplay(ReplayData data);
-    public void Unload();
+    public void LoadReplay(string path, bool validateChecksum = true);
+    public void LoadReplay(Stream stream, bool validateChecksum = true);
+    public void LoadReplay(byte[] data, bool validateChecksum = true);
+    public void LoadReplay(ReplayData replay);
+    public void UnloadReplay();
 
     // Playback control
     public void Play();
     public void Pause();
     public void Stop();
-    public void Step(int frames = 1);
-    public void StepBack(int frames = 1);
+    public void Step(int frames = 1);   // negative counts step backward
 
     // Timeline navigation
     public void SeekToFrame(int frameNumber);
     public void SeekToTime(TimeSpan time);
+    public SnapshotMarker? GetNearestSnapshot(int targetFrame);
 
     // Speed control
-    public float PlaybackSpeed { get; set; } // 0.25x to 4x, default 1.0
+    public float PlaybackSpeed { get; set; } // clamped 0.25x to 4x via PlaybackSpeeds
 
     // State
     public PlaybackState State { get; }
@@ -108,12 +113,27 @@ public sealed class ReplayPlayer
     public TimeSpan TotalDuration { get; }
 
     // Frame advancement (called by game loop or editor)
-    public void Update(float deltaTime);
+    public bool Update(float deltaTime);
 
-    // Events
-    public event EventHandler<PlaybackStateChangedEventArgs>? StateChanged;
-    public event EventHandler<FrameChangedEventArgs>? FrameChanged;
-    public event EventHandler? PlaybackCompleted;
+    // Frame data access - consumers read frames; the player never applies them
+    public ReplayFrame? GetCurrentFrame();
+    public ReplayFrame GetFrame(int frameIndex);
+
+    // Optional world attachment for validation and snapshot restoration
+    public void SetValidationContext(World world, IComponentSerializer serializer);
+    public void ClearValidationContext();
+    public bool AutoValidate { get; set; }
+    public bool EnableStateRestoration { get; set; }
+    public bool ValidateCurrentFrame();
+    public bool ValidateDeterminism(int iterations = 3);
+
+    // Events (Action-based)
+    public event Action? PlaybackStarted;
+    public event Action? PlaybackPaused;
+    public event Action? PlaybackStopped;
+    public event Action? PlaybackEnded;
+    public event Action<int>? FrameChanged;
+    public event Action<ReplayDesyncException>? DesyncDetected;
 }
 
 public enum PlaybackState
@@ -126,7 +146,7 @@ public enum PlaybackState
 
 ### Runtime Integration: ReplayPlaybackPlugin
 
-For games that want simple playback without editor:
+For games that want simple playback without editor. No serialization capability is required at install time, because the player does not apply state to the world:
 
 ```csharp
 namespace KeenEyes.Replay;
@@ -142,16 +162,21 @@ public sealed class ReplayPlaybackPlugin : IWorldPlugin
 
     public void Install(IPluginContext context)
     {
-        var serializer = context.GetCapability<ISerializationCapability>()
-            .ComponentRegistry.CreateSerializer();
-        player = new ReplayPlayer(context.World, serializer);
-        context.RegisterExtension(player);
+        // Mutual exclusion: a world cannot record and play back simultaneously
+        if (context.TryGetExtension<ReplayRecorder>(out _))
+        {
+            throw new InvalidOperationException(
+                "Cannot install ReplayPlaybackPlugin on a world that has ReplayPlugin installed.");
+        }
+
+        player = new ReplayPlayer();
+        context.SetExtension(player);
     }
 
     public void Uninstall(IPluginContext context)
     {
-        player?.Stop();
-        player?.Unload();
+        // Stops active playback, unloads the replay, disposes the player,
+        // and removes the extension
     }
 }
 ```
@@ -177,27 +202,33 @@ while (!gameQuit)
 
 ### Runtime Integration: Ghost Mode
 
-For racing/time-trial games that show a "ghost" of a previous run alongside live gameplay.
+For racing/time-trial games that show a "ghost" of a previous run alongside live gameplay. Shipped in the `KeenEyes.Replay.Ghost` namespace (`src/KeenEyes.Replay/Ghost/`).
 
 **Key differences from full replay:**
 - Runs **in parallel** with live game, not instead of it
 - Only tracks a **single entity** (player character/vehicle)
 - **Visual-only** - no collision or physics interaction
 - Supports **multiple simultaneous ghosts** (personal best, world record, friend)
-- **Lightweight format** - KBs instead of MBs
+- **Lightweight format** - KBs instead of MBs, persisted as `.keghost` files via `GhostFileFormat` (magic `KGHO`), separate from full `.kreplay` replays
+
+**Not yet implemented:** the originally proposed `GhostRecorder` (direct lightweight recording without full replay overhead) was not built. Ghosts are produced only by **extracting** from full replays via `GhostExtractor` or loading previously saved `.keghost` files — a game that wants to capture a ghost must record a full replay first with `ReplayPlugin`.
 
 ```csharp
 namespace KeenEyes.Replay.Ghost;
 
 /// <summary>
-/// Lightweight ghost data extracted from a replay or recorded directly.
+/// Lightweight ghost data extracted from a replay or loaded from a .keghost file.
 /// </summary>
-public sealed class GhostData
+public sealed record GhostData
 {
-    public string Name { get; }
-    public int TotalFrames { get; }
-    public TimeSpan Duration { get; }
-    public IReadOnlyList<GhostFrame> Frames { get; }
+    public string? Name { get; init; }
+    public string? EntityName { get; init; }
+    public required DateTimeOffset RecordingStarted { get; init; }
+    public required TimeSpan Duration { get; init; }
+    public required int FrameCount { get; init; }
+    public required IReadOnlyList<GhostFrame> Frames { get; init; }
+    public float TotalDistance { get; }
+    public double AverageFrameRate { get; }
 }
 
 /// <summary>
@@ -205,66 +236,81 @@ public sealed class GhostData
 /// </summary>
 public sealed class GhostExtractor
 {
-    public GhostData ExtractGhost(ReplayData replay, string entityName);
-    public GhostData ExtractGhost(ReplayData replay, Predicate<Entity> selector);
-}
+    public TimeSpan MinFrameInterval { get; set; }   // downsampling
+    public bool CalculateDistance { get; set; }
 
-/// <summary>
-/// Records ghost data directly (without full replay overhead).
-/// </summary>
-public sealed class GhostRecorder
-{
-    public GhostRecorder(IWorld world, string entityName);
-
-    public void StartRecording(string name);
-    public void Update(float deltaTime);
-    public GhostData StopRecording();
+    public GhostData? ExtractGhost(ReplayData replay, string entityName);
+    public GhostData? ExtractGhostById(ReplayData replay, int entityId);
+    public Dictionary<string, GhostData> ExtractAllGhosts(ReplayData replay);
 }
 
 /// <summary>
 /// Plays back a ghost alongside live gameplay.
 /// </summary>
-public sealed class GhostPlayer
+public sealed class GhostPlayer : IDisposable
 {
-    public GhostPlayer(GhostData ghost);
+    public GhostPlayer();
+
+    public void Load(GhostData ghost);
+    public void LoadFromFile(string path, bool validateChecksum = true);
+    public void Unload();
 
     public void Play();
     public void Pause();
-    public void Reset();
-    public void Update(float deltaTime);
+    public void Stop();
+    public bool Update(float deltaTime);
+    public bool UpdateByDistance(float distance);
+    public void SeekToTime(TimeSpan time);
+    public void SeekToFrame(int frameNumber);
+
+    public GhostPlaybackState State { get; }
+    public GhostSyncMode SyncMode { get; set; }  // TimeSynced/FrameSynced/Independent/DistanceSynced
+    public float PlaybackSpeed { get; set; }
 
     public Vector3 Position { get; }
     public Quaternion Rotation { get; }
-    public bool IsComplete { get; }
+    public Vector3 Scale { get; }
+    public float Distance { get; }
 }
 
 /// <summary>
 /// Manages multiple ghosts for racing scenarios.
 /// </summary>
-public sealed class GhostManager
+public sealed class GhostManager : IDisposable
 {
-    public void AddGhost(string id, GhostData data, GhostVisualConfig config);
-    public void RemoveGhost(string id);
+    public void AddGhost(string id, GhostData data, GhostVisualConfig? config = null);
+    public void AddGhostFromFile(string id, string path, GhostVisualConfig? config = null);
+    public bool RemoveGhost(string id);
+
     public void Update(float deltaTime);
-    public IEnumerable<(string Id, GhostPlayer Player)> ActiveGhosts { get; }
+    public void UpdateByDistance(float distance);
+    public void PlayAll();
+    public void PauseAll();
+    public void StopAll();
+    public void SeekAllToTime(TimeSpan time);
+    public void SetAllSyncMode(GhostSyncMode syncMode);
+    public void SetAllPlaybackSpeed(float speed);
+
+    // GhostInstance bundles Player + Config (Position/Rotation/Opacity/TintColor/...)
+    public IEnumerable<GhostInstance> ActiveGhosts { get; }
 }
 ```
 
 **Ghost mode usage:**
 ```csharp
-// Extract ghost from existing replay
-var replay = ReplayFileFormat.Load("best_lap.kreplay");
-var ghost = GhostExtractor.ExtractGhost(replay, "Player");
+// Extract ghost from an existing replay
+var (_, replay) = ReplayFileFormat.Read(File.ReadAllBytes("best_lap.kreplay"));
+var extractor = new GhostExtractor();
+var ghost = extractor.ExtractGhost(replay, "Player")
+    ?? throw new InvalidOperationException("Entity not found in replay.");
 
-// Or record ghost directly (lightweight)
-var recorder = new GhostRecorder(world, "Player");
-recorder.StartRecording("Time Trial");
-// ... race happens ...
-var ghost = recorder.StopRecording();
+// Persist it as a lightweight .keghost file for later sessions
+GhostFileFormat.WriteToFile("best_lap.keghost", ghost);
 
-// Play ghost alongside live game
-var ghostManager = new GhostManager();
+// Play ghosts alongside live game
+using var ghostManager = new GhostManager();
 ghostManager.AddGhost("pb", ghost, new GhostVisualConfig { Opacity = 0.5f });
+ghostManager.AddGhostFromFile("wr", "world_record.keghost");
 
 // In game loop - both run in parallel
 while (racing)
@@ -273,70 +319,73 @@ while (racing)
     ghostManager.Update(deltaTime);    // Ghost playback
 
     renderer.RenderWorld(world);
-    renderer.RenderGhosts(ghostManager);
+    foreach (var instance in ghostManager.ActiveGhosts)
+    {
+        renderer.RenderGhost(instance.Position, instance.Rotation, instance.Opacity);
+    }
 }
 ```
 
-**Note:** Ghost recording is separate from `ReplayPlugin` to avoid overhead. Games that only need ghost mode don't need full replay infrastructure.
+**Note:** Ghost playback is separate from `ReplayPlugin` to avoid overhead — games that only *play* ghosts (e.g. from downloaded `.keghost` files) don't need full replay infrastructure. Capturing a new ghost, however, does require full replay recording (see the `GhostRecorder` gap above).
 
 ### Editor Integration: ReplayPlaybackMode
 
-Extends existing `PlayModeManager` with replay capabilities:
+The shipped `ReplayPlaybackMode` (`editor/KeenEyes.Editor/PlayMode/ReplayPlaybackMode.cs`) is **decoupled from `PlayModeManager`**, unlike the original proposal: it is constructed with only an `IComponentSerializer` and owns an internally created, dedicated playback `World` (exposed as `PlaybackWorld`). It wraps `ReplayPlayer` with editor-friendly `EventHandler`-based events. The proposed `GetFrameInfos()`/`GetSnapshots()` timeline accessors do not exist; frame data is served through `FrameInspectionData`.
 
 ```csharp
 namespace KeenEyes.Editor.PlayMode;
 
 /// <summary>
-/// Extends PlayModeManager to support replay file playback.
+/// Editor playback mode wrapping ReplayPlayer with a dedicated playback world.
 /// </summary>
 public sealed class ReplayPlaybackMode : IDisposable
 {
-    private readonly PlayModeManager playModeManager;
-    private readonly IWorld world;
-    private readonly ReplayPlayer player;
+    public ReplayPlaybackMode(IComponentSerializer serializer);
 
-    public ReplayPlaybackMode(PlayModeManager playModeManager, IWorld world);
+    // Dedicated playback world, created per loaded replay
+    public World? PlaybackWorld { get; }
 
     // Loading
-    public void LoadReplay(string path);
-    public void LoadReplay(ReplayData data);
+    public void LoadReplay(string path, bool validateChecksum = true);
+    public void LoadReplay(Stream stream, bool validateChecksum = true);
+    public void LoadReplay(ReplayData replayData);
+    public void Unload();
 
     // Delegates to ReplayPlayer with editor synchronization
     public void Play();
     public void Pause();
     public void Stop();
+    public void TogglePlayPause();
     public void StepFrame();
     public void StepFrameBack();
     public void SeekToFrame(int frame);
-
-    // Timeline data for UI
-    public IReadOnlyList<FrameInfo> GetFrameInfos();
-    public IReadOnlyList<SnapshotMarker> GetSnapshots();
+    public void SeekToTime(TimeSpan time);
+    public bool Update(float deltaTime);
 
     // Current frame details for inspector
-    public FrameInspectionData GetCurrentFrameData();
+    public FrameInspectionData? GetCurrentFrameData();
+    public FrameInspectionData GetFrameData(int frameNumber);
+    public SnapshotMarker? GetNearestSnapshot(int targetFrame);
 
     // Events synchronized with editor
     public event EventHandler<FrameChangedEventArgs>? FrameChanged;
+    public event EventHandler<PlaybackStateChangedEventArgs>? StateChanged;
 }
 ```
 
 **Editor workflow:**
 ```csharp
-// In EditorApplication when user opens a .kreplay file
-var replayMode = new ReplayPlaybackMode(playModeManager, currentWorld);
+// EditorApplication constructs the mode at startup
+var replayMode = new ReplayPlaybackMode(serializer);
 replayMode.LoadReplay(replayFilePath);
 
-// TimelinePanel subscribes to events
-replayMode.FrameChanged += (s, e) => timelinePanel.UpdatePosition(e.Frame);
-
-// Inspector shows frame data
+// FrameInspectorPanel is wired in and renders the current frame's data
 var frameData = replayMode.GetCurrentFrameData();
-inspectorPanel.ShowReplayFrame(frameData);
 
-// Keyboard shortcuts
-shortcutManager.Register("Ctrl+Alt+P", () => replayMode.StepFrame());
-shortcutManager.Register("Ctrl+Alt+Shift+P", () => replayMode.StepFrameBack());
+// Keyboard shortcuts (EditorShortcuts):
+//   Ctrl+Alt+P       -> StepFrame
+//   Ctrl+Alt+Shift+P -> StepFrameBack
+//   Space            -> TogglePlayPause (during replay mode)
 ```
 
 ## Key Design Decisions
@@ -350,110 +399,62 @@ shortcutManager.Register("Ctrl+Alt+Shift+P", () => replayMode.StepFrameBack());
 - Allows comparing playback state to original recording
 - Clear separation: editing world vs. playback world
 
-**Implementation:**
+**Implementation (as shipped):** `ReplayPlaybackMode` creates a fresh `World` per loaded replay and restores the replay's initial snapshot into it; the editing world is never touched.
+
 ```csharp
-public sealed class ReplayPlaybackMode
+public sealed class ReplayPlaybackMode : IDisposable
 {
-    private readonly IWorld editingWorld;   // Preserved
-    private readonly IWorld playbackWorld;  // Created for playback
+    private World? playbackWorld;   // Dedicated; editing world untouched
 
-    public void LoadReplay(ReplayData data)
+    public void LoadReplay(ReplayData replayData)
     {
-        // Create fresh world for playback
-        playbackWorld = new World();
-        player = new ReplayPlayer(playbackWorld, serializer);
-        player.LoadReplay(data);
+        DisposePlaybackWorld();          // Tear down any previous playback world
+        player.LoadReplay(replayData);
+        playbackWorld = new World();     // Fresh world for this replay
 
-        // Restore initial snapshot to playback world
-        var initialSnapshot = data.Snapshots[0].WorldSnapshot;
-        SnapshotManager.RestoreSnapshot(playbackWorld, initialSnapshot, serializer);
+        // Restore initial snapshot into the playback world
+        SnapshotManager.RestoreSnapshot(playbackWorld, firstSnapshot.Snapshot, serializer);
     }
 }
 ```
 
-**Editor viewport** switches to render `playbackWorld` during replay mode.
+**Editor viewport** switches to render `PlaybackWorld` during replay mode.
 
-### 2. Seeking Implementation: Snapshot + Event Replay
+### 2. Seeking Implementation: Snapshot Restore
 
-**Decision:** Seek by restoring nearest snapshot, then replaying events to target frame.
+**Decision (as proposed):** Seek by restoring nearest snapshot, then replaying events to target frame.
 
-**Rationale:**
-- Fast seeking via snapshots (O(1) restore)
-- Frame-perfect accuracy via event replay
-- Backwards seeking possible (restore earlier snapshot)
-
-**Implementation:**
-```csharp
-public void SeekToFrame(int targetFrame)
-{
-    // Find nearest snapshot at or before target
-    var snapshot = FindNearestSnapshot(targetFrame);
-
-    // Restore world to snapshot state
-    SnapshotManager.RestoreSnapshot(world, snapshot.WorldSnapshot, serializer);
-    currentFrame = snapshot.Frame;
-
-    // Replay events from snapshot to target
-    while (currentFrame < targetFrame)
-    {
-        ApplyFrame(replayData.Frames[currentFrame]);
-        currentFrame++;
-    }
-}
-
-private SnapshotMarker FindNearestSnapshot(int targetFrame)
-{
-    // Binary search for largest snapshot.Frame <= targetFrame
-    return snapshots
-        .Where(s => s.Frame <= targetFrame)
-        .OrderByDescending(s => s.Frame)
-        .First();
-}
-```
+**As shipped, seeking is snapshot-only.** When `EnableStateRestoration` is set (with a validation context attached via `SetValidationContext`), navigation restores the **nearest preceding snapshot** into the attached world, atomically with rollback (`ReplayStateRestorationException` on failure), while `CurrentFrame` moves to the exact target frame. The player documents that it "has no built-in path for re-applying those events to reconstruct exact intermediate state" — the originally proposed event-replay step to reach frame-perfect world state was **not implemented**. Recorded events between snapshots remain available to consumers via `GetFrame(int)`/`GetCurrentFrame()`, but the player does not apply them.
 
 **Performance characteristics:**
-- Seek within same snapshot interval: O(frames between)
-- Seek across snapshots: O(snapshot restore) + O(frames to target)
-- Default snapshot interval (1 second @ 60fps): Max 60 frames to replay
+- Seek: O(binary search for snapshot) + O(snapshot restore) — `GetNearestSnapshot(int)` finds the largest snapshot frame ≤ target
+- Backwards seeking works the same way (restore an earlier snapshot)
+- World-state granularity is the snapshot interval (default 1 second @ 60fps), not frame-perfect; the timeline position itself is frame-exact
 
 ### 3. Event Application vs. State Comparison
 
-**Decision:** Apply recorded events during playback, validate with checksums.
+**Decision (as proposed):** Apply recorded events during playback, validate with checksums.
 
 **Options considered:**
 1. **State replay**: Restore full world state each frame (expensive, 100% accurate)
 2. **Event replay**: Apply recorded events, validate periodically (efficient, requires determinism)
 3. **Hybrid**: Restore snapshots at intervals, events between (balanced)
 
-**Chosen:** Option 3 (Hybrid) with checksum validation.
+**As shipped, the event-application half of the hybrid was not built.** The player is a timeline/data engine: it exposes per-frame events for consumers (game code, `FrameInspectorPanel`) to read, and its world-facing features are snapshot restoration (Decision 2) and checksum validation. There is no `ApplyFrame`/`ApplyEntityCreated` path that mutates a world.
 
 ```csharp
-private void ApplyFrame(ReplayFrame frame)
+// Consumers read frame events; the player validates rather than applies
+var frame = player.GetCurrentFrame();
+foreach (var evt in frame.Events)
 {
-    foreach (var evt in frame.Events)
-    {
-        switch (evt.EventType)
-        {
-            case ReplayEventType.EntityCreated:
-                ApplyEntityCreated(evt);
-                break;
-            case ReplayEventType.ComponentChanged:
-                ApplyComponentChanged(evt);
-                break;
-            // ... other event types
-        }
-    }
-
-    // Periodic checksum validation
-    if (options.ValidateChecksums && frame.Checksum.HasValue)
-    {
-        var actualChecksum = CalculateWorldChecksum();
-        if (actualChecksum != frame.Checksum.Value)
-        {
-            OnDesyncDetected(frame.FrameNumber, frame.Checksum.Value, actualChecksum);
-        }
-    }
+    // consumer-side handling (inspection, visualization, custom logic)
 }
+
+// Checksum validation against the attached validation world
+player.AutoValidate = true;                       // validate as frames advance
+player.DesyncDetected += ex => logger.Error(ex);  // desync diagnostics
+var frameOk = player.ValidateCurrentFrame();
+var deterministic = player.ValidateDeterminism(iterations: 3);
 ```
 
 ### 4. Input System Integration
@@ -465,35 +466,25 @@ private void ApplyFrame(ReplayFrame frame)
 - Input replay enables determinism validation
 - Decoupling allows phased implementation
 
-**Architecture:**
+**Shipped architecture ([#410](https://github.com/orion-ecs/keen-eye/issues/410), closed):** the interface shipped as `IInputRecorder` (not the proposed `IInputRecordable`), recording `InputEvent`s into replay frames. On the playback side there is no `InputProvider` property — instead, consumers register handlers and dispatch a frame's inputs explicitly:
+
 ```csharp
-public interface IInputRecordable
+// Recording side
+public interface IInputRecorder
 {
-    void RecordInput(InputFrame frame);
-    InputFrame GetRecordedInput(int frameNumber);
+    // Records InputEvents (typed via InputEventType) into replay frames
 }
 
-public sealed class ReplayPlayer
-{
-    // Optional input replay
-    public IInputRecordable? InputProvider { get; set; }
-
-    private void ApplyFrame(ReplayFrame frame)
-    {
-        // If input provider set, inject recorded inputs
-        if (InputProvider != null && frame.InputData != null)
-        {
-            InputProvider.InjectInput(frame.InputData);
-        }
-
-        // Then run systems normally (they read injected input)
-        world.Update(frame.DeltaTime);
-    }
-}
+// Playback side (ReplayPlayer members)
+public void RegisterInputHandler(InputEventType type, Action<InputEvent> handler);
+public void RegisterInputHandler<T>(string customType, Action<T> handler);
+public void ApplyInputFrame();                 // dispatch current frame's inputs to handlers
+public void ApplyInputFrame(int frameIndex);
+public IReadOnlyList<InputEvent> GetCurrentInputEvents();
+public IReadOnlyList<InputEvent> GetInputEvents(int frameIndex);
 ```
 
-**Phase 1 (this ADR):** State replay only - apply recorded events directly.
-**Phase 2 (#410):** Input replay - inject inputs and let systems run.
+Both originally planned phases shipped: state playback (#405–#409) and input replay (#410).
 
 ### 5. Plugin Architecture: Recording vs. Playback
 
@@ -514,13 +505,13 @@ world.InstallPlugin(new ReplayPlaybackPlugin());
 var player = world.GetExtension<ReplayPlayer>();
 ```
 
-**Mutual exclusion:** Installing both plugins on the same world throws `InvalidOperationException`. A world is either recording OR playing back, never both.
+**Mutual exclusion (as shipped, one-directional):** `ReplayPlaybackPlugin.Install` throws `InvalidOperationException` when a `ReplayRecorder` extension is already present. The reciprocal guard was not implemented — installing `ReplayPlugin` onto a world that already has a playback player is not checked.
 
 ## Editor UI Components
 
-### TimelinePanel (New)
+### TimelinePanel
 
-Displays replay timeline with frame markers:
+Displays replay timeline with frame markers (original design mock):
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -536,29 +527,34 @@ Displays replay timeline with frame markers:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### FrameInspectorPanel (New or Inspector Extension)
+**Status:** `TimelinePanel` is implemented with the full feature set (transport buttons, scrubber, speed control, snapshot/event marker tracks; `editor/KeenEyes.Editor/Panels/TimelinePanel.cs`) and covered by tests, but it is **not yet instantiated by `EditorApplication`** — the frame inspector is the wired-in replay debugging surface today.
 
-Shows details of current playback frame:
+### FrameInspectorPanel
+
+`FrameInspectorPanel` is wired into `EditorApplication` and shows details of the current playback frame via `FrameInspectionData` (as shipped — entity references are raw recorded IDs, and change/execution records are dedicated record structs):
 
 ```csharp
 public sealed class FrameInspectionData
 {
+    public FrameInspectionData(ReplayFrame frame);
+
     public int FrameNumber { get; }
-    public float DeltaTime { get; }
+    public TimeSpan DeltaTime { get; }
     public TimeSpan ElapsedTime { get; }
 
     // Events in this frame
     public IReadOnlyList<ReplayEvent> Events { get; }
+    public IReadOnlyList<ReplayEvent> CustomEvents { get; }
 
-    // Entities affected
-    public IReadOnlyList<Entity> CreatedEntities { get; }
-    public IReadOnlyList<Entity> DestroyedEntities { get; }
-    public IReadOnlyList<(Entity, Type)> ComponentChanges { get; }
-
-    // Comparison to previous frame
-    public WorldDiff? DiffFromPrevious { get; }
+    // Entities affected (raw entity IDs from the recording)
+    public IReadOnlyList<int> CreatedEntities { get; }
+    public IReadOnlyList<int> DestroyedEntities { get; }
+    public IReadOnlyList<ComponentChange> ComponentChanges { get; }
+    public IReadOnlyList<SystemExecution> SystemExecutions { get; }
 }
 ```
+
+**Not yet implemented:** the proposed `WorldDiff? DiffFromPrevious` frame-diffing member — no `WorldDiff` type exists; frame comparison was not built.
 
 ## Alternatives Considered
 
@@ -601,15 +597,15 @@ Playback directly modifies the scene being edited.
 
 1. **Clear separation** - Core player has no UI dependencies
 2. **Reusable** - Same player works in runtime, editor, and tests
-3. **Fast seeking** - Snapshots enable sub-100ms seek to any frame
-4. **Determinism validation** - Checksum comparison catches desyncs
-5. **Extensible** - Input replay can be added later without API changes
+3. **Fast seeking** - Snapshots enable sub-100ms seek to any frame (at snapshot-interval state granularity)
+4. **Determinism validation** - Checksum comparison catches desyncs (`AutoValidate`, `ValidateDeterminism`, `DesyncDetected`)
+5. **Extensible** - Input replay was added (#410) without breaking the core API
 
 ### Negative
 
 1. **Memory overhead** - Playback world duplicates state
 2. **Complexity** - Two worlds to manage in editor during playback
-3. **Event fidelity** - Some events may be hard to replay exactly (external state)
+3. **Event fidelity** - Recorded events are exposed but not re-applied; intermediate world state between snapshots cannot be reconstructed by the player
 
 ### Risks
 
@@ -619,65 +615,75 @@ Playback directly modifies the scene being edited.
 
 ## Implementation Phases
 
-### Phase 1: Core ReplayPlayer (#405)
-- `ReplayPlayer` class with basic playback control
-- Load/unload replay data
-- Play/pause/stop state machine
-- Frame stepping (forward only)
-- Events for state changes
+All phase issues (#405–#410) and the runtime/editor integration issues (#691–#695) are closed; the work shipped with the divergences noted per phase.
 
-### Phase 2: Timeline Navigation (#406)
-- `SeekToFrame()` / `SeekToTime()`
-- Snapshot-based seeking
-- Backward stepping via snapshot restore
+### Phase 1: Core ReplayPlayer (#405) — shipped
+- [x] `ReplayPlayer` class with basic playback control
+- [x] Load/unload replay data (`LoadReplay` overloads, `UnloadReplay`)
+- [x] Play/pause/stop state machine
+- [x] Frame stepping — shipped as `Step(int frames = 1)`, which also steps backward with negative counts
+- [x] Events for state changes (`Action`-based)
 
-### Phase 3: Speed Control (#407)
-- `PlaybackSpeed` property (0.25x - 4x)
-- Delta time scaling in `Update()`
+### Phase 2: Timeline Navigation (#406) — shipped
+- [x] `SeekToFrame()` / `SeekToTime()`
+- [x] Snapshot-based seeking (`GetNearestSnapshot`, `EnableStateRestoration`)
+- [x] Backward stepping via snapshot restore
 
-### Phase 4: Event Application (#408)
-- Apply recorded events to world
-- Entity creation/destruction
-- Component changes
-- System execution markers
+### Phase 3: Speed Control (#407) — shipped
+- [x] `PlaybackSpeed` property (0.25x - 4x, clamped via `PlaybackSpeeds`)
+- [x] Delta time scaling in `Update()`
 
-### Phase 5: Determinism Validation (#409)
-- Checksum calculation
-- Desync detection
-- Diagnostic events for debugging
+### Phase 4: Event Application (#408) — shipped with a changed model
+- [x] Frame events (entity creation/destruction, component changes, system execution markers) exposed to consumers via `GetFrame`/`GetCurrentFrame`
+- [ ] Not implemented as designed: the player does not apply recorded events to a world; state reconstruction is snapshot-based only (see Key Design Decisions 2–3)
 
-### Phase 6: Input Integration (#410)
-- `IInputRecordable` interface
-- Input injection during playback
-- Full deterministic replay
+### Phase 5: Determinism Validation (#409) — shipped
+- [x] Checksum calculation (`WorldChecksum`, CRC32)
+- [x] Desync detection (`DesyncDetected`, `ReplayDesyncException`)
+- [x] Diagnostic validation (`ValidateCurrentFrame`, `ValidateDeterminism`)
 
-### Phase 7: Editor Integration
-- `ReplayPlaybackMode` in editor
-- TimelinePanel implementation
-- Frame inspector extensions
-- Keyboard shortcuts
+### Phase 6: Input Integration (#410) — shipped
+- [x] Input recording interface — shipped as `IInputRecorder` (not `IInputRecordable`)
+- [x] Input dispatch during playback — `RegisterInputHandler` + `ApplyInputFrame` (no `InputProvider` property)
+- [x] Full deterministic replay
+
+### Phase 7: Editor Integration — mostly shipped
+- [x] `ReplayPlaybackMode` in editor (serializer-only ctor, owns `PlaybackWorld`)
+- [x] Frame inspector (`FrameInspectorPanel` + `FrameInspectionData`, wired into `EditorApplication`)
+- [x] Keyboard shortcuts (`Ctrl+Alt+P`, `Ctrl+Alt+Shift+P`, `Space`)
+- [ ] TimelinePanel implemented and tested, but not yet wired into `EditorApplication`
+
+Additionally, the proposed `GhostRecorder` (part of the ghost-mode amendment, #695) was not built — see Runtime Integration: Ghost Mode.
 
 ## Related
 
 ### Core Playback Issues
-- [#83](https://github.com/orion-ecs/keen-eye/issues/83) - Replay recording (complete)
-- [#84](https://github.com/orion-ecs/keen-eye/issues/84) - Replay playback (parent issue)
-- [#405](https://github.com/orion-ecs/keen-eye/issues/405) - Core engine API
-- [#406](https://github.com/orion-ecs/keen-eye/issues/406) - Timeline navigation
-- [#407](https://github.com/orion-ecs/keen-eye/issues/407) - Speed control
-- [#408](https://github.com/orion-ecs/keen-eye/issues/408) - Event system
-- [#409](https://github.com/orion-ecs/keen-eye/issues/409) - Determinism validation
-- [#410](https://github.com/orion-ecs/keen-eye/issues/410) - Input integration
+- [#83](https://github.com/orion-ecs/keen-eye/issues/83) - Replay recording (closed — shipped)
+- [#84](https://github.com/orion-ecs/keen-eye/issues/84) - Replay playback (parent issue; closed — shipped)
+- [#405](https://github.com/orion-ecs/keen-eye/issues/405) - Core engine API (closed — shipped)
+- [#406](https://github.com/orion-ecs/keen-eye/issues/406) - Timeline navigation (closed — shipped)
+- [#407](https://github.com/orion-ecs/keen-eye/issues/407) - Speed control (closed — shipped)
+- [#408](https://github.com/orion-ecs/keen-eye/issues/408) - Event system (closed — shipped as consumer-facing frame events, not player-applied)
+- [#409](https://github.com/orion-ecs/keen-eye/issues/409) - Determinism validation (closed — shipped)
+- [#410](https://github.com/orion-ecs/keen-eye/issues/410) - Input integration (closed — shipped)
 
 ### Runtime Integration
-- [#691](https://github.com/orion-ecs/keen-eye/issues/691) - ReplayPlaybackPlugin
-- [#695](https://github.com/orion-ecs/keen-eye/issues/695) - Ghost mode system
+- [#691](https://github.com/orion-ecs/keen-eye/issues/691) - ReplayPlaybackPlugin (closed — shipped)
+- [#695](https://github.com/orion-ecs/keen-eye/issues/695) - Ghost mode system (closed — shipped without `GhostRecorder`)
 
 ### Editor Integration
-- [#692](https://github.com/orion-ecs/keen-eye/issues/692) - ReplayPlaybackMode
-- [#693](https://github.com/orion-ecs/keen-eye/issues/693) - TimelinePanel
-- [#694](https://github.com/orion-ecs/keen-eye/issues/694) - Frame inspector
+- [#692](https://github.com/orion-ecs/keen-eye/issues/692) - ReplayPlaybackMode (closed — shipped)
+- [#693](https://github.com/orion-ecs/keen-eye/issues/693) - TimelinePanel (closed — panel implemented and tested, not yet wired into EditorApplication)
+- [#694](https://github.com/orion-ecs/keen-eye/issues/694) - Frame inspector (closed — shipped)
 
 ### Related ADRs
-- ADR-001: World Manager Architecture
-- ADR-007: Capability-Based Plugin Architecture
+- [ADR-001: World Manager Architecture](001-world-manager-architecture.md)
+- [ADR-007: Capability-Based Plugin Architecture](007-capability-based-plugin-architecture.md)
+
+---
+
+## Changelog
+
+- **v3 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Amended — all implementation issues (#405–#410, #691–#695) closed and the architecture shipped. Implementation marked Partial: `GhostRecorder` direct recording, player-driven per-frame event application (frame-perfect seek state), TimelinePanel wiring into EditorApplication, and `WorldDiff` frame-diffing did not ship. Body amended to as-built APIs: world-detached parameterless `ReplayPlayer` with `SetValidationContext` and `Action`-based events (`UnloadReplay`, `Step(int)` with negative counts), snapshot-only state restoration in place of the hybrid event-replay seek, `IInputRecorder` + `RegisterInputHandler`/`ApplyInputFrame` instead of `IInputRecordable`/`InputProvider`, one-directional plugin mutual exclusion, extraction-only ghost pipeline with `.keghost` persistence and `GhostInstance`-based `GhostManager`, and serializer-only `ReplayPlaybackMode` owning its own `PlaybackWorld` decoupled from `PlayModeManager`.
+- **v2 — 2026-01-03 (58aeaafb):** Amended: added the Ghost Mode runtime-integration section (GhostData/GhostExtractor/GhostRecorder/GhostPlayer/GhostManager sketches) and the runtime/editor integration issue references (#691-#695).
+- **v1 — 2026-01-02 (#84 / 3dead626):** Proposed — layered replay playback architecture: a UI-free core ReplayPlayer in KeenEyes.Replay, consumed differently by a runtime ReplayPlaybackPlugin and an editor ReplayPlaybackMode with timeline/frame-inspector panels, using snapshot+event hybrid seeking and checksum-based determinism validation.

--- a/docs/adr/015-component-schema-migrations.md
+++ b/docs/adr/015-component-schema-migrations.md
@@ -1,8 +1,10 @@
 # ADR-015: Component Schema Migrations
 
-**Status:** Proposed
-**Date:** 2026-01-03
-**Issue:** [#352](https://github.com/orion-ecs/keen-eye/issues/352)
+**Status:** Accepted
+**Revision:** v2
+**Implementation:** Partial
+**First accepted:** 2026-01-03 · **Last amended:** 2026-07-26
+**Relates to:** [ADR-004](004-reflection-elimination.md) (AOT / no reflection) · [ADR-007](007-capability-based-plugin-architecture.md) (plugin capabilities) · [#352](https://github.com/orion-ecs/keen-eye/issues/352) · [#96](https://github.com/orion-ecs/keen-eye/issues/96)
 
 ## Context
 
@@ -43,13 +45,13 @@ If this component changes (e.g., adding `Shield` field), existing save files bec
 
 ## Decision
 
-Implement a **versioned component migration system** with three layers:
+KeenEyes implements a **versioned component migration system** with three layers:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    Source Generators                         │
 │  - Generate version metadata                                 │
-│  - Generate migration delegates                              │
+│  - Generate component migrators                              │
 │  - Generate compatibility checks                             │
 └──────────────────────────┬──────────────────────────────────┘
                            │
@@ -89,81 +91,65 @@ public static partial class ComponentMigrationMetadata
 {
     public static int GetVersion<T>() where T : struct, IComponent;
     public static int GetVersion(Type componentType);
+    public static int GetVersion(string componentTypeName);
 }
 ```
 
 ### Migration Functions
 
-Migration functions transform data from one version to the next:
+Migration methods transform data from one version to the next. They are annotated with `[MigrateFrom(fromVersion)]` directly (there is no method-name argument — the generator discovers each method by attribute placement) and receive the old data as a `JsonElement` rather than a typed previous-version struct:
 
 ```csharp
 [Component(Version = 2)]
-[MigrateFrom(1, nameof(MigrateFromV1))]
 public partial struct Health
 {
     public int Current;
     public int Max;
     public int Shield;
 
-    private static Health MigrateFromV1(HealthV1 old)
+    [MigrateFrom(1)]
+    private static Health MigrateFromV1(JsonElement oldData)
     {
         return new Health
         {
-            Current = old.Current,
-            Max = old.Max,
+            Current = oldData.GetProperty("current").GetInt32(),
+            Max = oldData.GetProperty("max").GetInt32(),
             Shield = 0  // Default for new field
         };
     }
 }
-
-// Previous version preserved for migration
-[Obsolete("Use Health instead")]
-public readonly struct HealthV1
-{
-    public readonly int Current;
-    public readonly int Max;
-}
 ```
+
+Because the old data arrives as JSON, previous-version types (`HealthV1`, etc.) do not need to be preserved — only the current struct definition exists.
 
 ### Migration Chain Resolution
 
-The source generator builds a migration graph:
+Migration chaining is exposed through the `IComponentMigrator` interface, implemented by the source-generated `ComponentSerializer` with strongly-typed dispatch — no delegate dictionary and no `DynamicInvoke` (which would be reflection-adjacent):
 
 ```csharp
-// Generated
-public static partial class ComponentMigrationRegistry
+public interface IComponentMigrator
 {
-    private static readonly Dictionary<(Type, int, int), Delegate> migrations = new()
-    {
-        [(typeof(Health), 1, 2)] = (Func<HealthV1, Health>)Health.MigrateFromV1,
-        [(typeof(Health), 2, 3)] = (Func<HealthV2, Health>)Health.MigrateFromV2,
-    };
+    bool CanMigrate(string typeName, int fromVersion, int toVersion);
+    bool CanMigrate(Type type, int fromVersion, int toVersion);
 
-    public static T Migrate<T>(object source, int fromVersion) where T : struct, IComponent
-    {
-        var currentVersion = GetVersion<T>();
-        var current = source;
+    JsonElement? Migrate(string typeName, JsonElement data, int fromVersion, int toVersion);
+    JsonElement? Migrate(Type type, JsonElement data, int fromVersion, int toVersion);
 
-        // Chain migrations: v1 → v2 → v3
-        for (int v = fromVersion; v < currentVersion; v++)
-        {
-            var migration = migrations[(typeof(T), v, v + 1)];
-            current = migration.DynamicInvoke(current);
-        }
-
-        return (T)current;
-    }
+    IEnumerable<int> GetMigrationVersions(string typeName);
+    IEnumerable<int> GetMigrationVersions(Type type);
 }
 ```
+
+Multi-step chains execute inside the generated migrator: migrating v1 → v4 invokes v1→v2, v2→v3, then v3→v4 in sequence. `MigrationGraph` and the `KEEN114` analyzer warning detect gaps in the chain at build time; cycles are structurally impossible because each migration steps exactly one version forward toward the current version.
 
 ### Serialization Integration
 
 Version metadata is stored in serialized data:
 
-**Binary format:**
+**Binary format** (snapshot format v2; v1 files default every component to version 1):
 ```
 [ComponentTypeId: int32]
-[Version: int16]          // NEW: version tag
+[Version: int16]          // version tag
 [DataLength: int32]
 [ComponentData: bytes]
 ```
@@ -182,35 +168,11 @@ Version metadata is stored in serialized data:
 }
 ```
 
-Deserializers check version before instantiation:
+Version handling is integrated into `SnapshotManager` restoration rather than a per-serializer `DeserializeComponent<T>` method. Each `SerializedComponent` carries its schema version, and on restore `SnapshotManager` compares it against the generated serializer's `GetVersion(type)`:
 
-```csharp
-public T DeserializeComponent<T>(BinaryReader reader) where T : struct, IComponent
-{
-    var serializedVersion = reader.ReadInt16();
-    var currentVersion = ComponentMigrationMetadata.GetVersion<T>();
-
-    if (serializedVersion == currentVersion)
-    {
-        // Fast path: direct deserialization
-        return DeserializeDirect<T>(reader);
-    }
-    else if (serializedVersion < currentVersion)
-    {
-        // Migration path: deserialize old version, then migrate
-        var oldData = DeserializeVersioned(typeof(T), serializedVersion, reader);
-        return ComponentMigrationRegistry.Migrate<T>(oldData, serializedVersion);
-    }
-    else
-    {
-        // Future version: cannot downgrade
-        throw new ComponentVersionException(
-            $"Cannot load {typeof(T).Name} v{serializedVersion} " +
-            $"(current version is v{currentVersion}). " +
-            "Update the game to load this save file.");
-    }
-}
-```
+- **Version matches** — fast path: direct deserialization.
+- **Serialized version is older** — the old `JsonElement` data is migrated through `IComponentMigrator` before deserialization.
+- **Serialized version is newer, or no migration path exists** — restore throws `ComponentVersionException` (a save from a newer game build cannot be downgraded).
 
 ### Default Value Injection
 
@@ -228,42 +190,23 @@ public partial struct Health
 }
 ```
 
-The source generator produces an automatic migration:
-
-```csharp
-// Generated
-private static Health AutoMigrateFromV1(HealthV1 old)
-{
-    return new Health
-    {
-        Current = old.Current,
-        Max = old.Max,
-        Shield = 0  // From [DefaultValue]
-    };
-}
-```
+The source generator produces the automatic migration: existing fields are copied from the old JSON data and annotated fields receive their `[DefaultValue]` — no hand-written migration method is needed. The `Currency` component in `samples/KeenEyes.Sample.SchemaMigration` demonstrates a three-version evolution using only `[DefaultValue]` attributes.
 
 ### Batch Upgrader Tool
 
-CLI tool for upgrading save files:
+The `keeneyes migrate` command ships with dry-run, backup, glob-pattern, output-directory, verbose, and continue-on-error support, and analyzes component versions in both JSON and binary save files:
 
 ```bash
-# Preview migrations
+# Preview which files contain versioned components
 dotnet keeneyes migrate --path ./saves/ --dry-run
 
-# Output:
-# save1.dat:
-#   Health v1 → v3 (12 entities)
-#   Inventory v2 → v3 (5 entities)
-# save2.dat:
-#   Health v1 → v3 (8 entities)
-
-# Apply migrations
+# Validate files, creating backups first
 dotnet keeneyes migrate --path ./saves/ --backup
 
 # Creates backup: ./saves/save1.dat.backup
-# Upgrades: ./saves/save1.dat
 ```
+
+**Not yet implemented: offline data transformation.** Because the CLI cannot load the game's generated serializer, it validates and copies files rather than rewriting component data — actual migration executes when the game loads the save, via `SnapshotManager`. For the same reason the analysis reports the versions found in a file but cannot determine true target versions. Rewriting data offline would require the user to supply a serializer assembly (future work).
 
 ## Alternatives Considered
 
@@ -340,60 +283,61 @@ migrations:
 
 1. **Save compatibility** - Games can evolve components without breaking saves
 2. **Explicit migrations** - Developers control exactly how data transforms
-3. **AOT compatible** - Source-generated delegates, no reflection
-4. **Tooling support** - Batch upgrader for existing save files
+3. **AOT compatible** - Source-generated migrators, no reflection
+4. **Tooling support** - `keeneyes migrate` CLI analyzes and backs up existing save files (offline data rewriting not yet implemented)
 5. **Gradual adoption** - Version defaults to 1, migration optional
 
 ### Negative
 
 1. **Version tracking overhead** - 2 bytes per component in binary format
-2. **Old version types** - Must keep `HealthV1`, `HealthV2` for migrations
+2. **Untyped migration input** - Migration methods read old data from a `JsonElement`, so field access inside migrations is stringly-typed and not compiler-checked (the trade-off for not keeping old version types around)
 3. **Migration complexity** - Multi-step migrations can be hard to reason about
 4. **Testing burden** - Each migration path needs testing
 
 ### Risks
 
-1. **Circular dependencies** - Migration A→B→C→A (detected by generator)
-2. **Missing migrations** - Version gap with no handler (runtime error)
+1. **Circular dependencies** - Structurally impossible as-built: each migration steps exactly one version forward, so the real risk is gaps in the chain
+2. **Missing migrations** - Version gap with no handler (KEEN114 analyzer warning at build time; `ComponentVersionException` at load)
 3. **Cross-component migrations** - Component A needs data from Component B (not supported initially)
 4. **Performance during load** - Many migrations on large saves
 
 ## Implementation Phases
 
-### Phase 1: Version Infrastructure ([#697](https://github.com/orion-ecs/keen-eye/issues/697))
-- `[Component(Version = n)]` attribute support
-- Version metadata in serialization format
-- `ComponentMigrationMetadata` source generator
-- Version mismatch detection (throw, don't migrate yet)
+### Phase 1: Version Infrastructure ([#697](https://github.com/orion-ecs/keen-eye/issues/697)) — ✅ Shipped
+- [x] `[Component(Version = n)]` attribute support
+- [x] Version metadata in serialization format (int16 tag in binary snapshot format v2)
+- [x] `ComponentMigrationMetadata` source generator
+- [x] Version mismatch detection (`ComponentVersionException`)
 
-### Phase 2: Migration Pipeline ([#698](https://github.com/orion-ecs/keen-eye/issues/698))
-- `[MigrateFrom]` attribute
-- `ComponentMigrationRegistry` source generator
-- Single-step migration execution
-- Integration with `IComponentSerializer`
+### Phase 2: Migration Pipeline ([#698](https://github.com/orion-ecs/keen-eye/issues/698)) — ✅ Shipped
+- [x] `[MigrateFrom]` attribute
+- [x] Generated migrator (shipped as `IComponentMigrator` implemented by the generated `ComponentSerializer`, not a `ComponentMigrationRegistry`)
+- [x] Single-step migration execution
+- [x] Integration with `IComponentSerializer`
 
-### Phase 3: Migration Chaining ([#699](https://github.com/orion-ecs/keen-eye/issues/699))
-- Multi-step migration (v1 → v2 → v3)
-- Migration graph validation
-- Cycle detection
-- Gap detection
+### Phase 3: Migration Chaining ([#699](https://github.com/orion-ecs/keen-eye/issues/699)) — ✅ Shipped
+- [x] Multi-step migration (v1 → v2 → v3)
+- [x] Migration graph validation (`MigrationGraph`)
+- [x] Cycle detection (`MigrationGraph.HasCycles`; cycles are structurally impossible as-built)
+- [x] Gap detection (KEEN114 analyzer warning)
 
-### Phase 4: Default Value Injection ([#700](https://github.com/orion-ecs/keen-eye/issues/700))
-- `[DefaultValue]` attribute for new fields
-- Auto-generated migrations for simple additions
-- Combine with explicit migrations
+### Phase 4: Default Value Injection ([#700](https://github.com/orion-ecs/keen-eye/issues/700)) — ✅ Shipped
+- [x] `[DefaultValue]` attribute for new fields
+- [x] Auto-generated migrations for simple additions
+- [x] Combine with explicit migrations
 
-### Phase 5: Batch Upgrader Tool ([#701](https://github.com/orion-ecs/keen-eye/issues/701))
-- `dotnet keeneyes migrate` command
-- Dry-run mode
-- Backup creation
-- Progress reporting
+### Phase 5: Batch Upgrader Tool ([#701](https://github.com/orion-ecs/keen-eye/issues/701)) — ✅ Shipped (with caveat)
+- [x] `dotnet keeneyes migrate` command (plus `--pattern`, `--output`, `--continue-on-error`)
+- [x] Dry-run mode
+- [x] Backup creation
+- [x] Progress reporting
+- Not yet implemented: offline component-data rewriting — the CLI validates and copies files, and migration executes at game load (would require a user-supplied serializer assembly)
 
-### Phase 6: Documentation and Samples ([#702](https://github.com/orion-ecs/keen-eye/issues/702))
-- Migration best practices guide
-- Sample showing 3-version evolution
-- Troubleshooting guide
-- API documentation
+### Phase 6: Documentation and Samples ([#702](https://github.com/orion-ecs/keen-eye/issues/702)) — ✅ Shipped
+- [x] Migration best practices guide (`docs/migrations.md`)
+- [x] Sample showing 3-version evolution (`samples/KeenEyes.Sample.SchemaMigration`)
+- [x] Troubleshooting guide
+- [x] API documentation
 
 ## Related
 
@@ -405,5 +349,12 @@ migrations:
 - [#700](https://github.com/orion-ecs/keen-eye/issues/700) - Default Value Injection
 - [#701](https://github.com/orion-ecs/keen-eye/issues/701) - Batch Upgrader Tool
 - [#702](https://github.com/orion-ecs/keen-eye/issues/702) - Documentation and Samples
-- ADR-004: Reflection Elimination (AOT compatibility constraints)
-- ADR-007: Capability-Based Plugin Architecture (serialization capability)
+- [ADR-004: Reflection Elimination](004-reflection-elimination.md) (AOT compatibility constraints)
+- [ADR-007: Capability-Based Plugin Architecture](007-capability-based-plugin-architecture.md) (serialization capability)
+
+---
+
+## Changelog
+
+- **v2 — 2026-07-26 (living-ADR conversion):** Status corrected Proposed → Accepted — all six phase issues (#697–#702) and parent #352 closed. Implementation marked Partial: Phases 1–4 and 6 fully shipped; Phase 5's `keeneyes migrate` CLI analyzes, backs up, and copies save files but does not rewrite component data offline (migration runs at game load). Decision amended to the as-built API: `[MigrateFrom(fromVersion)]` methods taking `JsonElement` (no preserved `HealthV1`-style types), `IComponentMigrator` on the generated `ComponentSerializer` instead of a `ComponentMigrationRegistry` delegate dictionary with `DynamicInvoke`, version handling in `SnapshotManager` restore, and the circular-dependency risk reclassified as structurally impossible (KEEN114 gap detection is the real safeguard).
+- **v1 — 2026-01-03 (#352):** Proposed — versioned component schema migration system ([Component(Version)], [MigrateFrom], [DefaultValue], source-generated migrators, serialized version tags, and a CLI batch upgrader) so save files remain loadable as component definitions evolve.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,63 @@
+# ADR-NNN: Short Title
+
+<!--
+LIVING-ADR TEMPLATE — the canonical skeleton for new KeenEyes ADRs.
+ADRs are committed to git, so the header below is a CURRENT-STATE summary, not a
+re-derivation of history:
+
+  - Amend a decision IN PLACE — edit the body to present-tense reality, bump the
+    header, add ONE Changelog line. Do not let an ADR silently rot, and do not
+    mint a near-duplicate ADR for a refinement of an existing decision.
+  - A genuinely new decision area → a NEW ADR (next number).
+  - A reversal → a NEW ADR that supersedes this one; flip this one's Status to
+    "Superseded by ADR-NNN" and cross-link both ways. Never delete an ADR — git
+    keeps it regardless.
+
+Copy this file to `docs/adr/NNN-short-title.md` (next 3-digit number, kebab-case
+slug), fill it in, delete these comments, and add the ADR to the
+"Architecture Decisions" node in `docs/toc.yml` and the table in `index.md`.
+See `index.md` for the full policy.
+-->
+
+**Status:** Proposed <!-- Proposed | Accepted | Amended | Superseded by ADR-NNN | Deprecated -->
+**Revision:** v1 <!-- monotonic; == number of Changelog entries; top entry's vN must match -->
+**Implementation:** Not started <!-- Not started | Partial | Shipped -->
+**First accepted:** YYYY-MM-DD <!-- add " · **Last amended:** YYYY-MM-DD" once amended in place -->
+**Relates to:** ADR-NNN (topic) · [#NNN](https://github.com/orion-ecs/keen-eye/issues/1) <!-- related (non-superseding) ADRs as relative links, plus the driving GitHub issue(s)/PR(s); replace the placeholder issue number -->
+
+## Context
+
+<!-- FROZEN: the forces at play when the decision was made — the problem,
+     constraints, and what prompted it, in past tense where natural. Written
+     once; never rewritten to match later reality. Enough that a future reader
+     understands WHY without archaeology. -->
+
+## Decision
+
+<!-- LIVING: present-tense reality — what IS true now, not "what we will do".
+     Amend this in place as the decision evolves; don't append "Update:" notes
+     here — that's what the Changelog is for. -->
+
+## Consequences
+
+<!-- LIVING: trade-offs accepted, follow-on work, what this makes easier/harder,
+     known risks. Use ### Positive / ### Negative (+ optionally ### Neutral). -->
+
+### Positive
+
+### Negative
+
+## Alternatives Considered
+
+<!-- Optional but encouraged — the options weighed and why they lost; the record
+     that stops a decision from being re-litigated. Frozen once written. -->
+
+---
+
+## Changelog
+
+<!-- Newest-first. Each line: the what + the why (git diff is the how). The top
+     entry's vN must equal the header Revision. Reference the GitHub issue or PR
+     that drove the change. -->
+
+- **v1 — YYYY-MM-DD (#NNN):** Proposed/Accepted — what was decided and why.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,45 @@
+# Architecture Decision Records
+
+Major architectural decisions in KeenEyes are documented as ADRs. **ADRs are living documents, not immutable records** — each one describes present-tense reality and is amended in place as the decision evolves, with git and a per-ADR changelog preserving the history.
+
+## The header
+
+Every ADR carries a current-state header:
+
+| Field | Meaning |
+|-------|---------|
+| **Status** | `Proposed` (decision pending) · `Accepted` (adopted and binding) · `Amended` (accepted, then materially changed post-acceptance) · `Superseded by ADR-NNN` (reversed by a newer ADR) · `Deprecated` (no longer applies, nothing replaced it) |
+| **Revision** | `vN` — monotonic, always equal to the number of Changelog entries; the top changelog entry's `vN` must match. Gives every state of a decision a stable handle, e.g. "ADR-007 v3". |
+| **Implementation** | `Not started` · `Partial` · `Shipped` — so an accepted decision can't masquerade as built |
+| **First accepted** | Date of original acceptance; `**Last amended:**` is appended once the ADR is amended in place |
+| **Relates to** | Related (non-superseding) ADRs and the driving GitHub issues/PRs |
+
+## The lifecycle
+
+- **Refining an existing decision** → amend the ADR **in place**: edit the body to present-tense reality, bump `Revision`, add one Changelog line stating what changed and why. Do not append "Update:" notes to the body, and do not mint a near-duplicate ADR.
+- **A genuinely new decision area** → a new ADR. Copy [TEMPLATE.md](TEMPLATE.md), take the next number, add it to this index and to `docs/toc.yml`.
+- **Reversing a decision** → a new ADR that supersedes the old one. The old ADR's Status flips to `Superseded by ADR-NNN` and both link to each other. ADRs are never deleted.
+
+Section semantics: **Context is frozen** — it records the forces at play when the decision was made and is never rewritten to match later reality. **Decision and Consequences are living** — they are amended to stay true. **Alternatives Considered is frozen** — it's the record that stops decisions being re-litigated.
+
+If a code change invalidates something an ADR says, amend the ADR in the same PR.
+
+## Index
+
+| ADR | Title | Status | Implementation |
+|-----|-------|--------|----------------|
+| [ADR-001](001-world-manager-architecture.md) | World Manager Architecture | Amended | Shipped |
+| [ADR-002](002-iworld-entity-lifecycle-events.md) | Complete IWorld Event System | Accepted | Shipped |
+| [ADR-003](003-command-buffer-abstraction.md) | CommandBuffer Abstraction and Reflection Elimination | Accepted | Shipped |
+| [ADR-004](004-reflection-elimination.md) | Reflection Elimination for AOT Compatibility | Accepted | Shipped |
+| [ADR-005](005-graphics-input-abstraction-layers.md) | Graphics and Input Abstraction Layers | Accepted | Shipped |
+| [ADR-006](006-custom-msbuild-sdk.md) | Custom MSBuild SDK for KeenEyes Projects | Accepted | Shipped |
+| [ADR-007](007-capability-based-plugin-architecture.md) | Capability-Based Plugin Architecture | Accepted | Shipped |
+| [ADR-008](008-asset-management-architecture.md) | Asset Management Architecture | Accepted | Partial |
+| [ADR-009](009-kesl-shader-language.md) | KESL — KeenEyes Shader Language | Accepted | Partial |
+| [ADR-010](010-graph-node-editor.md) | Graph Node Editor Architecture | Accepted | Shipped |
+| [ADR-011](011-unified-scene-model.md) | Unified Scene Model | Accepted | Partial |
+| [ADR-012](012-editor-plugin-extension-architecture.md) | Editor Plugin Extension Architecture | Accepted | Partial |
+| [ADR-013](013-dynamic-plugin-loading.md) | Dynamic Plugin Loading | Accepted | Partial |
+| [ADR-014](014-replay-playback-runtime-editor-integration.md) | Replay Playback Runtime and Editor Integration | Amended | Partial |
+| [ADR-015](015-component-schema-migrations.md) | Component Schema Migrations | Accepted | Partial |

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -291,4 +291,4 @@ Two smaller enums round out the widget/connection styling surface: `ConnectionSt
 - [Plugins Guide](plugins.md) - How plugins work
 - [Systems Guide](systems.md) - System design patterns
 - [UI System Guide](ui.md) - The retained-mode UI system graphs render alongside
-- [ADR-010: Graph Node Editor Architecture](adr/010-graph-node-editor.md) - Original design document (note: aspirational in places — e.g. it shows `GraphNode.IsSelected` as a bool field, but the shipped implementation uses `GraphNodeSelectedTag` instead)
+- [ADR-010: Graph Node Editor Architecture](adr/010-graph-node-editor.md) - Design decision record (living document, kept in sync with the shipped implementation)

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,6 +229,7 @@ using var world = new WorldBuilder()
 
 Key design decisions are documented as Architecture Decision Records:
 
+- [ADR index](adr/index.md) - All architecture decision records, with status and implementation state
 - [ADR-001: World Manager Architecture](adr/001-world-manager-architecture.md) - Refactoring World into specialized managers
 - [ADR-002: Complete IWorld Event System](adr/002-iworld-entity-lifecycle-events.md) - Entity lifecycle events
 - [ADR-003: CommandBuffer Abstraction](adr/003-command-buffer-abstraction.md) - Plugin isolation (20-50x performance boost)

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -324,4 +324,4 @@ The `samples/KeenEyes.Sample.Racing` sample enables trails on its ghosts (`Ghost
 - [Systems Guide](systems.md) - System phases and ordering, relevant to the internal `ReplayFrameEndSystem` and `SystemEventPhase` filtering
 - [Serialization Guide](serialization.md) - `IComponentSerializer`, `WorldSnapshot`, and `SnapshotManager`, which underpin replay snapshots
 - `samples/KeenEyes.Sample.Replay` - Runnable sample covering recording, custom events, ring-buffer crash replay, file save/load, and snapshot-based seeking
-- [ADR-014: Replay Playback Runtime and Editor Integration](adr/014-replay-playback-runtime-editor-integration.md) - Original design document (note: proposed/aspirational; some API shapes in the ADR differ from the shipped implementation described above)
+- [ADR-014: Replay Playback Runtime and Editor Integration](adr/014-replay-playback-runtime-editor-integration.md) - Design decision record (living document, kept in sync with the shipped implementation)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -175,6 +175,7 @@
 - name: Troubleshooting
   href: troubleshooting.md
 - name: Architecture Decisions
+  href: adr/index.md
   items:
     - name: ADR-001 World Manager Architecture
       href: adr/001-world-manager-architecture.md


### PR DESCRIPTION
## Summary
- Converts all 15 ADRs from immutable-style records into living documents: each now carries a current-state header (`Status` / `Revision: vN` / `Implementation` / `First accepted` + `Last amended` / `Relates to`) and a newest-first `## Changelog` whose entry count always equals the Revision. Changelogs were reconstructed from real git history only — no invented or backdated entries; every status flip is a changelog entry dated 2026-07-26.
- Every claim in every ADR was verified against the actual codebase before amending (15 parallel read-only verification agents; evidence rule = grepped code symbols, never doc existence). Findings: all 7 "Proposed" ADRs had actually shipped (004, 008, 009, 012, 013, 014, 015) → now `Accepted` with honest `Implementation` values (**Shipped ×8, Partial ×7**, gaps named per ADR); 001 and 014 are `Amended` (real post-acceptance decision changes: ComponentArrayPoolManager static-state exception, ghost mode). ~100 stale body claims amended to as-built reality (ADR-014 heaviest — real `ReplayPlayer` API shapes, snapshot-only seeking, `.keghost`); wrong-year dates on 008/009/010, ADR-002's wrong-org links and "ADR-003 (TBD)" ref fixed; cross-references normalized to relative links. `Context` and `Alternatives` sections stayed frozen (verified by diff-hunk audit — the only Context hunk is a mechanical link fix in 010).
- Adds the process scaffolding: `docs/adr/TEMPLATE.md` (canonical skeleton with amend/supersede rules) and `docs/adr/index.md` (policy + status/implementation index table), wired into `docs/toc.yml`, `docs/index.md`, and `CONTRIBUTING.md` (replaces the partial "Key ADRs" table); CLAUDE.md gains an agent-facing ADR rules section (amend-in-place in the same PR, frozen vs living sections, Revision invariant, index sync). Stale "aspirational" caveats in `docs/replay.md` / `docs/graph.md` removed now that the ADRs match the shipped implementation.

## Test plan
- [x] Scripted invariant checker over all 15 ADRs + index + template: header fields valid, Revision == changelog entry count, contiguous newest-first vN numbering, top-entry/`Last amended` date agreement, legacy metadata lines gone, all relative links resolve, index table matches every ADR header
- [x] All `docs/toc.yml` hrefs verified to exist (112 links); relative links in CONTRIBUTING.md / docs/index.md / graph.md / replay.md verified (lychee `check-links` job will re-verify in CI)
- [x] Docs-only change — no code touched, no build/test impact
- [ ] Build passes with zero warnings (N/A — markdown + toc.yml only)

## Related Issues
None closed. The open ADR-004 / KeenEyes.Localization reflection policy question (tracked in the audit-triage epic #1282) is deliberately untouched — ADR-004 is now cleanly amendable once that call is made.