### PR TITLE
fix(graphics): Size the viewport from framebuffer pixels, not logical window points

### DIFF
--- a/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
+++ b/editor/KeenEyes.Editor/Panels/ViewportPanel.cs
@@ -279,7 +279,14 @@ public static class ViewportPanel
 
         // Set viewport and clear. The clear affects the whole framebuffer, which is
         // safe only because this pass runs before any UI is drawn this frame.
-        graphics.SetViewport(viewportX, viewportY, viewportWidth, viewportHeight);
+        // The panel bounds come from UI layout, which is in logical points, while the
+        // viewport is in device pixels - so scale across on HiDPI displays (#1352).
+        var (pixelScaleX, pixelScaleY) = GetPixelScale(graphics);
+        graphics.SetViewport(
+            (int)(viewportX * pixelScaleX),
+            (int)(viewportY * pixelScaleY),
+            (int)(viewportWidth * pixelScaleX),
+            (int)(viewportHeight * pixelScaleY));
         graphics.SetClearColor(EditorColors.ViewportBackground);
         graphics.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
         graphics.SetDepthTest(true);
@@ -354,10 +361,21 @@ public static class ViewportPanel
         // Hand the context back to the UI pass: full-window viewport with the 2D
         // pipeline state the UI renderer expects (the 2D renderer manages its own
         // blend state but not viewport or culling).
-        graphics.SetViewport(0, 0, graphics.Width, graphics.Height);
+        graphics.SetViewport(0, 0, graphics.FramebufferWidth, graphics.FramebufferHeight);
         graphics.SetDepthTest(false);
         graphics.SetCulling(false);
     }
+
+    /// <summary>
+    /// Gets how many device pixels there are per logical point.
+    /// </summary>
+    /// <remarks>
+    /// UI layout works in logical points so that it lines up with pointer input, but the GL
+    /// viewport is in device pixels. The two differ on any HiDPI display.
+    /// </remarks>
+    private static (float X, float Y) GetPixelScale(IGraphicsContext graphics)
+        => (graphics.Width > 0 ? (float)graphics.FramebufferWidth / graphics.Width : 1f,
+            graphics.Height > 0 ? (float)graphics.FramebufferHeight / graphics.Height : 1f);
 
     /// <summary>
     /// Focuses the viewport camera on a specific entity.

--- a/src/KeenEyes.Abstractions/ILoopProvider.cs
+++ b/src/KeenEyes.Abstractions/ILoopProvider.cs
@@ -47,6 +47,13 @@ public interface ILoopProvider
     /// <summary>
     /// Raised when the window or viewport is resized.
     /// </summary>
+    /// <remarks>
+    /// Parameters are the new width and height in logical points - the same space pointer
+    /// positions are reported in - which makes this the event UI layout should follow. On a
+    /// HiDPI display these are smaller than the framebuffer's pixel size, so anything measured
+    /// in pixels (viewports, render targets) must be sized from the graphics context's
+    /// framebuffer size instead.
+    /// </remarks>
     event Action<int, int>? OnResize;
 
     /// <summary>

--- a/src/KeenEyes.Graphics.Abstractions/Commands/SetViewportCommand.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Commands/SetViewportCommand.cs
@@ -3,14 +3,16 @@ namespace KeenEyes.Graphics.Abstractions;
 /// <summary>
 /// Command to set the rendering viewport.
 /// </summary>
-/// <param name="X">The left edge of the viewport in pixels.</param>
-/// <param name="Y">The bottom edge of the viewport in pixels.</param>
-/// <param name="Width">The width of the viewport in pixels.</param>
-/// <param name="Height">The height of the viewport in pixels.</param>
+/// <param name="X">The left edge of the viewport in device pixels.</param>
+/// <param name="Y">The bottom edge of the viewport in device pixels.</param>
+/// <param name="Width">The width of the viewport in device pixels.</param>
+/// <param name="Height">The height of the viewport in device pixels.</param>
 /// <remarks>
 /// <para>
 /// The viewport defines the rectangular region of the window where rendering occurs.
-/// Coordinates are typically in pixels with (0,0) at the bottom-left corner.
+/// Coordinates are in device pixels - not logical points - with (0,0) at the bottom-left
+/// corner. On a HiDPI display the two differ, so size a full-window viewport from
+/// <see cref="IGraphicsContext.FramebufferWidth"/>, never from the window's logical size.
 /// </para>
 /// <para>
 /// Viewport commands have a low sort key to ensure they execute before draw commands.
@@ -19,10 +21,10 @@ namespace KeenEyes.Graphics.Abstractions;
 /// <example>
 /// <code>
 /// // Set full-window viewport
-/// var viewport = new SetViewportCommand(0, 0, window.Width, window.Height);
+/// var viewport = new SetViewportCommand(0, 0, graphics.FramebufferWidth, graphics.FramebufferHeight);
 ///
 /// // Set split-screen viewport (left half)
