### PR TITLE
fix(ai): Move all execution state out of shared behavior definitions into per-entity memory

### DIFF
--- a/editor/KeenEyes.Editor/AI/AIDebugPanel.cs
+++ b/editor/KeenEyes.Editor/AI/AIDebugPanel.cs
@@ -181,9 +181,9 @@ public sealed class AIDebugPanel : IEditorPanel
         }
 
         var nodeInfos = new List<BTNodeDebugInfo>();
-        if (component.Definition.Root != null)
+        if (component.Definition.Root != null && component.Blackboard is { } blackboard)
         {
-            CollectNodeInfos(component.Definition.Root, 0, nodeInfos);
+            CollectNodeInfos(component.Definition.Root, blackboard, 0, nodeInfos);
         }
 
         return new BehaviorTreeDebugInfo
@@ -196,26 +196,26 @@ public sealed class AIDebugPanel : IEditorPanel
         };
     }
 
-    private static void CollectNodeInfos(BTNode node, int depth, List<BTNodeDebugInfo> infos)
+    private static void CollectNodeInfos(BTNode node, Blackboard blackboard, int depth, List<BTNodeDebugInfo> infos)
     {
         infos.Add(new BTNodeDebugInfo
         {
             Name = node.Name,
             TypeName = node.GetType().Name,
             Depth = depth,
-            LastState = node.LastState
+            LastState = node.GetLastState(blackboard)
         });
 
         if (node is CompositeNode composite)
         {
             foreach (var child in composite.Children)
             {
-                CollectNodeInfos(child, depth + 1, infos);
+                CollectNodeInfos(child, blackboard, depth + 1, infos);
             }
         }
         else if (node is DecoratorNode decorator && decorator.Child != null)
         {
-            CollectNodeInfos(decorator.Child, depth + 1, infos);
+            CollectNodeInfos(decorator.Child, blackboard, depth + 1, infos);
         }
     }
 

--- a/src/KeenEyes.AI/AIContext.cs
+++ b/src/KeenEyes.AI/AIContext.cs
@@ -160,7 +160,7 @@ public sealed class AIContext
             return false;
         }
 
-        component.Definition.Reset();
+        component.Definition.Reset(component.GetOrCreateBlackboard());
         component.RunningNode = null;
         component.LastResult = BTNodeState.Success;
 

--- a/src/KeenEyes.AI/Actions/ChaseAction.cs
+++ b/src/KeenEyes.AI/Actions/ChaseAction.cs
@@ -37,8 +37,6 @@ namespace KeenEyes.AI.Actions;
 /// </example>
 public sealed class ChaseAction : IAIAction
 {
-    private float timeSinceLastUpdate;
-    private bool initialPathRequested;
 
     /// <summary>
     /// The target entity to chase.
@@ -132,16 +130,17 @@ public sealed class ChaseAction : IAIAction
         }
 
         var deltaTime = blackboard.Get(BBKeys.DeltaTime, 0f);
-        timeSinceLastUpdate += deltaTime;
+        var memory = blackboard.GetMemory<ChaseMemory>(this);
+        memory.TimeSinceLastUpdate += deltaTime;
 
         // Request initial path or update path at intervals
-        bool shouldUpdatePath = !initialPathRequested || timeSinceLastUpdate >= UpdateInterval;
+        bool shouldUpdatePath = !memory.InitialPathRequested || memory.TimeSinceLastUpdate >= UpdateInterval;
 
         if (shouldUpdatePath)
         {
             nav.SetDestination(entity, targetPosition);
-            timeSinceLastUpdate = 0f;
-            initialPathRequested = true;
+            memory.TimeSinceLastUpdate = 0f;
+            memory.InitialPathRequested = true;
 
             // Store update timing in blackboard
             blackboard.Set(BBKeys.ChaseUpdateInterval, UpdateInterval);
@@ -149,11 +148,11 @@ public sealed class ChaseAction : IAIAction
         }
         else
         {
-            blackboard.Set(BBKeys.ChaseTimeSinceUpdate, timeSinceLastUpdate);
+            blackboard.Set(BBKeys.ChaseTimeSinceUpdate, memory.TimeSinceLastUpdate);
         }
 
         // Check if path is valid
