### PR TITLE
fix(graphics): Register render-target textures in the TextureManager ID space

### DIFF
--- a/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
+++ b/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
@@ -338,8 +338,14 @@ internal sealed class TextureManager : IDisposable
     /// <param name="gpuHandle">The GPU texture handle.</param>
     /// <param name="width">The texture width.</param>
     /// <param name="height">The texture height.</param>
+    /// <param name="ownsGpuTexture">
+    /// When true (default), the manager deletes the GPU texture when the entry is deleted
+    /// or the manager is disposed. Pass false when another owner (e.g. the render-target
+    /// manager) controls the GPU texture's lifetime; the entry then only provides handle
+    /// resolution and its removal never touches the GPU object.
+    /// </param>
     /// <returns>The texture resource handle.</returns>
-    public int RegisterExternalTexture(uint gpuHandle, int width, int height)
+    public int RegisterExternalTexture(uint gpuHandle, int width, int height, bool ownsGpuTexture = true)
     {
         var textureData = new TextureData
         {
@@ -347,12 +353,33 @@ internal sealed class TextureManager : IDisposable
             Width = width,
             Height = height,
             HasAlpha = true,
-            DeleteAction = DeleteTextureData
+            DeleteAction = ownsGpuTexture ? DeleteTextureData : null
         };
 
         int id = nextTextureId++;
         textures[id] = textureData;
         return id;
+    }
+
+    /// <summary>
+    /// Takes GPU ownership of a previously registered non-owning external texture.
+    /// </summary>
+    /// <remarks>
+    /// Used when the original owner relinquishes the GPU texture (e.g.
+    /// <c>DeleteRenderTargetKeepTexture</c> keeps the color texture alive); from then on
+    /// the manager deletes it like any other texture.
+    /// </remarks>
+    /// <param name="textureId">The texture resource handle.</param>
+    /// <returns>True when the entry exists and ownership was taken.</returns>
+    public bool AdoptExternalTexture(int textureId)
+    {
+        if (textures.TryGetValue(textureId, out var data))
+        {
+            data.DeleteAction = DeleteTextureData;
+            return true;
+        }
+
+        return false;
     }
 
     private void DeleteTextureData(TextureData data)

--- a/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
@@ -59,6 +59,10 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     private readonly ISilkWindowProvider windowProvider;
     private readonly MeshManager meshManager = new();
     private readonly TextureManager textureManager = new();
+
+    // Texture-manager handles minted for render-target attachments, keyed by
+    // (render target id, is-depth). See GetRenderTargetTexture (#1279).
+    private readonly Dictionary<(int TargetId, bool Depth), TextureHandle> renderTargetTextures = [];
     private readonly ShaderManager shaderManager = new();
     private readonly InstanceBufferManager instanceBufferManager = new();
 
@@ -198,6 +202,7 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
     internal MeshManager MeshManager => meshManager;
     internal TextureManager TextureManager => textureManager;
+    internal RenderTargetManager? RenderTargets => renderTargetManager;
     internal ShaderManager ShaderManager => shaderManager;
 
     /// <inheritdoc />
@@ -873,36 +878,78 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
     /// <inheritdoc />
     public TextureHandle GetRenderTargetColorTexture(RenderTargetHandle target)
-    {
-        if (renderTargetManager is null)
-        {
-            return TextureHandle.Invalid;
-        }
-
-        var textureId = renderTargetManager.GetColorTextureId(target);
-        if (textureId == 0)
-        {
-            return TextureHandle.Invalid;
-        }
-
-        return new TextureHandle((int)textureId, target.Width, target.Height);
-    }
+        => GetRenderTargetTexture(target, depth: false);
 
     /// <inheritdoc />
     public TextureHandle GetRenderTargetDepthTexture(RenderTargetHandle target)
