### PR TITLE
docs: Add mobile platform research and ADR-016 (iOS & Android support plan)

### DIFF
--- a/docs/adr/016-mobile-platform-support.md
+++ b/docs/adr/016-mobile-platform-support.md
@@ -1,0 +1,98 @@
+# ADR-016: Mobile Platform Support (iOS & Android)
+
+**Status:** Proposed
+**Revision:** v1
+**Implementation:** Not started
+**First accepted:** — (proposed 2026-07-27)
+**Relates to:** [ADR-004](004-reflection-elimination.md) (AOT compatibility) · [ADR-005](005-graphics-input-abstraction-layers.md) (graphics/input abstraction layers) · [ADR-009](009-kesl-shader-language.md) (KESL) · [Mobile Platform Support research](../research/mobile-platform-support.md) · tracking [#1344](https://github.com/orion-ecs/keen-eye/issues/1344) [#1345](https://github.com/orion-ecs/keen-eye/issues/1345) [#1346](https://github.com/orion-ecs/keen-eye/issues/1346) [#1347](https://github.com/orion-ecs/keen-eye/issues/1347) [#1348](https://github.com/orion-ecs/keen-eye/issues/1348) [#1349](https://github.com/orion-ecs/keen-eye/issues/1349) [#1350](https://github.com/orion-ecs/keen-eye/issues/1350)
+
+## Context
+
+As of mid-2026 KeenEyes ran only on desktop: Silk.NET 2.23 with GLFW windowing, an OpenGL 3.3 core renderer, `Silk.NET.Input` (keyboard/mouse/gamepad), and OpenAL Soft audio. The engine's hard constraints — Native AOT everywhere, zero reflection, engine-owned abstractions (`KeenEyes.Graphics.Abstractions`, `KeenEyes.Audio.Abstractions`, `KeenEyes.Input.Abstractions`) — were chosen partly with mobile in mind (Apple forbids JIT), but no mobile backend existed.
+
+Research in July 2026 ([research report](../research/mobile-platform-support.md)) established the forces:
+
+- **GLFW is desktop-only, permanently** — mobile requires a second platform backend regardless of any other choice.
+- **Silk.NET 3.0 had not shipped** (preview-only builds, ~49% milestone, no date); its own windowing rewrite targets SDL3.
+- **Apple** deprecated OpenGL ES (frozen at ES 3.0, still store-accepted) with Metal as the only first-class API; **Google** declared Vulkan the official Android API (~85% device coverage) while bundling ANGLE-on-Vulkan in Android 15+ as the long-term GLES story.
+- **The audio path did not carry over**: `Silk.NET.OpenAL.Soft.Native` ships desktop RIDs only, and OpenAL Soft's LGPL makes static linking into an iOS binary legally gray.
+- **.NET packaging**: `net10.0-ios` + `PublishAot` was officially supported and proven (FNA ships App Store titles this way); Android workload Native AOT was still experimental in .NET 10.
+- Mobile OSes forbid an app-owned blocking game loop; the OS drives frames.
+- The input abstraction had no touch model, and KESL emitted only desktop GLSL 450 and HLSL.
+
+## Decision
+
+KeenEyes adds mobile support as **new backends behind the existing abstractions** — no migration of the desktop stack. The mobile stack is:
+
+### Platform container: SDL3
+
+A new `KeenEyes.Platform.Sdl3` backend owns windowing, lifecycle, and input event delivery on mobile (and is desktop-capable, which is where it is built and tested first). Bindings are pure P/Invoke, AOT/trim-safe (vendored flibitijibibo-style SDL3-CS or ppy.SDL3-CS). GLFW remains the desktop default until SDL3 proves out.
+
+This entails engine changes that hold for any container choice:
+
+1. **Game-loop inversion of control** — the engine loop gains a per-frame `Tick(dt)` mode driven by SDL3 main callbacks (`SDL_AppInit`/`SDL_AppIterate`/`SDL_AppEvent`/`SDL_AppQuit`); desktop keeps the blocking loop.
+2. **Touch input model** in `KeenEyes.Input.Abstractions`: touch devices with per-finger points (device ID, finger ID, normalized position, deltas, pressure, phase including **Canceled**), suppression of touch→mouse double-delivery, engine-side gesture recognition (SDL3 core has none).
+3. **Text-input session API** (IME begin/end, composition events, keyboard-occlusion rect).
+4. **Lifecycle surface**: background/foreground, GL surface loss/recreation, low-memory; on Android, `DID_ENTER_BACKGROUND` is the save point (TERMINATING is not guaranteed).
+
+### Graphics: GLES 3.0 first, SDL3 GPU second
+
+- **Primary backend**: `KeenEyes.Graphics.Gles` on `Silk.NET.OpenGLES` — system GLES/EGL on Android (~100% device reach), **ANGLE-on-Metal on iOS** (the shipped app is a Metal app; Apple's GLES deprecation is irrelevant). The KESL compiler gains a **GLSL ES 300 emitter** (dialect variant of the existing GLSL generator). This is a port of the GL 3.3 renderer, not a rewrite.
+- **Strategic second backend**: **SDL3 GPU** (first-class Metal on iOS, Vulkan on Android), gated on a KESL **SPIR-V emitter** (offline pipeline: KESL → SPIR-V → SDL_shadercross → MSL/DXIL). Adopted when GLES 3.0's feature ceiling binds or the ANGLE-on-iOS path fails verification; iOS retires GLES first.
+- **Go/no-go verification item**: an `ios-arm64` static ANGLE build (check `Silk.NET.OpenGLES.ANGLE.Native` RID coverage; fall back to building ANGLE).
+
+### Audio: miniaudio on mobile
+
+A new `KeenEyes.Audio.MiniAudio` backend wraps vanilla miniaudio via a small **engine-owned `[LibraryImport]`/`[UnmanagedCallersOnly]` binding** (no third-party wrapper dependency). Public domain license (static-link freely on iOS), native AAudio on Android, CoreAudio on iOS, built-in WAV/FLAC/MP3/OGG decode and streaming; its source/listener spatial model maps ~1:1 onto the OpenAL-shaped abstraction. Desktop stays on OpenAL Soft for now; converging desktop onto miniaudio (one backend, no LGPL anywhere) is a candidate follow-up once the mobile backend is proven.
+
+### Packaging
+
+- **iOS:** `net10.0-ios` + `PublishAot=true`, statically linked natives (SDL3, ANGLE, miniaudio), standard Xcode signing.
+- **Android:** `net10.0-android` + MonoAOT now (store-ready; zero-reflection code runs identically on Mono), flipping to `PublishAot` on the same TFM when it exits experimental; `linux-bionic-arm64` + custom Gradle packaging is the escape hatch.
+
+### Sequencing
+
+1. `KeenEyes.Platform.Sdl3` + loop inversion (desktop-testable).
+2. Touch/lifecycle/IME abstraction additions.
+3. GLES backend + KESL GLSL ES emitter; verify iOS ANGLE early.
+4. miniaudio backend + native build recipes (iOS static `.a`, Android per-ABI `.so`).
+5. Packaging proof with a sample on both platforms.
+6. Later: KESL SPIR-V emitter → SDL3 GPU backend; re-evaluate desktop audio convergence; track Android Native AOT and Silk.NET 3.0.
+
+## Consequences
+
+### Positive
+
+- Mobile arrives without touching shipped desktop code paths — every piece is a new backend behind an existing seam, validating the ADR-005 abstraction investment.
+- The zero-reflection/AOT discipline (ADR-004) pays off directly: every chosen dependency is pure P/Invoke and the iOS Native AOT pipeline needs no engine changes.
+- SDL3 alignment matches where the C# ecosystem converged (FNA, osu!framework, Silk.NET 3.0's own direction), so the backend stays forward-compatible with future stacks.
+- The GLES-first path defers the SPIR-V toolchain; shipping mobile does not block on new shader infrastructure.
+- Tick-based loop inversion also benefits the editor and headless/CI hosting (an externally driven frame step is broadly useful).
+
+### Negative
+
+- Three new native artifacts to build and ship per mobile ABI (SDL3, ANGLE on iOS, miniaudio) — a cross-compile/CI pipeline the repo does not have today.
+- GLES 3.0 caps the mobile renderer below desktop GL 3.3 in places (no geometry shaders, UBO alignment care) until the SDL3 GPU backend lands; SDL_GPU on Android then imposes a Vulkan device floor (~85%, rising).
+- Two audio backends (OpenAL desktop, miniaudio mobile) until/unless desktop converges; miniaudio lacks OpenAL Soft's HRTF/EFX (currently unexposed by the engine).
+- Android runs MonoAOT interim — two runtime configurations to support until workload Native AOT stabilizes.
+- The engine owns gesture recognition and virtual-gamepad UI; SDL3 provides only raw fingers.
+- Betting against Silk.NET 3.0's windowing means a possible future migration if it ships and wins — mitigated by it also being SDL3-based.
+
+## Alternatives Considered
+
+- **Silk.NET 2.x SDL mobile windowing** — exists (2.22+ `SilkMobile.RunApp`) but SDL2-based, with a known-unfixed iOS blocking-run-loop defect (deferred to 3.0), no touch modeling, and near-zero shipping record. Prototype-grade only.
+- **Wait for Silk.NET 3.0** — unbounded timeline (preview feed only as of July 2026); its windowing is itself SDL3-backed, so building on SDL3 now shares the concepts anyway.
+- **Vulkan + MoltenVK as the primary graphics backend** — the "correct" explicit API, but a full renderer rewrite (memory, sync, pipelines) with per-device Android driver quirks; SDL3 GPU reaches the same native APIs (Metal/Vulkan) for a fraction of the effort.
+- **WebGPU native (wgpu/Dawn)** — healthy upstream but chronic `webgpu.h` churn (Silk.NET.WebGPU pinned to an older header) and a thin C#-on-mobile production record. Revisit ~2027.
+- **bgfx** — capable native library, but C# bindings are stale/unpackaged and its mandatory bgfx-dialect shader compiler fights KESL.
+- **Veldrid (ppy or other forks)** — proves the architecture (osu! ships on both stores) but the original is abandoned and each fork serves one project; KeenEyes already owns an equivalent abstraction layer.
+- **OpenAL Soft on mobile** — viable technically (Oboe/CoreAudio backends), but requires building all mobile natives in-house (upstream C# native package is desktop-only) plus LGPL compliance via embedded dynamic frameworks on iOS. Chosen only if HRTF/EFX or backend uniformity outweighs that cost.
+- **FAudio** — superbly maintained and AOT-proven, but XAudio2-shaped (impedance mismatch with the OpenAL-style abstraction), no OGG/MP3 decode, Android not a first-class target.
+- **SDL3_mixer** — coherent with an SDL3 stack but only stable since March 2026 with a less proven spatial model; re-evaluate after SDL3 adoption.
+- **SoLoud** — dormant since mid-2024.
+
+---
+
+## Changelog
+
+- **v1 — 2026-07-27 (#1344–#1350):** Proposed — SDL3 platform container, GLES 3.0-first graphics (ANGLE-on-Metal on iOS) with SDL3 GPU as the strategic successor, miniaudio mobile audio, and `net10.0-ios PublishAot` / `net10.0-android` packaging, based on the July 2026 mobile platform research.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -43,3 +43,4 @@ If a code change invalidates something an ADR says, amend the ADR in the same PR
 | [ADR-013](013-dynamic-plugin-loading.md) | Dynamic Plugin Loading | Accepted | Partial |
 | [ADR-014](014-replay-playback-runtime-editor-integration.md) | Replay Playback Runtime and Editor Integration | Amended | Partial |
 | [ADR-015](015-component-schema-migrations.md) | Component Schema Migrations | Accepted | Partial |
+| [ADR-016](016-mobile-platform-support.md) | Mobile Platform Support (iOS & Android) | Proposed | Not started |

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -47,6 +47,7 @@ Research reports document:
 | [Shader Management](shader-management.md) | Research Complete | Shader compilation and management |
 | [Shader Language (KESL)](shader-language.md) | Research Complete | Custom shader language design |
 | [Windowing & Input](windowing-input.md) | Research Complete | Window management and input handling |
+| [Mobile Platform Support](mobile-platform-support.md) | Research Complete | iOS/Android graphics, audio, input, and packaging under Native AOT |
 
 ## Contributing
 

--- a/docs/research/mobile-platform-support.md
+++ b/docs/research/mobile-platform-support.md
@@ -1,0 +1,151 @@
+# Mobile Platform Support (iOS & Android) - Research Report
+
+**Date:** July 2026
+**Purpose:** Evaluate graphics, audio, windowing/input, and packaging options for shipping KeenEyes games on iOS and Android under Native AOT
+
+## Executive Summary
+
+KeenEyes can reach iOS and Android without abandoning its current architecture. All three subsystems sit behind engine-owned abstractions (`KeenEyes.Graphics.Abstractions`, `KeenEyes.Audio.Abstractions`, `KeenEyes.Input.Abstractions`), so mobile support means **adding backends, not migrating**. The recommended stack:
+
+| Layer | Recommendation | Why |
+|-------|---------------|-----|
+| **App container / windowing / input** | **SDL3** (vendored AOT-safe P/Invoke bindings) | Only 2026-production-grade mobile container reachable from C# with zero reflection; first-class lifecycle, touch, IME, sensors, haptics. Both Silk.NET 3.0 and FNA converged on it. |
+| **Graphics** | **OpenGL ES 3.0** via `Silk.NET.OpenGLES` — system GLES on Android, **ANGLE-on-Metal** on iOS; **SDL3 GPU** as the strategic second backend | Smallest delta from the existing GL 3.3 renderer; ANGLE removes Apple's GLES-deprecation risk entirely; SDL_GPU is the modern successor path (FNA3D committed to it). |
+| **Audio** | **miniaudio** via a small engine-owned `[LibraryImport]` binding | Public domain (kills the OpenAL Soft LGPL problem on iOS), native AAudio on Android, built-in decode/streaming, ~1:1 mapping onto our OpenAL-shaped abstraction. |
+| **Packaging** | iOS: `net10.0-ios` + `PublishAot`. Android: `net10.0-android` + MonoAOT now, flip to Native AOT when it exits experimental; `linux-bionic-arm64` as escape hatch | iOS Native AOT is officially supported and proven (FNA ships this way). Android workload Native AOT is still experimental in .NET 10. |
+
+Key negative findings: **GLFW will never support mobile** (a second windowing backend is mandatory), **Silk.NET 3.0 has not shipped** (preview feed only — do not plan around it), and **`Silk.NET.OpenAL.Soft.Native` ships no mobile binaries** (verified by unpacking the package), so the current audio path does not carry over.
+
+---
+
+## Constraints
+
+- .NET 10, C# 13, zero reflection. Native AOT is **mandatory** on iOS (Apple forbids JIT) and strongly preferred on Android.
+- All native bindings must be AOT/trim-safe (`DllImport`/`[LibraryImport]` P/Invoke).
+- Current desktop stack: Silk.NET 2.23 — GLFW windowing, `Silk.NET.Input`, OpenGL 3.3 core, OpenAL Soft.
+- KESL shader compiler (`editor/KeenEyes.Shaders.Compiler`) emits GLSL (`#version 450`) and HLSL behind an `IShaderGenerator` seam — new shader targets are contained changes.
+- The input abstraction models keyboard/mouse/gamepad only; touch is not yet modeled.
+- The game loop is engine-owned; mobile lifecycle (suspend/resume, surface loss) must integrate with it.
+
+## Platform Ground Truths (2026)
+
+- **Apple:** OpenGL ES is deprecated since iOS 12 but still present and still App Store-accepted; frozen at ES 3.0, could be removed in any future release. Metal is the only first-class API. Building the iOS GLES backend on **ANGLE's Metal backend** (upstream since 2021; the older MetalANGLE fork is retired in its favor) removes the deprecation risk entirely — the shipped app is a Metal app.
+- **Google:** Vulkan was declared **the official Android graphics API** in 2025. GLES remains supported but feature-frozen; Android 15+ bundles **ANGLE-on-Vulkan** as the long-term GLES compatibility layer. ~85% of active devices support Vulkan; all 64-bit devices on Android 10+ have Vulkan 1.1.
+- **GLFW is desktop-only, permanently** (FAQ lists Windows/macOS/X11/Wayland; mobile has never been on the roadmap).
+- **SDL3 is stable and mature** (3.2.0 stable Jan 2025; 3.4.x through mid-2026), with iOS and Android as first-class platforms. SDL2 is in maintenance mode behind sdl2-compat.
+- **Silk.NET 3.0 has not shipped** (milestone ~49% complete, experimental builds on the GitHub feed only, no date; its windowing is itself moving to SDL3). Silk.NET 2.x remains maintained (2.23, Jan 2026) and is trim/AOT-compatible since 2.18.
+- **.NET mobile packaging:** `net10.0-ios` + `PublishAot` is officially documented and supported. `net10.0-android` + `PublishAot` is **experimental** in .NET 10 (big startup wins measured, but no built-in Java interop and active publish bugs). `linux-bionic-arm64` Native AOT with custom Gradle packaging is proven (Android-NativeAOT demo: 4.3 MB APK, ~120 ms startup) but you own the entire packaging/JNI story.
+
+---
+
+## Graphics
+
+### Comparison
+
+| Candidate | iOS | Android | C# bindings / AOT | Shader input | Effort from GL 3.3 | Verdict |
+|---|---|---|---|---|---|---|
+| **GLES 3.0 (system / ANGLE)** | ANGLE-on-Metal: store-safe, no deprecation risk | Fully supported (~100% devices); ANGLE-on-Vulkan is Android's own future | `Silk.NET.OpenGLES` 2.23 — pure P/Invoke, AOT-safe, near-identical to current `Silk.NET.OpenGL` | GLSL ES 300 | **Lowest** (port, not rewrite) | **Primary** |
+| **SDL3 GPU** | First-class Metal, no translation layer | Vulkan only (~85% devices, rising; feature-toggle props widen coverage) | SDL3-CS variants — raw P/Invoke, AOT-safe | SPIR-V / MSL / DXIL via SDL_shadercross | Medium | **Strategic second backend** |
+| Vulkan + MoltenVK | MoltenVK 1.4 "nearly conformant"; framework packaging solved | Native 1.1+ | `Silk.NET.Vulkan`, AOT-safe | SPIR-V | **Highest** (full explicit-API renderer) | Not now — SDL_GPU gives the same targets for far less |
+| WebGPU (wgpu/Dawn) | Metal backend works | Vulkan backend, Android artifacts published | `Silk.NET.WebGPU` pinned to an older `webgpu.h`; header churn is chronic | WGSL / SPIR-V | High | Revisit 2027 |
+| bgfx | Metal, iOS 16+ | GLES/Vulkan | C# bindings stale/unpackaged — we'd own them | **Own shaderc dialect** — fights KESL | Medium-high | Rejected |
+| Veldrid | ppy fork ships osu! on iOS | ppy fork: GLES/Vulkan | Original abandoned (2023); forks serve one project each | SPIR-V | Medium | Rejected (stewardship); useful as reference code |
+
+### Recommendation
+
+**Primary: a GLES 3.0 backend on `Silk.NET.OpenGLES`** — system GLES/EGL on Android, ANGLE-on-Metal on iOS.
+
+- Smallest delta from the existing GL 3.3 renderer: GLES 3.0 ≈ GL 3.3 core minus a few features (no geometry shaders, UBO alignment care, multisample-texture nuances).
+- KESL needs only a **GLSL ES 300 emitter** (`#version 300 es`, precision qualifiers, in/out renames) — a dialect tweak on the existing `GlslGenerator`, no SPIR-V toolchain required to ship.
+- Reaches ~100% of Android devices (no Vulkan floor); Google itself blessed the ANGLE architecture by bundling it in Android 15+.
+- **Open verification item:** confirm an `ios-arm64` static ANGLE build. `Silk.NET.OpenGLES.ANGLE.Native` (2025.9.12) exists but its RID list must be checked; fall back to building ANGLE ourselves or nutiteq-style prebuilts.
+
+**Strategic second backend: SDL3 GPU.** First-class Metal on iOS with zero translation layers, Vulkan on Android, superbly maintained, and FNA3D has committed to it as its sole future graphics path — the strongest endorsement available from the most AOT-disciplined C# game stack. Shader pipeline: KESL → GLSL → glslang → SPIR-V → SDL_shadercross → MSL/DXIL, all offline at build time. Since SDL3 is already the recommended windowing layer, this backend adds no new runtime native dependency.
+
+Proof-of-path evidence: MonoGame and KNI ship GLES on both stores today; osu! ships on iOS/Android via ppy.Veldrid (Metal + GLES/Vulkan); FNA ships iOS under Native AOT.
+
+## Audio
+
+### Comparison
+
+| | OpenAL Soft (current) | **miniaudio** | FAudio | SDL3_mixer | SoLoud |
+|---|---|---|---|---|---|
+| Maintenance | Active (1.25.2) | Active (0.11.25, Mar 2026) | Very active (monthly) | Active, young (first stable Mar 2026) | **Dormant since Aug 2024** |
+| License | **LGPL-2.0+** | **Public domain / MIT-0** | zlib | zlib | zlib |
+| iOS story | Static link legally gray; clean path = embedded dynamic framework + custom AOT publish plumbing | **Static link freely, zero obligations** | Clean, FNA-proven under AOT | Clean | — |
+| Android backend | Oboe/OpenSL — build your own `.so` | **Native AAudio** + OpenSL fallback | Via SDL3 audio | Via SDL3 audio | OpenSL (old) |
+| Mobile natives in C# pkg | **None** (`Silk.NET.OpenAL.Soft.Native` = desktop RIDs only, verified) | Build-your-own (tiny) or MiniAudioEx | FNA tooling | SDL3-CS ecosystem | None |
+| Spatial audio | Full OpenAL (+HRTF, EFX) | ≈ OpenAL parity (cones, doppler, attenuation; no HRTF/EFX) | X3DAudio calculator model | Positional (new, less proven) | — |
+| Decode/streaming | None (BYO — status quo) | **WAV/FLAC/MP3/OGG built-in + streaming** | PCM/ADPCM/WMA only | OGG/MP3/WAV/FLAC | — |
+| Migration effort | Zero abstraction change, heavy packaging/licensing cost | Low-moderate (near-1:1 concept map) | Moderate-high (XAudio2 shape) | Moderate; couples to SDL3 | n/a |
+
+### Recommendation
+
+**Switch mobile to miniaudio; keep OpenAL Soft on desktop initially.** The license alone decides iOS (static link with zero obligations vs the LGPL framework-embedding dance), and miniaudio's native AAudio backend is the best Android latency path of any candidate. Its `ma_engine`/`ma_sound` model (source, listener, cones, doppler, attenuation) maps nearly 1:1 onto the current OpenAL-shaped `KeenEyes.Audio.Abstractions` — exactly the swap the abstraction exists for.
+
+Prefer an **engine-owned thin `[LibraryImport]` + `[UnmanagedCallersOnly]` binding over vanilla miniaudio** rather than depending on MiniAudioEx (active but single-maintainer, wraps a fork, no formal releases) — the needed surface (engine init, load/play/stream, 3D params, groups) is small. Use MiniAudioEx's repo as a reference for iOS/Android build recipes. On iOS: static `.a` + `DirectPInvoke`; on Android: per-ABI `.so`.
+
+**Follow-up worth considering:** once the miniaudio backend is proven, converge desktop onto it too — one backend everywhere, no LGPL anywhere, built-in decoders replace managed ones. The loss would be OpenAL Soft's HRTF/EFX, which KeenEyes doesn't currently expose. **SDL3_mixer** is the re-evaluation candidate if we want maximal stack coherence after SDL3 adoption, but at ~4 months post-1.0 it's too young to displace miniaudio.
+
+## Windowing, Input, and App Lifecycle
+
+### Recommendation: SDL3 direct
+
+Build a new **`KeenEyes.Platform.Sdl3`** backend on SDL3 with vendored, auto-generated pure-P/Invoke bindings (flibitijibibo/SDL3-CS consumed as source, or ppy.SDL3-CS from NuGet — battle-tested in osu!framework's shipping iOS/Android packages). GLFW remains the desktop backend short-term.
+
+Why not the alternatives:
+
+- **Silk.NET 2.x SDL mobile:** exists (2.22 added iOS support via `SilkMobile.RunApp`) but is SDL2-based, has a known-unfixed iOS run-loop defect (blocking `Run()` instead of the animation callback — fix deferred to 3.0), models no touch devices, and has near-zero real-world shipping record. Prototype-grade only.
+- **Silk.NET 3.0:** preview-only builds on a GitHub feed; timeline unbounded. Its windowing is itself SDL3-backed, so a KeenEyes SDL3 backend built now shares concepts with any eventual migration.
+- **SDL2/FNA-legacy stack:** superseded; FNA itself defaulted to SDL3.
+
+What SDL3 provides that the engine needs:
+
+- **Lifecycle:** `SDL_EVENT_WILL/DID_ENTER_BACKGROUND/FOREGROUND`, `SDL_EVENT_TERMINATING`, `SDL_EVENT_LOW_MEMORY`. (Caveat: Android task-kill may skip TERMINATING — treat `DID_ENTER_BACKGROUND` as the save point.)
+- **Touch:** finger down/motion/up/**canceled** events with device ID, finger ID, normalized coords, deltas, pressure. Touch-synthesized mouse events are tagged (`SDL_TOUCH_MOUSEID`) and filterable. Gesture recognition is **not** in SDL3 core — the engine owns tap/long-press/pinch/pan and virtual-gamepad overlays.
+- **Text input:** IME sessions (`SDL_StartTextInput`, composition events, on-screen keyboard management), plus sensors, haptics, pen.
+- **Main callbacks** (`SDL_AppInit`/`SDL_AppIterate`/`SDL_AppEvent`/`SDL_AppQuit`): exist precisely because iOS/Android forbid an app-owned blocking loop.
+
+### Required engine changes (independent of library choice)
+
+1. **Game loop inversion of control** — the single largest engineering item. Mobile requires the OS to drive frames: the engine loop must support a per-frame `Tick(dt)` mode mapped onto SDL3 main callbacks. Desktop keeps the blocking loop.
+2. **Touch input model** in `KeenEyes.Input.Abstractions`: `TouchDevice` with per-finger `TouchPoint { DeviceId, FingerId, NormalizedX/Y, DeltaX/Y, Pressure, Phase }` including a **Canceled** phase (OS-stolen touches); a policy suppressing touch→mouse double-delivery; engine-side gesture recognizers.
+3. **Text-input session API** (begin/end IME, composition, keyboard-occlusion rect) — mobile keyboards are request-driven.
+4. **Lifecycle surface** to the engine: background/foreground, GL surface lost/recreated (Android context loss), low-memory.
+5. **Known .NET seam:** naive `SDL_Init` from P/Invoke fails on mobile ("did you include SDL_main.h") — solved by exporting an entry point via `[UnmanagedCallersOnly]` or `SDL_RunApp`; a one-time integration cost with osu!framework and FNA as working references.
+
+## Packaging Pipelines
+
+**iOS (one real path):** `net10.0-ios` + `PublishAot=true` (use `dotnet publish`), statically linked SDL3/ANGLE/miniaudio (`NativeReference` / `-force_load`), standard Xcode signing. FNA ships App Store titles this way; documented limitations are no on-device managed debugging and no DXT textures.
+
+**Android (sequenced):**
+1. **Now:** `net10.0-android` + MonoAOT — mature, store-ready, standard AAB flow, `SDLActivity` Java glue (osu!framework's approach). Acceptable interim: the zero-reflection codebase runs identically on Mono.
+2. **When stable:** flip to `PublishAot` on the same TFM (experimental in .NET 10; measured startup ~1.3 s → ~300 ms).
+3. **Escape hatch:** `linux-bionic-arm64` Native AOT + custom Gradle packaging with embedded `SDLActivity` glue — full control, zero Mono, but we own Gradle/signing/ABI splits/JNI for platform services.
+
+## Proposed Roadmap
+
+1. **`KeenEyes.Platform.Sdl3`** — SDL3 windowing/lifecycle backend + game-loop `Tick(dt)` inversion (desktop-testable: SDL3 runs everywhere, which also derisks it before any mobile toolchain work).
+2. **Touch + lifecycle + IME additions** to `KeenEyes.Input.Abstractions` and the platform abstraction.
+3. **`KeenEyes.Graphics.Gles`** backend (`Silk.NET.OpenGLES`) + KESL GLSL ES 300 emitter. Verify the `ios-arm64` ANGLE static build early (go/no-go for the iOS graphics plan).
+4. **`KeenEyes.Audio.MiniAudio`** backend with engine-owned bindings + native build recipes (iOS static lib, Android per-ABI `.so`).
+5. **Packaging proof:** NOVAFALL (or a smaller sample) on `net10.0-ios PublishAot` and `net10.0-android` MonoAOT.
+6. **Later:** KESL SPIR-V emitter (independent work item) → **SDL3 GPU backend**, retiring GLES on iOS first; re-evaluate desktop audio convergence on miniaudio; watch Android workload Native AOT and Silk.NET 3.0.
+
+## Rejected Options (summary)
+
+- **Vulkan + MoltenVK now:** correct long-term API, worst effort/reward for a GL 3.3-shaped engine; SDL_GPU reaches the same native APIs for far less.
+- **WebGPU native:** healthy upstream but `webgpu.h` churn and thin mobile production record in C#; revisit 2027.
+- **bgfx:** stale/unpackaged C# bindings and a proprietary shader dialect that fights the KESL compiler.
+- **Veldrid:** original abandoned; maintained forks each serve one project. KeenEyes already owns its abstraction layer — adopting someone else's adds stewardship risk without capability.
+- **SoLoud:** dormant since mid-2024.
+- **FAudio:** superbly maintained but XAudio2-shaped (fights the OpenAL-style abstraction), no OGG/MP3 decode, Android not first-class.
+- **Keeping OpenAL Soft on mobile:** viable but inherits a cross-compile CI pipeline (no upstream mobile artifacts in the Silk native package) plus the iOS LGPL framework-embedding dance.
+
+## Key Sources
+
+Graphics: [Android: Vulkan official](https://developer.android.com/games/develop/vulkan/overview) · [LunarG: Vulkan on Apple, Jan 2026](https://www.lunarg.com/the-state-of-vulkan-on-apple-jan-2026/) · [ANGLE Metal backend](https://groups.google.com/g/angleproject/c/DkD0rdMQCbM) · [Silk.NET.OpenGLES.ANGLE.Native](https://www.nuget.org/packages/Silk.NET.OpenGLES.ANGLE.Native) · [SDL3 GPU](https://wiki.libsdl.org/SDL3/CategoryGPU) · [SDL_shadercross](https://github.com/libsdl-org/SDL_shadercross) · [FNA3D → SDL_GPU commitment](https://github.com/FNA-XNA/FNA3D/issues/230) · [Silk.NET 3.0 milestone](https://github.com/dotnet/Silk.NET/milestone/9) · [Apple GLES store acceptance](https://developer.apple.com/forums/thread/735391)
+
+Audio: [openal-soft](https://github.com/kcat/openal-soft) · [Silk.NET.OpenAL.Soft.Native (desktop RIDs only)](https://www.nuget.org/packages/Silk.NET.OpenAL.Soft.Native/) · [miniaudio](https://miniaud.io/) · [miniaudio spatialization](https://github.com/mackron/miniaudio/discussions/523) · [MiniAudioExNET](https://github.com/japajoe/MiniAudioExNET) · [FAudio](https://github.com/FNA-XNA/FAudio) · [SDL_mixer](https://github.com/libsdl-org/SDL_mixer) · [LGPL static-linking discussion](https://developer.apple.com/forums/thread/702873)
+
+Platform: [GLFW FAQ (desktop-only)](https://www.glfw.org/faq) · [SDL3 README-android](https://wiki.libsdl.org/SDL3/README-android) / [README-ios](https://wiki.libsdl.org/SDL3/README-ios) / [README-touch](https://wiki.libsdl.org/SDL3/README-touch) · [SDL #13201 (C# SDL_main)](https://github.com/libsdl-org/SDL/issues/13201) · [flibitijibibo/SDL3-CS](https://github.com/flibitijibibo/SDL3-CS) · [ppy.SDL3-CS](https://www.nuget.org/packages/ppy.SDL3-CS/) · [FNA on Apple platforms](https://fna-xna.github.io/docs/appendix/Appendix-C:-FNA-on-Apple-Platforms/) · [Native AOT for iOS-like platforms](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/ios-like-platforms/) · [Android Native AOT status](https://github.com/dotnet/runtime/issues/106748) · [Android-NativeAOT demo](https://github.com/jonathanpeppers/Android-NativeAOT)

--- a/docs/research/toc.yml
+++ b/docs/research/toc.yml
@@ -40,6 +40,8 @@
       href: shader-language.md
     - name: Windowing & Input
       href: windowing-input.md
+    - name: Mobile Platform Support
+      href: mobile-platform-support.md
 - name: Architecture Research
   items:
     - name: Scene Editor Architecture

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -207,6 +207,8 @@
       href: adr/014-replay-playback-runtime-editor-integration.md
     - name: ADR-015 Component Schema Migrations
       href: adr/015-component-schema-migrations.md
+    - name: ADR-016 Mobile Platform Support
+      href: adr/016-mobile-platform-support.md
 - name: Performance
   items:
     - name: AOT vs JIT Benchmarks


### PR DESCRIPTION
## Summary
- Adds `docs/research/mobile-platform-support.md`: evaluation of graphics (GLES/ANGLE, SDL3 GPU, Vulkan+MoltenVK, WebGPU, bgfx, Veldrid), audio (miniaudio, OpenAL Soft, FAudio, SDL3_mixer, SoLoud), and platform/input (SDL3, Silk.NET 2.x/3.0) options for iOS and Android under the engine's Native AOT / zero-reflection constraints.
- Adds ADR-016 (Proposed): SDL3 platform container with a per-frame `Tick` loop mode, GLES 3.0-first graphics (system GLES on Android, ANGLE-on-Metal on iOS) with SDL3 GPU as the strategic successor, miniaudio mobile audio via engine-owned bindings, and `net10.0-ios PublishAot` / `net10.0-android` packaging.
- Wires both docs into `docs/toc.yml`, the ADR index, and the research index.

## Test plan
- [x] Docs-only change; `dotnet format` pre-commit and `dotnet build` pre-push hooks passed
- [x] ADR follows the living-ADR template (header, frozen/living sections, changelog v1 == Revision)
- [x] Index/toc entries mirror the ADR's Status/Implementation

## Related Issues
Tracking issues for the phased work: #1344, #1345, #1346, #1347, #1348, #1349, #1350 (intentionally left open — they track implementation, not this doc).