-        if (!agent.HasPath && !agent.PathPending && initialPathRequested)
+        if (!agent.HasPath && !agent.PathPending && memory.InitialPathRequested)
         {
             // Path computation failed - target may be unreachable
             return BTNodeState.Failure;
@@ -169,16 +168,17 @@ public sealed class ChaseAction : IAIAction
     }
 
     /// <inheritdoc/>
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
-        timeSinceLastUpdate = 0f;
-        initialPathRequested = false;
+        var memory = blackboard.GetMemory<ChaseMemory>(this);
+        memory.TimeSinceLastUpdate = 0f;
+        memory.InitialPathRequested = false;
     }
 
     /// <inheritdoc/>
     public void OnInterrupted(Entity entity, Blackboard blackboard, IWorld world)
     {
-        Reset();
+        Reset(blackboard);
 
         // Stop the agent when interrupted
         if (world.Has<NavMeshAgent>(entity) &&
@@ -187,5 +187,14 @@ public sealed class ChaseAction : IAIAction
         {
             nav.Stop(entity);
         }
+    }
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="ChaseAction"/>.
+    /// </summary>
+    internal sealed class ChaseMemory
+    {
+        public float TimeSinceLastUpdate { get; set; }
+        public bool InitialPathRequested { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Actions/FleeAction.cs
+++ b/src/KeenEyes.AI/Actions/FleeAction.cs
@@ -33,9 +33,6 @@ namespace KeenEyes.AI.Actions;
 /// </example>
 public sealed class FleeAction : IAIAction
 {
-    private bool pathRequested;
-    private Vector3 fleeDestination;
-    private int retryCount;
 
     /// <summary>
     /// The minimum distance to maintain from the threat.
@@ -70,7 +67,6 @@ public sealed class FleeAction : IAIAction
     /// </summary>
     public float UpdateInterval { get; set; } = 1.0f;
 
-    private float timeSinceLastUpdate;
 
     /// <inheritdoc/>
     public BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
@@ -107,11 +103,12 @@ public sealed class FleeAction : IAIAction
         }
 
         var deltaTime = blackboard.Get(BBKeys.DeltaTime, 0f);
-        timeSinceLastUpdate += deltaTime;
+        var memory = blackboard.GetMemory<FleeMemory>(this);
+        memory.TimeSinceLastUpdate += deltaTime;
 
         // Calculate flee destination if needed
-        bool shouldUpdatePath = !pathRequested ||
-                                (UpdateWhileFleeing && timeSinceLastUpdate >= UpdateInterval);
+        bool shouldUpdatePath = !memory.PathRequested ||
+                                (UpdateWhileFleeing && memory.TimeSinceLastUpdate >= UpdateInterval);
 
         if (shouldUpdatePath)
         {
@@ -123,17 +120,17 @@ public sealed class FleeAction : IAIAction
 
             if (newDestination.HasValue)
             {
-                fleeDestination = newDestination.Value;
-                nav.SetDestination(entity, fleeDestination);
-                pathRequested = true;
-                timeSinceLastUpdate = 0f;
-                retryCount = 0;
-                blackboard.Set(BBKeys.Destination, fleeDestination);
+                memory.FleeDestination = newDestination.Value;
+                nav.SetDestination(entity, memory.FleeDestination);
+                memory.PathRequested = true;
+                memory.TimeSinceLastUpdate = 0f;
+                memory.RetryCount = 0;
+                blackboard.Set(BBKeys.Destination, memory.FleeDestination);
             }
-            else if (!pathRequested)
+            else if (!memory.PathRequested)
             {
-                retryCount++;
-                if (retryCount >= MaxRetries)
+                memory.RetryCount++;
+                if (memory.RetryCount >= MaxRetries)
                 {
                     return BTNodeState.Failure;
                 }
@@ -141,17 +138,17 @@ public sealed class FleeAction : IAIAction
         }
 
         // Check for pathfinding failure
-        if (!agent.HasPath && !agent.PathPending && pathRequested)
+        if (!agent.HasPath && !agent.PathPending && memory.PathRequested)
         {
-            retryCount++;
-            if (retryCount >= MaxRetries)
+            memory.RetryCount++;
+            if (memory.RetryCount >= MaxRetries)
             {
                 return BTNodeState.Failure;
             }
 
             // Try a new flee destination
-            pathRequested = false;
-            timeSinceLastUpdate = UpdateInterval; // Force recalculation
+            memory.PathRequested = false;
+            memory.TimeSinceLastUpdate = UpdateInterval; // Force recalculation
         }
 
         // Check if we've reached the flee destination
@@ -163,8 +160,8 @@ public sealed class FleeAction : IAIAction
             }
 
             // Not far enough, find a new flee point
-            pathRequested = false;
-            timeSinceLastUpdate = UpdateInterval;
+            memory.PathRequested = false;
+            memory.TimeSinceLastUpdate = UpdateInterval;
         }
 
         // Store current path in blackboard
@@ -261,18 +258,19 @@ public sealed class FleeAction : IAIAction
     }
 
     /// <inheritdoc/>
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
-        pathRequested = false;
-        fleeDestination = Vector3.Zero;
-        retryCount = 0;
-        timeSinceLastUpdate = 0f;
+        var memory = blackboard.GetMemory<FleeMemory>(this);
+        memory.PathRequested = false;
+        memory.FleeDestination = Vector3.Zero;
+        memory.RetryCount = 0;
+        memory.TimeSinceLastUpdate = 0f;
     }
 
     /// <inheritdoc/>
     public void OnInterrupted(Entity entity, Blackboard blackboard, IWorld world)
     {
-        Reset();
+        Reset(blackboard);
 
         // Stop the agent when interrupted
         if (world.Has<NavMeshAgent>(entity) &&
@@ -281,5 +279,16 @@ public sealed class FleeAction : IAIAction
         {
             nav.Stop(entity);
         }
+    }
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="FleeAction"/>.
+    /// </summary>
+    internal sealed class FleeMemory
+    {
+        public bool PathRequested { get; set; }
+        public Vector3 FleeDestination { get; set; }
+        public int RetryCount { get; set; }
+        public float TimeSinceLastUpdate { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Actions/MoveToAction.cs
+++ b/src/KeenEyes.AI/Actions/MoveToAction.cs
@@ -34,8 +34,6 @@ namespace KeenEyes.AI.Actions;
 /// </example>
 public sealed class MoveToAction : IAIAction
 {
-    private bool pathRequested;
-    private float pathRequestTime;
 
     /// <summary>
     /// The destination to move to.
@@ -101,13 +99,14 @@ public sealed class MoveToAction : IAIAction
         }
 
         var currentTime = blackboard.Get(BBKeys.Time, 0f);
+        var memory = blackboard.GetMemory<MoveToMemory>(this);
 
         // Request path if we haven't yet
-        if (!pathRequested)
+        if (!memory.PathRequested)
         {
             nav.SetDestination(entity, destination);
-            pathRequested = true;
-            pathRequestTime = currentTime;
+            memory.PathRequested = true;
+            memory.PathRequestTime = currentTime;
             return BTNodeState.Running;
         }
 
@@ -118,7 +117,7 @@ public sealed class MoveToAction : IAIAction
             return BTNodeState.Failure;
         }
 
-        if (agent.PathPending && currentTime - pathRequestTime > PathTimeout)
+        if (agent.PathPending && currentTime - memory.PathRequestTime > PathTimeout)
         {
             // Timeout waiting for path
             return BTNodeState.Failure;
@@ -134,16 +133,17 @@ public sealed class MoveToAction : IAIAction
     }
 
     /// <inheritdoc/>
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
-        pathRequested = false;
-        pathRequestTime = 0f;
+        var memory = blackboard.GetMemory<MoveToMemory>(this);
+        memory.PathRequested = false;
+        memory.PathRequestTime = 0f;
     }
 
     /// <inheritdoc/>
     public void OnInterrupted(Entity entity, Blackboard blackboard, IWorld world)
     {
-        Reset();
+        Reset(blackboard);
 
         // Stop the agent when interrupted
         if (world.Has<NavMeshAgent>(entity) &&
@@ -152,5 +152,14 @@ public sealed class MoveToAction : IAIAction
         {
             nav.Stop(entity);
         }
+    }
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="MoveToAction"/>.
+    /// </summary>
+    internal sealed class MoveToMemory
+    {
+        public bool PathRequested { get; set; }
+        public float PathRequestTime { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Actions/PatrolAction.cs
+++ b/src/KeenEyes.AI/Actions/PatrolAction.cs
@@ -37,9 +37,6 @@ namespace KeenEyes.AI.Actions;
 /// </example>
 public sealed class PatrolAction : IAIAction
 {
-    private bool isWaiting;
-    private float waitTimer;
-    private bool pathRequested;
 
     /// <summary>
     /// The waypoints to patrol through.
@@ -73,8 +70,6 @@ public sealed class PatrolAction : IAIAction
     /// </summary>
     public float ArrivalTolerance { get; set; } = 0.5f;
 
-    // Track direction for ping-pong mode
-    private bool reverseDirection;
 
     /// <inheritdoc/>
     public BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
@@ -112,29 +107,30 @@ public sealed class PatrolAction : IAIAction
         blackboard.Set(BBKeys.PatrolIndex, currentIndex);
 
         var deltaTime = blackboard.Get(BBKeys.DeltaTime, 0f);
+        var memory = blackboard.GetMemory<PatrolMemory>(this);
 
         // Handle waiting at waypoint
-        if (isWaiting)
+        if (memory.IsWaiting)
         {
-            waitTimer -= deltaTime;
-            if (waitTimer > 0)
+            memory.WaitTimer -= deltaTime;
+            if (memory.WaitTimer > 0)
             {
                 return BTNodeState.Running;
             }
 
-            isWaiting = false;
-            pathRequested = false;
+            memory.IsWaiting = false;
+            memory.PathRequested = false;
 
             // Move to next waypoint
             if (PingPong)
             {
-                if (reverseDirection)
+                if (memory.ReverseDirection)
                 {
                     currentIndex--;
                     if (currentIndex < 0)
                     {
                         currentIndex = 1;
-                        reverseDirection = false;
+                        memory.ReverseDirection = false;
                     }
                 }
                 else
@@ -143,7 +139,7 @@ public sealed class PatrolAction : IAIAction
                     if (currentIndex >= waypoints.Length)
                     {
                         currentIndex = waypoints.Length - 2;
-                        reverseDirection = true;
+                        memory.ReverseDirection = true;
                     }
                 }
             }
@@ -176,28 +172,28 @@ public sealed class PatrolAction : IAIAction
         // Check if we've reached the waypoint
         var distanceToWaypoint = Vector3.Distance(transform.Position, targetWaypoint);
         if (distanceToWaypoint <= ArrivalTolerance ||
-            (agent.HasPath && agent.RemainingDistance <= agent.StoppingDistance && pathRequested))
+            (agent.HasPath && agent.RemainingDistance <= agent.StoppingDistance && memory.PathRequested))
         {
             if (WaitTimeAtWaypoint > 0)
             {
-                isWaiting = true;
-                waitTimer = WaitTimeAtWaypoint;
+                memory.IsWaiting = true;
+                memory.WaitTimer = WaitTimeAtWaypoint;
                 nav.Stop(entity);
                 return BTNodeState.Running;
             }
 
             // No wait, move to next waypoint immediately
-            pathRequested = false;
+            memory.PathRequested = false;
 
             if (PingPong)
             {
-                if (reverseDirection)
+                if (memory.ReverseDirection)
                 {
                     currentIndex--;
                     if (currentIndex < 0)
                     {
                         currentIndex = Math.Min(1, waypoints.Length - 1);
-                        reverseDirection = false;
+                        memory.ReverseDirection = false;
                     }
                 }
                 else
@@ -206,7 +202,7 @@ public sealed class PatrolAction : IAIAction
                     if (currentIndex >= waypoints.Length)
                     {
                         currentIndex = Math.Max(0, waypoints.Length - 2);
-                        reverseDirection = true;
+                        memory.ReverseDirection = true;
                     }
                 }
             }
@@ -231,19 +227,19 @@ public sealed class PatrolAction : IAIAction
 
             // Request path to new waypoint
             nav.SetDestination(entity, waypoints[currentIndex]);
-            pathRequested = true;
+            memory.PathRequested = true;
             return BTNodeState.Running;
         }
 
         // Request initial path if not yet done
-        if (!pathRequested)
+        if (!memory.PathRequested)
         {
             nav.SetDestination(entity, targetWaypoint);
-            pathRequested = true;
+            memory.PathRequested = true;
         }
 
         // Check for pathfinding failure
-        if (!agent.HasPath && !agent.PathPending && pathRequested)
+        if (!agent.HasPath && !agent.PathPending && memory.PathRequested)
         {
             // Try next waypoint if current is unreachable
             return BTNodeState.Running; // Keep trying
@@ -259,18 +255,19 @@ public sealed class PatrolAction : IAIAction
     }
 
     /// <inheritdoc/>
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
-        isWaiting = false;
-        waitTimer = 0f;
-        pathRequested = false;
-        reverseDirection = false;
+        var memory = blackboard.GetMemory<PatrolMemory>(this);
+        memory.IsWaiting = false;
+        memory.WaitTimer = 0f;
+        memory.PathRequested = false;
+        memory.ReverseDirection = false;
     }
 
     /// <inheritdoc/>
     public void OnInterrupted(Entity entity, Blackboard blackboard, IWorld world)
     {
-        Reset();
+        Reset(blackboard);
 
         // Stop the agent when interrupted
         if (world.Has<NavMeshAgent>(entity) &&
@@ -279,5 +276,16 @@ public sealed class PatrolAction : IAIAction
         {
             nav.Stop(entity);
         }
+    }
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="PatrolAction"/>.
+    /// </summary>
+    internal sealed class PatrolMemory
+    {
+        public bool IsWaiting { get; set; }
+        public float WaitTimer { get; set; }
+        public bool PathRequested { get; set; }
+        public bool ReverseDirection { get; set; }
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/BehaviorTreeSystem.cs
+++ b/src/KeenEyes.AI/BehaviorTree/BehaviorTreeSystem.cs
@@ -59,7 +59,7 @@ public sealed class BehaviorTreeSystem : SystemBase
             {
                 // Tree completed - reset for next tick
                 bt.RunningNode = null;
-                definition.Reset();
+                definition.Reset(blackboard);
             }
         }
     }

--- a/src/KeenEyes.AI/BehaviorTree/Composites/Parallel.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Composites/Parallel.cs
@@ -62,7 +62,7 @@ public sealed class Parallel : CompositeNode
     {
         if (Children.Count == 0)
         {
-            return SetState(BTNodeState.Success);
+            return SetState(blackboard, BTNodeState.Success);
         }
 
         var successCount = 0;
@@ -97,7 +97,7 @@ public sealed class Parallel : CompositeNode
 
         if (shouldFail)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
         // Check success policy
@@ -110,10 +110,10 @@ public sealed class Parallel : CompositeNode
 
         if (shouldSucceed)
         {
-            return SetState(BTNodeState.Success);
+            return SetState(blackboard, BTNodeState.Success);
         }
 
         // Still running if neither success nor failure conditions are met
-        return SetState(BTNodeState.Running);
+        return SetState(blackboard, BTNodeState.Running);
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Composites/RandomSelector.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Composites/RandomSelector.cs
@@ -27,40 +27,44 @@ namespace KeenEyes.AI.BehaviorTree.Composites;
 /// </example>
 public sealed class RandomSelector : CompositeNode
 {
-    private readonly List<int> shuffledIndices = [];
-    private bool needsShuffle = true;
-
     /// <summary>
     /// Gets or sets the random seed. If null, uses system random.
     /// </summary>
     public int? Seed { get; set; }
 
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        needsShuffle = true;
-        shuffledIndices.Clear();
+        base.Reset(blackboard);
+        var memory = (RandomSelectorMemory)GetMemory(blackboard);
+        memory.NeedsShuffle = true;
+        memory.ShuffledIndices.Clear();
     }
+
+    /// <inheritdoc/>
+    protected internal override BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<RandomSelectorMemory>(this);
 
     /// <inheritdoc/>
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
         if (Children.Count == 0)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
+
+        var memory = (RandomSelectorMemory)GetMemory(blackboard);
 
         // Shuffle on first execution
-        if (needsShuffle)
+        if (memory.NeedsShuffle)
         {
-            ShuffleIndices();
-            needsShuffle = false;
+            ShuffleIndices(memory.ShuffledIndices);
+            memory.NeedsShuffle = false;
         }
 
-        while (currentChildIndex < shuffledIndices.Count)
+        while (memory.CurrentChildIndex < memory.ShuffledIndices.Count)
         {
-            var childIndex = shuffledIndices[currentChildIndex];
+            var childIndex = memory.ShuffledIndices[memory.CurrentChildIndex];
             var child = Children[childIndex];
             var state = child.Execute(entity, blackboard, world);
 
@@ -68,28 +72,28 @@ public sealed class RandomSelector : CompositeNode
             {
                 case BTNodeState.Success:
                     // Found a successful child - reset for next run
-                    currentChildIndex = 0;
-                    needsShuffle = true;
-                    return SetState(BTNodeState.Success);
+                    memory.CurrentChildIndex = 0;
+                    memory.NeedsShuffle = true;
+                    return SetState(blackboard, BTNodeState.Success);
 
                 case BTNodeState.Running:
                     // Child still running - wait for completion
-                    return SetState(BTNodeState.Running);
+                    return SetState(blackboard, BTNodeState.Running);
 
                 case BTNodeState.Failure:
                     // Child failed - try next child
-                    currentChildIndex++;
+                    memory.CurrentChildIndex++;
                     break;
             }
         }
 
         // All children failed - reset for next run
-        currentChildIndex = 0;
-        needsShuffle = true;
-        return SetState(BTNodeState.Failure);
+        memory.CurrentChildIndex = 0;
+        memory.NeedsShuffle = true;
+        return SetState(blackboard, BTNodeState.Failure);
     }
 
-    private void ShuffleIndices()
+    private void ShuffleIndices(List<int> shuffledIndices)
     {
         shuffledIndices.Clear();
 
@@ -106,5 +110,14 @@ public sealed class RandomSelector : CompositeNode
             var j = random.Next(i + 1);
             (shuffledIndices[i], shuffledIndices[j]) = (shuffledIndices[j], shuffledIndices[i]);
         }
+    }
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="RandomSelector"/>.
+    /// </summary>
+    internal sealed class RandomSelectorMemory : CompositeMemory
+    {
+        public List<int> ShuffledIndices { get; } = [];
+        public bool NeedsShuffle { get; set; } = true;
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Composites/Selector.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Composites/Selector.cs
@@ -34,31 +34,32 @@ public sealed class Selector : CompositeNode
     /// <inheritdoc/>
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
-        while (currentChildIndex < Children.Count)
+        var memory = GetCompositeMemory(blackboard);
+        while (memory.CurrentChildIndex < Children.Count)
         {
-            var child = Children[currentChildIndex];
+            var child = Children[memory.CurrentChildIndex];
             var state = child.Execute(entity, blackboard, world);
 
             switch (state)
             {
                 case BTNodeState.Success:
                     // Found a successful child - selector succeeds
-                    currentChildIndex = 0;
-                    return SetState(BTNodeState.Success);
+                    memory.CurrentChildIndex = 0;
+                    return SetState(blackboard, BTNodeState.Success);
 
                 case BTNodeState.Running:
                     // Child still running - wait for completion
-                    return SetState(BTNodeState.Running);
+                    return SetState(blackboard, BTNodeState.Running);
 
                 case BTNodeState.Failure:
                     // Child failed - try next child
-                    currentChildIndex++;
+                    memory.CurrentChildIndex++;
                     break;
             }
         }
 
         // All children failed - selector fails
-        currentChildIndex = 0;
-        return SetState(BTNodeState.Failure);
+        memory.CurrentChildIndex = 0;
+        return SetState(blackboard, BTNodeState.Failure);
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Composites/Sequence.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Composites/Sequence.cs
@@ -33,31 +33,32 @@ public sealed class Sequence : CompositeNode
     /// <inheritdoc/>
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
-        while (currentChildIndex < Children.Count)
+        var memory = GetCompositeMemory(blackboard);
+        while (memory.CurrentChildIndex < Children.Count)
         {
-            var child = Children[currentChildIndex];
+            var child = Children[memory.CurrentChildIndex];
             var state = child.Execute(entity, blackboard, world);
 
             switch (state)
             {
                 case BTNodeState.Failure:
                     // Child failed - sequence fails
-                    currentChildIndex = 0;
-                    return SetState(BTNodeState.Failure);
+                    memory.CurrentChildIndex = 0;
+                    return SetState(blackboard, BTNodeState.Failure);
 
                 case BTNodeState.Running:
                     // Child still running - wait for completion
-                    return SetState(BTNodeState.Running);
+                    return SetState(blackboard, BTNodeState.Running);
 
                 case BTNodeState.Success:
                     // Child succeeded - try next child
-                    currentChildIndex++;
+                    memory.CurrentChildIndex++;
                     break;
             }
         }
 
         // All children succeeded - sequence succeeds
-        currentChildIndex = 0;
-        return SetState(BTNodeState.Success);
+        memory.CurrentChildIndex = 0;
+        return SetState(blackboard, BTNodeState.Success);
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Core/BTNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Core/BTNode.cs
@@ -29,13 +29,16 @@ public abstract class BTNode
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets the last execution state of this node.
+    /// Gets the last execution state of this node for the entity owning the blackboard.
     /// </summary>
+    /// <param name="blackboard">The blackboard of the entity whose state to read.</param>
+    /// <returns>The last state this node returned for that entity.</returns>
     /// <remarks>
     /// Useful for debugging and visualization to see the state of each node
-    /// after tree evaluation.
+    /// after tree evaluation. Node definitions are shared between entities, so the
+    /// last state is per-entity and lives in the blackboard (#1281).
     /// </remarks>
-    public BTNodeState LastState { get; protected set; } = BTNodeState.Running;
+    public BTNodeState GetLastState(Blackboard blackboard) => GetMemory(blackboard).LastState;
 
     /// <summary>
     /// Executes this node for the given entity.
@@ -47,16 +50,32 @@ public abstract class BTNode
     public abstract BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world);
 
     /// <summary>
-    /// Resets the node state for a new execution.
+    /// Resets the node's per-entity execution state for a new run.
     /// </summary>
+    /// <param name="blackboard">The blackboard of the entity whose state to reset.</param>
     /// <remarks>
     /// Called when the behavior tree restarts or when this node needs to be
-    /// re-evaluated from scratch. Override to reset internal state.
+    /// re-evaluated from scratch. Override to reset state stored in the node's memory;
+    /// never store execution state on the node instance itself — definitions are
+    /// shared between entities.
     /// </remarks>
-    public virtual void Reset()
+    public virtual void Reset(Blackboard blackboard)
     {
-        LastState = BTNodeState.Running;
+        GetMemory(blackboard).LastState = BTNodeState.Running;
     }
+
+    /// <summary>
+    /// Gets this node's per-entity execution memory from the blackboard.
+    /// </summary>
+    /// <param name="blackboard">The blackboard of the entity executing this node.</param>
+    /// <returns>The memory holding this node's mutable state for that entity.</returns>
+    /// <remarks>
+    /// Override in nodes that need more state than <see cref="BTNodeMemory.LastState"/>,
+    /// returning a <see cref="BTNodeMemory"/> subclass. A node must always return the
+    /// same memory type — the blackboard stores one entry per node.
+    /// </remarks>
+    protected internal virtual BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<BTNodeMemory>(this);
 
     /// <summary>
     /// Called when this node is interrupted before completion.
@@ -73,13 +92,14 @@ public abstract class BTNode
     }
 
     /// <summary>