+        => GetRenderTargetTexture(target, depth: true);
+
+    /// <summary>
+    /// Resolves a render-target attachment to a handle in the texture manager's ID space.
+    /// </summary>
+    /// <remarks>
+    /// Render-target textures are created by the render-target manager with raw GL ids,
+    /// but consumers bind the returned handle through <see cref="BindTexture"/>, which
+    /// resolves ids in the texture manager's separate space (#1279). The GL id is
+    /// therefore registered (non-owning — the render-target manager keeps GPU ownership)
+    /// and the resulting handle cached so per-frame lookups stay allocation-free.
+    /// </remarks>
+    private TextureHandle GetRenderTargetTexture(RenderTargetHandle target, bool depth)
     {
         if (renderTargetManager is null)
         {
             return TextureHandle.Invalid;
         }
 
-        var textureId = renderTargetManager.GetDepthTextureId(target);
+        var textureId = depth
+            ? renderTargetManager.GetDepthTextureId(target)
+            : renderTargetManager.GetColorTextureId(target);
         if (textureId == 0)
         {
             return TextureHandle.Invalid;
         }
 
-        return new TextureHandle((int)textureId, target.Width, target.Height);
+        var key = (target.Id, depth);
+        if (renderTargetTextures.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var handleId = textureManager.RegisterExternalTexture(
+            textureId, target.Width, target.Height, ownsGpuTexture: false);
+        var handle = new TextureHandle(handleId, target.Width, target.Height);
+        renderTargetTextures[key] = handle;
+        return handle;
+    }
+
+    /// <summary>
+    /// Drops the texture-manager registrations for a render target's attachments.
+    /// </summary>
+    /// <param name="target">The render target being deleted.</param>
+    /// <param name="adoptColorTexture">
+    /// When true, the color attachment's registration survives and the texture manager
+    /// takes GPU ownership of it (the keep-texture delete flow); otherwise both
+    /// registrations are removed (never GPU-deleting — the render-target manager owns
+    /// the GL objects while the target exists).
+    /// </param>
+    private void ReleaseRenderTargetTextures(RenderTargetHandle target, bool adoptColorTexture)
+    {
+        if (renderTargetTextures.Remove((target.Id, false), out var color))
+        {
+            if (adoptColorTexture)
+            {
+                textureManager.AdoptExternalTexture(color.Id);
+            }
+            else
+            {
+                textureManager.DeleteTexture(color.Id);
+            }
+        }
+
+        if (renderTargetTextures.Remove((target.Id, true), out var depthHandle))
+        {
+            textureManager.DeleteTexture(depthHandle.Id);
+        }
     }
 
     /// <inheritdoc />
@@ -925,12 +972,16 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     /// <inheritdoc />
     public void DeleteRenderTarget(RenderTargetHandle target)
     {
+        ReleaseRenderTargetTextures(target, adoptColorTexture: false);
         renderTargetManager?.DeleteRenderTarget(target);
     }
 
     /// <inheritdoc />
     public void DeleteRenderTargetKeepTexture(RenderTargetHandle target)
     {
+        // The color texture outlives the target: its registration stays and the texture
+        // manager takes over GPU ownership so a later DeleteTexture/Dispose cleans it up.
+        ReleaseRenderTargetTextures(target, adoptColorTexture: true);
         renderTargetManager?.DeleteRenderTargetKeepTexture(target);
     }
 

--- a/tests/KeenEyes.Graphics.Tests/RenderTargetTextureIdSpaceTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/RenderTargetTextureIdSpaceTests.cs
@@ -1,0 +1,167 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Regression tests for #1279: render-target attachment handles must live in the
+/// texture manager's ID space so <see cref="IGraphicsContext.BindTexture"/> binds the
+/// actual attachment. Before the fix they carried raw GL ids, so binding resolved to
+/// whatever unrelated texture occupied that manager slot (or nothing).
+/// </summary>
+public class RenderTargetTextureIdSpaceTests
+{
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device) CreateLoadedGraphics()
+    {
+        var world = new World();
+        world.SetExtension<ISilkWindowProvider>(new MockSilkWindowProvider());
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        var context = world.GetExtension<SilkGraphicsContext>();
+        var device = new MockGraphicsDevice();
+        context.InitializeResources(device);
+
+        return (world, context, device);
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_HandleResolvesToAttachmentGlTexture()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(64, 64, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+
+            Assert.True(handle.IsValid);
+
+            // The handle must resolve in the texture manager's ID space...
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+
+            // ...to exactly the GL texture the render target manager attached.
+            var glId = context.RenderTargets!.GetColorTextureId(target);
+            Assert.Equal(glId, data.Handle);
+
+            // And BindTexture must bind that GL texture (the observable symptom before
+            // the fix: no bind, or a bind of an unrelated texture).
+            device.Calls.Clear();
+            context.BindTexture(handle, unit: 3);
+            Assert.Contains($"BindTexture(Texture2D, {glId})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetDepthTexture_HandleResolvesToAttachmentGlTexture()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(32, 32, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetDepthTexture(target);
+
+            Assert.True(handle.IsValid);
+
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+            Assert.Equal(context.RenderTargets!.GetDepthTextureId(target), data.Handle);
+
+            device.Calls.Clear();
+            context.BindTexture(handle, unit: 0);
+            Assert.Contains($"BindTexture(Texture2D, {data.Handle})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_CalledRepeatedly_ReturnsSameHandle()
+    {
+        var (world, context, _) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+
+            var first = context.GetRenderTargetColorTexture(target);
+            var second = context.GetRenderTargetColorTexture(target);
+
+            // Per-frame lookups must not mint a new registration each call.
+            Assert.Equal(first.Id, second.Id);
+        }
+    }
+
+    [Fact]
+    public void DeleteRenderTarget_ReleasesRegistration_AndDeletesGlTextureExactlyOnce()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+            var glId = context.TextureManager.GetTexture(handle.Id)!.Handle;
+
+            context.DeleteRenderTarget(target);
+
+            // Registration gone; the render target manager deleted the GL texture once
+            // (a double delete would corrupt an unrelated texture reusing the id).
+            Assert.Null(context.TextureManager.GetTexture(handle.Id));
+            Assert.Equal(1, device.Calls.Count(c => c == $"DeleteTexture({glId})"));
+
+            // Manager teardown must not delete it a second time.
+            device.Calls.Clear();
+            world.UninstallPlugin<SilkGraphicsPlugin>();
+            Assert.DoesNotContain($"DeleteTexture({glId})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void DeleteRenderTargetKeepTexture_ColorHandleSurvives_AndManagerTakesOwnership()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+            var glId = context.TextureManager.GetTexture(handle.Id)!.Handle;
+
+            context.DeleteRenderTargetKeepTexture(target);
+
+            // The kept color texture still resolves and binds (the IBL BRDF-LUT flow).
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+            Assert.Equal(glId, data.Handle);
+            Assert.DoesNotContain($"DeleteTexture({glId})", device.Calls);
+
+            // Ownership transferred: deleting the handle now deletes the GL texture.
+            context.DeleteTexture(handle);
+            Assert.Equal(1, device.Calls.Count(c => c == $"DeleteTexture({glId})"));
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_DoesNotAliasUnrelatedManagerTextures()
+    {
+        var (world, context, _) = CreateLoadedGraphics();
+        using (world)
+        {
+            // Populate the texture manager so low-numbered manager ids are taken; raw GL
+            // ids from the render target would collide with them before the fix.
+            byte[] pixel = [255, 0, 0, 255];
+            var unrelated = new List<TextureHandle>();
+            for (var i = 0; i < 8; i++)
+            {
+                unrelated.Add(context.CreateTexture(1, 1, pixel));
+            }
+
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+
+            // The render-target handle must not equal any unrelated texture's handle,
+            // and must resolve to the attachment rather than one of them.
+            Assert.DoesNotContain(handle.Id, unrelated.Select(u => u.Id));
+            Assert.Equal(
+                context.RenderTargets!.GetColorTextureId(target),
+                context.TextureManager.GetTexture(handle.Id)!.Handle);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug (confirmed critical, 2026-07-25 audit):** `GetRenderTargetColorTexture`/`GetRenderTargetDepthTexture` wrapped **raw OpenGL texture ids** in `TextureHandle`s, but consumers bind those handles via `BindTexture`, which resolves ids in the `TextureManager`'s **separate ID space** — so sampling a render target bound whatever unrelated texture occupied that manager slot, or silently nothing. This broke every render-to-texture consumer: shadow-map binding in `RenderSystem`, the IBL BRDF LUT, visualization, post-processing.
- **Fix:** the getters now register the attachment's GL id through the existing `RegisterExternalTexture` path — extended with an `ownsGpuTexture: false` mode since the render-target manager keeps GPU ownership — and cache the handle per `(target, attachment)`, so per-frame lookups return a stable handle with no registration growth.
- **Lifetime correctness:** `DeleteRenderTarget` releases the registration without a second GPU delete (double-delete would corrupt an unrelated texture reusing the id); `DeleteRenderTargetKeepTexture` transfers GPU ownership to the `TextureManager` via a new `AdoptExternalTexture`, so the kept color texture (the IBL BRDF-LUT flow in `IblManager`) keeps resolving and is cleaned up by a later `DeleteTexture`/disposal.
- Cubemap render targets deliberately keep their existing raw-GL-id convention — it is internally consistent (`BindCubemapTexture`/`DeleteCubemapTexture` consume raw ids); unifying that convention is out of scope here.

## Test plan
- [x] 6 new tests in `RenderTargetTextureIdSpaceTests` using the headless `MockGraphicsDevice` harness: handle resolution to the exact attached GL texture (color + depth), observable `BindTexture(Texture2D, <gl id>)` on the device, handle stability across repeated lookups, no aliasing against pre-existing manager textures, delete-exactly-once on `DeleteRenderTarget` (including no second delete at plugin teardown), and keep-texture ownership transfer
- [x] 5 of 6 fail on the unfixed code (verified by reverting the fix; the survivor is the idempotency test, which raw ids also satisfy)
- [x] Full suite: 14,838 passed / 0 failed / 60 skipped; zero warnings; `dotnet format` clean

## Related Issues
Fixes #1279

This is a prerequisite for #1280 (shadow pipeline) — shadow-map sampling goes through these getters.
