### PR TITLE
fix(testbridge): Keep pipe names inside the macOS domain-socket path limit

### DIFF
--- a/src/KeenEyes.TestBridge.Ipc/Transport/NamedPipeTransport.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Transport/NamedPipeTransport.cs
@@ -38,6 +38,11 @@ public sealed class NamedPipeTransport : IIpcTransport
     public NamedPipeTransport(string pipeName, bool isServer)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+
+        // Fail here, with the name and the limit, rather than letting the BCL throw an
+        // ArgumentOutOfRangeException from inside the pipe stream that mentions neither.
+        UnixPipePath.ThrowIfTooLong(pipeName, nameof(pipeName));
+
         this.pipeName = pipeName;
         this.isServer = isServer;
     }

--- a/src/KeenEyes.TestBridge.Ipc/Transport/UnixPipePath.cs
+++ b/src/KeenEyes.TestBridge.Ipc/Transport/UnixPipePath.cs
@@ -1,0 +1,115 @@
+namespace KeenEyes.TestBridge.Ipc.Transport;
+
+/// <summary>
+/// Validates named-pipe names against the Unix domain socket path limit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// On Windows a pipe name becomes an entry in the <c>\\.\pipe\</c> namespace and is
+/// effectively unbounded for our purposes. On Linux and macOS .NET emulates named pipes
+/// with Unix domain sockets, placing a file at
+/// <c>{TempPath}/CoreFxPipe_{pipeName}</c> — and a socket path must fit the
+/// <c>sockaddr_un.sun_path</c> field, which is 104 bytes on macOS/BSD and 108 on Linux.
+/// </para>
+/// <para>
+/// Exceeding it surfaces from the BCL as a bare
+/// <see cref="ArgumentOutOfRangeException"/> about "an invalid length for use with domain
+/// sockets", naming neither the pipe nor the limit — so this check exists to report which
+/// name was too long, by how much, and what to do about it. macOS is where this bites
+/// first: its per-user temp directory is ~48 characters before the name is even appended.
+/// </para>
+/// </remarks>
+public static class UnixPipePath
+{
+    /// <summary>
+    /// The prefix .NET prepends to the socket file backing a named pipe on Unix.
+    /// </summary>
+    /// <remarks>
+    /// This mirrors the runtime's own convention; it is not configurable. If a future
+    /// runtime changes it, this check becomes conservative rather than wrong.
+    /// </remarks>
+    private const string SocketFilePrefix = "CoreFxPipe_";
+
+    /// <summary>
+    /// Maximum socket path length on macOS and other BSD-derived platforms.
+    /// </summary>
+    public const int MacOsPathLimit = 104;
+
+    /// <summary>
+    /// Maximum socket path length on Linux.
+    /// </summary>
+    public const int LinuxPathLimit = 108;
+
+    /// <summary>
+    /// Gets the socket path limit for the current platform, or <c>null</c> on platforms
+    /// where named pipes are not backed by Unix domain sockets (Windows).
+    /// </summary>
+    public static int? CurrentPlatformLimit =>
+        OperatingSystem.IsWindows() ? null
+        : OperatingSystem.IsLinux() ? LinuxPathLimit
+        : MacOsPathLimit;
+
+    /// <summary>
+    /// Builds the socket path .NET would use to back a named pipe on Unix.
+    /// </summary>
+    /// <param name="tempPath">The temporary directory (<see cref="Path.GetTempPath"/>).</param>
+    /// <param name="pipeName">The pipe name.</param>
+    /// <returns>The full socket file path.</returns>
+    public static string BuildSocketPath(string tempPath, string pipeName) =>
+        Path.Combine(tempPath, SocketFilePrefix + pipeName);
+
+    /// <summary>
+    /// Checks whether a pipe name fits the socket path limit, and explains it if not.
+    /// </summary>
+    /// <param name="tempPath">The temporary directory the socket file would live in.</param>
+    /// <param name="pipeName">The pipe name to validate.</param>
+    /// <param name="limit">The platform's socket path limit, in characters.</param>
+    /// <param name="error">
+    /// When this method returns <c>false</c>, a message naming the pipe, the resulting
+    /// path length, the limit, and how to resolve it; otherwise <c>null</c>.
+    /// </param>
+    /// <returns><c>true</c> when the resulting path fits; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// Kept as a pure function over an explicit temp path and limit so the behaviour is
+    /// testable on any platform, rather than only on the one that rejects the path.
+    /// </remarks>
+    public static bool TryValidate(string tempPath, string pipeName, int limit, out string? error)
+    {
+        var path = BuildSocketPath(tempPath, pipeName);
+        if (path.Length <= limit)
+        {
+            error = null;
+            return true;
+        }
+
+        var excess = path.Length - limit;
+        error =
+            $"The pipe name '{pipeName}' is too long for this platform. It resolves to a "
+            + $"Unix domain socket path of {path.Length} characters ('{path}'), but the limit "
+            + $"is {limit}. Shorten the pipe name by at least {excess} character(s), or set "
+            + "TMPDIR to a shorter directory.";
+        return false;
+    }
+
+    /// <summary>
+    /// Throws when a pipe name cannot fit the current platform's socket path limit.
+    /// </summary>
+    /// <param name="pipeName">The pipe name to validate.</param>
+    /// <param name="paramName">The parameter name to report on failure.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the resulting socket path would exceed the platform limit.
+    /// </exception>
+    /// <remarks>No-ops on Windows, where the limit does not apply.</remarks>
+    public static void ThrowIfTooLong(string pipeName, string paramName)
+    {
+        if (CurrentPlatformLimit is not int limit)
+        {
+            return;
+        }
+
+        if (!TryValidate(Path.GetTempPath(), pipeName, limit, out var error))
+        {
+            throw new ArgumentException(error, paramName);
+        }
+    }
+}

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/IpcBridgeIntegrationTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/IpcBridgeIntegrationTests.cs
@@ -8,7 +8,7 @@ namespace KeenEyes.TestBridge.Tests.Ipc;
 /// </summary>
 public class IpcBridgeIntegrationTests : IAsyncLifetime
 {
-    private readonly string testPipeName = $"KeenEyes.TestBridge.Tests.{Guid.NewGuid():N}";
+    private readonly string testPipeName = TestPipeName.Create();
     private World? world;
     private InProcessBridge? inProcessBridge;
     private KeenEyes.TestBridge.Ipc.IpcBridgeServer? server;

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/TestPipeName.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/TestPipeName.cs
@@ -1,0 +1,25 @@
+namespace KeenEyes.TestBridge.Tests.Ipc;
+
+/// <summary>
+/// Generates unique, deliberately short pipe names for IPC tests.
+/// </summary>
+/// <remarks>
+/// On macOS a named pipe is a Unix domain socket under the per-user temp directory, whose
+/// full path may not exceed 104 characters. That directory alone is around 48 characters
+/// (<c>/var/folders/xx/xxxxxxxxxxxxxxxxxxxxxxxxxxxx/T/</c>), and .NET prepends
+/// <c>CoreFxPipe_</c>, so a descriptive name plus a full GUID overruns the limit and every
+/// IPC test fails on macOS. This keeps names small enough to leave real headroom rather
+/// than only just fitting.
+/// </remarks>
+internal static class TestPipeName
+{
+    /// <summary>
+    /// Creates a unique pipe name short enough for the macOS socket path limit.
+    /// </summary>
+    /// <returns>A pipe name of the form <c>ke-<em>12 hex digits</em></c>.</returns>
+    /// <remarks>
+    /// 48 bits of randomness is ample for isolating concurrently running tests, and keeps
+    /// the resulting socket path near 75 characters on macOS.
+    /// </remarks>
+    internal static string Create() => $"ke-{Guid.NewGuid():N}"[..15];
+}

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/TransportConcurrencyTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/TransportConcurrencyTests.cs
@@ -82,7 +82,7 @@ public class TransportConcurrencyTests
     public async Task NamedPipeTransport_ConcurrentSends_PreserveFrameIntegrity()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        var pipeName = $"KeenEyes.TestBridge.Tests.{Guid.NewGuid():N}";
+        var pipeName = TestPipeName.Create();
 
         using var server = new NamedPipeTransport(pipeName, isServer: true);
         using var client = new NamedPipeTransport(pipeName, isServer: false);

--- a/tests/KeenEyes.TestBridge.Tests/Ipc/UnixPipePathTests.cs
+++ b/tests/KeenEyes.TestBridge.Tests/Ipc/UnixPipePathTests.cs
@@ -1,0 +1,162 @@
+using KeenEyes.TestBridge.Ipc.Transport;
+
+namespace KeenEyes.TestBridge.Tests.Ipc;
+
+/// <summary>
+/// Tests for the Unix domain socket path limit that named pipes are subject to on
+/// macOS and Linux.
+/// </summary>
+/// <remarks>
+/// These drive the pure validation function with an explicit temp path and limit, so the
+/// macOS behaviour is verified on any platform. That matters: the failure they describe
+/// was found by the first macOS CI run and cannot be reproduced on Linux, whose temp
+/// directory is short enough that the same names fit comfortably.
+/// </remarks>
+public class UnixPipePathTests
+{
+    /// <summary>A realistic macOS per-user temp directory (48 characters).</summary>
+    private const string MacTempPath = "/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/";
+
+    [Fact]
+    public void TryValidate_MacOsTempWithVerboseNameAndFullGuid_Rejects()
+    {
+        // The exact shape that failed on the first macOS CI run: 118 characters against
+        // a 104 limit.
+        var pipeName = $"KeenEyes.TestBridge.Tests.{new string('a', 32)}";
+
+        var fits = UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out var error);
+
+        Assert.False(fits);
+        Assert.NotNull(error);
+        Assert.Contains(pipeName, error, StringComparison.Ordinal);
+        Assert.Contains("118", error, StringComparison.Ordinal);
+        Assert.Contains("104", error, StringComparison.Ordinal);
+        Assert.Contains("14", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryValidate_ShortTestName_FitsWithHeadroom()
+    {
+        var pipeName = TestPipeName.Create();
+
+        var fits = UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out var error);
+
+        Assert.True(fits);
+        Assert.Null(error);
+
+        // Not merely under the limit — comfortably so, since a longer TMPDIR should not
+        // start failing tests again.
+        var path = UnixPipePath.BuildSocketPath(MacTempPath, pipeName);
+        Assert.True(
+            UnixPipePath.MacOsPathLimit - path.Length >= 20,
+            $"Expected >= 20 characters of headroom, path was {path.Length}.");
+    }
+
+    [Fact]
+    public void TryValidate_ProductionPipeNames_FitOnMacOs()
+    {
+        // The names real applications register; a regression here breaks shipping games,
+        // not just tests.
+        string[] production =
+        [
+            "KeenEyes.TestBridge",
+            "KeenEyes.Editor.TestBridge",
+            "KeenEyes.Editor.Scene.TestBridge",
+            "KeenEyes.Sample.UI.TestBridge",
+            "KeenEyes.InputDebugger.TestBridge",
+            "KeenEyes.NovaFall.TestBridge",
+        ];
+
+        foreach (var pipeName in production)
+        {
+            var fits = UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out var error);
+            Assert.True(fits, error);
+        }
+    }
+
+    [Fact]
+    public void TryValidate_AtExactlyTheLimit_Fits()
+    {
+        // Boundary: the limit is inclusive.
+        var prefixLength = UnixPipePath.BuildSocketPath(MacTempPath, string.Empty).Length;
+        var pipeName = new string('a', UnixPipePath.MacOsPathLimit - prefixLength);
+
+        var fits = UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out var error);
+
+        Assert.True(fits, error);
+    }
+
+    [Fact]
+    public void TryValidate_OneCharacterOverTheLimit_Rejects()
+    {
+        var prefixLength = UnixPipePath.BuildSocketPath(MacTempPath, string.Empty).Length;
+        var pipeName = new string('a', UnixPipePath.MacOsPathLimit - prefixLength + 1);
+
+        var fits = UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out var error);
+
+        Assert.False(fits);
+        Assert.Contains("at least 1 character", error!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryValidate_LinuxAllowsSlightlyLongerPaths()
+    {
+        // Linux permits 108 where macOS permits 104, so a name can be valid on one and
+        // not the other; the check must use the platform's own limit.
+        var prefixLength = UnixPipePath.BuildSocketPath(MacTempPath, string.Empty).Length;
+        var pipeName = new string('a', UnixPipePath.LinuxPathLimit - prefixLength);
+
+        Assert.True(UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.LinuxPathLimit, out _));
+        Assert.False(UnixPipePath.TryValidate(MacTempPath, pipeName, UnixPipePath.MacOsPathLimit, out _));
+    }
+
+    [Fact]
+    public void CurrentPlatformLimit_IsNullOnWindowsAndSetOnUnix()
+    {
+        var limit = UnixPipePath.CurrentPlatformLimit;
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Null(limit);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            Assert.Equal(UnixPipePath.LinuxPathLimit, limit);
+        }
+        else
+        {
+            Assert.Equal(UnixPipePath.MacOsPathLimit, limit);
+        }
+    }
+
+    [Fact]
+    public void NamedPipeTransport_WithOverlongName_ThrowsNamingThePipeAndLimit()
+    {
+        // On Windows the limit does not apply, so the constructor must accept the name.
+        var pipeName = new string('a', 300);
+
+        if (OperatingSystem.IsWindows())
+        {
+            using var transport = new NamedPipeTransport(pipeName, isServer: true);
+            Assert.False(transport.IsConnected);
+            return;
+        }
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new NamedPipeTransport(pipeName, isServer: true));
+
+        // The whole point of the guard: the message must identify the pipe and the limit,
+        // unlike the BCL's bare "invalid length for use with domain sockets".
+        Assert.Contains("too long", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(UnixPipePath.CurrentPlatformLimit!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture), exception.Message, StringComparison.Ordinal);
+        Assert.Equal("pipeName", exception.ParamName);
+    }
+
+    [Fact]
+    public void NamedPipeTransport_WithShortName_Constructs()
+    {
+        using var transport = new NamedPipeTransport(TestPipeName.Create(), isServer: true);
+
+        Assert.False(transport.IsConnected);
+    }
+}