-    /// Updates the last state and returns it.
+    /// Updates the last state for the entity owning the blackboard and returns it.
     /// </summary>
+    /// <param name="blackboard">The blackboard of the entity executing this node.</param>
     /// <param name="state">The new state.</param>
     /// <returns>The state (for chaining).</returns>
-    protected BTNodeState SetState(BTNodeState state)
+    protected BTNodeState SetState(Blackboard blackboard, BTNodeState state)
     {
-        LastState = state;
+        GetMemory(blackboard).LastState = state;
         return state;
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Core/BehaviorTree.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Core/BehaviorTree.cs
@@ -88,33 +88,38 @@ public sealed class BehaviorTree
     }
 
     /// <summary>
-    /// Resets the entire behavior tree.
+    /// Resets the entire behavior tree's execution state for one entity.
     /// </summary>
-    public void Reset()
+    /// <param name="blackboard">The blackboard of the entity whose run should restart.</param>
+    /// <remarks>
+    /// Definitions are shared between entities; resetting one entity's blackboard leaves
+    /// every other entity's progress through this tree untouched (#1281).
+    /// </remarks>
+    public void Reset(Blackboard blackboard)
     {
-        ResetNode(Root);
+        ResetNode(Root, blackboard);
     }
 
-    private static void ResetNode(BTNode? node)
+    private static void ResetNode(BTNode? node, Blackboard blackboard)
     {
         if (node == null)
         {
             return;
         }
 
-        node.Reset();
+        node.Reset(blackboard);
 
         // Recursively reset children based on node type
         if (node is CompositeNode composite)
         {
             foreach (var child in composite.Children)
             {
-                ResetNode(child);
+                ResetNode(child, blackboard);
             }
         }
         else if (node is DecoratorNode decorator)
         {
-            ResetNode(decorator.Child);
+            ResetNode(decorator.Child, blackboard);
         }
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Core/CompositeNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Core/CompositeNode.cs
@@ -18,20 +18,15 @@ public abstract class CompositeNode : BTNode
     /// </summary>
     public List<BTNode> Children { get; set; } = [];
 
-    /// <summary>
-    /// The index of the currently executing child (for resumable composites).
-    /// </summary>
-    protected int currentChildIndex;
-
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        currentChildIndex = 0;
+        base.Reset(blackboard);
+        GetCompositeMemory(blackboard).CurrentChildIndex = 0;
 
         foreach (var child in Children)
         {
-            child.Reset();
+            child.Reset(blackboard);
         }
     }
 