-/// var leftViewport = new SetViewportCommand(0, 0, window.Width / 2, window.Height);
+/// var leftViewport = new SetViewportCommand(0, 0, graphics.FramebufferWidth / 2, graphics.FramebufferHeight);
 /// </code>
 /// </example>
 public readonly record struct SetViewportCommand(
@@ -39,8 +41,8 @@ public readonly record struct SetViewportCommand(
     /// <summary>
     /// Creates a viewport command for the entire window.
     /// </summary>
-    /// <param name="width">The window width in pixels.</param>
-    /// <param name="height">The window height in pixels.</param>
+    /// <param name="width">The framebuffer width in device pixels.</param>
+    /// <param name="height">The framebuffer height in device pixels.</param>
     /// <returns>A viewport command covering the entire window.</returns>
     public static SetViewportCommand FullWindow(int width, int height) =>
         new(0, 0, width, height);

--- a/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IGraphicsContext.cs
@@ -55,14 +55,48 @@ public interface IGraphicsContext : IDisposable
     bool IsInitialized { get; }
 
     /// <summary>
-    /// Gets the current window width in pixels.
+    /// Gets the current window width in logical points.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Logical points are the coordinate space pointer positions are reported in, so this is
+    /// the size UI layout, hit-testing, and 2D projections must be built from. On a HiDPI
+    /// display (Retina, Windows display scaling, Linux fractional scaling) it is smaller than
+    /// <see cref="FramebufferWidth"/>.
+    /// </para>
+    /// <para>
+    /// Use <see cref="FramebufferWidth"/> instead for anything measured in device pixels: the
+    /// viewport, scissor rectangles, and full-screen framebuffer reads.
+    /// </para>
+    /// </remarks>
     int Width { get; }
 
     /// <summary>
-    /// Gets the current window height in pixels.
+    /// Gets the current window height in logical points.
     /// </summary>
+    /// <remarks>
+    /// See <see cref="Width"/> for the distinction between logical points and device pixels.
+    /// </remarks>
     int Height { get; }
+
+    /// <summary>
+    /// Gets the current framebuffer width in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// This is the resolution the window is actually rendered at. It equals <see cref="Width"/>
+    /// at 1x scaling and exceeds it on a HiDPI display. Size the viewport, scissor rectangles,
+    /// and screenshots from this pair; size layout and projections from <see cref="Width"/>.
+    /// </remarks>
+    int FramebufferWidth { get; }
+
+    /// <summary>
+    /// Gets the current framebuffer height in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="FramebufferWidth"/> for the distinction between device pixels and
+    /// logical points.
+    /// </remarks>
+    int FramebufferHeight { get; }
 
     #endregion
 
@@ -470,10 +504,16 @@ public interface IGraphicsContext : IDisposable
     /// <summary>
     /// Sets the viewport.
     /// </summary>
-    /// <param name="x">The left edge in pixels.</param>
-    /// <param name="y">The bottom edge in pixels.</param>
-    /// <param name="width">The width in pixels.</param>
-    /// <param name="height">The height in pixels.</param>
+    /// <param name="x">The left edge in device pixels.</param>
+    /// <param name="y">The bottom edge in device pixels.</param>
+    /// <param name="width">The width in device pixels.</param>
+    /// <param name="height">The height in device pixels.</param>
+    /// <remarks>
+    /// All four arguments are in device pixels, not logical points. To cover the whole window,
+    /// pass <see cref="FramebufferWidth"/> and <see cref="FramebufferHeight"/> - passing
+    /// <see cref="Width"/> and <see cref="Height"/> renders into a fraction of the window on a
+    /// HiDPI display.
+    /// </remarks>
     void SetViewport(int x, int y, int width, int height);
 
     /// <summary>

--- a/src/KeenEyes.Graphics.Abstractions/IWindow.cs
+++ b/src/KeenEyes.Graphics.Abstractions/IWindow.cs
@@ -26,13 +26,21 @@ namespace KeenEyes.Graphics.Abstractions;
 public interface IWindow : IDisposable
 {
     /// <summary>
-    /// Gets the current window width in pixels.
+    /// Gets the current window width in logical points.
     /// </summary>
+    /// <remarks>
+    /// Logical points are the space pointer positions are reported in, which on a HiDPI display
+    /// is smaller than the framebuffer. For the pixel size the window is rendered at, use
+    /// <see cref="IGraphicsContext.FramebufferWidth"/>.
+    /// </remarks>
     int Width { get; }
 
     /// <summary>
-    /// Gets the current window height in pixels.
+    /// Gets the current window height in logical points.
     /// </summary>
+    /// <remarks>
+    /// See <see cref="Width"/> for the distinction between logical points and device pixels.
+    /// </remarks>
     int Height { get; }
 
     /// <summary>
@@ -68,8 +76,9 @@ public interface IWindow : IDisposable
     /// Event raised when the window is resized.
     /// </summary>
     /// <remarks>
-    /// Parameters are the new width and height in pixels.
-    /// Use this to update viewport dimensions and projection matrices.
+    /// Parameters are the new width and height in logical points (see <see cref="Width"/>).
+    /// Use this to update projection matrices and layout. Viewport dimensions are in device
+    /// pixels and must follow the framebuffer size instead.
     /// </remarks>
     event Action<int, int>? OnResize;
 

--- a/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
+++ b/src/KeenEyes.Graphics.Silk/Rendering2D/Silk2DRenderer.cs
@@ -57,6 +57,7 @@ public sealed class Silk2DRenderer : I2DRenderer
     private Matrix4x4 screenProjection;
     private Matrix4x4 activeProjection;
     private Vector2 screenSize;
+    private Vector2 pixelScale = Vector2.One;
     private bool disposed;
 
     /// <summary>
@@ -85,12 +86,38 @@ public sealed class Silk2DRenderer : I2DRenderer
     /// <summary>
     /// Updates the screen size for projection matrix calculation.
     /// </summary>
-    /// <param name="width">The new screen width.</param>
-    /// <param name="height">The new screen height.</param>
+    /// <param name="width">The new screen width in logical points.</param>
+    /// <param name="height">The new screen height in logical points.</param>
+    /// <remarks>
+    /// The size is in logical points, not device pixels, so that drawing coordinates share a
+    /// space with the pointer positions the input layer reports.
+    /// </remarks>
     public void SetScreenSize(float width, float height)
     {
         screenSize = new Vector2(width, height);
         UpdateProjection();
+    }
+
+    /// <summary>
+    /// Sets how many device pixels there are per logical point.
+    /// </summary>
+    /// <param name="scaleX">Horizontal device pixels per logical point.</param>
+    /// <param name="scaleY">Vertical device pixels per logical point.</param>
+    /// <remarks>
+    /// Scissor rectangles are the one part of this renderer that OpenGL interprets in device
+    /// pixels rather than in the projection's space, so clip rectangles supplied in logical
+    /// points are scaled by this factor. It is 1 when the framebuffer matches the window's
+    /// logical size, which leaves 1x displays untouched.
+    /// </remarks>
+    public void SetPixelScale(float scaleX, float scaleY)
+    {
+        pixelScale = new Vector2(scaleX, scaleY);
+
+        if (clipStack.Count > 0)
+        {
+            Flush();
+            ApplyClip(clipStack.Peek());
+        }
     }
 
     /// <inheritdoc />
@@ -745,9 +772,17 @@ public sealed class Silk2DRenderer : I2DRenderer
     private void ApplyClip(in Rectangle rect)
     {
         device.Enable(RenderCapability.ScissorTest);
-        // OpenGL scissor uses bottom-left origin, so flip Y
-        int y = (int)(screenSize.Y - rect.Y - rect.Height);
-        device.Scissor((int)rect.X, y, (uint)rect.Width, (uint)rect.Height);
+
+        // OpenGL scissor uses bottom-left origin, so flip Y.
+        float y = screenSize.Y - rect.Y - rect.Height;
+
+        // The clip rectangle arrives in logical points, but OpenGL interprets scissor
+        // rectangles in device pixels - so convert before handing it over (#1352).
+        device.Scissor(
+            (int)(rect.X * pixelScale.X),
+            (int)(y * pixelScale.Y),
+            (uint)(rect.Width * pixelScale.X),
+            (uint)(rect.Height * pixelScale.Y));
     }
 
     /// <inheritdoc />

--- a/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
@@ -86,6 +86,7 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
         // Subscribe to window lifecycle events
         windowProvider.OnLoad += HandleWindowLoad;
         windowProvider.OnResize += HandleWindowResize;
+        windowProvider.OnFramebufferResize += HandleFramebufferResize;
         windowProvider.OnClosing += HandleWindowClosing;
     }
 
@@ -103,15 +104,17 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     /// <inheritdoc />
     public bool IsInitialized => initialized;
 
-    /// <summary>
-    /// Gets the current window width in pixels.
-    /// </summary>
-    public int Width => window?.Width ?? 0;
+    /// <inheritdoc />
+    public int Width => windowProvider.Width;
 
-    /// <summary>
-    /// Gets the current window height in pixels.
-    /// </summary>
-    public int Height => window?.Height ?? 0;
+    /// <inheritdoc />
+    public int Height => windowProvider.Height;
+
+    /// <inheritdoc />
+    public int FramebufferWidth => windowProvider.FramebufferWidth;
+
+    /// <inheritdoc />
+    public int FramebufferHeight => windowProvider.FramebufferHeight;
 
     /// <summary>
     /// The built-in unlit shader handle.
@@ -265,18 +268,57 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
         // Set clear color
         device.ClearColor(config.ClearColor.X, config.ClearColor.Y, config.ClearColor.Z, config.ClearColor.W);
 
+        // Cover the whole framebuffer. Drivers default the viewport to the framebuffer size,
+        // but stating it explicitly means the first frame is correct even when the window was
+        // created at a size the driver default did not account for.
+        if (FramebufferWidth > 0 && FramebufferHeight > 0)
+        {
+            device.Viewport(0, 0, (uint)FramebufferWidth, (uint)FramebufferHeight);
+        }
+
         // Create built-in resources
         CreateBuiltInResources();
 
         initialized = true;
     }
 
+    /// <summary>
+    /// Follows the window's logical size, which drives the 2D and text projections.
+    /// </summary>
+    /// <remarks>
+    /// The projections stay in logical points so that drawing coordinates keep matching the
+    /// pointer positions the input layer reports. The viewport is deliberately not touched
+    /// here - it is sized in device pixels and follows <see cref="HandleFramebufferResize"/>.
+    /// </remarks>
     private void HandleWindowResize(int width, int height)
     {
-        device?.Viewport(0, 0, (uint)width, (uint)height);
         renderer2D?.SetScreenSize(width, height);
         textRenderer?.SetScreenSize(width, height);
+        renderer2D?.SetPixelScale(PixelScaleX, PixelScaleY);
     }
+
+    /// <summary>
+    /// Follows the framebuffer's pixel size, which drives the viewport.
+    /// </summary>
+    /// <remarks>
+    /// A viewport sized from logical points covers only a fraction of the framebuffer on a
+    /// HiDPI display, which renders the whole frame small in one corner (#1352).
+    /// </remarks>
+    private void HandleFramebufferResize(int width, int height)
+    {
+        device?.Viewport(0, 0, (uint)width, (uint)height);
+        renderer2D?.SetPixelScale(PixelScaleX, PixelScaleY);
+    }
+
+    /// <summary>
+    /// Gets the horizontal device pixels per logical point, 1 when the two spaces agree.
+    /// </summary>
+    private float PixelScaleX => Width > 0 ? (float)FramebufferWidth / Width : 1f;
+
+    /// <summary>
+    /// Gets the vertical device pixels per logical point, 1 when the two spaces agree.
+    /// </summary>
+    private float PixelScaleY => Height > 0 ? (float)FramebufferHeight / Height : 1f;
 
     private void HandleWindowClosing()
     {
@@ -337,10 +379,13 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
         var whiteId = textureManager.CreateSolidColorTexture(255, 255, 255, 255);
         WhiteTexture = new TextureHandle(whiteId, 1, 1);
 
-        // Create 2D renderer
+        // Create 2D renderer. Its projection is in logical points so that 2D drawing
+        // coordinates match the pointer positions the input layer reports; only its scissor
+        // rectangles are converted to device pixels via the pixel scale.
         renderer2D = new Silk2DRenderer(device!, textureManager, Width, Height);
+        renderer2D.SetPixelScale(PixelScaleX, PixelScaleY);
 
-        // Create font manager and text renderer
+        // Create font manager and text renderer (also projected in logical points)
         fontManager = new SilkFontManager(device!);
         textRenderer = new SilkTextRenderer(device!, fontManager, fontManager.TextureManager, Width, Height);
     }
@@ -864,10 +909,11 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     {
         renderTargetManager?.UnbindRenderTarget();
 
-        // Restore the default viewport
-        if (window is not null)
+        // Restore the default viewport. Render target sizes are in texels, so the size we
+        // return to must be in device pixels too - not logical points.
+        if (FramebufferWidth > 0 && FramebufferHeight > 0)
         {
-            device?.Viewport(0, 0, (uint)window.Width, (uint)window.Height);
+            device?.Viewport(0, 0, (uint)FramebufferWidth, (uint)FramebufferHeight);
         }
     }
 
@@ -1027,6 +1073,7 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
         // Unsubscribe from window provider events
         windowProvider.OnLoad -= HandleWindowLoad;
         windowProvider.OnResize -= HandleWindowResize;
+        windowProvider.OnFramebufferResize -= HandleFramebufferResize;
         windowProvider.OnClosing -= HandleWindowClosing;
 
         DisposeGpuResources();

--- a/src/KeenEyes.Platform.Silk.Abstractions/ISilkWindowProvider.cs
+++ b/src/KeenEyes.Platform.Silk.Abstractions/ISilkWindowProvider.cs
@@ -46,6 +46,44 @@ public interface ISilkWindowProvider : IDisposable
     IWindow Window { get; }
 
     /// <summary>
+    /// Gets the window width in logical points.
+    /// </summary>
+    /// <remarks>
+    /// Logical points are the coordinate space Silk.NET reports pointer positions in, so this
+    /// is the space UI layout and hit-testing must use. On a HiDPI display it is smaller than
+    /// <see cref="FramebufferWidth"/>. Use <see cref="FramebufferWidth"/> for anything measured
+    /// in device pixels, such as the GL viewport.
+    /// </remarks>
+    int Width { get; }
+
+    /// <summary>
+    /// Gets the window height in logical points.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="Width"/> for the distinction between logical points and device pixels.
+    /// </remarks>
+    int Height { get; }
+
+    /// <summary>
+    /// Gets the framebuffer width in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// On a HiDPI display (Retina, Windows display scaling, Linux fractional scaling) the
+    /// framebuffer is larger than the window's logical size. This is the value the GL viewport,
+    /// scissor rectangles, and full-screen pixel reads must be sized from.
+    /// </remarks>
+    int FramebufferWidth { get; }
+
+    /// <summary>
+    /// Gets the framebuffer height in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="FramebufferWidth"/> for the distinction between device pixels and
+    /// logical points.
+    /// </remarks>
+    int FramebufferHeight { get; }
+
+    /// <summary>
     /// Gets the Silk.NET input context for keyboard, mouse, and gamepad access.
     /// </summary>
     /// <remarks>
@@ -84,9 +122,23 @@ public interface ISilkWindowProvider : IDisposable
     /// Raised when the window is resized.
     /// </summary>
     /// <remarks>
-    /// Parameters are the new width and height in pixels.
+    /// Parameters are the new width and height in <b>logical points</b> (see
+    /// <see cref="Width"/>). Subscribe to this for UI layout and anything else that shares a
+    /// coordinate space with pointer input. Framebuffer-sized resources must follow
+    /// <see cref="OnFramebufferResize"/> instead, because the two sizes differ on a HiDPI
+    /// display and do not always change together.
     /// </remarks>
     event Action<int, int>? OnResize;
+
+    /// <summary>
+    /// Raised when the framebuffer is resized.
+    /// </summary>
+    /// <remarks>
+    /// Parameters are the new width and height in <b>device pixels</b> (see
+    /// <see cref="FramebufferWidth"/>). Subscribe to this for the GL viewport and any resource
+    /// measured in texels.
+    /// </remarks>
+    event Action<int, int>? OnFramebufferResize;
 
     /// <summary>
     /// Raised when the window is closing.

--- a/src/KeenEyes.Platform.Silk/SilkWindowProvider.cs
+++ b/src/KeenEyes.Platform.Silk/SilkWindowProvider.cs
@@ -36,11 +36,24 @@ internal sealed class SilkWindowProvider : ISilkWindowProvider
         window.Update += HandleWindowUpdate;
         window.Render += HandleWindowRender;
         window.Resize += HandleWindowResize;
+        window.FramebufferResize += HandleFramebufferResize;
         window.Closing += HandleWindowClosing;
     }
 
     /// <inheritdoc />
     public IWindow Window => window;
