### PR TITLE
fix(samples): Keep the NOVAFALL ball inside the shaft so a lucky fall cannot escape the floors

### DIFF
--- a/samples/KeenEyes.Sample.NovaFall/Systems/BallMovementSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/BallMovementSystem.cs
@@ -4,13 +4,29 @@ namespace KeenEyes.Sample.NovaFall;
 
 /// <summary>
 /// Integrates ball motion: gravity, steering acceleration, horizontal speed clamp,
-/// and wall clamping at the shaft edges.
+/// and clamping to the shaft edges — the side walls and the shaft floor.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Vertical integration is skipped while the ball rests on a floor —
 /// <see cref="CollisionSystem"/> keeps the resting ball glued to the floor that
 /// carries it upward. Horizontal steering always applies, which is how the player
 /// slides a resting ball toward the gap.
+/// </para>
+/// <para>
+/// TEACHING NOTE — the play field is a box, and every side of it must be a wall.
+/// The ball falls faster (<see cref="Tuning.MaxFallSpeed"/>) than the shaft rises
+/// (<see cref="Tuning.MaxScrollSpeed"/>), so a player who threads several gaps in
+/// a row genuinely outruns the shaft. Without the shaft-floor clamp below, such a
+/// run leaves the play field entirely: no floor can ever be spawned deep enough
+/// to reach it again, no collision can fire, and — because depth (and therefore
+/// score) accrues from the scroll speed rather than from the ball — the run
+/// becomes unloseable with an ever-climbing score. Clamping instead of killing is
+/// deliberate: NOVAFALL's fantasy is that falling is safety, so the original
+/// TI-83 behaviour is the right one — the ball rides the bottom of the shaft and
+/// the rising floors sweep up into it, which is self-correcting and creates
+/// tension rather than punishing good play.
+/// </para>
 /// </remarks>
 public sealed class BallMovementSystem : SystemBase
 {
@@ -67,6 +83,27 @@ public sealed class BallMovementSystem : SystemBase
             {
                 velocity.Y = Math.Min(velocity.Y + Tuning.Gravity * dt, Tuning.MaxFallSpeed);
                 position.Y += velocity.Y * dt;
+            }
+
+            // Shaft-floor clamp: the same idea as the wall clamp above, applied to
+            // the bottom edge of the play field. The bound mirrors the horizontal
+            // one exactly — the shaft's extent minus the ball's radius — so the
+            // ball comes to rest with its lowest point on the bottom edge.
+            //
+            // Applied outside the airborne branch on purpose: this is an
+            // invariant of the ball, not a step of the fall integration.
+            var maxY = Tuning.ShaftHeight - ball.Radius;
+            if (position.Y > maxY)
+            {
+                position.Y = maxY;
+
+                // Rest, don't bank speed. Leaving the accumulated fall velocity in
+                // place would store energy the ball can never spend and would make
+                // the very next frame's floor contact read as a colossal impact.
+                // Zero (rather than a bounce) also keeps velocity.Y >= 0, which is
+                // what CollisionSystem's landing test requires, so a floor rising
+                // into a bottomed-out ball still lands it normally.
+                velocity.Y = 0f;
             }
         }
     }

--- a/samples/KeenEyes.Sample.NovaFall/Systems/FloorScrollSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/FloorScrollSystem.cs
@@ -6,7 +6,8 @@ namespace KeenEyes.Sample.NovaFall;
 
 /// <summary>
 /// Scrolls floors upward, escalates scroll speed with depth, spawns new floors
-/// below the view, and despawns floors that scroll past the Furnace ceiling.
+/// below the deepest point that can matter (the view bottom or the ball,
+/// whichever is lower), and despawns floors that scroll past the Furnace ceiling.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -96,9 +97,26 @@ public sealed class FloorScrollSystem : SystemBase
             World.Despawn(entity);
         }
 