@@ -43,10 +38,33 @@ public abstract class CompositeNode : BTNode
         // Interrupt all running children
         foreach (var child in Children)
         {
-            if (child.LastState == BTNodeState.Running)
+            if (child.GetLastState(blackboard) == BTNodeState.Running)
             {
                 child.OnInterrupted(entity, blackboard, world);
             }
         }
+    }
+
+    /// <inheritdoc/>
+    protected internal override BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<CompositeMemory>(this);
+
+    /// <summary>
+    /// Gets this composite's per-entity memory, including the resumable child cursor.
+    /// </summary>
+    /// <param name="blackboard">The blackboard of the entity executing this node.</param>
+    /// <returns>The composite memory for that entity.</returns>
+    protected CompositeMemory GetCompositeMemory(Blackboard blackboard)
+        => (CompositeMemory)GetMemory(blackboard);
+
+    /// <summary>
+    /// Per-entity execution memory for composite nodes.
+    /// </summary>
+    public class CompositeMemory : BTNodeMemory
+    {
+        /// <summary>
+        /// Gets or sets the index of the currently executing child (for resumable composites).
+        /// </summary>
+        public int CurrentChildIndex { get; set; }
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Core/DecoratorNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Core/DecoratorNode.cs
@@ -19,10 +19,10 @@ public abstract class DecoratorNode : BTNode
     public BTNode? Child { get; set; }
 
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        Child?.Reset();
+        base.Reset(blackboard);
+        Child?.Reset(blackboard);
     }
 
     /// <inheritdoc/>
