### PR TITLE
fix(core): Keep aliased extensions alive when one registration is replaced

### DIFF
--- a/src/KeenEyes.Core/ExtensionManager.cs
+++ b/src/KeenEyes.Core/ExtensionManager.cs
@@ -46,22 +46,19 @@ internal sealed class ExtensionManager
     /// <remarks>
     /// If an owned extension of the same type already exists and implements
     /// <see cref="IDisposable"/>, it is disposed before being replaced. Re-setting the
-    /// exact same instance never disposes it, regardless of ownership.
+    /// exact same instance never disposes it, regardless of ownership, and neither does
+    /// replacing one registration of an instance that is still registered under another
+    /// type — plugins routinely alias a single object under both its interface and its
+    /// concrete type, and disposing it out from under the surviving alias would leave a
+    /// dead object reachable through the manager.
     /// </remarks>
     internal void SetExtension<T>(T extension, bool owned = true) where T : class
     {
         ArgumentNullException.ThrowIfNull(extension);
         lock (syncRoot)
         {
-            // Only dispose the previous instance when it is a different, manager-owned
-            // object. Re-setting the same instance (or replacing a caller-owned one)
-            // must never dispose it out from under a live user.
-            if (extensions.TryGetValue(typeof(T), out var existing)
-                && !ReferenceEquals(existing, extension)
-                && !unownedExtensions.Contains(typeof(T)))
-            {
-                (existing as IDisposable)?.Dispose();
-            }
+            extensions.TryGetValue(typeof(T), out var existing);
+            var existingWasOwned = !unownedExtensions.Contains(typeof(T));
 
             extensions[typeof(T)] = extension;
             if (owned)
@@ -72,7 +69,38 @@ internal sealed class ExtensionManager
             {
                 unownedExtensions.Add(typeof(T));
             }
+
+            // Only dispose the previous instance when it is a different, manager-owned
+            // object that no surviving registration still points at. Re-setting the same
+            // instance, replacing a caller-owned one, or dropping one alias of a
+            // multi-registered object must never dispose it out from under a live user.
+            if (existing is not null
+                && !ReferenceEquals(existing, extension)
+                && existingWasOwned
+                && !IsRegistered(existing))
+            {
+                (existing as IDisposable)?.Dispose();
+            }
         }
+    }
+
+    /// <summary>
+    /// Determines whether an instance is still reachable through any registration.
+    /// </summary>
+    /// <param name="instance">The instance to look for.</param>
+    /// <returns>True if some registered type still resolves to <paramref name="instance"/>.</returns>
+    /// <remarks>Callers must hold <c>syncRoot</c>.</remarks>
+    private bool IsRegistered(object instance)
+    {
+        foreach (var registered in extensions.Values)
+        {
+            if (ReferenceEquals(registered, instance))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -137,7 +165,8 @@ internal sealed class ExtensionManager
     /// <remarks>
     /// If the extension is manager-owned and implements <see cref="IDisposable"/>, it is
     /// disposed. Caller-owned extensions (registered with <c>owned: false</c>) are removed
-    /// without being disposed, leaving disposal to the registrant that created them.
+    /// without being disposed, leaving disposal to the registrant that created them, and
+    /// so are instances still registered under another type.
     /// </remarks>
     internal bool RemoveExtension<T>() where T : class
     {
@@ -146,8 +175,9 @@ internal sealed class ExtensionManager
             if (extensions.Remove(typeof(T), out var existing))
             {
                 // HashSet.Remove returns true when the type was caller-owned; in that
-                // case the manager must not dispose it.
-                if (!unownedExtensions.Remove(typeof(T)))
+                // case the manager must not dispose it. Neither may it dispose an
+                // instance that is still aliased under another registered type.
+                if (!unownedExtensions.Remove(typeof(T)) && !IsRegistered(existing))
                 {
                     (existing as IDisposable)?.Dispose();
                 }

--- a/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
+++ b/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
@@ -70,4 +70,82 @@ public class ExtensionOwnershipTests
         Assert.True(extension.IsDisposed);
         Assert.Equal(1, extension.DisposeCount);
     }
+
+    #region Aliased Registration Tests
+
+    [Fact]
+    public void SetExtension_ReplacingAliasOfMultiRegisteredInstance_DoesNotDisposeIt()
+    {
+        // Plugins routinely register one object under both its interface and its concrete
+        // type (SilkInputPlugin does exactly this). Replacing the interface alias must not
+        // dispose the instance while the concrete registration still resolves to it —
+        // doing so left NOVAFALL with a disposed input context that never initialized.
+        using var world = new World();
+        var shared = new AliasedTestExtension();
+        world.SetExtension<IAliasedTestExtension>(shared);
+        world.SetExtension(shared);
+
+        world.SetExtension<IAliasedTestExtension>(new AliasedTestExtension());
+
+        Assert.False(shared.IsDisposed);
+        Assert.Same(shared, world.GetExtension<AliasedTestExtension>());
+    }
+
+    [Fact]
+    public void RemoveExtension_WhenInstanceStillAliased_DoesNotDisposeIt()
+    {
+        using var world = new World();
+        var shared = new AliasedTestExtension();
+        world.SetExtension<IAliasedTestExtension>(shared);
+        world.SetExtension(shared);
+
+        var removed = world.RemoveExtension<IAliasedTestExtension>();
+
+        Assert.True(removed);
+        Assert.False(shared.IsDisposed);
+        Assert.Same(shared, world.GetExtension<AliasedTestExtension>());
+    }
+
+    [Fact]
+    public void RemoveExtension_WhenLastAliasRemoved_DisposesInstance()
+    {
+        // The flip side: once no registration resolves to the instance any more, the
+        // manager still owns it and must dispose it exactly once.
+        using var world = new World();
+        var shared = new AliasedTestExtension();
+        world.SetExtension<IAliasedTestExtension>(shared);
+        world.SetExtension(shared);
+
+        world.RemoveExtension<IAliasedTestExtension>();
+        world.RemoveExtension<AliasedTestExtension>();
+
+        Assert.True(shared.IsDisposed);
+        Assert.Equal(1, shared.DisposeCount);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Interface used to register a single instance under two extension keys.
+/// </summary>
+public interface IAliasedTestExtension;
+
+/// <summary>
+/// A disposable extension registered under both its interface and its concrete type.
+/// </summary>
+public sealed class AliasedTestExtension : IAliasedTestExtension, IDisposable
+{
+    /// <summary>Gets whether <see cref="Dispose"/> has been called.</summary>
+    public bool IsDisposed { get; private set; }
+
+    /// <summary>Gets how many times <see cref="Dispose"/> has been called.</summary>
+    public int DisposeCount { get; private set; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        DisposeCount++;
+        IsDisposed = true;
+    }
 }


### PR DESCRIPTION
## Summary

- `ExtensionManager` treated disposal ownership as **per-key**, so replacing or removing one alias of a multi-registered instance disposed it while the other registrations still resolved to it — leaving a dead object reachable through the manager. Ownership is now **reference-based**: `SetExtension` and `RemoveExtension` dispose the displaced instance only when no surviving registration still points at it.
- This broke the NOVAFALL sample outright. `SilkInputPlugin` registers one `SilkInputContext` under both `IInputContext` and its concrete type; `TestBridgePlugin.Install` then replaces `IInputContext` with its `CompositeInputContext`, which disposed the still-registered Silk context. `Dispose()` unsubscribes from `ISilkWindowProvider.OnLoad`, so the window loaded with the input context no longer listening and it never initialized. The first keyboard read threw `Input is not initialized, so Keyboard is unavailable` from `OnReady`, before the first frame — with a message pointing at a window that had already loaded.
- Also closes the same latent hazard for `SilkGraphicsPlugin` (one context aliased across five keys) and `SilkAudioPlugin` (two keys).

## Test plan

- [x] Unit tests added — 3 regression tests in `ExtensionOwnershipTests.cs` covering replace-alias, remove-alias, and the flip side (removing the *last* alias still disposes exactly once). Verified they fail 3/3 against the unfixed manager.
- [x] Manual testing performed — `samples/KeenEyes.Sample.NovaFall` now reaches `Ready.` and runs windowed; `--simulate 600` headless determinism run unaffected.
- [x] Build passes with zero warnings
- [x] `dotnet test` — 14,811 passed, 0 failed, 60 skipped
- [x] `dotnet format --verify-no-changes` clean

## Related Issues

None filed — found while getting NOVAFALL to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)