-        // Keep the shaft filled one floor beyond the bottom of the view. The
-        // spacing is a mode knob: Daily Inferno packs the shaft denser.
-        while (!anyFloors || lowestY < Tuning.ShaftHeight + settings.FloorSpacing)
+        // Keep the shaft filled one floor beyond the LOWEST point that can
+        // matter. That is normally the bottom of the view, but the ball is the
+        // thing collisions are about, so it counts too: filling relative to
+        // max(view bottom, ball) makes "no floor below the ball" structurally
+        // impossible instead of merely unlikely.
+        //
+        // BallMovementSystem clamps the ball into the play field (and runs
+        // first, at order 10), so the view bound wins every frame in practice
+        // and the floor script is byte-identical to before this guard existed.
+        // That is exactly what defence in depth should look like: inert while
+        // the primary invariant holds, load-bearing the moment it does not.
+        var fillToY = Tuning.ShaftHeight;
+        foreach (var entity in World.Query<Ball, Position2D>())
+        {
+            fillToY = Math.Max(fillToY, World.Get<Position2D>(entity).Y);
+            break;
+        }
+
+        // The spacing is a mode knob: Daily Inferno packs the shaft denser.
+        while (!anyFloors || lowestY < fillToY + settings.FloorSpacing)
         {
             var y = anyFloors ? lowestY + settings.FloorSpacing : Tuning.FirstFloorY;
             SpawnFloor(seed, scroll.NextFloorIndex, y);

--- a/samples/KeenEyes.Sample.NovaFall/Systems/ScoreSystem.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Systems/ScoreSystem.cs
@@ -5,11 +5,24 @@ namespace KeenEyes.Sample.NovaFall;
 /// tier's multiplier — plus flat bonuses for grazes and Floor Smashes.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Score integrates per frame from the depth delta, so the multiplier active
 /// <em>while</em> each meter is fallen is what counts — stoking heat early
 /// compounds for the whole run. Bonuses are read from the same
 /// <see cref="FrameEvents"/> the heat system consumes; because events are only
 /// cleared at the start of the next frame, every consumer sees them exactly once.
+/// </para>
+/// <para>
+/// TEACHING NOTE — depth comes from <see cref="ScrollState.Depth"/>, which accrues
+/// from the scroll speed and never reads the ball. That indirection is what made a
+/// ball outside the play field score forever, and it is why
+/// <see cref="BallMovementSystem"/> clamps the ball into the shaft: this system is
+/// only fair because every meter of depth is a meter the ball had to survive. In
+/// EMBER GARDEN score does still grow for as long as the player keeps playing —
+/// but that is the mode, not a leak: it has no crusher by design and pins the
+/// multiplier at x1 (<see cref="ModeSettings.HeatAffectsScore"/>), so its score is
+/// exactly its depth and means "how long a walk did you take".
+/// </para>
 /// </remarks>
 public sealed class ScoreSystem : SystemBase
 {

--- a/tests/KeenEyes.Sample.NovaFall.Tests/PlayFieldBoundsTests.cs
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/PlayFieldBoundsTests.cs
@@ -1,0 +1,406 @@
+using KeenEyes.Common;
+
+namespace KeenEyes.Sample.NovaFall.Tests;
+
+/// <summary>
+/// Property tests for NOVAFALL's hardest gameplay invariant: the ball is always
+/// inside the shaft, and the shaft always has a floor below it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// THE BUG THESE GUARD — the ball falls faster (<see cref="Tuning.MaxFallSpeed"/>)
+/// than the shaft rises (<see cref="Tuning.MaxScrollSpeed"/>), so a player who
+/// threads several gaps in a row genuinely outruns the shaft. Before the
+/// shaft-floor clamp, such a run left the play field: floors were only ever
+/// maintained down to a fixed screen-space band, so once the ball was below it no
+/// floor could ever exist beneath it, <see cref="CollisionSystem"/> could never
+/// fire again, and — because depth accrues from the scroll speed rather than from
+/// the ball — the run became unloseable with an ever-climbing score.
+/// </para>
+/// <para>
+/// TEACHING NOTE — why property tests instead of example tests? The escape was
+/// reachable in ordinary play but only with luck, which is exactly the shape of
+/// bug an example test misses and a simulated invariant sweep catches. The
+/// headless harness (the same one <c>--simulate</c> uses) makes thousands of
+/// frames across many seeds cheap, and the adversarial steering below reproduces
+/// the lucky run on purpose rather than hoping for it.
+/// </para>
+/// </remarks>
+public class PlayFieldBoundsTests
+{
+    /// <summary>Fixed simulation timestep, matching headless <c>--simulate</c> mode.</summary>
+    private const float FixedDeltaTime = 1f / 60f;
+
+    /// <summary>Slack for accumulated float error when comparing positions.</summary>
+    private const float PositionTolerance = 0.01f;
+
+    /// <summary>
+    /// The lowest center Y the ball may ever reach: the shaft's full extent minus
+    /// its radius, mirroring the horizontal wall clamp. Derived here exactly as
+    /// <see cref="BallMovementSystem"/> derives it, so the test pins the rule and
+    /// not a magic number.
+    /// </summary>
+    private const float BallMaxY = Tuning.ShaftHeight - Tuning.BallRadius;
+
+    /// <summary>How a simulated run steers, in place of a human at the keyboard.</summary>
+    private enum Steering
+    {
+        /// <summary>Hands off the controls — the ball falls straight down.</summary>
+        None,
+
+        /// <summary>
+        /// Always steer toward the gap in the nearest floor below. This is the
+        /// "lucky threading" run that caused the reported escape, made relentless.
+        /// </summary>
+        TowardNearestGap,
+    }
+
+    #region Invariant sweeps
+
+    [Theory]
+    [InlineData(0xD00DFEEDUL)]
+    [InlineData(0x5EEDF00DUL)]
+    [InlineData(1UL)]
+    [InlineData(42UL)]
+    [InlineData(0xFEEDBEEFCAFEUL)]
+    public void PlayFieldInvariants_EverySteeringAndMode_HoldForThousandsOfFrames(ulong seed)
+    {
+        // Both modes matter: FREEFALL escalates the scroll and can end the run,
+        // EMBER GARDEN never ends one, so it is the mode a runaway would show up
+        // in. Both steering strategies matter: hands-off is the common case,
+        // gap-chasing is the case that broke.
+        foreach (var mode in new[] { GameMode.Freefall, GameMode.EmberGarden })
+        {
+            foreach (var steering in new[] { Steering.None, Steering.TowardNearestGap })
+            {
+                SimulateAndAssertInvariants(seed, mode, steering, frames: 1800);
+            }
+        }
+    }
+
+    [Fact]
+    public void PlayFieldInvariants_AdversarialGapChasing_OutrunsTheShaftAndStillHolds()
+    {
+        // A run long enough that the ball spends most of it pinned to the shaft
+        // floor: gap-chasing reaches terminal velocity within a second, and
+        // terminal velocity is more than three times the fastest the shaft rises.
+        var result = SimulateAndAssertInvariants(
+            0xD00DFEEDUL, GameMode.EmberGarden, Steering.TowardNearestGap, frames: 6000);
+
+        Assert.True(
+            result.FramesOnShaftFloor > 1000,
+            $"expected the gap-chasing ball to ride the shaft floor; only {result.FramesOnShaftFloor} frames did");
+        Assert.True(result.DeepestBallY <= BallMaxY + PositionTolerance);
+    }
+
+    [Fact]
+    public void Score_LongGapChasingRun_StaysBoundedByDepthTimesMaxMultiplier()
+    {
+        // Score integrates meters of depth times the live heat multiplier, plus
+        // flat event bonuses. The multiplier is capped at the Nova tier, so a
+        // legitimate score can never exceed depth x 8 plus the bonuses actually
+        // earned. The reported bug never broke that formula — it broke the thing
+        // that makes the formula honest, namely that depth is only survivable
+        // while the ball is in play. Hence both assertions here.
+        using var world = CreateSimulatedWorld(0xD00DFEEDUL, GameMode.Freefall);
+        var ball = RequireBall(world);
+
+        for (var i = 0; i < 6000; i++)
+        {
+            SetSteering(world, ball, Steering.TowardNearestGap);
+            world.Update(FixedDeltaTime);
+        }
+
+        var depth = world.GetSingleton<ScrollState>().Depth;
+        var score = world.GetSingleton<ScoreState>().Score;
+        var counters = world.GetSingleton<RunEventCounters>();
+
+        // A bound over a run that went nowhere would prove nothing.
+        Assert.True(depth > 100f, $"the gap-chasing run only reached {depth}m");
+
+        var maxMultiplier = HeatSystem.MultiplierForTier(3);
+        var bonuses = (counters.Grazes * Tuning.GrazeScoreBonus)
+            + (counters.Smashes * Tuning.SmashScoreBonus)
+            + (counters.SurgeWindows * Tuning.SurgeSweepBonus);
+
+        // The +1 absorbs float accumulation across 6000 integration steps.
+        Assert.True(
+            score <= (depth * maxMultiplier) + bonuses + 1.0,
+            $"score {score} exceeds the bound for depth {depth}m (bonuses {bonuses})");
+
+        // And the ball that earned it is still a target the Furnace can reach.
+        var ballY = world.Get<Position2D>(ball).Y;
+        Assert.True(
+            ballY <= BallMaxY + PositionTolerance,
+            $"score {score} was earned by a ball outside the play field at Y = {ballY}");
+    }
+
+    [Fact]
+    public void Run_WithoutSteering_StillEndsInDeath()
+    {
+        // The complaint was an UNLOSEABLE run. A hands-off FREEFALL run must
+        // still end: the ball lands, the floor carries it into the Furnace, and
+        // the crusher does its job.
+        using var world = CreateSimulatedWorld(0x5EEDF00DUL, GameMode.Freefall);
+
+        for (var i = 0; i < 3600 && world.GetSingleton<GameState>().Phase != GamePhase.Dead; i++)
+        {
+            world.Update(FixedDeltaTime);
+        }
+
+        Assert.Equal(GamePhase.Dead, world.GetSingleton<GameState>().Phase);
+    }
+
+    #endregion
+
+    #region Reported-state regression
+
+    [Fact]
+    public void Ball_ForcedBelowTheOldSpawnBand_IsClampedBackIntoTheFieldAndCollidesAgain()
+    {
+        // The exact state the player reported: the ball below every floor the old
+        // spawn rule would ever maintain (a fixed band at
+        // ShaftHeight + FloorSpacing), falling at terminal velocity, with nothing
+        // left to collide with. THIS TEST FAILS ON THE PRE-FIX CODE.
+        using var world = CreateSimulatedWorld(0xD00DFEEDUL, GameMode.Freefall);
+        var ball = RequireBall(world);
+
+        // One frame to populate the shaft the way the real game does.
+        world.Update(FixedDeltaTime);
+
+        // Hard against the left wall: gaps are kept at least Tuning.GapWallMargin
+        // from a wall, so a ball parked there is never over one and is guaranteed
+        // to be caught by the next floor that rises into it.
+        world.Get<Position2D>(ball).X = Tuning.BallRadius;
+        world.Get<Position2D>(ball).Y = Tuning.ShaftHeight + (4f * Tuning.FloorSpacing);
+        world.Get<Velocity2D>(ball).Y = Tuning.MaxFallSpeed;
+
+        world.Update(FixedDeltaTime);
+
+        Assert.True(
+            world.Get<Position2D>(ball).Y <= BallMaxY + PositionTolerance,
+            $"escaped ball was not brought back into the field: Y = {world.Get<Position2D>(ball).Y}");
+
+        // ...and collisions resume: a rising floor catches the bottomed-out ball.
+        var collided = false;
+        for (var i = 0; i < 900 && !collided; i++)
+        {
+            world.Update(FixedDeltaTime);
+            collided = world.Has<RestingOn>(ball) || world.GetSingleton<FrameEvents>().Landed;
+        }
+
+        Assert.True(collided, "the recovered ball never collided with a floor again");
+    }
+
+    [Fact]
+    public void FloorSpawning_WithTheClampBypassed_StillKeepsAFloorBelowTheBall()
+    {
+        // Defence in depth, tested on its own terms: with the clamp switched off
+        // there is nothing keeping the ball in the field, so floor spawning has to
+        // be the thing that makes "no floor below the ball" impossible. Disabling
+        // one system to test the guard behind it is why systems are individually
+        // addressable. THIS TEST FAILS ON THE PRE-FIX CODE.
+        using var world = CreateSimulatedWorld(0xD00DFEEDUL, GameMode.EmberGarden);
+        world.GetSystem<BallMovementSystem>()!.Enabled = false;
+
+        var ball = RequireBall(world);
+        var forcedY = Tuning.ShaftHeight + (6f * Tuning.FloorSpacing);
+
+        for (var i = 0; i < 120; i++)
+        {
+            // Re-force the position every frame: a landing would otherwise lift
+            // the ball back into the field and end the scenario early.
+            world.Get<Position2D>(ball).Y = forcedY;
+            world.Update(FixedDeltaTime);
+
+            Assert.True(
+                TryFindDeepestFloorY(world, out var deepestFloorY) && deepestFloorY > forcedY,
+                $"frame {i}: no floor exists below a ball at Y = {forcedY} (deepest floor {deepestFloorY})");
+        }
+    }
+
+    [Fact]
+    public void Ball_RestingOnTheShaftFloor_DoesNotAccumulateFallVelocity()
+    {
+        // Velocity the ball can never spend would turn its next floor contact into
+        // a colossal fake impact (squash scales with landing speed) and would let
+        // one slow frame teleport it back out of the field.
+        using var world = CreateSimulatedWorld(0xD00DFEEDUL, GameMode.EmberGarden);
+        var ball = RequireBall(world);
+
+        world.Get<Position2D>(ball).X = Tuning.BallRadius;
+        world.Get<Position2D>(ball).Y = BallMaxY;
+        world.Get<Velocity2D>(ball).Y = Tuning.MaxFallSpeed;
+
+        // One frame's worth of gravity is all the speed a bottomed-out ball may
+        // ever hold: it is applied, spent against the clamp, and zeroed again.
+        var oneFrameOfGravity = Tuning.Gravity * FixedDeltaTime;
+
+        for (var i = 0; i < 30; i++)
+        {
+            world.Update(FixedDeltaTime);
+
+            if (world.Has<RestingOn>(ball))
+            {
+                // A floor rose into the ball and caught it — the self-correcting
+                // behaviour this fix exists to restore. Nothing left to measure.
+                return;
+            }
+
+            Assert.Equal(BallMaxY, world.Get<Position2D>(ball).Y, tolerance: PositionTolerance);
+            Assert.True(
+                world.Get<Velocity2D>(ball).Y <= oneFrameOfGravity + PositionTolerance,
+                $"frame {i}: banked fall velocity {world.Get<Velocity2D>(ball).Y}");
+        }
+    }
+
+    #endregion
+
+    #region Harness
+
+    /// <summary>Per-frame invariant results, kept for the sweep's own assertions.</summary>
+    private readonly record struct SweepResult(float DeepestBallY, int FramesOnShaftFloor);
+
+    /// <summary>
+    /// Steps a headless run and asserts, every single frame, that the ball is
+    /// inside the play field and that a floor exists below it.
+    /// </summary>
+    private static SweepResult SimulateAndAssertInvariants(
+        ulong seed, GameMode mode, Steering steering, int frames)
+    {
+        using var world = CreateSimulatedWorld(seed, mode);
+        var ball = RequireBall(world);
+
+        var deepestBallY = float.MinValue;
+        var framesOnShaftFloor = 0;
+
+        for (var i = 0; i < frames; i++)
+        {
+            SetSteering(world, ball, steering);
+            world.Update(FixedDeltaTime);
+
+            var ballY = world.Get<Position2D>(ball).Y;
+            deepestBallY = Math.Max(deepestBallY, ballY);
+
+            Assert.True(
+                ballY <= BallMaxY + PositionTolerance,
+                $"seed {seed} / {mode} / {steering}, frame {i}: ball escaped the field at Y = {ballY}");
+
+            if (ballY.ApproximatelyEquals(BallMaxY, epsilon: 0.5f))
+            {
+                framesOnShaftFloor++;
+            }
+
+            // A dead run stops moving anything; the field invariant above still
+            // has to hold, but "a floor below the ball" is only meaningful while
+            // the shaft is live.
+            if (world.GetSingleton<GameState>().Phase != GamePhase.Playing)
+            {
+                continue;
+            }
+
+            Assert.True(
+                TryFindDeepestFloorY(world, out var deepestFloorY) && deepestFloorY > ballY,
+                $"seed {seed} / {mode} / {steering}, frame {i}: no floor below a ball at Y = {ballY}");
+        }
+
+        return new SweepResult(deepestBallY, framesOnShaftFloor);
+    }
+
+    /// <summary>
+    /// Builds a world exactly the way <c>--simulate</c> does — no presentation
+    /// plugins, no save files — and starts the run.
+    /// </summary>
+    private static World CreateSimulatedWorld(ulong seed, GameMode mode)
+    {
+        var world = new World();
+
+        GameSetup.InstallSimulationPlugins(world);
+        GameSetup.InitializeSingletons(world, seed, pinSeed: true, presentation: false, mode);
+        GameSetup.RegisterSystems(world, fontPath: null);
+        GameSetup.StartRun(world, seed);
+
+        // No input device exists to press a start key, so the harness dives itself.
+        world.GetSingleton<GameState>().Phase = GamePhase.Playing;
+
+        return world;
+    }
+
+    private static Entity RequireBall(World world)
+    {
+        foreach (var entity in world.Query<Ball>())
+        {
+            return entity;
+        }
+
+        throw new InvalidOperationException("the run has no ball entity");
+    }
+
+    /// <summary>
+    /// Writes the strategy's steering axis onto the ball, standing in for
+    /// <see cref="InputSteerSystem"/> (which no-ops with no input device).
+    /// </summary>
+    private static void SetSteering(World world, Entity ball, Steering steering)
+    {
+        world.Get<SteerInput>(ball).Axis = steering switch
+        {
+            Steering.TowardNearestGap => AxisTowardNearestGapBelow(world, ball),
+            _ => 0f,
+        };
+    }
+
+    /// <summary>
+    /// Returns the steering axis that aims the ball at the gap in the nearest
+    /// floor below it — a relentless, deterministic stand-in for a lucky player.
+    /// </summary>
+    private static float AxisTowardNearestGapBelow(World world, Entity ball)
+    {
+        var ballPosition = world.Get<Position2D>(ball);
+        var musicSeconds = world.GetSingleton<MusicClock>().Seconds;
+
+        var nearestFloorY = float.MaxValue;
+        var targetX = ballPosition.X;
+
+        foreach (var entity in world.Query<Floor, Position2D>())
+        {
+            var floorY = world.Get<Position2D>(entity).Y;
+            if (floorY <= ballPosition.Y || floorY >= nearestFloorY)
+            {
+                continue;
+            }
+
+            ref readonly var floor = ref world.Get<Floor>(entity);
+
+            // Ignore a gap the ball could not fit through anyway (a Pulse floor
+            // mid-close), so the chase never aims at a closed slab.
+            if (FloorLayout.EffectiveGapWidth(in floor, musicSeconds) <= 2f * Tuning.BallRadius)
+            {
+                continue;
+            }
+
+            nearestFloorY = floorY;
+            targetX = floor.GapCenterX;
+        }
+
+        var delta = targetX - ballPosition.X;
+
+        // Inside a design unit of the target is close enough — never == on floats.
+        return delta.IsApproximatelyZero(epsilon: 1f) ? 0f : Math.Sign(delta);
+    }
+
+    private static bool TryFindDeepestFloorY(World world, out float deepestFloorY)
+    {
+        deepestFloorY = float.MinValue;
+        var found = false;
+
+        foreach (var entity in world.Query<Floor, Position2D>())
+        {
+            deepestFloorY = Math.Max(deepestFloorY, world.Get<Position2D>(entity).Y);
+            found = true;
+        }
+
+        return found;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Reported from real play: *"I managed to get the ball past the bottom of the screen, and then I got lucky and fell below where the platforms were spawning. So now I don't collide with anything and my score just goes up and up and up."*

Four compounding gaps made that reachable:

1. `BallMovementSystem` clamped `velocity.Y` to `MaxFallSpeed` and clamped X in both directions, but **`position.Y` had no lower bound**.
2. `FloorScrollSystem` filled floors against a fixed screen constant (`Tuning.ShaftHeight + settings.FloorSpacing`) with **no reference to the ball**, so in FREEFALL the deepest floor always lived in `[1250, 1420)` and nothing below it ever existed.
3. The ball falls at 1100 u/s while the shaft rises at ≤340 (≤459 during a Surge) — **≥640 u/s of escape velocity**.
4. `CrushSystem` only tests the ceiling, so once out of the field the run could not end.

**It wasn't even lucky.** Measured on the unfixed code with adversarial "steer toward the nearest gap" input, the ball crossed the bound at **frame 203–298 (3.4–5.0 s of play) on all 5 seeds tested**.

### Correcting one thing in the report
The *score formula* never broke: `Σ(depthΔ × multiplier) + bonuses ≤ depth × 8 + bonuses` held even mid-escape. What broke is that **depth stopped being earned** — the shaft kept scrolling with the ball outside the world. So this was an unbounded *run*, not runaway arithmetic. The score test asserts both halves, and on old code the arithmetic bound passed while "ball still in play" failed.

### The fix
- **Clamp**: `position.Y > Tuning.ShaftHeight - ball.Radius` → snap and zero `velocity.Y`. No new tuning constant — this mirrors the existing wall clamp (`ShaftWidth - ball.Radius`) exactly. Applied outside the `if (!resting)` branch because it is an invariant of the ball, not a step of the fall integration. Zeroing (rather than damping or bouncing) keeps `velocity.Y >= 0`, which `CollisionSystem`'s landing test requires, so a floor rising into a bottomed-out ball still lands normally — verified across the resting, gap-through and Bumper paths.
- **Spawn robustness** (defence in depth): fill to `max(Tuning.ShaftHeight, ballY) + settings.FloorSpacing`. Floor identity is untouched — still `FloorLayout.GapForFloor(seed, index)` / `KindForFloor`, spawned in index order. Because the clamp caps ball Y at 1064 < 1080, the view bound wins every frame, so **no extra floors are spawned in practice** and the printed floor script is byte-identical.

### Design note
This deliberately does **not** add a death-by-falling. The game's premise is that falling is safety, so punishing a player for threading gaps well would invert it; the original TI-83 game keeps the ball on screen and lets the rising floors sweep up into it, which is self-correcting. The clamp also becomes the lower edge of the proposed DRAFT zone (#1331) — the tests already observe the ball riding the shaft floor for >1000 frames, which is exactly that zone.

## Test plan
`tests/KeenEyes.Sample.NovaFall.Tests/PlayFieldBoundsTests.cs` — 11 tests, written as **invariants over long runs** rather than single repros:
- [x] Ball always inside the play field — 5 seeds × {Freefall, EmberGarden} × {hands-off, steer-toward-nearest-gap}, 1800 frames each, asserted every frame; plus a 6000-frame gap-chasing run that also asserts >1000 frames were spent riding the shaft floor (proving the adversarial steering genuinely outruns the shaft).
- [x] A floor always exists below the ball while Playing — same sweep, every frame.
- [x] Score bounded by `depth × 8 + earned bonuses` over a 100 s run, with a `depth > 100 m` guard so the bound isn't vacuous, **and** the ball still in the field at the end.
- [x] Reported-state regression: ball forced to `ShaftHeight + 4×FloorSpacing` at terminal velocity against the left wall — asserts recovery next frame, then that a floor catches it again.
- [x] Spawn guard on its own terms (movement system disabled, ball re-forced below each frame).
- [x] No banked velocity on the shaft floor; and a hands-off FREEFALL run **still ends in death** (the "unloseable" complaint, inverted).
- [x] **Fail-on-old: 10 of 11 fail** on the reverted systems (the one pass is the hands-off-death test, which was never broken).
- [x] Sample + slnx build 0 warnings; full suite **14,879, 0 failed**; format clean; `--simulate 600` double-run byte-identical *and* identical to pre-fix.

`Program.cs` untouched — no conflict with #1330.