@@ -30,7 +30,7 @@ public abstract class DecoratorNode : BTNode
     {
         base.OnInterrupted(entity, blackboard, world);
 
-        if (Child?.LastState == BTNodeState.Running)
+        if (Child?.GetLastState(blackboard) == BTNodeState.Running)
         {
             Child.OnInterrupted(entity, blackboard, world);
         }

--- a/src/KeenEyes.AI/BehaviorTree/Decorators/Cooldown.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Decorators/Cooldown.cs
@@ -28,7 +28,6 @@ namespace KeenEyes.AI.BehaviorTree.Decorators;
 /// </example>
 public sealed class Cooldown : DecoratorNode
 {
-    private float lastExecutionTime = float.MinValue;
 
     /// <summary>
     /// Gets or sets the cooldown duration in seconds.
@@ -45,19 +44,20 @@ public sealed class Cooldown : DecoratorNode
     public bool CooldownOnFailure { get; set; }
 
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        // Note: We don't reset lastExecutionTime here because
+        base.Reset(blackboard);
+        // Note: We don't reset LastExecutionTime here because
         // cooldowns should persist across tree resets
     }
 
     /// <summary>
-    /// Resets the cooldown timer, allowing immediate execution.
+    /// Resets the cooldown timer for one entity, allowing immediate execution.
     /// </summary>
-    public void ResetCooldown()
+    /// <param name="blackboard">The blackboard of the entity whose cooldown to clear.</param>
+    public void ResetCooldown(Blackboard blackboard)
     {
-        lastExecutionTime = float.MinValue;
+        ((CooldownMemory)GetMemory(blackboard)).LastExecutionTime = float.MinValue;
     }
 
     /// <inheritdoc/>
@@ -65,16 +65,18 @@ public sealed class Cooldown : DecoratorNode
     {
         if (Child == null)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
+
+        var memory = (CooldownMemory)GetMemory(blackboard);
 
         // Get current time from blackboard
         var currentTime = blackboard.Get(BBKeys.Time, 0f);
 
         // Check if still on cooldown
-        if (currentTime - lastExecutionTime < Duration)
+        if (currentTime - memory.LastExecutionTime < Duration)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
         var state = Child.Execute(entity, blackboard, world);
@@ -82,9 +84,21 @@ public sealed class Cooldown : DecoratorNode
         // Start cooldown on completion (based on settings)
         if (state == BTNodeState.Success || (CooldownOnFailure && state == BTNodeState.Failure))
         {
-            lastExecutionTime = currentTime;
+            memory.LastExecutionTime = currentTime;
         }
 
-        return SetState(state);
+        return SetState(blackboard, state);
+    }
+
+    /// <inheritdoc/>
+    protected internal override BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<CooldownMemory>(this);
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="Cooldown"/>.
+    /// </summary>
+    internal sealed class CooldownMemory : BTNodeMemory
+    {
+        public float LastExecutionTime { get; set; } = float.MinValue;
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Decorators/Inverter.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Decorators/Inverter.cs
@@ -28,12 +28,12 @@ public sealed class Inverter : DecoratorNode
     {
         if (Child == null)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
         var state = Child.Execute(entity, blackboard, world);
 
-        return SetState(state switch
+        return SetState(blackboard, state switch
         {
             BTNodeState.Success => BTNodeState.Failure,
             BTNodeState.Failure => BTNodeState.Success,

--- a/src/KeenEyes.AI/BehaviorTree/Decorators/Repeater.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Decorators/Repeater.cs
@@ -34,8 +34,6 @@ namespace KeenEyes.AI.BehaviorTree.Decorators;
 /// </example>
 public sealed class Repeater : DecoratorNode
 {
-    private int currentCount;
-
     /// <summary>
     /// Gets or sets the number of times to repeat. Use -1 for infinite.
     /// </summary>
@@ -51,10 +49,10 @@ public sealed class Repeater : DecoratorNode
     public bool IgnoreFailure { get; set; }
 
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        currentCount = 0;
+        base.Reset(blackboard);
+        ((RepeaterMemory)GetMemory(blackboard)).CurrentCount = 0;
     }
 
     /// <inheritdoc/>
@@ -62,14 +60,16 @@ public sealed class Repeater : DecoratorNode
     {
         if (Child == null)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
+        var memory = (RepeaterMemory)GetMemory(blackboard);
+
         // Check if we've reached the count (for non-infinite)
-        if (Count >= 0 && currentCount >= Count)
+        if (Count >= 0 && memory.CurrentCount >= Count)
         {
-            currentCount = 0;
-            return SetState(BTNodeState.Success);
+            memory.CurrentCount = 0;
+            return SetState(blackboard, BTNodeState.Success);
         }
 
         var state = Child.Execute(entity, blackboard, world);
@@ -77,29 +77,41 @@ public sealed class Repeater : DecoratorNode
         switch (state)
         {
             case BTNodeState.Running:
-                return SetState(BTNodeState.Running);
+                return SetState(blackboard, BTNodeState.Running);
 
             case BTNodeState.Failure when !IgnoreFailure:
-                currentCount = 0;
-                return SetState(BTNodeState.Failure);
+                memory.CurrentCount = 0;
+                return SetState(blackboard, BTNodeState.Failure);
 
             case BTNodeState.Success:
             case BTNodeState.Failure: // when IgnoreFailure is true
-                currentCount++;
-                Child.Reset();
+                memory.CurrentCount++;
+                Child.Reset(blackboard);
 
                 // Check if we just hit the count
-                if (Count >= 0 && currentCount >= Count)
+                if (Count >= 0 && memory.CurrentCount >= Count)
                 {
-                    currentCount = 0;
-                    return SetState(BTNodeState.Success);
+                    memory.CurrentCount = 0;
+                    return SetState(blackboard, BTNodeState.Success);
                 }
 
                 // More iterations needed - keep running
-                return SetState(BTNodeState.Running);
+                return SetState(blackboard, BTNodeState.Running);
 
             default:
-                return SetState(state);
+                return SetState(blackboard, state);
         }
+    }
+
+    /// <inheritdoc/>
+    protected internal override BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<RepeaterMemory>(this);
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="Repeater"/>.
+    /// </summary>
+    internal sealed class RepeaterMemory : BTNodeMemory
+    {
+        public int CurrentCount { get; set; }
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Decorators/Succeeder.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Decorators/Succeeder.cs
@@ -37,12 +37,12 @@ public sealed class Succeeder : DecoratorNode
     {
         if (Child == null)
         {
-            return SetState(BTNodeState.Success);
+            return SetState(blackboard, BTNodeState.Success);
         }
 
         var state = Child.Execute(entity, blackboard, world);
 
-        return SetState(state == BTNodeState.Running
+        return SetState(blackboard, state == BTNodeState.Running
             ? BTNodeState.Running
             : BTNodeState.Success);
     }

--- a/src/KeenEyes.AI/BehaviorTree/Decorators/UntilFail.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Decorators/UntilFail.cs
@@ -39,7 +39,7 @@ public sealed class UntilFail : DecoratorNode
     {
         if (Child == null)
         {
-            return SetState(BTNodeState.Success);
+            return SetState(blackboard, BTNodeState.Success);
         }
 
         var state = Child.Execute(entity, blackboard, world);
@@ -48,15 +48,15 @@ public sealed class UntilFail : DecoratorNode
         {
             case BTNodeState.Failure:
                 // Child failed - we're done (successfully)
-                return SetState(BTNodeState.Success);
+                return SetState(blackboard, BTNodeState.Success);
 
             case BTNodeState.Success:
                 // Child succeeded - reset and continue
-                Child.Reset();
-                return SetState(BTNodeState.Running);
+                Child.Reset(blackboard);
+                return SetState(blackboard, BTNodeState.Running);
 
             default:
-                return SetState(state);
+                return SetState(blackboard, state);
         }
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Leaves/ActionNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Leaves/ActionNode.cs
@@ -29,18 +29,18 @@ public sealed class ActionNode : BTNode
     {
         if (Action == null)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
         var state = Action.Execute(entity, blackboard, world);
-        return SetState(state);
+        return SetState(blackboard, state);
     }
 
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        Action?.Reset();
+        base.Reset(blackboard);
+        Action?.Reset(blackboard);
     }
 
     /// <inheritdoc/>

--- a/src/KeenEyes.AI/BehaviorTree/Leaves/ConditionNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Leaves/ConditionNode.cs
@@ -40,10 +40,10 @@ public sealed class ConditionNode : BTNode
     {
         if (Condition == null)
         {
-            return SetState(BTNodeState.Failure);
+            return SetState(blackboard, BTNodeState.Failure);
         }
 
         var result = Condition.Evaluate(entity, blackboard, world);
-        return SetState(result ? BTNodeState.Success : BTNodeState.Failure);
+        return SetState(blackboard, result ? BTNodeState.Success : BTNodeState.Failure);
     }
 }

--- a/src/KeenEyes.AI/BehaviorTree/Leaves/WaitNode.cs
+++ b/src/KeenEyes.AI/BehaviorTree/Leaves/WaitNode.cs
@@ -24,8 +24,6 @@ namespace KeenEyes.AI.BehaviorTree.Leaves;
 /// </example>
 public sealed class WaitNode : BTNode
 {
-    private float elapsed;
-
     /// <summary>
     /// Gets or sets the duration to wait in seconds.
     /// </summary>
@@ -50,37 +48,38 @@ public sealed class WaitNode : BTNode
     /// </summary>
     public float MaxDuration { get; set; } = 2f;
 
-    private float? randomizedDuration;
-
     /// <inheritdoc/>
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
-        elapsed = 0f;
-        randomizedDuration = null;
+        base.Reset(blackboard);
+        var memory = (WaitMemory)GetMemory(blackboard);
+        memory.Elapsed = 0f;
+        memory.RandomizedDuration = null;
     }
 
     /// <inheritdoc/>
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
+        var memory = (WaitMemory)GetMemory(blackboard);
+
         // Determine target duration
-        var targetDuration = GetTargetDuration();
+        var targetDuration = GetTargetDuration(memory);
 
         // Get delta time from blackboard
         var deltaTime = blackboard.Get(BBKeys.DeltaTime, 0f);
-        elapsed += deltaTime;
+        memory.Elapsed += deltaTime;
 
-        if (elapsed >= targetDuration)
+        if (memory.Elapsed >= targetDuration)
         {
-            elapsed = 0f;
-            randomizedDuration = null;
-            return SetState(BTNodeState.Success);
+            memory.Elapsed = 0f;
+            memory.RandomizedDuration = null;
+            return SetState(blackboard, BTNodeState.Success);
         }
 
-        return SetState(BTNodeState.Running);
+        return SetState(blackboard, BTNodeState.Running);
     }
 
-    private float GetTargetDuration()
+    private float GetTargetDuration(WaitMemory memory)
     {
         if (!UseRandomDuration)
         {
@@ -88,7 +87,20 @@ public sealed class WaitNode : BTNode
         }
 
         // Calculate randomized duration once per execution
-        randomizedDuration ??= MinDuration + (Random.Shared.NextSingle() * (MaxDuration - MinDuration));
-        return randomizedDuration.Value;
+        memory.RandomizedDuration ??= MinDuration + (Random.Shared.NextSingle() * (MaxDuration - MinDuration));
+        return memory.RandomizedDuration.Value;
+    }
+
+    /// <inheritdoc/>
+    protected internal override BTNodeMemory GetMemory(Blackboard blackboard)
+        => blackboard.GetMemory<WaitMemory>(this);
+
+    /// <summary>
+    /// Per-entity execution memory for <see cref="WaitNode"/>.
+    /// </summary>
+    internal sealed class WaitMemory : BTNodeMemory
+    {
+        public float Elapsed { get; set; }
+        public float? RandomizedDuration { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Core/BTNodeMemory.cs
+++ b/src/KeenEyes.AI/Core/BTNodeMemory.cs
@@ -1,0 +1,25 @@
+namespace KeenEyes.AI;
+
+/// <summary>
+/// Base class for the per-entity execution memory of a behavior tree node.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Behavior tree definitions are shared between every entity that runs them, so node
+/// instances must stay immutable while executing. All state that changes during a run
+/// (last result, child cursors, timers) lives in a memory object stored on the entity's
+/// <see cref="Blackboard"/> via <see cref="Blackboard.GetMemory{TMemory}"/> (#1281).
+/// </para>
+/// <para>
+/// Nodes that track more than their last state derive a memory type from this class and
+/// override <see cref="BehaviorTree.BTNode.GetMemory"/> so the shared entry always holds
+/// the most-derived memory.
+/// </para>
+/// </remarks>
+public class BTNodeMemory
+{
+    /// <summary>
+    /// Gets or sets the last execution state this node returned for the owning entity.
+    /// </summary>
+    public BTNodeState LastState { get; set; } = BTNodeState.Running;
+}

--- a/src/KeenEyes.AI/Core/Blackboard.cs
+++ b/src/KeenEyes.AI/Core/Blackboard.cs
@@ -17,6 +17,52 @@ namespace KeenEyes.AI;
 public sealed class Blackboard
 {
     private readonly Dictionary<string, object> data = [];
+    private Dictionary<object, object>? nodeMemories;
+
+    /// <summary>
+    /// Gets the per-entity execution memory for a behavior definition node or action,
+    /// creating it on first access.
+    /// </summary>
+    /// <typeparam name="TMemory">The memory type the node stores its execution state in.</typeparam>
+    /// <param name="node">
+    /// The definition object (BT node, AI action, utility action) the memory belongs to.
+    /// Keyed by reference identity, so shared definitions get one memory per blackboard.
+    /// </param>
+    /// <returns>The memory instance for this blackboard's entity.</returns>
+    /// <remarks>
+    /// Behavior definitions (trees, state machines, utility sets) are shared between
+    /// entities; anything that changes while a definition runs must live here rather
+    /// than in the definition instance (#1281). Each definition object must always
+    /// request the same <typeparamref name="TMemory"/>; requesting a different type
+    /// discards the previously stored memory.
+    /// </remarks>
+    public TMemory GetMemory<TMemory>(object node) where TMemory : class, new()
+    {
+        nodeMemories ??= [];
+        if (nodeMemories.TryGetValue(node, out var existing) && existing is TMemory typed)
+        {
+            return typed;
+        }
+
+        var created = new TMemory();
+        nodeMemories[node] = created;
+        return created;
+    }
+
+    /// <summary>
+    /// Removes the stored execution memory for a definition node, if any.
+    /// </summary>
+    /// <param name="node">The definition object whose memory should be discarded.</param>
+    /// <returns>True when a memory entry existed and was removed.</returns>
+    public bool RemoveMemory(object node) => nodeMemories?.Remove(node) ?? false;
+
+    /// <summary>
+    /// Removes all stored node execution memories.
+    /// </summary>
+    /// <remarks>
+    /// Blackboard data set via <see cref="Set{T}"/> is unaffected.
+    /// </remarks>
+    public void ClearMemories() => nodeMemories?.Clear();
 
     /// <summary>
     /// Sets a value in the blackboard.

--- a/src/KeenEyes.AI/Core/IAIAction.cs
+++ b/src/KeenEyes.AI/Core/IAIAction.cs
@@ -27,12 +27,18 @@ public interface IAIAction
     BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world);
 
     /// <summary>
-    /// Resets the action state for a new execution.
+    /// Resets the action's per-entity execution state for a new run.
     /// </summary>
+    /// <param name="blackboard">The blackboard of the entity whose state to reset.</param>
     /// <remarks>
     /// Called when the behavior tree restarts or when this action needs to be re-evaluated.
+    /// Action instances are shared between every entity running the same behavior
+    /// definition; store mutable state in a memory object obtained from
+    /// <see cref="Blackboard.GetMemory{TMemory}"/>, never in instance fields (#1281).
     /// </remarks>
-    void Reset() { }
+    void Reset(Blackboard blackboard)
+    {
+    }
 
     /// <summary>
     /// Called when the action is interrupted before completion.

--- a/src/KeenEyes.AI/FSM/State.cs
+++ b/src/KeenEyes.AI/FSM/State.cs
@@ -108,21 +108,21 @@ public sealed class State
     /// <summary>
     /// Resets all actions in this state.
     /// </summary>
-    internal void ResetActions()
+    internal void ResetActions(Blackboard blackboard)
     {
         foreach (var action in OnEnterActions)
         {
-            action.Reset();
+            action.Reset(blackboard);
         }
 
         foreach (var action in OnUpdateActions)
         {
-            action.Reset();
+            action.Reset(blackboard);
         }
 
         foreach (var action in OnExitActions)
         {
-            action.Reset();
+            action.Reset(blackboard);
         }
     }
 }

--- a/src/KeenEyes.AI/FSM/StateMachineSystem.cs
+++ b/src/KeenEyes.AI/FSM/StateMachineSystem.cs
@@ -139,7 +139,7 @@ public sealed class StateMachineSystem : SystemBase
 
         // Reset actions in the new state
         var newState = definition.GetState(fsm.CurrentStateIndex);
-        newState.ResetActions();
+        newState.ResetActions(blackboard);
 
         // Execute OnEnter for new state
         newState.ExecuteEnterActions(entity, blackboard, World);

--- a/src/KeenEyes.AI/Utility/Core/Consideration.cs
+++ b/src/KeenEyes.AI/Utility/Core/Consideration.cs
@@ -48,12 +48,18 @@ public sealed class Consideration
     /// <summary>
     /// Gets or sets the last raw input value (for debugging).
     /// </summary>
-    public float LastInputValue { get; private set; }
+    /// <param name="blackboard">The blackboard of the entity whose evaluation to read.</param>
+    /// <returns>The raw input value from the entity's most recent evaluation.</returns>
+    public float GetLastInputValue(Blackboard blackboard)
+        => blackboard.GetMemory<ConsiderationMemory>(this).LastInputValue;
 
     /// <summary>
     /// Gets or sets the last output value (for debugging).
     /// </summary>
-    public float LastOutputValue { get; private set; }
+    /// <param name="blackboard">The blackboard of the entity whose evaluation to read.</param>
+    /// <returns>The curved output score from the entity's most recent evaluation.</returns>
+    public float GetLastOutputValue(Blackboard blackboard)
+        => blackboard.GetMemory<ConsiderationMemory>(this).LastOutputValue;
 
     /// <summary>
     /// Evaluates this consideration for the given entity.
@@ -64,15 +70,25 @@ public sealed class Consideration
     /// <returns>The consideration's score (typically 0-1).</returns>
     public float Evaluate(Entity entity, Blackboard blackboard, IWorld world)
     {
+        var memory = blackboard.GetMemory<ConsiderationMemory>(this);
         if (Input == null || Curve == null)
         {
-            LastInputValue = 1f;
-            LastOutputValue = 1f;
+            memory.LastInputValue = 1f;
+            memory.LastOutputValue = 1f;
             return 1f;
         }
 
-        LastInputValue = Input.GetValue(entity, blackboard, world);
-        LastOutputValue = Curve.Evaluate(LastInputValue);
-        return LastOutputValue;
+        memory.LastInputValue = Input.GetValue(entity, blackboard, world);
+        memory.LastOutputValue = Curve.Evaluate(memory.LastInputValue);
+        return memory.LastOutputValue;
+    }
+
+    /// <summary>
+    /// Per-entity evaluation memory for <see cref="Consideration"/>.
+    /// </summary>
+    internal sealed class ConsiderationMemory
+    {
+        public float LastInputValue { get; set; }
+        public float LastOutputValue { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Utility/Core/UtilityAction.cs
+++ b/src/KeenEyes.AI/Utility/Core/UtilityAction.cs
@@ -71,7 +71,10 @@ public sealed class UtilityAction
     /// <summary>
     /// Gets or sets the last calculated score (for debugging).
     /// </summary>
-    public float LastScore { get; private set; }
+    /// <param name="blackboard">The blackboard of the entity whose score to read.</param>
+    /// <returns>The score from the entity's most recent <see cref="CalculateScore"/> call.</returns>
+    public float GetLastScore(Blackboard blackboard)
+        => blackboard.GetMemory<UtilityActionMemory>(this).LastScore;
 
     /// <summary>
     /// Calculates the utility score for this action.
@@ -82,9 +85,10 @@ public sealed class UtilityAction
     /// <returns>The action's utility score.</returns>
     public float CalculateScore(Entity entity, Blackboard blackboard, IWorld world)
     {
+        var memory = blackboard.GetMemory<UtilityActionMemory>(this);
         if (Considerations.Count == 0)
         {
-            LastScore = Weight;
+            memory.LastScore = Weight;
             return Weight;
         }
 
@@ -98,7 +102,7 @@ public sealed class UtilityAction
             // Early exit if score becomes negligible
             if (score.IsApproximatelyZero())
             {
-                LastScore = 0f;
+                memory.LastScore = 0f;
                 return 0f;
             }
         }
@@ -110,7 +114,15 @@ public sealed class UtilityAction
         var makeUpValue = (1f - score) * modificationFactor;
         score += makeUpValue * score;
 
-        LastScore = score;
+        memory.LastScore = score;
         return score;
+    }
+
+    /// <summary>
+    /// Per-entity scoring memory for <see cref="UtilityAction"/>.
+    /// </summary>
+    internal sealed class UtilityActionMemory
+    {
+        public float LastScore { get; set; }
     }
 }

--- a/src/KeenEyes.AI/Utility/UtilitySystem.cs
+++ b/src/KeenEyes.AI/Utility/UtilitySystem.cs
@@ -66,7 +66,7 @@ public sealed class UtilitySystem : SystemBase
                 // If action completed (not running), trigger re-evaluation next tick
                 if (state != BTNodeState.Running)
                 {
-                    utility.CurrentAction.Action.Reset();
+                    utility.CurrentAction.Action.Reset(blackboard);
                     utility.TimeSinceEvaluation = utility.EvaluationInterval;
                 }
             }
@@ -120,7 +120,7 @@ public sealed class UtilitySystem : SystemBase
         if (selectedAction != utility.CurrentAction && utility.CurrentAction?.Action != null)
         {
             utility.CurrentAction.Action.OnInterrupted(entity, blackboard, world);
-            utility.CurrentAction.Action.Reset();
+            utility.CurrentAction.Action.Reset(blackboard);
         }
 
         utility.CurrentAction = selectedAction;

--- a/tests/KeenEyes.AI.Tests/AIPluginTests.cs
+++ b/tests/KeenEyes.AI.Tests/AIPluginTests.cs
@@ -376,13 +376,7 @@ internal sealed class TestPluginBTNode(BTNodeState resultState) : BTNode
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
         ExecuteCount++;
-        LastState = resultState;
-        return resultState;
-    }
-
-    public override void Reset()
-    {
-        base.Reset();
+        return SetState(blackboard, resultState);
     }
 }
 
@@ -397,7 +391,7 @@ internal sealed class TestPluginAction(Action? onExecute = null) : IAIAction
         return BTNodeState.Running;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
     }
 
@@ -417,7 +411,7 @@ internal sealed class OrderTrackingAction(List<string> order, string name) : IAI
         return BTNodeState.Success;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
     }
 

--- a/tests/KeenEyes.AI.Tests/BehaviorTree/DecoratorTests.cs
+++ b/tests/KeenEyes.AI.Tests/BehaviorTree/DecoratorTests.cs
@@ -390,6 +390,7 @@ public class DecoratorTests
     [Fact]
     public void Decorator_Reset_ResetsChild()
     {
+        var blackboard = new Blackboard();
         var child = new TestBTNode(BTNodeState.Success);
         var inverter = new Inverter
         {
@@ -397,7 +398,7 @@ public class DecoratorTests
             Child = child
         };
 
-        inverter.Reset();
+        inverter.Reset(blackboard);
 
         child.WasReset.ShouldBeTrue();
     }

--- a/tests/KeenEyes.AI.Tests/BehaviorTree/LeafTests.cs
+++ b/tests/KeenEyes.AI.Tests/BehaviorTree/LeafTests.cs
@@ -76,6 +76,7 @@ public class LeafTests
     [Fact]
     public void ActionNode_Reset_ResetsAction()
     {
+        var blackboard = new Blackboard();
         var action = new TestAction();
 
         var actionNode = new ActionNode
@@ -84,7 +85,7 @@ public class LeafTests
             Action = action
         };
 
-        actionNode.Reset();
+        actionNode.Reset(blackboard);
 
         action.WasReset.ShouldBeTrue();
     }
@@ -232,7 +233,7 @@ public class LeafTests
         waitNode.Execute(entity, blackboard, world);
 
         // Reset
-        waitNode.Reset();
+        waitNode.Reset(blackboard);
 
         // Execute again - should still be running
         var result = waitNode.Execute(entity, blackboard, world);
@@ -272,7 +273,7 @@ internal sealed class InterruptibleAction(Action onInterrupted) : IAIAction
         return BTNodeState.Running;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
     }
 

