### PR TITLE
ci: Run the test suite on macOS (non-blocking to start)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ on:
       - 'Directory.Packages.props'
       - 'Directory.Build.props'
       - '.editorconfig'
+      # So a change to this workflow actually runs it. Without this the filter skips
+      # CI-only commits, which would leave a newly added job unverified until some
+      # unrelated PR happened to touch code.
+      - '.github/workflows/build.yml'
   pull_request:
     branches:
       - main
@@ -31,6 +35,7 @@ on:
       - 'Directory.Packages.props'
       - 'Directory.Build.props'
       - '.editorconfig'
+      - '.github/workflows/build.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -102,6 +107,47 @@ jobs:
           file: coverage-report/Cobertura.xml
           format: cobertura
         continue-on-error: true
+
+  # The suite has never run on macOS: until now the only Apple Silicon coverage in the
+  # repo was the AOT publish job in aot-compatibility.yml. This job exists to find out
+  # what breaks, so it is deliberately NON-BLOCKING for its first outings — nothing here
+  # has ever executed on macOS and wedging every PR on unknown platform failures would
+  # be the wrong trade. Promote it to required once it has been green for a while
+  # (tracked in the issue that added it).
+  #
+  # Coverage/reporting is intentionally omitted: Linux already produces those, and this
+  # job answers a different question — does the engine work on Apple Silicon.
+  test-macos:
+    name: Test (macOS, Apple Silicon)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: ./global.json
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      # No display on the runner, so windowed samples cannot be launched here; this
+      # covers the headless suite only. Retina-specific rendering is covered by the
+      # scaled-framebuffer unit tests rather than by real hardware.
+      - name: Test
+        timeout-minutes: 20
+        run: dotnet test --no-build --configuration Release --verbosity normal
 
   format-check:
     name: Format Check


### PR DESCRIPTION
## Summary
Closes #1353. The suite has never executed on macOS — the only Apple Silicon coverage in the repo was the AOT publish job in `aot-compatibility.yml`, so ~14,900 tests were unverified on the platform the iOS work (#1344–#1350) will be built from.

- Adds a **`test-macos`** job on `macos-latest` (Apple Silicon): restore → build → test.
- **Deliberately `continue-on-error: true` to begin with.** Nothing in this suite has ever run on macOS, so expect failures from path assumptions, timing, or file-system case sensitivity. Discovering them is the point; wedging every PR on them is not. Promote to required once it has been green for a while — the follow-up is noted in #1353.
- Coverage and reporting are omitted on purpose: Linux already produces those, and this job answers a different question — *does the engine work on Apple Silicon*.
- The runner has no display, so this covers the **headless** suite only. Retina-specific rendering is covered by the scaled-framebuffer unit tests in #1352, not by hardware.

## Also: the workflow can now test itself
Added `.github/workflows/build.yml` to both path filters. Without it a CI-only commit doesn't match `push.paths`/`pull_request.paths`, so **this very job would not have run on its own PR** — it would have sat unverified until some unrelated PR happened to touch `src/`. That's the same filter gap that silently skipped a workflow change earlier this week, and it's worth closing while we're here.

## What this is expected to prove (or disprove)
Groundwork already verified locally, which is why this is worth turning on now rather than after the mobile work:
- Mac natives already ship — a sample's output carries `runtimes/osx-arm64` and `runtimes/osx-x64` with real `libglfw.3.dylib` and `libopenal.dylib`.
- `WindowOptions.Default` resolves to `OpenGL / Core / ForwardCompatible / 3.3` — exactly what macOS requires (it refuses compatibility profiles above 2.1), and our `#version 330 core` shaders sit inside Mac's 4.1 ceiling.
- Font discovery and theme detection already have macOS branches; the render-thread queue drains on the main thread.

## Test plan
- [x] Workflow validated: no tabs, three jobs parse, macOS job is non-blocking, two self-trigger path entries present
- [ ] **First real run happens on this PR** (that's what the path-filter change enables) — the result is the deliverable, not a green check

Known issues that also affect macOS and are already filed, so this job's output shouldn't re-diagnose them: #1267 (`TerminateAsync` sends SIGKILL on Unix), #1268 (`.mcp.json` hardcodes `.exe`), #1352 (HiDPI viewport).