+
+    /// <inheritdoc />
+    public int Width => window.Size.X;
+
+    /// <inheritdoc />
+    public int Height => window.Size.Y;
+
+    /// <inheritdoc />
+    public int FramebufferWidth => window.FramebufferSize.X;
+
+    /// <inheritdoc />
+    public int FramebufferHeight => window.FramebufferSize.Y;
 
     /// <inheritdoc />
     public IInputContext InputContext
@@ -79,6 +92,9 @@ internal sealed class SilkWindowProvider : ISilkWindowProvider
     public event Action<int, int>? OnResize;
 
     /// <inheritdoc />
+    public event Action<int, int>? OnFramebufferResize;
+
+    /// <inheritdoc />
     public event Action? OnClosing;
 
     private void HandleWindowLoad()
@@ -102,6 +118,11 @@ internal sealed class SilkWindowProvider : ISilkWindowProvider
         OnResize?.Invoke(size.X, size.Y);
     }
 
+    private void HandleFramebufferResize(Vector2D<int> size)
+    {
+        OnFramebufferResize?.Invoke(size.X, size.Y);
+    }
+
     private void HandleWindowClosing()
     {
         OnClosing?.Invoke();
@@ -122,6 +143,7 @@ internal sealed class SilkWindowProvider : ISilkWindowProvider
         window.Update -= HandleWindowUpdate;
         window.Render -= HandleWindowRender;
         window.Resize -= HandleWindowResize;
+        window.FramebufferResize -= HandleFramebufferResize;
         window.Closing -= HandleWindowClosing;
 
         inputContext?.Dispose();

--- a/src/KeenEyes.TestBridge/Capture/CaptureControllerImpl.cs
+++ b/src/KeenEyes.TestBridge/Capture/CaptureControllerImpl.cs
@@ -74,10 +74,15 @@ internal sealed class CaptureControllerImpl(IGraphicsContext? graphicsContext = 
     /// <summary>
     /// Core frame capture logic that must run on the render thread.
     /// </summary>
+    /// <remarks>
+    /// Sized from the framebuffer rather than the window's logical size: a screenshot is a
+    /// pixel read, so on a HiDPI display a logically-sized read would capture a quarter of the
+    /// frame and stretch it (#1352).
+    /// </remarks>
     private FrameCapture CaptureFrameCore()
     {
-        var width = graphicsContext!.Width;
-        var height = graphicsContext.Height;
+        var width = graphicsContext!.FramebufferWidth;
+        var height = graphicsContext.FramebufferHeight;
         var pixels = new byte[width * height * 4];
 
         // Read pixels from GPU framebuffer
@@ -128,7 +133,9 @@ internal sealed class CaptureControllerImpl(IGraphicsContext? graphicsContext = 
             return Task.FromResult((0, 0));
         }
 
-        return Task.FromResult((graphicsContext!.Width, graphicsContext.Height));
+        // The "frame" is what a capture returns, so this reports pixels to match
+        // CaptureFrameCore rather than the window's logical size.
+        return Task.FromResult((graphicsContext!.FramebufferWidth, graphicsContext.FramebufferHeight));
     }
 
     /// <inheritdoc />
@@ -149,10 +156,15 @@ internal sealed class CaptureControllerImpl(IGraphicsContext? graphicsContext = 
     /// <summary>
     /// Core region capture logic that must run on the render thread.
     /// </summary>
+    /// <remarks>
+    /// The region is in framebuffer pixels, the same space the returned pixels are in, so the
+    /// bounds check and the Y flip use the framebuffer size rather than the window's logical
+    /// size (#1352).
+    /// </remarks>
     private FrameCapture CaptureRegionCore(int x, int y, int width, int height)
     {
-        var screenWidth = graphicsContext!.Width;
-        var screenHeight = graphicsContext.Height;
+        var frameWidth = graphicsContext!.FramebufferWidth;
+        var frameHeight = graphicsContext.FramebufferHeight;
 
         // Validate bounds
         if (x < 0 || y < 0 || width <= 0 || height <= 0)
@@ -160,16 +172,16 @@ internal sealed class CaptureControllerImpl(IGraphicsContext? graphicsContext = 
             throw new ArgumentOutOfRangeException(nameof(width), "Region dimensions must be positive and coordinates non-negative.");
         }
 
-        if (x + width > screenWidth || y + height > screenHeight)
+        if (x + width > frameWidth || y + height > frameHeight)
         {
             throw new ArgumentOutOfRangeException(nameof(width),
-                $"Region ({x}, {y}, {width}x{height}) extends outside screen bounds ({screenWidth}x{screenHeight}).");
+                $"Region ({x}, {y}, {width}x{height}) extends outside screen bounds ({frameWidth}x{frameHeight}).");
         }
 
         var pixels = new byte[width * height * 4];
 
-        // Convert screen coordinates (top-left origin) to OpenGL (bottom-left origin)
-        var glY = screenHeight - y - height;
+        // Convert region coordinates (top-left origin) to OpenGL (bottom-left origin)
+        var glY = frameHeight - y - height;
 
         graphicsContext.Device!.ReadFramebuffer(x, glY, width, height, PixelFormat.RGBA, pixels);
 

--- a/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
+++ b/src/KeenEyes.Testing/Graphics/MockGraphicsContext.cs
@@ -34,6 +34,8 @@ namespace KeenEyes.Testing.Graphics;
 public sealed class MockGraphicsContext : IGraphicsContext
 {
     private int nextHandleId = 1;
+    private int? framebufferWidth;
+    private int? framebufferHeight;
     private bool disposed;
     private ShaderHandle boundShader;
     private MeshHandle boundMesh;
@@ -168,6 +170,32 @@ public sealed class MockGraphicsContext : IGraphicsContext
 
     /// <inheritdoc />
     public int Height { get; set; } = 600;
+
+    /// <summary>
+    /// Gets or sets the framebuffer width in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Width"/> (1x scaling). Set it to a multiple of <see cref="Width"/>
+    /// to simulate a HiDPI display without HiDPI hardware.
+    /// </remarks>
+    public int FramebufferWidth
+    {
+        get => framebufferWidth ?? Width;
+        set => framebufferWidth = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the framebuffer height in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Height"/> (1x scaling). Set it to a multiple of
+    /// <see cref="Height"/> to simulate a HiDPI display without HiDPI hardware.
+    /// </remarks>
+    public int FramebufferHeight
+    {
+        get => framebufferHeight ?? Height;
+        set => framebufferHeight = value;
+    }
 
     /// <inheritdoc />
     public ShaderHandle LitShader { get; }

--- a/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
+++ b/tests/KeenEyes.Assets.Tests/BuiltInAssetTests.cs
@@ -289,6 +289,10 @@ file sealed class MockGraphicsContext : IGraphicsContext
     public int Width => 800;
     public int Height => 600;
 
+    // 1x display: the framebuffer matches the window's logical size.
+    public int FramebufferWidth => 800;
+    public int FramebufferHeight => 600;
+
     // Default resources
     public ShaderHandle LitShader => new(1);
     public ShaderHandle UnlitShader => new(2);

--- a/tests/KeenEyes.Graphics.Tests/HiDpiViewportTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/HiDpiViewportTests.cs
@@ -1,0 +1,268 @@
+using System.Numerics;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+// This project carries a local mock of the same name; the shared testing double is the one that
+// records render state.
+using MockGraphicsDevice = KeenEyes.Testing.Graphics.MockGraphicsDevice;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Pins the mapping between the two coordinate spaces the renderer straddles: framebuffer
+/// pixels (the viewport, scissor rectangles) and logical points (projections, layout, pointer
+/// input).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Regression coverage for #1352. The viewport used to be sized from the window's logical size,
+/// so on any display where the framebuffer is larger than the window - every Retina Mac, Windows
+/// at 150%, Linux with fractional scaling - it covered a fraction of the window and the whole
+/// frame rendered small in one corner.
+/// </para>
+/// <para>
+/// These tests simulate a 2x display through <see cref="MockSilkWindowProvider"/>, which is the
+/// only way to cover the bug on 1x CI hardware.
+/// </para>
+/// </remarks>
+public class HiDpiViewportTests
+{
+    private const int LogicalWidth = 800;
+    private const int LogicalHeight = 600;
+
+    /// <summary>
+    /// Builds a graphics context whose window reports the given logical and framebuffer sizes,
+    /// with its GPU resources created against a recording mock device.
+    /// </summary>
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device, MockSilkWindowProvider Provider) CreateGraphics(
+        int logicalWidth,
+        int logicalHeight,
+        int framebufferWidth,
+        int framebufferHeight)
+    {
+        var world = new World();
+        var provider = new MockSilkWindowProvider
+        {
+            Width = logicalWidth,
+            Height = logicalHeight,
+            FramebufferWidth = framebufferWidth,
+            FramebufferHeight = framebufferHeight,
+        };
+
+        world.SetExtension<ISilkWindowProvider>(provider);
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        var context = world.GetExtension<SilkGraphicsContext>();
+        var device = new MockGraphicsDevice();
+        context.InitializeResources(device);
+
+        return (world, context, device, provider);
+    }
+
+    /// <summary>
+    /// A 2x display: 800x600 points of window backed by a 1600x1200 pixel framebuffer.
+    /// </summary>
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device, MockSilkWindowProvider Provider) CreateRetinaGraphics()
+        => CreateGraphics(LogicalWidth, LogicalHeight, LogicalWidth * 2, LogicalHeight * 2);
+
+    /// <summary>
+    /// Reads back the orthographic projection the 2D renderer handed to the GPU.
+    /// </summary>
+    private static Matrix4x4 GetRecordedProjection(MockGraphicsDevice device)
+    {
+        var recorded = device.Programs.Values
+            .Where(program => program.UniformLocations.TryGetValue("uProjection", out var location)
+                && program.UniformValues.ContainsKey(location))
+            .Select(program => program.UniformValues[program.UniformLocations["uProjection"]])
+            .OfType<Matrix4x4>()
+            .ToList();
+
+        return Assert.Single(recorded);
+    }
+
+    #region Viewport is sized in framebuffer pixels
+
+    [Fact]
+    public void InitializeResources_WhenFramebufferExceedsLogicalSize_SizesViewportInPixels()
+    {
+        var (world, _, device, _) = CreateRetinaGraphics();
+        using (world)
+        {
+            // The whole framebuffer, not the 800x600 logical rectangle that used to be passed.
+            Assert.Equal((0, 0, 1600, 1200), device.RenderState.Viewport);
+        }
+    }
+
+    [Fact]
+    public void UnbindRenderTarget_WhenFramebufferExceedsLogicalSize_RestoresViewportInPixels()
+    {
+        var (world, context, device, _) = CreateRetinaGraphics();
+        using (world)
+        {
+            // Rendering to an offscreen target retargets the viewport to the target's texels...
+            var target = context.CreateRenderTarget(256, 128, RenderTargetFormat.RGBA8Depth24);
+            context.BindRenderTarget(target);
+            Assert.Equal((0, 0, 256, 128), device.RenderState.Viewport);
+
+            // ...so coming back must restore the framebuffer's pixel size, not the logical one.
+            context.UnbindRenderTarget();
+
+            Assert.Equal((0, 0, 1600, 1200), device.RenderState.Viewport);
+        }
+    }
+
+    #endregion
+
+    #region Projection and reported sizes stay in logical points
+
+    [Fact]
+    public void Width_ReportsLogicalPoints_WhileFramebufferWidthReportsPixels()
+    {
+        var (world, context, _, _) = CreateRetinaGraphics();
+        using (world)
+        {
+            // UI layout and pointer handling consume Width/Height, so they must stay logical.
+            Assert.Equal(LogicalWidth, context.Width);
+            Assert.Equal(LogicalHeight, context.Height);
+
+            Assert.Equal(LogicalWidth * 2, context.FramebufferWidth);
+            Assert.Equal(LogicalHeight * 2, context.FramebufferHeight);
+        }
+    }
+
+    [Fact]
+    public void Begin_WhenFramebufferExceedsLogicalSize_Builds2DProjectionFromLogicalPoints()
+    {
+        var (world, context, device, _) = CreateRetinaGraphics();
+        using (world)
+        {
+            context.Renderer2D!.Begin();
+
+            // A projection in logical points keeps drawing coordinates aligned with the pointer
+            // positions Silk reports; combined with the pixel viewport, the result is a
+            // full-window frame rendered at native resolution.
+            var expected = Matrix4x4.CreateOrthographicOffCenter(0, LogicalWidth, LogicalHeight, 0, -1, 1);
+
+            Assert.Equal(expected, GetRecordedProjection(device));
+        }
+    }
+
+    [Fact]
+    public void PushClip_WhenFramebufferExceedsLogicalSize_ConvertsScissorRectToPixels()
+    {
+        var (world, context, device, _) = CreateRetinaGraphics();
+        using (world)
+        {
+            context.Renderer2D!.Begin();
+
+            // A clip rectangle in logical points, as UI code supplies it.
+            context.Renderer2D.PushClip(new Rectangle(100, 50, 200, 100));
+
+            // OpenGL reads scissor rectangles in device pixels with a bottom-left origin, so
+            // every component doubles: x 100 -> 200, and y (600 - 50 - 100) = 450 -> 900.
+            Assert.Equal((200, 900, 400, 200), device.RenderState.ScissorRect);
+        }
+    }
+
+    #endregion
+
+    #region Which event drives which space
+
+    [Fact]
+    public void FramebufferResize_UpdatesViewport()
+    {
+        var (world, _, device, provider) = CreateRetinaGraphics();
+        using (world)
+        {
+            provider.SimulateFramebufferResize(2048, 1024);
+
+            Assert.Equal((0, 0, 2048, 1024), device.RenderState.Viewport);
+        }
+    }
+
+    [Fact]
+    public void Resize_UpdatesProjectionButLeavesViewportToFramebufferResize()
+    {
+        var (world, context, device, provider) = CreateRetinaGraphics();
+        using (world)
+        {
+            // A logical resize alone says nothing about the pixel size of the framebuffer, so
+            // it must not touch the viewport - the paired FramebufferResize event does that.
+            provider.SimulateResize(1000, 500);
+            context.Renderer2D!.Begin();
+
+            Assert.Equal((0, 0, 1600, 1200), device.RenderState.Viewport);
+            Assert.Equal(
+                Matrix4x4.CreateOrthographicOffCenter(0, 1000, 500, 0, -1, 1),
+                GetRecordedProjection(device));
+        }
+    }
+
+    [Fact]
+    public void FramebufferResize_DoesNotChangeTheLogicalProjection()
+    {
+        var (world, context, device, provider) = CreateRetinaGraphics();
+        using (world)
+        {
+            provider.SimulateFramebufferResize(2048, 1024);
+            context.Renderer2D!.Begin();
+
+            // Rendering at a different pixel density must not move any UI element.
+            Assert.Equal(
+                Matrix4x4.CreateOrthographicOffCenter(0, LogicalWidth, LogicalHeight, 0, -1, 1),
+                GetRecordedProjection(device));
+        }
+    }
+
+    #endregion
+
+    #region 1x displays are unaffected
+
+    [Fact]
+    public void InitializeResources_AtOneToOneScaling_SizesViewportFromTheSharedSize()
+    {
+        var (world, context, device, _) = CreateGraphics(LogicalWidth, LogicalHeight, LogicalWidth, LogicalHeight);
+        using (world)
+        {
+            Assert.Equal((0, 0, LogicalWidth, LogicalHeight), device.RenderState.Viewport);
+            Assert.Equal(context.Width, context.FramebufferWidth);
+            Assert.Equal(context.Height, context.FramebufferHeight);
+        }
+    }
+
+    [Fact]
+    public void PushClip_AtOneToOneScaling_PassesTheClipRectStraightThrough()
+    {
+        var (world, context, device, _) = CreateGraphics(LogicalWidth, LogicalHeight, LogicalWidth, LogicalHeight);
+        using (world)
+        {
+            context.Renderer2D!.Begin();
+            context.Renderer2D.PushClip(new Rectangle(100, 50, 200, 100));
+
+            // Unscaled, exactly as before the HiDPI fix: only the Y flip is applied.
+            Assert.Equal((100, 450, 200, 100), device.RenderState.ScissorRect);
+        }
+    }
+
+    [Fact]
+    public void Resize_AtOneToOneScaling_KeepsViewportAndProjectionInStep()
+    {
+        var (world, context, device, provider) = CreateGraphics(LogicalWidth, LogicalHeight, LogicalWidth, LogicalHeight);
+        using (world)
+        {
+            // A 1x window resizes both spaces together, so the two events agree.
+            provider.SimulateResize(1024, 768);
+            provider.SimulateFramebufferResize(1024, 768);
+            context.Renderer2D!.Begin();
+
+            Assert.Equal((0, 0, 1024, 768), device.RenderState.Viewport);
+            Assert.Equal(
+                Matrix4x4.CreateOrthographicOffCenter(0, 1024, 768, 0, -1, 1),
+                GetRecordedProjection(device));
+        }
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Graphics.Tests/Mocks/MockSilkWindowProvider.cs
+++ b/tests/KeenEyes.Graphics.Tests/Mocks/MockSilkWindowProvider.cs
@@ -19,10 +19,37 @@ public sealed class MockSilkWindowProvider : ISilkWindowProvider
 
     public IInputContext InputContext => null!;
 
+    /// <summary>
+    /// Gets or sets the window width in logical points.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the window height in logical points.
+    /// </summary>
+    public int Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the framebuffer width in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// Set this to a multiple of <see cref="Width"/> to simulate a HiDPI display.
+    /// </remarks>
+    public int FramebufferWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the framebuffer height in device pixels.
+    /// </summary>
+    /// <remarks>
+    /// Set this to a multiple of <see cref="Height"/> to simulate a HiDPI display.
+    /// </remarks>
+    public int FramebufferHeight { get; set; }
+
     public event Action? OnLoad;
     public event Action<double>? OnUpdate;
     public event Action<double>? OnRender;
     public event Action<int, int>? OnResize;
+    public event Action<int, int>? OnFramebufferResize;
     public event Action? OnClosing;
 
     /// <summary>
@@ -50,11 +77,32 @@ public sealed class MockSilkWindowProvider : ISilkWindowProvider
     }
 
     /// <summary>
-    /// Simulates window resize.
+    /// Simulates a window resize, which reports logical points.
     /// </summary>
+    /// <remarks>
+    /// Updates <see cref="Width"/>/<see cref="Height"/> before raising the event, the way a
+    /// real window does. The framebuffer size is deliberately left alone - raise
+    /// <see cref="SimulateFramebufferResize"/> for that.
+    /// </remarks>
     public void SimulateResize(int width, int height)
     {
+        Width = width;
+        Height = height;
         OnResize?.Invoke(width, height);
+    }
+
+    /// <summary>
+    /// Simulates a framebuffer resize, which reports device pixels.
+    /// </summary>
+    /// <remarks>
+    /// Updates <see cref="FramebufferWidth"/>/<see cref="FramebufferHeight"/> before raising
+    /// the event, the way a real window does.
+    /// </remarks>
+    public void SimulateFramebufferResize(int width, int height)
+    {
+        FramebufferWidth = width;
+        FramebufferHeight = height;
+        OnFramebufferResize?.Invoke(width, height);
     }
 
     /// <summary>

--- a/tests/KeenEyes.Input.Silk.Tests/SilkInputContextDeviceAvailabilityTests.cs
+++ b/tests/KeenEyes.Input.Silk.Tests/SilkInputContextDeviceAvailabilityTests.cs
@@ -158,6 +158,15 @@ public class SilkInputContextDeviceAvailabilityTests
 
         public SilkInput.IInputContext InputContext => silkInputContext!;
 
+        // Sizes are irrelevant to input; nothing here is ever measured.
+        public int Width => 0;
+
+        public int Height => 0;
+
+        public int FramebufferWidth => 0;
+
+        public int FramebufferHeight => 0;
+
         public event Action? OnLoad;
 
         // The rest of the lifecycle is irrelevant to input, so these accept subscribers
@@ -167,6 +176,8 @@ public class SilkInputContextDeviceAvailabilityTests
         public event Action<double>? OnRender { add { } remove { } }
 
         public event Action<int, int>? OnResize { add { } remove { } }
+
+        public event Action<int, int>? OnFramebufferResize { add { } remove { } }
 
         public event Action? OnClosing { add { } remove { } }
 

--- a/tests/KeenEyes.TestBridge.Tests/Capture/CaptureControllerImplTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Capture/CaptureControllerImplTests.cs
@@ -608,5 +608,74 @@ public class CaptureControllerImplTests
         return (new CaptureControllerImpl(context), device);
     }
 
+    /// <summary>
+    /// Builds a controller for a 2x display: a window of <paramref name="logicalWidth"/> x
+    /// <paramref name="logicalHeight"/> points backed by a framebuffer twice that in pixels.
+    /// </summary>
+    private static CaptureControllerImpl CreateRetinaController(int logicalWidth, int logicalHeight)
+    {
+        var device = new MockGraphicsDevice
+        {
+            SimulatedFramebufferData = new byte[logicalWidth * 2 * logicalHeight * 2 * 4],
+            SimulatedFramebufferWidth = logicalWidth * 2,
+            SimulatedFramebufferHeight = logicalHeight * 2,
+        };
+
+        var context = new MockGraphicsContext
+        {
+            IsInitialized = true,
+            Device = device,
+            Width = logicalWidth,
+            Height = logicalHeight,
+            FramebufferWidth = logicalWidth * 2,
+            FramebufferHeight = logicalHeight * 2,
+        };
+
+        return new CaptureControllerImpl(context);
+    }
+
+    #endregion
+
+    #region HiDPI displays (#1352)
+
+    [Fact]
+    public async Task CaptureFrameAsync_OnHiDpiDisplay_CapturesTheWholeFramebufferInPixels()
+    {
+        var controller = CreateRetinaController(400, 300);
+
+        var frame = await controller.CaptureFrameAsync();
+
+        // A screenshot is a pixel read: sizing it from the window's logical size would capture
+        // a quarter of the frame.
+        frame.Width.ShouldBe(800);
+        frame.Height.ShouldBe(600);
+        frame.Pixels.Length.ShouldBe(800 * 600 * 4);
+    }
+
+    [Fact]
+    public async Task GetFrameSizeAsync_OnHiDpiDisplay_ReportsFramebufferPixels()
+    {
+        var controller = CreateRetinaController(400, 300);
+
+        var (width, height) = await controller.GetFrameSizeAsync();
+
+        // Must agree with what CaptureFrameAsync actually returns.
+        width.ShouldBe(800);
+        height.ShouldBe(600);
+    }
+
+    [Fact]
+    public async Task CaptureRegionAsync_OnHiDpiDisplay_AcceptsRegionsAcrossTheWholeFramebuffer()
+    {
+        var controller = CreateRetinaController(400, 300);
+
+        // A region beyond the logical size but inside the framebuffer used to be rejected as
+        // "outside screen bounds".
+        var frame = await controller.CaptureRegionAsync(500, 400, 100, 100);
+
+        frame.Width.ShouldBe(100);
+        frame.Height.ShouldBe(100);
+    }
+
     #endregion
 }

--- a/tests/KeenEyes.UI.Tests/UILayoutHiDpiTests.cs
+++ b/tests/KeenEyes.UI.Tests/UILayoutHiDpiTests.cs
@@ -1,0 +1,107 @@
+using System.Numerics;
+
+using KeenEyes.Common;
+using KeenEyes.Testing.Graphics;
+using KeenEyes.UI.Abstractions;
+
+namespace KeenEyes.UI.Tests;
+
+/// <summary>
+/// Pins that UI layout is driven by the graphics context's logical size, never its framebuffer
+/// size.
+/// </summary>
+/// <remarks>
+/// Part of the fix for #1352. The renderer's viewport is sized in framebuffer pixels, but layout
+/// must stay in logical points, because that is the space pointer positions are reported in. If
+/// layout ever switched to pixels, everything would still render crisply while every click landed
+/// in the wrong place - so the split is worth a test of its own.
+/// </remarks>
+public class UILayoutHiDpiTests
+{
+    /// <summary>
+    /// A 2x display: 800x600 points of window backed by a 1600x1200 pixel framebuffer.
+    /// </summary>
+    private static MockGraphicsContext CreateRetinaGraphics() => new()
+    {
+        Width = 800,
+        Height = 600,
+        FramebufferWidth = 1600,
+        FramebufferHeight = 1200,
+    };
+
+    [Fact]
+    public void SetScreenSize_FedFromGraphicsContext_UsesLogicalPointsNotFramebufferPixels()
+    {
+        using var world = new World();
+        var layoutSystem = new UILayoutSystem();
+        world.AddSystem(layoutSystem);
+
+        var canvas = world.Spawn()
+            .With(UIElement.Default)
+            .With(UIRect.Stretch())
+            .With(new UIRootTag())
+            .Build();
+
+        var graphics = CreateRetinaGraphics();
+
+        // This is the call every host makes (samples, editor): Width/Height, not the
+        // Framebuffer* pair.
+        layoutSystem.SetScreenSize(graphics.Width, graphics.Height);
+        layoutSystem.Update(0);
+
+        ref readonly var rect = ref world.Get<UIRect>(canvas);
+
+        Assert.True(rect.ComputedBounds.Width.ApproximatelyEquals(800f));
+        Assert.True(rect.ComputedBounds.Height.ApproximatelyEquals(600f));
+    }
+
+    [Fact]
+    public void SetScreenSize_WhenFedFramebufferPixels_MisplacesLayoutRelativeToPointerSpace()
+    {
+        using var world = new World();
+        var layoutSystem = new UILayoutSystem();
+        world.AddSystem(layoutSystem);
+
+        var canvas = world.Spawn()
+            .With(UIElement.Default)
+            .With(UIRect.Stretch())
+            .With(new UIRootTag())
+            .Build();
+
+        // A bottom-right anchored element is where the mismatch shows up: its position is
+        // derived from the root size, so feeding pixels moves it off the visible window.
+        var corner = world.Spawn()
+            .With(UIElement.Default)
+            .With(new UIRect
+            {
+                AnchorMin = Vector2.One,
+                AnchorMax = Vector2.One,
+                Pivot = Vector2.One,
+                Size = new Vector2(100f, 40f),
+                WidthMode = UISizeMode.Fixed,
+                HeightMode = UISizeMode.Fixed,
+            })
+            .Build();
+
+        world.SetParent(corner, canvas);
+
+        var graphics = CreateRetinaGraphics();
+
+        layoutSystem.SetScreenSize(graphics.FramebufferWidth, graphics.FramebufferHeight);
+        layoutSystem.Update(0);
+
+        ref readonly var wrong = ref world.Get<UIRect>(corner);
+        var wrongRight = wrong.ComputedBounds.X + wrong.ComputedBounds.Width;
+
+        // Pointer coordinates only ever reach 800, so an element sitting at x=1600 is
+        // unclickable. Documents why SetScreenSize must be fed logical points.
+        Assert.True(wrongRight > graphics.Width);
+
+        layoutSystem.SetScreenSize(graphics.Width, graphics.Height);
+        layoutSystem.Update(0);
+
+        ref readonly var right = ref world.Get<UIRect>(corner);
+
+        Assert.True((right.ComputedBounds.X + right.ComputedBounds.Width).ApproximatelyEquals(800f));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1352. Nothing in the repo referenced `FramebufferSize`, so the GL viewport was sized from logical window points. On a 2× Retina display that covers a quarter of the window and renders everything half-scale in the corner — the first thing a Mac user would see, and structurally invisible to CI on any platform.

Scoping it turned up **two more live bugs of the same kind**:

- **Scissor/clip was wrong too.** `Silk2DRenderer.ApplyClip` passes UI clip rects (points) straight to `device.Scissor`, which reads pixels. Every clipped region — scroll views, modals, the clip stack — would be misplaced and half-sized on Retina. Fixed via a new pixel-scale on the renderer.
- **Screenshots were wrong on all three capture paths.** `CaptureControllerImpl` used logical sizes, so a Retina screenshot captured a quarter of the frame, and `CaptureRegionAsync` rejected valid regions beyond the logical size as "outside screen bounds".

## Contract chosen: `Width`/`Height` stay points
`IGraphicsContext.Width`/`Height` keep their current meaning and are **now documented as logical points**; new `FramebufferWidth`/`FramebufferHeight` are device pixels.

Rationale: the audit showed the clear majority of existing callers already wanted points — UI layout, pointer math (`Sample.InputDebugger` divides `mouse.Position` by `graphics.Width`), design-space scaling, aspect ratio — so flipping the meaning would have silently broken code that was already correct. Keeping `Width` as the "UI space" pair is also what keeps hit-testing aligned with the pointer.

Docs corrected along the way: `IWindow.Width/Height` and `OnResize` were labelled "pixels" and are actually points; `SetViewport`/`SetViewportCommand` now state pixels (example fixed); `ILoopProvider.OnResize` documented as points.

`ISilkWindowProvider` gained the size properties and `OnFramebufferResize`, so the context reads sizes from the provider rather than double-sourcing through the window wrapper — which is also what makes this testable headlessly (the mock provider's `Window` is `null!`, so sizes were previously uncontrollable).

## Event split
| Event | Space | Drives |
|---|---|---|
| `OnFramebufferResize` | pixels | GL viewport, 2D pixel scale for scissor |
| `OnResize` | points | 2D + text projections; existing subscribers unchanged |

Deliberately asserted: a logical-only `Resize` updates the projection and **does not** touch the viewport — a logical resize says nothing about pixel size.

## Consumer audit
Full table in the issue thread. Highlights: `RenderTargetManager` and `ShadowRenderingSystem` were already correct (they viewport from texel sizes); the leak was `UnbindRenderTarget` restoring the viewport to logical points after a texel-sized target. `NovaFallRenderSystem` confirmed unaffected — its camera matrix maps a fixed design space into the same logical space the 2D projection uses.

## Test plan
- [x] `HiDpiViewportTests` (11) drive a mock window whose framebuffer is **2× its logical size**: viewport gets pixels, projection gets points, scissor gets pixels, `UnbindRenderTarget` restores pixels. Plus 1× parity cases so the common path can't regress.
- [x] `UILayoutHiDpiTests` (2) — layout keeps receiving points.
- [x] 3 HiDPI capture cases in `CaptureControllerImplTests`.
- [x] **Fail-on-old**: 5 of 11 graphics tests fail against the pre-fix code with exactly the reported symptom — viewport `(0,0,800,600)` instead of `(0,0,1600,1200)`, scissor `(100,450,200,100)` instead of `(200,900,400,200)`. The other 6 are 1×/points guards that pass either way by design. All 3 capture tests fail on old code.
- [x] Full suite **14,908, 0 failed**; build 0 warnings (`--no-incremental`); format clean; NOVAFALL `--simulate 600` double-run byte-identical.

## Not verifiable without HiDPI hardware
1. That Silk.NET actually reports `FramebufferSize ≠ Size` on Retina and raises `FramebufferResize` — the mock enforces our side of the contract, not Silk's.
2. Event ordering when dragging between monitors with different scale factors. The explicit viewport set in `InitializeResources` covers the startup case regardless of ordering.

## Deliberately out of scope (both worth follow-ups)
- **Text is geometrically correct but soft at 2×**: glyph atlases are still rasterized at 1× point sizes. Needs DPI-aware rasterization — a separate change.
- **`ViewportPanel` Y origin**: `SetViewport(viewportY, …)` passes a top-left-origin UI Y into GL's bottom-left-origin viewport. A **pre-existing** bug independent of HiDPI, visible on any display where the panel isn't vertically centred. Left alone.