--- a/tests/KeenEyes.AI.Tests/BehaviorTree/SelectorTests.cs
+++ b/tests/KeenEyes.AI.Tests/BehaviorTree/SelectorTests.cs
@@ -183,6 +183,7 @@ public class SelectorTests
     [Fact]
     public void Reset_ResetsAllChildren()
     {
+        var blackboard = new Blackboard();
         var child1 = new TestBTNode(BTNodeState.Success);
         var child2 = new TestBTNode(BTNodeState.Success);
 
@@ -192,7 +193,7 @@ public class SelectorTests
             Children = [child1, child2]
         };
 
-        selector.Reset();
+        selector.Reset(blackboard);
 
         child1.WasReset.ShouldBeTrue();
         child2.WasReset.ShouldBeTrue();
@@ -212,13 +213,12 @@ internal sealed class TestBTNode(BTNodeState resultState) : BTNode
     public override BTNodeState Execute(Entity entity, Blackboard blackboard, IWorld world)
     {
         ExecuteCount++;
-        LastState = resultState;
-        return resultState;
+        return SetState(blackboard, resultState);
     }
 
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
+        base.Reset(blackboard);
         WasReset = true;
     }
 
@@ -236,13 +236,12 @@ internal sealed class StateChangingBTNode(BTNodeState[] states) : BTNode
     {
         var state = states[Math.Min(currentIndex, states.Length - 1)];
         currentIndex++;
-        LastState = state;
-        return state;
+        return SetState(blackboard, state);
     }
 
