### PR TITLE
fix(network): Chunk full snapshots and guard sends against transport message limits

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -357,6 +357,11 @@ New clients automatically receive a full world snapshot:
 serverPlugin.SendFullSnapshot(clientId);
 ```
 
+The snapshot is chunked: entities are packed into as many `FullSnapshot` messages as
+the transport's `MaxMessageSize` requires, and the client applies each message
+incrementally. A single entity whose replicated state exceeds the transport budget is
+skipped with a diagnostic rather than crashing the server.
+
 ## Transport Layer
 
 Implement `INetworkTransport` for your networking library:
@@ -369,6 +374,8 @@ public interface INetworkTransport : IDisposable
     event Action<int, ReadOnlySpan<byte>>? DataReceived;
     event Action<ConnectionState>? StateChanged;
 
+    int MaxMessageSize { get; }
+
     Task ListenAsync(int port, CancellationToken cancellationToken = default);
     Task ConnectAsync(string address, int port, CancellationToken cancellationToken = default);
     void Disconnect(int clientId = 0);
@@ -378,6 +385,12 @@ public interface INetworkTransport : IDisposable
     void Update();
 }
 ```
+
+`MaxMessageSize` is the largest payload a single `Send` accepts (UDP: 1192 bytes from
+its MTU budget; TCP: 1 MiB framing limit; LocalTransport: unbounded). The replication
+layer splits full snapshots so every message fits, and the server plugin's send helpers
+drop oversized payloads with a diagnostic instead of letting the exception kill the
+game loop.
 
 ### LocalTransport (Testing)
 

--- a/src/KeenEyes.Network.Abstractions/Transport/INetworkTransport.cs
+++ b/src/KeenEyes.Network.Abstractions/Transport/INetworkTransport.cs
@@ -80,6 +80,23 @@ public interface INetworkTransport : IDisposable
     Task ConnectAsync(string address, int port, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the maximum payload size in bytes that a single <see cref="Send"/> call accepts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Callers that build variable-size messages (e.g. replication snapshots) must split
+    /// them so each message fits within this limit. Passing a larger payload to
+    /// <see cref="Send"/> is a caller error and transports may throw.
+    /// </para>
+    /// <para>
+    /// Datagram transports return their MTU-derived budget (UDP: 1192 bytes); stream
+    /// transports return their framing limit (TCP: 1 MiB); in-memory transports return
+    /// <see cref="int.MaxValue"/>.
+    /// </para>
+    /// </remarks>
+    int MaxMessageSize { get; }
+
+    /// <summary>
     /// Sends data to a specific connection.
     /// </summary>
     /// <param name="connectionId">

--- a/src/KeenEyes.Network.Transport.Tcp/TcpTransport.cs
+++ b/src/KeenEyes.Network.Transport.Tcp/TcpTransport.cs
@@ -36,7 +36,7 @@ namespace KeenEyes.Network.Transport.Tcp;
 public sealed class TcpTransport : INetworkTransport
 {
     private const int HeaderSize = 4; // 4 bytes for message length
-    private const int MaxMessageSize = 1024 * 1024; // 1 MB max message
+    private const int MaxMessageBytes = 1024 * 1024; // 1 MB max message
 
     private readonly ConcurrentDictionary<int, ClientConnection> connections = new();
 
@@ -94,6 +94,9 @@ public sealed class TcpTransport : INetworkTransport
 
     /// <inheritdoc/>
     public bool IsClient => !isServer && State == ConnectionState.Connected;
+
+    /// <inheritdoc/>
+    public int MaxMessageSize => TcpTransport.MaxMessageBytes;
 
     /// <summary>
     /// Gets the local port the transport is bound to.
@@ -189,7 +192,7 @@ public sealed class TcpTransport : INetworkTransport
                 }
 
                 var messageLength = BitConverter.ToInt32(headerBuffer, 0);
-                if (messageLength <= 0 || messageLength > MaxMessageSize)
+                if (messageLength <= 0 || messageLength > MaxMessageBytes)
                 {
                     break; // Invalid message, disconnect
                 }
@@ -308,7 +311,7 @@ public sealed class TcpTransport : INetworkTransport
                 }
 
                 var messageLength = BitConverter.ToInt32(headerBuffer, 0);
