### PR TITLE
fix(core): Restore tag components in SnapshotManager.RestoreSnapshot

### DIFF
--- a/src/KeenEyes.Core/Serialization/SnapshotManager.cs
+++ b/src/KeenEyes.Core/Serialization/SnapshotManager.cs
@@ -290,6 +290,19 @@ public static class SnapshotManager
                 var info = (ComponentInfo?)serialization.Components.Get(type)
                     ?? RegisterComponent(serialization, type, component.TypeName, component.IsTag, serializer);
 
+                if (component.IsTag || !componentData.HasValue)
+                {
+                    // Tags are serialized with null data (see CreateSnapshot), so restore
+                    // a default instance — mirrors DeltaRestorer.CreateEntity.
+                    var defaultValue = serializer.CreateDefault(component.TypeName);
+                    if (defaultValue is not null)
+                    {
+                        builder.WithBoxed(info, defaultValue);
+                    }
+
+                    continue;
+                }
+
                 // Convert the data to the correct type if needed
                 var value = ConvertComponentData(componentData, type, serializer);
                 if (value is not null)

--- a/tests/KeenEyes.Core.Tests/SerializationTests.cs
+++ b/tests/KeenEyes.Core.Tests/SerializationTests.cs
@@ -699,6 +699,71 @@ public class SerializationTests
     #region RestoreSnapshot Tests
 
     [Fact]
+    public void RestoreSnapshot_WithTagComponent_RestoresTagOnEntity()
+    {
+        using var world1 = new World();
+        world1.Spawn("Tagged")
+            .With(new SerializablePosition { X = 1, Y = 2 })
+            .WithTag<SerializableTag>()
+            .Build();
+
+        var snapshot = SnapshotManager.CreateSnapshot(world1, TestSerializerFactory.CreateForSerializationTests());
+        var json = SnapshotManager.ToJson(snapshot);
+        var loadedSnapshot = SnapshotManager.FromJson(json);
+
+        using var world2 = new World();
+        _ = SnapshotManager.RestoreSnapshot(world2, loadedSnapshot!, testSerializer);
+
+        var restoredEntity = world2.GetEntityByName("Tagged");
+        Assert.True(restoredEntity.IsValid);
+        Assert.True(world2.Has<SerializablePosition>(restoredEntity));
+        Assert.True(world2.Has<SerializableTag>(restoredEntity));
+    }
+
+    [Fact]
+    public void RestoreSnapshot_WithTagComponent_FromBinary_RestoresTagOnEntity()
+    {
+        using var world1 = new World();
+        world1.Spawn("Tagged")
+            .With(new SerializablePosition { X = 1, Y = 2 })
+            .WithTag<SerializableTag>()
+            .Build();
+
+        var snapshot = SnapshotManager.CreateSnapshot(world1, TestSerializerFactory.CreateForSerializationTests());
+        var binary = SnapshotManager.ToBinary(snapshot, testSerializer);
+        var loadedSnapshot = SnapshotManager.FromBinary(binary, testSerializer);
+
+        using var world2 = new World();
+        _ = SnapshotManager.RestoreSnapshot(world2, loadedSnapshot, testSerializer);
+
+        var restoredEntity = world2.GetEntityByName("Tagged");
+        Assert.True(restoredEntity.IsValid);
+        Assert.True(world2.Has<SerializableTag>(restoredEntity));
+    }
+
+    [Fact]
+    public void RestoreSnapshot_WithTagComponent_RestoredTagMatchesQueries()
+    {
+        using var world1 = new World();
+        world1.Spawn("Tagged")
+            .With(new SerializablePosition { X = 1, Y = 2 })
+            .WithTag<SerializableTag>()
+            .Build();
+        world1.Spawn("Untagged")
+            .With(new SerializablePosition { X = 3, Y = 4 })
+            .Build();
+
+        var snapshot = SnapshotManager.CreateSnapshot(world1, TestSerializerFactory.CreateForSerializationTests());
+
+        using var world2 = new World();
+        _ = SnapshotManager.RestoreSnapshot(world2, snapshot, testSerializer);
+
+        var tagged = world2.Query<SerializablePosition>().With<SerializableTag>().ToList();
+        Assert.Single(tagged);
+        Assert.Equal("Tagged", world2.GetName(tagged[0]));
+    }
+
+    [Fact]
     public void RestoreSnapshot_RecreatesEntities()
     {
         using var world1 = new World();


### PR DESCRIPTION
## Summary
- `CreateSnapshot` serializes tag components with `Data = null`, but `RestoreSnapshot`'s component loop only attached components whose converted data was non-null — so **every `ITagComponent` was silently dropped on save/load** (`SaveManager` and `KeenEyes.Persistence` both route through `RestoreSnapshot`). Found and empirically reproduced during the 2026-07-25 full-engine audit.
- Fix mirrors the fallback `DeltaRestorer.CreateEntity` already uses: when `component.IsTag || !componentData.HasValue`, attach `serializer.CreateDefault(component.TypeName)` via `WithBoxed`. The two restore paths now behave symmetrically.
- Adds three regression tests (JSON round-trip, binary round-trip, and tag-query visibility after restore) that assert restored **entity state**, not just the DTO — the gap that let this go uncaught (`BinaryRoundTrip_PreservesTagComponents` only checked the DTO). All three fail without the fix.

## Test plan
- [x] Unit tests added/updated — 3 new tests in `SerializationTests`; verified they fail on the unfixed code
- [x] Full suite: 14,724 passed / 0 failed / 60 skipped
- [x] Build passes with zero warnings; `dotnet format --verify-no-changes` clean

## Related Issues
Fixes #1277

Note: the sibling gap — string tags (`TagManager` state) never captured in snapshots at all — is tracked separately in #1307 and is intentionally out of scope here.