-    public override void Reset()
+    public override void Reset(Blackboard blackboard)
     {
-        base.Reset();
+        base.Reset(blackboard);
         currentIndex = 0;
     }
 }

--- a/tests/KeenEyes.AI.Tests/BehaviorTree/SequenceTests.cs
+++ b/tests/KeenEyes.AI.Tests/BehaviorTree/SequenceTests.cs
@@ -208,6 +208,7 @@ public class SequenceTests
     [Fact]
     public void Reset_ResetsAllChildren()
     {
+        var blackboard = new Blackboard();
         var child1 = new TestBTNode(BTNodeState.Success);
         var child2 = new TestBTNode(BTNodeState.Success);
 
@@ -217,7 +218,7 @@ public class SequenceTests
             Children = [child1, child2]
         };
 
-        sequence.Reset();
+        sequence.Reset(blackboard);
 
         child1.WasReset.ShouldBeTrue();
         child2.WasReset.ShouldBeTrue();
@@ -243,7 +244,7 @@ public class SequenceTests
         sequence.Execute(entity, blackboard, world);
 
         // Reset
-        sequence.Reset();
+        sequence.Reset(blackboard);
         node1.ResetExecuteCount();
 
         // Execute again - should start from first child

--- a/tests/KeenEyes.AI.Tests/FSM/StateTests.cs
+++ b/tests/KeenEyes.AI.Tests/FSM/StateTests.cs
@@ -134,6 +134,7 @@ public class StateTests
     [Fact]
     public void ResetActions_ResetsAllActions()
     {
+        var blackboard = new Blackboard();
         var action1 = new TestAction();
         var action2 = new TestAction();
 
@@ -148,7 +149,7 @@ public class StateTests
         action1.SetState(BTNodeState.Success);
         action2.SetState(BTNodeState.Failure);
 
-        state.ResetActions();
+        state.ResetActions(blackboard);
 
         action1.WasReset.ShouldBeTrue();
         action2.WasReset.ShouldBeTrue();
@@ -174,7 +175,7 @@ internal sealed class TestAction(Action? onExecute = null) : IAIAction
         return state;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
         WasReset = true;
     }

--- a/tests/KeenEyes.AI.Tests/NavigationActionsTests.cs
+++ b/tests/KeenEyes.AI.Tests/NavigationActionsTests.cs
@@ -124,7 +124,7 @@ public class NavigationActionsTests : IDisposable
         action.Execute(entity, blackboard, world);
 
         // Reset
-        action.Reset();
+        action.Reset(blackboard);
 
         // Execute again - should request new path
         var result = action.Execute(entity, blackboard, world);