-                if (messageLength <= 0 || messageLength > MaxMessageSize)
+                if (messageLength <= 0 || messageLength > MaxMessageBytes)
                 {
                     break; // Invalid message, disconnect
                 }

--- a/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
+++ b/src/KeenEyes.Network.Transport.Udp/UdpTransport.cs
@@ -114,6 +114,9 @@ public sealed class UdpTransport : INetworkTransport
     /// <inheritdoc/>
     public bool IsClient => !isServer && State == ConnectionState.Connected;
 
+    /// <inheritdoc/>
+    public int MaxMessageSize => MaxPayloadSize;
+
     /// <summary>
     /// Gets the local port the transport is bound to.
     /// </summary>

--- a/src/KeenEyes.Network/NetworkServerPlugin.cs
+++ b/src/KeenEyes.Network/NetworkServerPlugin.cs
@@ -31,6 +31,10 @@ namespace KeenEyes.Network;
 /// </example>
 public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetworkConfig? config = null) : INetworkPlugin
 {
+    // Scratch buffer for building full-snapshot messages; also the upper bound on a
+    // single snapshot message for transports whose MaxMessageSize is larger than this.
+    private const int SnapshotBufferSize = 64 * 1024;
+
     private readonly INetworkTransport transport = transport;
     private readonly ServerNetworkConfig config = config ?? new ServerNetworkConfig();
     private readonly NetworkIdManager networkIdManager = new(isServer: true);
@@ -227,8 +231,18 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     /// <param name="clientId">The client ID.</param>
     /// <param name="data">The data to send.</param>
     /// <param name="mode">The delivery mode.</param>
+    /// <remarks>
+    /// Payloads larger than the transport's <see cref="INetworkTransport.MaxMessageSize"/>
+    /// are dropped with a diagnostic instead of being sent; a dropped message must never
+    /// take down the server's game loop (#1278).
+    /// </remarks>
     public void SendToClient(int clientId, ReadOnlySpan<byte> data, DeliveryMode mode)
     {
+        if (ExceedsTransportLimit(data.Length))
+        {
+            return;
+        }
+
         transport.Send(clientId, data, mode);
     }
 
@@ -237,8 +251,18 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     /// </summary>
     /// <param name="data">The data to send.</param>
     /// <param name="mode">The delivery mode.</param>
+    /// <remarks>
+    /// Payloads larger than the transport's <see cref="INetworkTransport.MaxMessageSize"/>
+    /// are dropped with a diagnostic instead of being sent; a dropped message must never
+    /// take down the server's game loop (#1278).
+    /// </remarks>
     public void SendToAll(ReadOnlySpan<byte> data, DeliveryMode mode)
     {
+        if (ExceedsTransportLimit(data.Length))
+        {
+            return;
+        }
+
         transport.SendToAll(data, mode);
     }
 
@@ -248,9 +272,32 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
     /// <param name="excludeClientId">The client ID to exclude.</param>
     /// <param name="data">The data to send.</param>
     /// <param name="mode">The delivery mode.</param>
+    /// <remarks>
+    /// Payloads larger than the transport's <see cref="INetworkTransport.MaxMessageSize"/>
+    /// are dropped with a diagnostic instead of being sent; a dropped message must never
+    /// take down the server's game loop (#1278).
+    /// </remarks>
     public void SendToAllExcept(int excludeClientId, ReadOnlySpan<byte> data, DeliveryMode mode)
     {
+        if (ExceedsTransportLimit(data.Length))
+        {
+            return;
+        }
+
         transport.SendToAllExcept(excludeClientId, data, mode);
+    }
+
+    private bool ExceedsTransportLimit(int payloadLength)
+    {
+        if (payloadLength <= transport.MaxMessageSize)
+        {
+            return false;
+        }
+
+        System.Diagnostics.Debug.WriteLine(
+            $"[NetworkServer] Dropped {payloadLength}-byte message: exceeds transport MaxMessageSize " +
+            $"({transport.MaxMessageSize} bytes). Split the message or reduce replicated component payloads.");
+        return true;
     }
 
     /// <summary>
@@ -320,40 +367,108 @@ public sealed class NetworkServerPlugin(INetworkTransport transport, ServerNetwo
             entities.Add((entity, netId, owner.ClientId));
         }
 
-        // Use a large buffer for the snapshot
-        var buffer = new byte[64 * 1024]; // 64KB buffer
-        var writer = new NetworkMessageWriter(buffer);
-        writer.WriteHeader(MessageType.FullSnapshot, currentTick);
-        writer.WriteEntityCount((ushort)entities.Count);
+        // Entities are packed greedily into as many FullSnapshot messages as the
+        // transport's MaxMessageSize requires; a whole-world message would exceed a
+        // datagram transport's budget and crash the send (#1278). The client handler
+        // is incremental (it spawns/updates per message), so the chunks compose.
+        var buffer = new byte[SnapshotBufferSize];
+        var scratch = new byte[SnapshotBufferSize];
 
-        foreach (var (entity, netId, ownerId) in entities)
+        // Per-message overhead: header + entity count.
+        var probe = new NetworkMessageWriter(scratch);
+        probe.WriteHeader(MessageType.FullSnapshot, currentTick);
+        probe.WriteEntityCount(0);
+        var overhead = probe.BytesWritten;
+
+        var budget = Math.Min(transport.MaxMessageSize, buffer.Length);
+
+        // Measuring each entity separately over-estimates the packed message size
+        // (byte-rounding per entity), so accumulating byte sizes can never overflow
+        // the budget once written for real.
+        var batch = new List<(Entity entity, NetworkId netId, int ownerId)>();
+        var batchBytes = overhead;
+        foreach (var item in entities)
         {
-            writer.WriteEntitySpawn(netId.Value, ownerId);
+            var measureWriter = new NetworkMessageWriter(scratch);
+            WriteEntityFullState(ref measureWriter, item.entity, item.netId, item.ownerId, serializer);
+            var entityBytes = measureWriter.BytesWritten;
 
-            // Write all replicated components
-            var toSend = new List<(Type, object)>();
-            if (context.World is ISnapshotCapability snapshot)
+            if (overhead + entityBytes > budget)
             {
-                foreach (var (type, value) in snapshot.GetComponents(entity))
-                {
-                    if (serializer.IsNetworkSerializable(type))
-                    {
-                        toSend.Add((type, value));
-                    }
-                }
+                System.Diagnostics.Debug.WriteLine(
+                    $"[NetworkServer] Entity with network id {item.netId.Value} skipped in full snapshot: " +
+                    $"{entityBytes} bytes of component state cannot fit in one transport message " +
+                    $"(budget {budget} bytes). The client will not receive this entity.");
+                continue;
             }
 
-            writer.WriteComponentCount((byte)toSend.Count);
-            foreach (var (type, value) in toSend)
+            if (batch.Count > 0 && batchBytes + entityBytes > budget)
             {
-                writer.WriteComponent(serializer, type, value);
+                SendFullSnapshotBatch(clientId, batch, buffer, serializer);
+                batch.Clear();
+                batchBytes = overhead;
             }
+
+            batch.Add(item);
+            batchBytes += entityBytes;
         }
 
-        transport.Send(clientId, writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+        // Flush the final batch; an empty world still sends one empty snapshot message
+        // so late joiners observe the same message flow as before.
+        if (batch.Count > 0 || entities.Count == 0)
+        {
+            SendFullSnapshotBatch(clientId, batch, buffer, serializer);
+        }
 
         // Send hierarchy relationships
         SendHierarchySnapshot(clientId);
+    }
+
+    private void SendFullSnapshotBatch(
+        int clientId,
+        List<(Entity entity, NetworkId netId, int ownerId)> batch,
+        byte[] buffer,
+        INetworkSerializer serializer)
+    {
+        var writer = new NetworkMessageWriter(buffer);
+        writer.WriteHeader(MessageType.FullSnapshot, currentTick);
+        writer.WriteEntityCount((ushort)batch.Count);
+
+        foreach (var (entity, netId, ownerId) in batch)
+        {
+            WriteEntityFullState(ref writer, entity, netId, ownerId, serializer);
+        }
+
+        SendToClient(clientId, writer.GetWrittenSpan(), DeliveryMode.ReliableOrdered);
+    }
+
+    private void WriteEntityFullState(
+        ref NetworkMessageWriter writer,
+        Entity entity,
+        NetworkId netId,
+        int ownerId,
+        INetworkSerializer serializer)
+    {
+        writer.WriteEntitySpawn(netId.Value, ownerId);
+
+        // Write all replicated components
+        var toSend = new List<(Type, object)>();
+        if (context?.World is ISnapshotCapability snapshot)
+        {
+            foreach (var (type, value) in snapshot.GetComponents(entity))
+            {
+                if (serializer.IsNetworkSerializable(type))
+                {
+                    toSend.Add((type, value));
+                }
+            }
+        }
+
+        writer.WriteComponentCount((byte)toSend.Count);
+        foreach (var (type, value) in toSend)
+        {
+            writer.WriteComponent(serializer, type, value);
+        }
     }
 
     private void SendHierarchySnapshot(int clientId)

--- a/src/KeenEyes.Network/Transport/LocalTransport.cs
+++ b/src/KeenEyes.Network/Transport/LocalTransport.cs
@@ -92,6 +92,9 @@ public sealed class LocalTransport : INetworkTransport
     public bool IsClient => !isServer && State == ConnectionState.Connected;
 
     /// <inheritdoc/>
+    public int MaxMessageSize => int.MaxValue;
+
+    /// <inheritdoc/>
     public event Action<ConnectionState>? StateChanged;
 
     /// <inheritdoc/>

--- a/tests/KeenEyes.Network.Tests/FullSnapshotChunkingTests.cs
+++ b/tests/KeenEyes.Network.Tests/FullSnapshotChunkingTests.cs
@@ -1,0 +1,315 @@
+using KeenEyes.Network.Protocol;
+using KeenEyes.Network.Serialization;
+using KeenEyes.Network.Transport;
+using KeenEyes.Network.Transport.Tcp;
+using KeenEyes.Network.Transport.Udp;
+using KeenEyes.Testing.Network;
+
+namespace KeenEyes.Network.Tests;
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations
+#pragma warning disable xUnit1051 // Use TestContext.Current.CancellationToken
+
+/// <summary>
+/// Regression tests for #1278: the replication layer must never hand the transport a
+/// message larger than <see cref="INetworkTransport.MaxMessageSize"/>, and an oversized
+/// payload must be dropped with a diagnostic instead of crashing the server game loop.
+/// </summary>
+public sealed class FullSnapshotChunkingTests
+{
+    private const int TickRate = 60;
+    private const float TickDelta = 0.02f;
+
+    private static MockNetworkSerializer CreatePositionSerializer()
+    {
+        var serializer = new MockNetworkSerializer();
+        serializer.RegisterComponent<NetPosition>(
+            serialize: (ref BitWriter w, NetPosition p) =>
+            {
+                w.WriteFloat(p.X);
+                w.WriteFloat(p.Y);
+            },
+            deserialize: (ref BitReader r) => new NetPosition { X = r.ReadFloat(), Y = r.ReadFloat() },
+            new NetworkComponentInfo
+            {
+                Type = typeof(NetPosition),
+                NetworkTypeId = 1,
+                Strategy = SyncStrategy.Authoritative,
+                Frequency = 0,
+                Priority = 128,
+                SupportsInterpolation = false,
+                SupportsPrediction = false,
+                SupportsDelta = false,
+            });
+        return serializer;
+    }
+
+    #region MaxMessageSize contract
+
+    [Fact]
+    public void UdpTransport_MaxMessageSize_IsMtuBudget()
+    {
+        using var transport = new UdpTransport();
+        Assert.Equal(1192, transport.MaxMessageSize);
+    }
+
+    [Fact]
+    public void TcpTransport_MaxMessageSize_IsFramingLimit()
+    {
+        using var transport = new TcpTransport();
+        Assert.Equal(1024 * 1024, transport.MaxMessageSize);
+    }
+
+    [Fact]
+    public void LocalTransport_MaxMessageSize_IsUnbounded()
+    {
+        var (server, client) = LocalTransport.CreatePair();
+        using (server)
+        using (client)
+        {
+            Assert.Equal(int.MaxValue, server.MaxMessageSize);
+        }
+    }
+
+    #endregion
+
+    #region Chunking (deterministic, via recording transport)
+
+    [Fact]
+    public void SendFullSnapshot_ManyEntities_EveryMessageFitsTransportBudget()
+    {
+        using var transport = new RecordingTransport(maxMessageSize: 200);
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(transport, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        world.InstallPlugin(plugin);
+
+        for (var i = 0; i < 30; i++)
+        {
+            var entity = world.Spawn().With(new NetPosition { X = i, Y = -i }).Build();
+            plugin.RegisterNetworkedEntity(entity);
+        }
+
+        plugin.SendFullSnapshot(clientId: 1);
+
+        var snapshotMessages = transport.SentMessages
+            .Where(m => PeekType(m.Data) == MessageType.FullSnapshot)
+            .ToList();
+
+        Assert.True(snapshotMessages.Count > 1, "30 entities cannot fit one 200-byte message");
+        Assert.All(transport.SentMessages, m => Assert.True(
+            m.Data.Length <= transport.MaxMessageSize,
+            $"message of {m.Data.Length} bytes exceeds the {transport.MaxMessageSize}-byte budget"));
+
+        // Every registered entity arrives across the chunked messages exactly once.
+        var serializer = CreatePositionSerializer();
+        var seen = new List<uint>();
+        foreach (var message in snapshotMessages)
+        {
+            var reader = new NetworkMessageReader(message.Data);
+            reader.ReadHeader(out _, out _);
+            var count = reader.ReadEntityCount();
+            for (var i = 0; i < count; i++)
+            {
+                reader.ReadEntitySpawn(out var networkId, out _);
+                seen.Add(networkId);
+
+                var componentCount = reader.ReadComponentCount();
+                for (var c = 0; c < componentCount; c++)
+                {
+                    _ = reader.ReadComponent(serializer, out _);
+                }
+            }
+        }
+
+        Assert.Equal(30, seen.Count);
+        Assert.Equal(30, seen.Distinct().Count());
+
+        world.UninstallPlugin("NetworkServer");
+    }
+
+    [Fact]
+    public void SendFullSnapshot_EntityLargerThanBudget_IsSkippedWithoutThrow()
+    {
+        // Budget so small that the per-entity state (~20 bytes) cannot fit even alone.
+        using var transport = new RecordingTransport(maxMessageSize: 12);
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(transport, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        world.InstallPlugin(plugin);
+
+        var entity = world.Spawn().With(new NetPosition { X = 1, Y = 2 }).Build();
+        plugin.RegisterNetworkedEntity(entity);
+
+        // Must not throw; the oversized entity is skipped with a diagnostic.
+        plugin.SendFullSnapshot(clientId: 1);
+
+        Assert.All(transport.SentMessages, m =>
+            Assert.True(m.Data.Length <= transport.MaxMessageSize));
+
+        world.UninstallPlugin("NetworkServer");
+    }
+
+    [Fact]
+    public void SendToAll_PayloadLargerThanBudget_IsDroppedWithoutThrow()
+    {
+        using var transport = new RecordingTransport(maxMessageSize: 100);
+        using var world = new World();
+        var plugin = new NetworkServerPlugin(transport, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        world.InstallPlugin(plugin);
+
+        plugin.SendToAll(new byte[500], DeliveryMode.ReliableOrdered);
+        plugin.SendToClient(1, new byte[500], DeliveryMode.ReliableOrdered);
+        plugin.SendToAllExcept(1, new byte[500], DeliveryMode.ReliableOrdered);
+
+        Assert.Empty(transport.SentMessages);
+
+        world.UninstallPlugin("NetworkServer");
+    }
+
+    private static MessageType PeekType(byte[] data)
+    {
+        var reader = new NetworkMessageReader(data);
+        return reader.PeekMessageType();
+    }
+
+    #endregion
+
+    #region End-to-end over UDP
+
+    [Fact]
+    public async Task FullSnapshot_LargerThanUdpBudget_ClientReceivesAllEntities()
+    {
+        using var server = new UdpTransport();
+        using var client = new UdpTransport();
+
+        await server.ListenAsync(0);
+        var port = server.LocalPort;
+
+        using var serverWorld = new World();
+        using var clientWorld = new World();
+
+        var serverPlugin = new NetworkServerPlugin(server, new ServerNetworkConfig
+        {
+            TickRate = TickRate,
+            Serializer = CreatePositionSerializer(),
+        });
+        serverWorld.InstallPlugin(serverPlugin);
+
+        // 100 entities x ~18 bytes of snapshot state comfortably exceeds the 1192-byte
+        // UDP budget; before the fix this send threw and killed the server update.
+        const int EntityCount = 100;
+        for (var i = 0; i < EntityCount; i++)
+        {
+            var entity = serverWorld.Spawn().With(new NetPosition { X = i, Y = i }).Build();
+            serverPlugin.RegisterNetworkedEntity(entity);
+        }
+
+        var clientPlugin = new NetworkClientPlugin(client, new ClientNetworkConfig
+        {
+            TickRate = TickRate,
+            EnablePrediction = false,
+            Serializer = CreatePositionSerializer(),
+            ServerAddress = "127.0.0.1",
+            ServerPort = port,
+        });
+        clientWorld.InstallPlugin(clientPlugin);
+        clientWorld.Components.Register<NetPosition>();
+
+        using var cts = new CancellationTokenSource(2000);
+        try
+        {
+            await clientPlugin.ConnectAsync(cts.Token);
+        }
+        catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+        {
+            Assert.Skip("UDP networking not available in this environment");
+            return;
+        }
+
+        // Pump both ends until the snapshot chunks are delivered and applied.
+        var received = 0;
+        for (var i = 0; i < 100 && received < EntityCount; i++)
+        {
+            serverWorld.Update(TickDelta);
+            clientWorld.Update(TickDelta);
+            await Task.Delay(10);
+            received = clientWorld.Query<NetPosition>().Count();
+        }
+
+        Assert.Equal(EntityCount, received);
+
+        clientWorld.UninstallPlugin("NetworkClient");
+        serverWorld.UninstallPlugin("NetworkServer");
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Minimal server-side transport that records every accepted send and enforces a
+    /// configurable <see cref="MaxMessageSize"/> the way a datagram transport would.
+    /// </summary>
+    private sealed class RecordingTransport(int maxMessageSize) : INetworkTransport
+    {
+        public List<(int ConnectionId, byte[] Data, DeliveryMode Mode)> SentMessages { get; } = [];
+
+        public ConnectionState State => ConnectionState.Connected;
+        public bool IsServer => true;
+        public bool IsClient => false;
+        public int MaxMessageSize { get; } = maxMessageSize;
+
+#pragma warning disable CS0067 // Events required by the interface are never raised here
+        public event Action<ConnectionState>? StateChanged;
+        public event Action<int>? ClientConnected;
+        public event Action<int>? ClientDisconnected;
+        public event DataReceivedHandler? DataReceived;
+#pragma warning restore CS0067
+
+        public Task ListenAsync(int port, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task ConnectAsync(string address, int port, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public void Send(int connectionId, ReadOnlySpan<byte> data, DeliveryMode mode)
+        {
+            if (data.Length > MaxMessageSize)
+            {
+                throw new ArgumentException(
+                    $"Data exceeds maximum payload size of {MaxMessageSize} bytes.", nameof(data));
+            }
+
+            SentMessages.Add((connectionId, data.ToArray(), mode));
+        }
+
+        public void SendToAll(ReadOnlySpan<byte> data, DeliveryMode mode) => Send(0, data, mode);
+
+        public void SendToAllExcept(int excludeConnectionId, ReadOnlySpan<byte> data, DeliveryMode mode)
+            => Send(0, data, mode);
+
+        public void Disconnect(int connectionId = 0)
+        {
+        }
+
+        public void Update()
+        {
+        }
+
+        public float GetRoundTripTime(int connectionId) => 0f;
+
+        public ConnectionStatistics GetStatistics(int connectionId) => default;
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug (confirmed critical, 2026-07-25 audit):** `SendFullSnapshot` wrote every networked entity into a single `FullSnapshot` message and handed it to the transport unchecked. `UdpTransport` throws `ArgumentException` on payloads over its 1192-byte MTU budget, so the moment a client connected to any real-sized world, the exception killed the server game loop.
- **Contract:** `INetworkTransport` gains `MaxMessageSize` — the largest payload one `Send` accepts (UDP: 1192, TCP: 1 MiB, LocalTransport: unbounded). Replication no longer hardcodes any transport's limit.
- **Chunking:** `SendFullSnapshot` measures each entity's serialized size and packs entities greedily into as many `FullSnapshot` messages as the budget requires. Byte-level per-entity measurement over-estimates the packed bit stream (`ceil((a+b)/8) ≤ ceil(a/8)+ceil(b/8)`), so a batch can never overflow once written for real. The client's `HandleFullSnapshot` was already incremental, so chunked messages compose with **no protocol change**. A single entity whose state cannot fit alone is skipped with a diagnostic naming its network id.
- **Guard:** `SendToClient`/`SendToAll`/`SendToAllExcept` now drop oversized payloads with a diagnostic instead of letting the transport exception propagate into `World.Update` — a dropped message must never take down the server (this also protects the per-entity delta path against pathologically large single entities).
- Docs: `docs/networking.md` updated (interface snippet + late-joiner chunking note).

## Test plan
- [x] 7 new tests in `FullSnapshotChunkingTests`: `MaxMessageSize` contract per transport; deterministic chunk verification via a recording transport (every message ≤ budget, all 30 entities decoded exactly once across chunks); oversized-entity skip; oversized-payload drop on all three send helpers; **real-UDP end-to-end** — a 100-entity snapshot (>1192 bytes) converges on the client across multiple datagrams
- [x] 4 of the 7 fail on the unfixed plugin (verified by reverting the fix and re-running)
- [x] Full suite: 14,829 passed / 0 failed / 60 skipped; build zero warnings; `dotnet format` clean

## Related Issues
Fixes #1278

The sibling delta-path desync findings (#1293 baseline-without-ack on the interest-managed path, #1294 per-tick ack granularity) and the UDP receive-buffer findings (#1309) are intentionally out of scope.
