### PR TITLE
fix(core): Dispose each aliased extension exactly once when clearing

### DIFF
--- a/src/KeenEyes.Core/ExtensionManager.cs
+++ b/src/KeenEyes.Core/ExtensionManager.cs
@@ -191,21 +191,34 @@ internal sealed class ExtensionManager
     /// Clears all extensions.
     /// </summary>
     /// <remarks>
-    /// All manager-owned extensions implementing <see cref="IDisposable"/> are disposed.
-    /// Caller-owned extensions (registered with <c>owned: false</c>) are removed without
-    /// being disposed.
+    /// All manager-owned extensions implementing <see cref="IDisposable"/> are disposed
+    /// <em>exactly once</em>, even when the same instance is registered under several types —
+    /// plugins routinely alias one object across its interfaces and its concrete type
+    /// (<c>SilkGraphicsPlugin</c> registers a single context under five). Caller-owned
+    /// extensions (registered with <c>owned: false</c>) are removed without being disposed;
+    /// an instance is disposed if <em>any</em> of its registrations is manager-owned.
     /// </remarks>
     internal void Clear()
     {
         lock (syncRoot)
         {
+            // Collect distinct instances first: disposing inside the loop would call
+            // Dispose() once per registration, which only stays harmless for as long as
+            // every extension happens to be idempotent.
+            var owned = new HashSet<object>(ReferenceEqualityComparer.Instance);
             foreach (var (type, extension) in extensions)
             {
                 if (!unownedExtensions.Contains(type))
                 {
-                    (extension as IDisposable)?.Dispose();
+                    owned.Add(extension);
                 }
             }
+
+            foreach (var extension in owned)
+            {
+                (extension as IDisposable)?.Dispose();
+            }
+
             extensions.Clear();
             unownedExtensions.Clear();
         }

--- a/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
+++ b/tests/KeenEyes.Core.Tests/ExtensionOwnershipTests.cs
@@ -123,6 +123,59 @@ public class ExtensionOwnershipTests
         Assert.Equal(1, shared.DisposeCount);
     }
 
+    [Fact]
+    public void WorldDispose_WithInstanceAliasedUnderSeveralTypes_DisposesItExactlyOnce()
+    {
+        // World.Dispose() clears the extension manager, which used to dispose once per
+        // registration rather than once per instance. SilkGraphicsPlugin aliases a single
+        // context under five keys, so teardown called Dispose() on it five times; that only
+        // stayed harmless because those implementations happen to guard on a disposed flag.
+        var shared = new AliasedTestExtension();
+
+        using (var world = new World())
+        {
+            world.SetExtension<IAliasedTestExtension>(shared);
+            world.SetExtension(shared);
+        }
+
+        Assert.True(shared.IsDisposed);
+        Assert.Equal(1, shared.DisposeCount);
+    }
+
+    [Fact]
+    public void WorldDispose_WithAliasedInstanceOwnedUnderOnlyOneType_StillDisposesItOnce()
+    {
+        // Ownership is per-registration, so an instance can be owned under one key and
+        // caller-owned under another. Any owned registration means the manager disposes it,
+        // and it must still happen exactly once regardless of which key is seen first.
+        var shared = new AliasedTestExtension();
+
+        using (var world = new World())
+        {
+            world.SetExtension<IAliasedTestExtension>(shared, owned: false);
+            world.SetExtension(shared);
+        }
+
+        Assert.True(shared.IsDisposed);
+        Assert.Equal(1, shared.DisposeCount);
+    }
+
+    [Fact]
+    public void WorldDispose_WithAliasedInstanceCallerOwnedThroughout_NeverDisposesIt()
+    {
+        // No registration claimed ownership, so disposal stays the caller's job.
+        var shared = new AliasedTestExtension();
+
+        using (var world = new World())
+        {
+            world.SetExtension<IAliasedTestExtension>(shared, owned: false);
+            world.SetExtension(shared, owned: false);
+        }
+
+        Assert.False(shared.IsDisposed);
+        Assert.Equal(0, shared.DisposeCount);
+    }
+
     #endregion
 }
 


### PR DESCRIPTION
## Summary
> ⚠️ **Stacked on #1330** — branched from that PR's head so the diff shows only the `Clear()` change. Merge #1330 first; this will then fast-forward cleanly.

#1330 made *replacement* and *removal* reference-based, but left `Clear()` disposing **per registration rather than per instance**:

```csharp
foreach (var (type, extension) in extensions)
{
    if (!unownedExtensions.Contains(type)) { (extension as IDisposable)?.Dispose(); }
}
```

So on `World.Dispose()`, `SilkGraphicsPlugin` — which aliases one context under **five** keys (`SilkGraphicsPlugin.cs:80,83,86,89,92`) — had its graphics context disposed five times; the input and audio contexts twice each.

That stayed harmless only because those implementations happen to guard on a `disposed` flag — which is precisely the assumption #1330 removed everywhere else, and one a future extension has no obligation to honour.

## Fix
`Clear()` collects the distinct owned instances by reference (`HashSet<object>` with `ReferenceEqualityComparer.Instance`) before disposing, so each is disposed exactly once. Semantics preserved: an instance is disposed when **any** of its registrations is manager-owned, and never when **all** are caller-owned. The allocation happens once per world teardown.

## Test plan
Three tests covering the ownership matrix:

| Test | Old code | New code |
|---|---|---|
| aliased under two owned keys → disposed once | **fails** (`DisposeCount == 2`) | passes |
| owned under one key, caller-owned under the other → disposed once | passes | passes |
| caller-owned throughout → never disposed | passes | passes |

- [x] **Fail-on-old verified**: 1 of 10 fails against the unfixed `Clear()` (exit 2). Only one *should* fail — the other two pass either way by design and exist to pin the ownership semantics, so they're guards rather than discriminators. The fixture (`AliasedTestExtension`) counts every `Dispose()` with no idempotency guard, which is what makes the multi-dispose observable.
- [x] Full suite **14,874, 0 failed**; build 0 warnings; format clean.

## Deliberately not addressed
`Clear()` still has no per-item exception guard, so one throwing `Dispose()` abandons the remaining teardown. That's **#1262**'s scope, which has its own acceptance criteria (including a test that the original exception isn't masked) — folding a partial version in here would half-implement it.

Closes the review gap raised on #1330.