--- a/tests/KeenEyes.AI.Tests/SharedDefinitionTests.cs
+++ b/tests/KeenEyes.AI.Tests/SharedDefinitionTests.cs
@@ -1,0 +1,279 @@
+using KeenEyes.AI.BehaviorTree;
+using KeenEyes.AI.BehaviorTree.Composites;
+using KeenEyes.AI.BehaviorTree.Decorators;
+using KeenEyes.AI.BehaviorTree.Leaves;
+using KeenEyes.AI.Tests.BehaviorTree;
+using KeenEyes.AI.Utility;
+using KeenEyes.Testing;
+
+namespace KeenEyes.AI.Tests;
+
+/// <summary>
+/// Regression tests for #1281: behavior definitions (trees, actions, utility sets) are
+/// shared between entities, so all execution state must be per-entity. Each test runs
+/// one shared definition against two blackboards and asserts the runs do not bleed
+/// into each other.
+/// </summary>
+public class SharedDefinitionTests
+{
+    #region Composite cursor isolation
+
+    [Fact]
+    public void Sequence_SharedBetweenTwoEntities_AdvancesIndependently()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var first = new TestBTNode(BTNodeState.Success);
+        var second = new TestBTNode(BTNodeState.Running);
+        var sequence = new Sequence
+        {
+            Name = "Shared",
+            Children = [first, second]
+        };
+
+        // Entity A advances past the first child and parks on the running second child.
+        sequence.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+        first.ExecuteCount.ShouldBe(1);
+
+        // Entity B starts its own run: it must execute the first child from the top,
+        // not resume from entity A's cursor.
+        sequence.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+        first.ExecuteCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Selector_SharedBetweenTwoEntities_KeepsSeparateCursors()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var failing = new TestBTNode(BTNodeState.Failure);
+        var running = new TestBTNode(BTNodeState.Running);
+        var selector = new Selector
+        {
+            Name = "Shared",
+            Children = [failing, running]
+        };
+
+        selector.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+        failing.ExecuteCount.ShouldBe(1);
+
+        // B must retry the failing child itself rather than resuming at A's cursor.
+        selector.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+        failing.ExecuteCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Leaf and decorator state isolation
+
+    [Fact]
+    public void WaitNode_SharedBetweenTwoEntities_TracksElapsedPerEntity()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        blackboardA.Set(BBKeys.DeltaTime, 0.6f);
+        blackboardB.Set(BBKeys.DeltaTime, 0.6f);
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var wait = new WaitNode { Duration = 1f };
+
+        wait.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+
+        // With shared elapsed state, B's first tick would already exceed the duration.
+        wait.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+
+        // A's second tick completes A; B is still waiting.
+        wait.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Success);
+        wait.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Success);
+    }
+
+    [Fact]
+    public void Cooldown_SharedBetweenTwoEntities_CoolsDownPerEntity()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        blackboardA.Set(BBKeys.Time, 0f);
+        blackboardB.Set(BBKeys.Time, 1f);
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var cooldown = new Cooldown
+        {
+            Duration = 10f,
+            Child = new TestBTNode(BTNodeState.Success)
+        };
+
+        // A succeeds and starts A's cooldown.
+        cooldown.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Success);
+
+        // A is now on cooldown, but B never executed and must not be.
+        cooldown.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Failure);
+        cooldown.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Success);
+    }
+
+    [Fact]
+    public void Repeater_SharedBetweenTwoEntities_CountsPerEntity()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var repeater = new Repeater
+        {
+            Count = 2,
+            Child = new TestBTNode(BTNodeState.Success)
+        };
+
+        // A completes one of two iterations.
+        repeater.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+
+        // B starts from zero: its first tick is also iteration one, not A's second.
+        repeater.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+
+        // Each entity independently completes on its own second tick.
+        repeater.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Success);
+        repeater.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Success);
+    }
+
+    [Fact]
+    public void Reset_ForOneEntity_LeavesOtherEntityProgressIntact()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var first = new TestBTNode(BTNodeState.Success);
+        var second = new TestBTNode(BTNodeState.Running);
+        var tree = new KeenEyes.AI.BehaviorTree.BehaviorTree
+        {
+            Name = "Shared",
+            Root = new Sequence { Children = [first, second] }
+        };
+
+        // Both entities park on the running second child.
+        tree.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+        tree.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+        first.ExecuteCount.ShouldBe(2);
+
+        // Resetting A must not rewind B's cursor.
+        tree.Reset(blackboardA);
+        tree.Execute(entityB, blackboardB, world).ShouldBe(BTNodeState.Running);
+        first.ExecuteCount.ShouldBe(2); // B resumed at the second child
+
+        tree.Execute(entityA, blackboardA, world).ShouldBe(BTNodeState.Running);
+        first.ExecuteCount.ShouldBe(3); // A restarted from the first child
+    }
+
+    #endregion
+
+    #region Per-entity last state
+
+    [Fact]
+    public void GetLastState_SharedNode_ReportsPerEntityState()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var node = new StateChangingBTNode([BTNodeState.Failure, BTNodeState.Success]);
+
+        node.Execute(entityA, blackboardA, world);
+        node.Execute(entityB, blackboardB, world);
+
+        node.GetLastState(blackboardA).ShouldBe(BTNodeState.Failure);
+        node.GetLastState(blackboardB).ShouldBe(BTNodeState.Success);
+    }
+
+    #endregion
+
+    #region Utility scoring isolation
+
+    [Fact]
+    public void UtilityAction_SharedBetweenTwoEntities_KeepsPerEntityLastScore()
+    {
+        using var world = new World();
+        var blackboardA = new Blackboard();
+        var blackboardB = new Blackboard();
+        blackboardA.Set("threat", 0.2f);
+        blackboardB.Set("threat", 0.8f);
+        var entityA = world.Spawn().Build();
+        var entityB = world.Spawn().Build();
+
+        var action = new UtilityAction
+        {
+            Name = "Flee",
+            Weight = 1f,
+            Considerations =
+            [
+                new Consideration
+                {
+                    Name = "Threat",
+                    Input = new BlackboardInput { Key = "threat" },
+                    Curve = new LinearCurve()
+                }
+            ]
+        };
+
+        var scoreA = action.CalculateScore(entityA, blackboardA, world);
+        var scoreB = action.CalculateScore(entityB, blackboardB, world);
+
+        scoreA.ShouldNotBe(scoreB);
+
+        // Scoring B must not overwrite A's recorded score.
+        action.GetLastScore(blackboardA).ShouldBe(scoreA);
+        action.GetLastScore(blackboardB).ShouldBe(scoreB);
+    }
+
+    #endregion
+
+    #region End-to-end through the system
+
+    [Fact]
+    public void BehaviorTreeSystem_TwoEntitiesOneDefinition_ProgressIndependently()
+    {
+        using var world = new World();
+        world.InstallPlugin(new AIPlugin());
+
+        var definition = new KeenEyes.AI.BehaviorTree.BehaviorTree
+        {
+            Name = "SharedWait",
+            Root = new WaitNode { Duration = 1f }
+        };
+
+        var entityA = world.Spawn()
+            .With(BehaviorTreeComponent.Create(definition))
+            .Build();
+
+        // A accumulates 0.6s of wait time.
+        world.Update(0.6f);
+
+        var entityB = world.Spawn()
+            .With(BehaviorTreeComponent.Create(definition))
+            .Build();
+
+        // Both tick 0.6s: A crosses 1.0s and completes; B has only 0.6s accumulated.
+        world.Update(0.6f);
+
+        world.Get<BehaviorTreeComponent>(entityA).LastResult.ShouldBe(BTNodeState.Success);
+        world.Get<BehaviorTreeComponent>(entityB).LastResult.ShouldBe(BTNodeState.Running);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.AI.Tests/Utility/ConsiderationTests.cs
+++ b/tests/KeenEyes.AI.Tests/Utility/ConsiderationTests.cs
@@ -165,7 +165,7 @@ public class ConsiderationTests
 
         consideration.Evaluate(entity, blackboard, world);
 
-        consideration.LastInputValue.ShouldBe(0.7f);
+        consideration.GetLastInputValue(blackboard).ShouldBe(0.7f);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class ConsiderationTests
 
         consideration.Evaluate(entity, blackboard, world);
 
-        consideration.LastOutputValue.ShouldBe(0.25f);
+        consideration.GetLastOutputValue(blackboard).ShouldBe(0.25f);
     }
 
     [Fact]
@@ -203,8 +203,8 @@ public class ConsiderationTests
 
         consideration.Evaluate(entity, blackboard, world);
 
-        consideration.LastInputValue.ShouldBe(1f);
-        consideration.LastOutputValue.ShouldBe(1f);
+        consideration.GetLastInputValue(blackboard).ShouldBe(1f);
+        consideration.GetLastOutputValue(blackboard).ShouldBe(1f);
     }
 
     #endregion

--- a/tests/KeenEyes.AI.Tests/Utility/UtilityActionTests.cs
+++ b/tests/KeenEyes.AI.Tests/Utility/UtilityActionTests.cs
@@ -141,7 +141,7 @@ public class UtilityActionTests
 
         action.CalculateScore(entity, blackboard, world);
 
-        action.LastScore.ShouldBe(0.75f);
+        action.GetLastScore(blackboard).ShouldBe(0.75f);
     }
 
     [Fact]

--- a/tests/KeenEyes.AI.Tests/Utility/UtilitySystemTests.cs
+++ b/tests/KeenEyes.AI.Tests/Utility/UtilitySystemTests.cs
@@ -531,7 +531,7 @@ internal sealed class TestUtilityAction(Action? onExecute = null) : IAIAction
         return state;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
         WasReset = true;
     }
@@ -551,7 +551,7 @@ internal sealed class InterruptibleUtilityAction(Action onInterrupted) : IAIActi
         return BTNodeState.Running;
     }
 
-    public void Reset()
+    public void Reset(Blackboard blackboard)
     {
     }
 


### PR DESCRIPTION
## Summary
- **Bug (confirmed critical, 2026-07-25 audit):** behavior definitions — BT nodes, `IAIAction`s, utility actions/considerations — are shared between every entity running them, but stored per-execution state in instance fields: composite child cursors, `RandomSelector` shuffle state, `BTNode.LastState` (which also drives `OnInterrupted` propagation), `Cooldown` timestamps, `Repeater` counts, `WaitNode` elapsed time, path-request state in all four navigation actions, and utility scoring debug values. Any two entities sharing one definition corrupted each other's runs.
- **Fix:** execution state moves into per-entity **memory objects** stored on the entity's `Blackboard`, keyed by definition-node reference (`Blackboard.GetMemory<TMemory>(node)`). Each stateful node/action defines its own memory class (`CompositeMemory`, `CooldownMemory`, `MoveToMemory`, …); `BTNode.GetMemory` is virtual so a node's most-derived memory owns the single blackboard entry.
- **API shape:** `Execute(entity, blackboard, world)` signatures are unchanged. State-touching members now take the blackboard: `Reset(Blackboard)`, `GetLastState(Blackboard)`, `SetState(Blackboard, state)`, `ResetCooldown(Blackboard)`, `Consideration.GetLastInputValue/GetLastOutputValue(Blackboard)`, `UtilityAction.GetLastScore(Blackboard)`. Resetting one entity's run no longer rewinds any other entity (covered by a dedicated test). Editor `AIDebugPanel` and all call sites updated.
- Per the no-back-compat policy, the old mutable members were removed outright rather than shimmed.

## Test plan
- [x] 8 new `SharedDefinitionTests`: shared `Sequence`/`Selector` cursor isolation, `WaitNode` elapsed isolation, `Cooldown` per-entity cooldowns, `Repeater` per-entity counts, per-entity `GetLastState`, `UtilityAction` per-entity `LastScore`, cross-entity `Reset` isolation, and an end-to-end `BehaviorTreeSystem` test (later-spawned entity does not inherit the first entity's wait progress)
- [x] All 267 AI tests pass; full suite 14,831 passed / 0 failed / 60 skipped
- [x] Build zero warnings; `dotnet format` clean
- Note: the new tests cannot be run against the pre-fix code because the fix intentionally removes the old mutable APIs (compile-breaking); on the old semantics, every isolation assertion above is false by construction (single shared field).

## Related Issues
Fixes #1281

Out of scope, tracked separately: `StateMachineSystem` validation throw-loop and per-frame LINQ (#1315), TestBridge Blackboard reflection (#1306 — the new `nodeMemories` store is a separate private field, so the existing `ai_*` blackboard tools are unaffected).