### PR DESCRIPTION
## Summary
The first macOS CI run (#1356) failed **21 of 14,892** tests — all with a single root cause.

On Unix, .NET backs a named pipe with a domain socket at `{TempPath}/CoreFxPipe_{name}`, and `sockaddr_un.sun_path` caps the path at **104 bytes on macOS** (108 on Linux). The test names were `KeenEyes.TestBridge.Tests.{full guid}`, which resolves to **118 characters** under macOS's ~48-character per-user temp directory:

```
/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/CoreFxPipe_KeenEyes.TestBridge.Tests.e1f4a45…
└────────────────── 48 ──────────────────┘└─ 11 ─┘└──────────── 58 ────────────┘  = 118 > 104
```

**Why Linux never caught it:** its temp directory is `/tmp/` — 5 characters, not 48. The identical names land at 75 there, comfortably inside Linux's larger limit. Verified locally.

## Changes

**1. Shorter test names.** A shared `TestPipeName.Create()` yields `ke-` plus 12 hex digits → **75 characters on macOS, 29 to spare**. Sized for headroom deliberately, so a longer `TMPDIR` doesn't resurrect this.

**2. A guard that explains itself.** `NamedPipeTransport` now validates in its constructor and throws naming the pipe, the computed length, the platform limit, and how many characters to cut. Previously the BCL threw this — reproduced locally:

> `ArgumentOutOfRangeException`: The path '/tmp/CoreFxPipe_aaaa…300 chars…' is of an invalid length for use with domain sockets on this platform.

That prints the path but identifies neither the pipe nor the remedy, and arrives **late** — at `ListenAsync`/`ConnectAsync` rather than construction.

## Production names are fine, but the margin is thinner than it looks

| Pipe | macOS path length | Headroom |
|---|---|---|
| `KeenEyes.NovaFall.TestBridge` | 88 | 16 |
| `KeenEyes.Editor.Scene.TestBridge` | 92 | 12 |

Nothing is broken today, but a game with a longer name would have hit the same opaque failure. The guard reports it clearly instead — the #1274 diagnostics-contract pattern: state the observation and the remedy rather than surfacing a bare platform error.

## Test plan
- [x] 8 new tests. Validation is a **pure function over an explicit temp path and limit**, so macOS behaviour is verified from Linux — covering the exact 118-character shape that failed in CI, both boundary cases (at the limit fits, one over rejects), the Linux-vs-macOS limit difference, and **every production pipe name in the repo**.
- [x] Constructor guard tested both ways: throws with a legible message on Unix, accepts on Windows where the limit does not apply.
- [x] TestBridge.Tests 274 (was 267); full suite **14,877, 0 failed**; build 0 warnings; format clean.

## Merge order
Land this **before** #1356, or land both and expect #1356's macOS job to stay red until this is in. It should then go green — at which point promoting that job to required (#1353) becomes reasonable.
