### PR TITLE
fix(graphics): Make the shadow pipeline work end-to-end within GL 3.3 limits

### DIFF
--- a/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
+++ b/src/KeenEyes.Graphics.Silk/RenderTargetManager.cs
@@ -454,11 +454,10 @@ internal sealed class RenderTargetManager(IGraphicsDevice device) : IDisposable
         device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapS, (int)TextureWrapMode.ClampToEdge);
         device.TexParameter(TextureTarget.Texture2D, TextureParam.WrapT, (int)TextureWrapMode.ClampToEdge);
 
-        // For shadow mapping: enable depth comparison
-        // GL_TEXTURE_COMPARE_MODE = 0x884C, GL_COMPARE_REF_TO_TEXTURE = 0x884E
-        device.TexParameter(TextureTarget.Texture2D, TextureParam.CompareMode, 0x884E);
-        // GL_TEXTURE_COMPARE_FUNC with GL_LEQUAL = 0x0203
-        device.TexParameter(TextureTarget.Texture2D, TextureParam.CompareFunc, 0x0203);
+        // No GL_TEXTURE_COMPARE_MODE here: the shadow shaders sample these textures
+        // through plain sampler2D and compare depths manually. Combining
+        // COMPARE_REF_TO_TEXTURE with a non-shadow sampler yields undefined results
+        // per the GL spec (#1280); hardware PCF would require sampler2DShadow.
 
         return texture;
     }

--- a/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
+++ b/src/KeenEyes.Graphics.Silk/Resources/TextureData.cs
@@ -338,8 +338,14 @@ internal sealed class TextureManager : IDisposable
     /// <param name="gpuHandle">The GPU texture handle.</param>
     /// <param name="width">The texture width.</param>
     /// <param name="height">The texture height.</param>
+    /// <param name="ownsGpuTexture">
+    /// When true (default), the manager deletes the GPU texture when the entry is deleted
+    /// or the manager is disposed. Pass false when another owner (e.g. the render-target
+    /// manager) controls the GPU texture's lifetime; the entry then only provides handle
+    /// resolution and its removal never touches the GPU object.
+    /// </param>
     /// <returns>The texture resource handle.</returns>
-    public int RegisterExternalTexture(uint gpuHandle, int width, int height)
+    public int RegisterExternalTexture(uint gpuHandle, int width, int height, bool ownsGpuTexture = true)
     {
         var textureData = new TextureData
         {
@@ -347,12 +353,33 @@ internal sealed class TextureManager : IDisposable
             Width = width,
             Height = height,
             HasAlpha = true,
-            DeleteAction = DeleteTextureData
+            DeleteAction = ownsGpuTexture ? DeleteTextureData : null
         };
 
         int id = nextTextureId++;
         textures[id] = textureData;
         return id;
+    }
+
+    /// <summary>
+    /// Takes GPU ownership of a previously registered non-owning external texture.
+    /// </summary>
+    /// <remarks>
+    /// Used when the original owner relinquishes the GPU texture (e.g.
+    /// <c>DeleteRenderTargetKeepTexture</c> keeps the color texture alive); from then on
+    /// the manager deletes it like any other texture.
+    /// </remarks>
+    /// <param name="textureId">The texture resource handle.</param>
+    /// <returns>True when the entry exists and ownership was taken.</returns>
+    public bool AdoptExternalTexture(int textureId)
+    {
+        if (textures.TryGetValue(textureId, out var data))
+        {
+            data.DeleteAction = DeleteTextureData;
+            return true;
+        }
+
+        return false;
     }
 
     private void DeleteTextureData(TextureData data)

--- a/src/KeenEyes.Graphics.Silk/Shaders/PbrShadowShaders.cs
+++ b/src/KeenEyes.Graphics.Silk/Shaders/PbrShadowShaders.cs
@@ -102,24 +102,18 @@ internal static class PbrShadowShaders
         // Spot light shadow maps
         uniform sampler2D uSpotShadowMap0;
         uniform sampler2D uSpotShadowMap1;
-        uniform sampler2D uSpotShadowMap2;
-        uniform sampler2D uSpotShadowMap3;
         uniform mat4 uSpotLightSpaceMatrix0;
         uniform mat4 uSpotLightSpaceMatrix1;
-        uniform mat4 uSpotLightSpaceMatrix2;
-        uniform mat4 uSpotLightSpaceMatrix3;
         uniform int uSpotShadowCount;
-        uniform int uSpotShadowLightIndices[4];
+        uniform int uSpotShadowLightIndices[2];
 
         // Point light shadow maps (cubemaps)
         uniform samplerCube uPointShadowMap0;
         uniform samplerCube uPointShadowMap1;
-        uniform samplerCube uPointShadowMap2;
-        uniform samplerCube uPointShadowMap3;
-        uniform vec3 uPointLightPositions[4];
-        uniform float uPointLightFarPlanes[4];
+        uniform vec3 uPointLightPositions[2];
+        uniform float uPointLightFarPlanes[2];
         uniform int uPointShadowCount;
-        uniform int uPointShadowLightIndices[4];
+        uniform int uPointShadowLightIndices[2];
 
         // Material factors
         uniform vec4 uBaseColorFactor;
@@ -320,33 +314,27 @@ internal static class PbrShadowShaders
         mat4 getSpotLightSpaceMatrix(int shadowIndex)
         {
             if (shadowIndex == 0) return uSpotLightSpaceMatrix0;
-            if (shadowIndex == 1) return uSpotLightSpaceMatrix1;
-            if (shadowIndex == 2) return uSpotLightSpaceMatrix2;
-            return uSpotLightSpaceMatrix3;
+            return uSpotLightSpaceMatrix1;
         }
 
         // Sample spot shadow map by index
         float sampleSpotShadowMap(int shadowIndex, vec2 coords)
         {
             if (shadowIndex == 0) return texture(uSpotShadowMap0, coords).r;
-            if (shadowIndex == 1) return texture(uSpotShadowMap1, coords).r;
-            if (shadowIndex == 2) return texture(uSpotShadowMap2, coords).r;
-            return texture(uSpotShadowMap3, coords).r;
+            return texture(uSpotShadowMap1, coords).r;
         }
 
         // Get spot shadow map texel size by index
         vec2 getSpotShadowMapTexelSize(int shadowIndex)
         {
             if (shadowIndex == 0) return 1.0 / textureSize(uSpotShadowMap0, 0);
-            if (shadowIndex == 1) return 1.0 / textureSize(uSpotShadowMap1, 0);
-            if (shadowIndex == 2) return 1.0 / textureSize(uSpotShadowMap2, 0);
-            return 1.0 / textureSize(uSpotShadowMap3, 0);
+            return 1.0 / textureSize(uSpotShadowMap1, 0);
         }
 
         // Find the shadow map index for a given light index
         int findSpotShadowIndex(int lightIndex)
         {
-            for (int s = 0; s < uSpotShadowCount && s < 4; ++s)
+            for (int s = 0; s < uSpotShadowCount && s < 2; ++s)
             {
                 if (uSpotShadowLightIndices[s] == lightIndex) return s;
             }
@@ -405,15 +393,13 @@ internal static class PbrShadowShaders
         float samplePointShadowMap(int shadowIndex, vec3 direction)
         {
             if (shadowIndex == 0) return texture(uPointShadowMap0, direction).r;
-            if (shadowIndex == 1) return texture(uPointShadowMap1, direction).r;
-            if (shadowIndex == 2) return texture(uPointShadowMap2, direction).r;
-            return texture(uPointShadowMap3, direction).r;
+            return texture(uPointShadowMap1, direction).r;
         }
 
         // Find the shadow map index for a given point light index
         int findPointShadowIndex(int lightIndex)
         {
-            for (int s = 0; s < uPointShadowCount && s < 4; ++s)
+            for (int s = 0; s < uPointShadowCount && s < 2; ++s)
             {
                 if (uPointShadowLightIndices[s] == lightIndex) return s;
             }

--- a/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
+++ b/src/KeenEyes.Graphics.Silk/SilkGraphicsContext.cs
@@ -59,6 +59,10 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     private readonly ISilkWindowProvider windowProvider;
     private readonly MeshManager meshManager = new();
     private readonly TextureManager textureManager = new();
+
+    // Texture-manager handles minted for render-target attachments, keyed by
+    // (render target id, is-depth). See GetRenderTargetTexture (#1279).
+    private readonly Dictionary<(int TargetId, bool Depth), TextureHandle> renderTargetTextures = [];
     private readonly ShaderManager shaderManager = new();
     private readonly InstanceBufferManager instanceBufferManager = new();
 
@@ -198,6 +202,7 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
     internal MeshManager MeshManager => meshManager;
     internal TextureManager TextureManager => textureManager;
+    internal RenderTargetManager? RenderTargets => renderTargetManager;
     internal ShaderManager ShaderManager => shaderManager;
 
     /// <inheritdoc />
@@ -873,36 +878,78 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
 
     /// <inheritdoc />
     public TextureHandle GetRenderTargetColorTexture(RenderTargetHandle target)
-    {
-        if (renderTargetManager is null)
-        {
-            return TextureHandle.Invalid;
-        }
-
-        var textureId = renderTargetManager.GetColorTextureId(target);
-        if (textureId == 0)
-        {
-            return TextureHandle.Invalid;
-        }
-
-        return new TextureHandle((int)textureId, target.Width, target.Height);
-    }
+        => GetRenderTargetTexture(target, depth: false);
 
     /// <inheritdoc />
     public TextureHandle GetRenderTargetDepthTexture(RenderTargetHandle target)
+        => GetRenderTargetTexture(target, depth: true);
+
+    /// <summary>
+    /// Resolves a render-target attachment to a handle in the texture manager's ID space.
+    /// </summary>
+    /// <remarks>
+    /// Render-target textures are created by the render-target manager with raw GL ids,
+    /// but consumers bind the returned handle through <see cref="BindTexture"/>, which
+    /// resolves ids in the texture manager's separate space (#1279). The GL id is
+    /// therefore registered (non-owning — the render-target manager keeps GPU ownership)
+    /// and the resulting handle cached so per-frame lookups stay allocation-free.
+    /// </remarks>
+    private TextureHandle GetRenderTargetTexture(RenderTargetHandle target, bool depth)
     {
         if (renderTargetManager is null)
         {
             return TextureHandle.Invalid;
         }
 
-        var textureId = renderTargetManager.GetDepthTextureId(target);
+        var textureId = depth
+            ? renderTargetManager.GetDepthTextureId(target)
+            : renderTargetManager.GetColorTextureId(target);
         if (textureId == 0)
         {
             return TextureHandle.Invalid;
         }
 
-        return new TextureHandle((int)textureId, target.Width, target.Height);
+        var key = (target.Id, depth);
+        if (renderTargetTextures.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var handleId = textureManager.RegisterExternalTexture(
+            textureId, target.Width, target.Height, ownsGpuTexture: false);
+        var handle = new TextureHandle(handleId, target.Width, target.Height);
+        renderTargetTextures[key] = handle;
+        return handle;
+    }
+
+    /// <summary>
+    /// Drops the texture-manager registrations for a render target's attachments.
+    /// </summary>
+    /// <param name="target">The render target being deleted.</param>
+    /// <param name="adoptColorTexture">
+    /// When true, the color attachment's registration survives and the texture manager
+    /// takes GPU ownership of it (the keep-texture delete flow); otherwise both
+    /// registrations are removed (never GPU-deleting — the render-target manager owns
+    /// the GL objects while the target exists).
+    /// </param>
+    private void ReleaseRenderTargetTextures(RenderTargetHandle target, bool adoptColorTexture)
+    {
+        if (renderTargetTextures.Remove((target.Id, false), out var color))
+        {
+            if (adoptColorTexture)
+            {
+                textureManager.AdoptExternalTexture(color.Id);
+            }
+            else
+            {
+                textureManager.DeleteTexture(color.Id);
+            }
+        }
+
+        if (renderTargetTextures.Remove((target.Id, true), out var depthHandle))
+        {
+            textureManager.DeleteTexture(depthHandle.Id);
+        }
     }
 
     /// <inheritdoc />
@@ -925,12 +972,16 @@ public sealed class SilkGraphicsContext : IGraphicsContext, I2DRendererProvider,
     /// <inheritdoc />
     public void DeleteRenderTarget(RenderTargetHandle target)
     {
+        ReleaseRenderTargetTextures(target, adoptColorTexture: false);
         renderTargetManager?.DeleteRenderTarget(target);
     }
 
     /// <inheritdoc />
     public void DeleteRenderTargetKeepTexture(RenderTargetHandle target)
     {
+        // The color texture outlives the target: its registration stays and the texture
+        // manager takes over GPU ownership so a later DeleteTexture/Dispose cleans it up.
+        ReleaseRenderTargetTextures(target, adoptColorTexture: true);
         renderTargetManager?.DeleteRenderTargetKeepTexture(target);
     }
 

--- a/src/KeenEyes.Graphics/Shadows/ShadowRenderingSystem.cs
+++ b/src/KeenEyes.Graphics/Shadows/ShadowRenderingSystem.cs
@@ -24,6 +24,7 @@ public sealed class ShadowRenderingSystem : ISystem
     private IGraphicsContext? graphics;
     private ShadowMapManager? shadowManager;
     private ShaderHandle depthShader;
+    private ShaderHandle pointDepthShader;
     private bool shadersCreated;
     private bool disposed;
 
@@ -179,6 +180,49 @@ public sealed class ShadowRenderingSystem : ISystem
             """;
 
         depthShader = graphics!.CreateShader(depthVertexSource, depthFragmentSource);
+
+        // Point-light pass: the sampled cubemap is the COLOR attachment of the cubemap
+        // render target (depth goes to a discarded renderbuffer), so the fragment shader
+        // must write the normalized light distance as color — a depth-only shader leaves
+        // the sampled faces unwritten and point shadows never appear (#1280).
+        const string pointVertexSource = """
+            #version 330 core
+
+            layout (location = 0) in vec3 aPosition;
+
+            uniform mat4 uModel;
+            uniform mat4 uLightSpaceMatrix;
+
+            out vec3 vWorldPos;
+
+            void main()
+            {
+                vec4 worldPos = uModel * vec4(aPosition, 1.0);
+                vWorldPos = worldPos.xyz;
+                gl_Position = uLightSpaceMatrix * worldPos;
+            }
+            """;
+
+        const string pointFragmentSource = """
+            #version 330 core
+
+            in vec3 vWorldPos;
+
+            uniform vec3 uLightPos;
+            uniform float uFarPlane;
+
+            out vec4 FragColor;
+
+            void main()
+            {
+                // Linear distance normalized to [0, 1]; the PBR shader reconstructs it
+                // by multiplying with the light's far plane.
+                float lightDistance = length(vWorldPos - uLightPos) / uFarPlane;
+                FragColor = vec4(lightDistance, 0.0, 0.0, 1.0);
+            }
+            """;
+
+        pointDepthShader = graphics.CreateShader(pointVertexSource, pointFragmentSource);
     }
 
     private void CollectShadowCasters()
@@ -342,12 +386,17 @@ public sealed class ShadowRenderingSystem : ISystem
         var data = shadowData.Value;
         int resolution = data.RenderTarget.Size;
 
-        // Bind depth shader
-        graphics!.BindShader(depthShader);
+        // Bind the distance-writing point shadow shader
+        graphics!.BindShader(pointDepthShader);
+        graphics.SetUniform("uLightPos", lightPosition);
+        graphics.SetUniform("uFarPlane", range);
 
         // Configure render state
         graphics.SetDepthTest(true);
         graphics.SetCulling(true, CullFaceMode.Front); // Render back faces to reduce peter-panning
+
+        // Faces clear to 1.0 = max distance = fully lit where nothing is rendered.
+        graphics.SetClearColor(new Vector4(1f, 1f, 1f, 1f));
 
         // Render each cubemap face
         CubemapFace[] faces =
@@ -365,7 +414,7 @@ public sealed class ShadowRenderingSystem : ISystem
             // Bind the cubemap face as render target
             graphics.BindCubemapRenderTarget(data.RenderTarget, faces[faceIndex]);
             graphics.SetViewport(0, 0, resolution, resolution);
-            graphics.Clear(ClearMask.DepthBuffer);
+            graphics.Clear(ClearMask.ColorBuffer | ClearMask.DepthBuffer);
 
             // Get the light-space matrix for this face
             var lightSpaceMatrix = CascadeUtils.GetPointLightShadowMatrix(lightPosition, range, faceIndex);
@@ -400,6 +449,7 @@ public sealed class ShadowRenderingSystem : ISystem
         if (shadersCreated && graphics is not null)
         {
             graphics.DeleteShader(depthShader);
+            graphics.DeleteShader(pointDepthShader);
         }
 
         shadowManager?.Dispose();

--- a/src/KeenEyes.Graphics/Systems/RenderSystem.cs
+++ b/src/KeenEyes.Graphics/Systems/RenderSystem.cs
@@ -27,15 +27,19 @@ namespace KeenEyes.Graphics;
 public sealed class RenderSystem : ISystem
 {
     private const int MaxLights = 8;
-    private const int MaxCascades = 4;
-    private const int MaxSpotShadows = 4;
-    private const int MaxPointShadows = 4;
-    private const int ShadowMapBaseTextureUnit = 8;
+    internal const int MaxCascades = 4;
+    // Spot and point shadow capacity is bounded by texture units: OpenGL 3.3 only
+    // guarantees 16 fragment texture units, and material (0-4), IBL (5-7), and the four
+    // CSM cascades (8-11) already occupy twelve. Two point cubemaps (12-13) and two spot
+    // maps (14-15) fill the guaranteed range exactly (#1280).
+    internal const int MaxSpotShadows = 2;
+    internal const int MaxPointShadows = 2;
+    internal const int ShadowMapBaseTextureUnit = 8;
     private const int IblIrradianceTextureUnit = 5;
     private const int IblSpecularTextureUnit = 6;
     private const int IblBrdfLutTextureUnit = 7;
-    private const int PointShadowMapBaseTextureUnit = 12;
-    private const int SpotShadowMapBaseTextureUnit = 16;
+    internal const int PointShadowMapBaseTextureUnit = 12;
+    internal const int SpotShadowMapBaseTextureUnit = 14;
 
     private IWorld? world;
     private IGraphicsContext? graphics;
@@ -577,7 +581,7 @@ public sealed class RenderSystem : ISystem
 
         graphics!.SetUniform("uSpotShadowCount", spotShadowCount);
 
-        // Bind spot shadow map textures to slots 16-19
+        // Bind spot shadow map textures to slots 14-15
         for (int i = 0; i < MaxSpotShadows; i++)
         {
             int textureUnit = SpotShadowMapBaseTextureUnit + i;
@@ -630,7 +634,7 @@ public sealed class RenderSystem : ISystem
 
         graphics!.SetUniform("uPointShadowCount", pointShadowCount);
 
-        // Bind point shadow map cubemap textures to slots 12-15
+        // Bind point shadow map cubemap textures to slots 12-13
         for (int i = 0; i < MaxPointShadows; i++)
         {
             int textureUnit = PointShadowMapBaseTextureUnit + i;
@@ -644,7 +648,11 @@ public sealed class RenderSystem : ISystem
                 {
                     var data = pointShadowData.Value;
                     var shadowMapTexture = graphics.GetCubemapRenderTargetTexture(data.RenderTarget);
-                    graphics.BindTexture(shadowMapTexture, textureUnit);
+
+                    // Cubemap handles carry raw GL ids and must go through the cubemap
+                    // binding path; BindTexture would resolve them in the TextureManager
+                    // ID space and bind the wrong texture (#1280).
+                    graphics.BindCubemapTexture(shadowMapTexture, textureUnit);
                     graphics.SetUniform($"uPointShadowMap{i}", textureUnit);
                     graphics.SetUniform($"uPointLightPositions[{i}]", data.LightPosition);
                     graphics.SetUniform($"uPointLightFarPlanes[{i}]", data.FarPlane);
@@ -652,8 +660,10 @@ public sealed class RenderSystem : ISystem
                 }
                 else
                 {
-                    // Shadow data not available yet, bind fallback
-                    graphics.BindTexture(graphics.WhiteTexture, textureUnit);
+                    // Shadow data not available yet. Units 12-13 are reserved for point
+                    // cubemaps; the shader never samples slots at or beyond
+                    // uPointShadowCount, so an unbound unit is safe and binding the 2D
+                    // white texture here would be a sampler-type mismatch.
                     graphics.SetUniform($"uPointShadowMap{i}", textureUnit);
                     graphics.SetUniform($"uPointLightPositions[{i}]", Vector3.Zero);
                     graphics.SetUniform($"uPointLightFarPlanes[{i}]", 1f);
@@ -662,8 +672,7 @@ public sealed class RenderSystem : ISystem
             }
             else
             {
-                // Bind white texture as fallback for unused slots
-                graphics.BindTexture(graphics.WhiteTexture, textureUnit);
+                // Unused slot: see comment above — never sampled, keep the unit unbound.
                 graphics.SetUniform($"uPointShadowMap{i}", textureUnit);
                 graphics.SetUniform($"uPointLightPositions[{i}]", Vector3.Zero);
                 graphics.SetUniform($"uPointLightFarPlanes[{i}]", 1f);

--- a/tests/KeenEyes.Graphics.Tests/RenderTargetTextureIdSpaceTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/RenderTargetTextureIdSpaceTests.cs
@@ -1,0 +1,167 @@
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Regression tests for #1279: render-target attachment handles must live in the
+/// texture manager's ID space so <see cref="IGraphicsContext.BindTexture"/> binds the
+/// actual attachment. Before the fix they carried raw GL ids, so binding resolved to
+/// whatever unrelated texture occupied that manager slot (or nothing).
+/// </summary>
+public class RenderTargetTextureIdSpaceTests
+{
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device) CreateLoadedGraphics()
+    {
+        var world = new World();
+        world.SetExtension<ISilkWindowProvider>(new MockSilkWindowProvider());
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        var context = world.GetExtension<SilkGraphicsContext>();
+        var device = new MockGraphicsDevice();
+        context.InitializeResources(device);
+
+        return (world, context, device);
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_HandleResolvesToAttachmentGlTexture()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(64, 64, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+
+            Assert.True(handle.IsValid);
+
+            // The handle must resolve in the texture manager's ID space...
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+
+            // ...to exactly the GL texture the render target manager attached.
+            var glId = context.RenderTargets!.GetColorTextureId(target);
+            Assert.Equal(glId, data.Handle);
+
+            // And BindTexture must bind that GL texture (the observable symptom before
+            // the fix: no bind, or a bind of an unrelated texture).
+            device.Calls.Clear();
+            context.BindTexture(handle, unit: 3);
+            Assert.Contains($"BindTexture(Texture2D, {glId})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetDepthTexture_HandleResolvesToAttachmentGlTexture()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(32, 32, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetDepthTexture(target);
+
+            Assert.True(handle.IsValid);
+
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+            Assert.Equal(context.RenderTargets!.GetDepthTextureId(target), data.Handle);
+
+            device.Calls.Clear();
+            context.BindTexture(handle, unit: 0);
+            Assert.Contains($"BindTexture(Texture2D, {data.Handle})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_CalledRepeatedly_ReturnsSameHandle()
+    {
+        var (world, context, _) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+
+            var first = context.GetRenderTargetColorTexture(target);
+            var second = context.GetRenderTargetColorTexture(target);
+
+            // Per-frame lookups must not mint a new registration each call.
+            Assert.Equal(first.Id, second.Id);
+        }
+    }
+
+    [Fact]
+    public void DeleteRenderTarget_ReleasesRegistration_AndDeletesGlTextureExactlyOnce()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+            var glId = context.TextureManager.GetTexture(handle.Id)!.Handle;
+
+            context.DeleteRenderTarget(target);
+
+            // Registration gone; the render target manager deleted the GL texture once
+            // (a double delete would corrupt an unrelated texture reusing the id).
+            Assert.Null(context.TextureManager.GetTexture(handle.Id));
+            Assert.Equal(1, device.Calls.Count(c => c == $"DeleteTexture({glId})"));
+
+            // Manager teardown must not delete it a second time.
+            device.Calls.Clear();
+            world.UninstallPlugin<SilkGraphicsPlugin>();
+            Assert.DoesNotContain($"DeleteTexture({glId})", device.Calls);
+        }
+    }
+
+    [Fact]
+    public void DeleteRenderTargetKeepTexture_ColorHandleSurvives_AndManagerTakesOwnership()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+            var glId = context.TextureManager.GetTexture(handle.Id)!.Handle;
+
+            context.DeleteRenderTargetKeepTexture(target);
+
+            // The kept color texture still resolves and binds (the IBL BRDF-LUT flow).
+            var data = context.TextureManager.GetTexture(handle.Id);
+            Assert.NotNull(data);
+            Assert.Equal(glId, data.Handle);
+            Assert.DoesNotContain($"DeleteTexture({glId})", device.Calls);
+
+            // Ownership transferred: deleting the handle now deletes the GL texture.
+            context.DeleteTexture(handle);
+            Assert.Equal(1, device.Calls.Count(c => c == $"DeleteTexture({glId})"));
+        }
+    }
+
+    [Fact]
+    public void GetRenderTargetColorTexture_DoesNotAliasUnrelatedManagerTextures()
+    {
+        var (world, context, _) = CreateLoadedGraphics();
+        using (world)
+        {
+            // Populate the texture manager so low-numbered manager ids are taken; raw GL
+            // ids from the render target would collide with them before the fix.
+            byte[] pixel = [255, 0, 0, 255];
+            var unrelated = new List<TextureHandle>();
+            for (var i = 0; i < 8; i++)
+            {
+                unrelated.Add(context.CreateTexture(1, 1, pixel));
+            }
+
+            var target = context.CreateRenderTarget(16, 16, RenderTargetFormat.RGBA8Depth24);
+            var handle = context.GetRenderTargetColorTexture(target);
+
+            // The render-target handle must not equal any unrelated texture's handle,
+            // and must resolve to the attachment rather than one of them.
+            Assert.DoesNotContain(handle.Id, unrelated.Select(u => u.Id));
+            Assert.Equal(
+                context.RenderTargets!.GetColorTextureId(target),
+                context.TextureManager.GetTexture(handle.Id)!.Handle);
+        }
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/ShadowPipelineTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/ShadowPipelineTests.cs
@@ -1,0 +1,152 @@
+using System.Numerics;
+using KeenEyes.Common;
+using KeenEyes.Graphics.Abstractions;
+using KeenEyes.Graphics.Shadows;
+using KeenEyes.Graphics.Silk;
+using KeenEyes.Graphics.Tests.Mocks;
+using KeenEyes.Platform.Silk;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Regression tests for #1280: the shadow pipeline shipped with three defects that made
+/// it unusable end-to-end — spot shadows bound texture units 16-19 that
+/// <c>OpenGLDevice.ToGL</c> cannot represent (and GL 3.3 does not guarantee), the
+/// point-light pass wrote only <c>gl_FragDepth</c> while the sampled cubemap is the
+/// color attachment, and depth textures enabled <c>COMPARE_REF_TO_TEXTURE</c> while the
+/// shaders sample them through plain <c>sampler2D</c> (undefined per the GL spec).
+/// </summary>
+public class ShadowPipelineTests
+{
+    private static (World World, SilkGraphicsContext Context, MockGraphicsDevice Device) CreateLoadedGraphics()
+    {
+        var world = new World();
+        world.SetExtension<ISilkWindowProvider>(new MockSilkWindowProvider());
+        world.InstallPlugin(new SilkGraphicsPlugin());
+
+        var context = world.GetExtension<SilkGraphicsContext>();
+        var device = new MockGraphicsDevice();
+        context.InitializeResources(device);
+
+        return (world, context, device);
+    }
+
+    #region Texture unit budget
+
+    [Fact]
+    public void ShadowTextureUnits_StayWithinGl33GuaranteedRange()
+    {
+        // OpenGL 3.3 guarantees exactly 16 fragment texture units (0-15), and the
+        // engine's TextureUnit enum ends at Texture15. Every unit the render system
+        // assigns must stay inside that range — unit 16 threw in OpenGLDevice.ToGL.
+        Assert.InRange(
+            RenderSystem.ShadowMapBaseTextureUnit + RenderSystem.MaxCascades - 1, 0, 15);
+        Assert.InRange(
+            RenderSystem.PointShadowMapBaseTextureUnit + RenderSystem.MaxPointShadows - 1, 0, 15);
+        Assert.InRange(
+            RenderSystem.SpotShadowMapBaseTextureUnit + RenderSystem.MaxSpotShadows - 1, 0, 15);
+    }
+
+    [Fact]
+    public void ShadowTextureUnitRanges_DoNotOverlap()
+    {
+        var cascades = Enumerable.Range(RenderSystem.ShadowMapBaseTextureUnit, RenderSystem.MaxCascades);
+        var points = Enumerable.Range(RenderSystem.PointShadowMapBaseTextureUnit, RenderSystem.MaxPointShadows);
+        var spots = Enumerable.Range(RenderSystem.SpotShadowMapBaseTextureUnit, RenderSystem.MaxSpotShadows);
+
+        var all = cascades.Concat(points).Concat(spots).ToList();
+        Assert.Equal(all.Count, all.Distinct().Count());
+    }
+
+    #endregion
+
+    #region Depth-compare mode
+
+    [Fact]
+    public void CreateRenderTarget_DepthTexture_DoesNotEnableDepthCompare()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            device.Calls.Clear();
+            context.CreateRenderTarget(64, 64, RenderTargetFormat.Depth24);
+
+            // The shadow shaders compare depths manually through plain sampler2D;
+            // COMPARE_REF_TO_TEXTURE on such a texture is undefined per the GL spec.
+            Assert.DoesNotContain(device.Calls, c => c.Contains("CompareMode"));
+            Assert.DoesNotContain(device.Calls, c => c.Contains("CompareFunc"));
+        }
+    }
+
+    #endregion
+
+    #region Point shadow pass writes the sampled cubemap
+
+    private static void SpawnPointShadowScene(World world)
+    {
+        world.Spawn("Camera")
+            .With(new Camera { FieldOfView = 60f, NearPlane = 0.1f, FarPlane = 100f })
+            .With(new Transform3D { Position = new Vector3(0, 0, 5) })
+            .Build();
+
+        var light = Light.Point(Vector3.One, 1f, 25f);
+        light.CastShadows = true;
+        world.Spawn("PointLight")
+            .With(light)
+            .With(new Transform3D { Position = new Vector3(0, 3, 0) })
+            .Build();
+
+        world.Spawn("Caster")
+            .With(new Transform3D { Position = Vector3.Zero })
+            .With(new Renderable(meshId: 1, materialId: 1) { CastShadows = true })
+            .Build();
+    }
+
+    [Fact]
+    public void PointShadowPass_ClearsAndWritesColorFaces()
+    {
+        var (world, _, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            SpawnPointShadowScene(world);
+
+            var system = new ShadowRenderingSystem();
+            system.Initialize(world);
+            device.Calls.Clear();
+            system.Update(0.016f);
+            system.Dispose();
+
+            // Faces must clear to white (1.0 = max distance = lit) including the COLOR
+            // buffer; before the fix only the depth buffer was cleared and the sampled
+            // color faces stayed unwritten forever.
+            Assert.Contains("ClearColor(1, 1, 1, 1)", device.Calls);
+            var colorClears = device.Calls.Count(c =>
+                c.StartsWith("Clear(") && c.Contains("ColorBuffer") && c.Contains("DepthBuffer"));
+            Assert.True(colorClears >= 6, $"expected 6 face clears with color, saw {colorClears}");
+        }
+    }
+
+    [Fact]
+    public void PointShadowPass_UsesDistanceWritingShader()
+    {
+        var (world, context, device) = CreateLoadedGraphics();
+        using (world)
+        {
+            SpawnPointShadowScene(world);
+
+            var system = new ShadowRenderingSystem();
+            system.Initialize(world);
+            device.Calls.Clear();
+            system.Update(0.016f);
+
+            // The pass must parameterize the distance shader; a depth-only shader has
+            // neither uniform and leaves the cubemap unwritten.
+            Assert.Contains(device.Calls, c => c.StartsWith("GetUniformLocation(") && c.Contains("uLightPos"));
+            Assert.Contains(device.Calls, c => c.StartsWith("GetUniformLocation(") && c.Contains("uFarPlane"));
+
+            system.Dispose();
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
> **Stacked on #1361** (render-target ID-space fix) — shadow-map sampling flows through the getters fixed there, so this PR's base branch is `fix/render-target-texture-id-space`. Merge #1361 first; this diff then reduces to the shadow changes.

## Summary
Three confirmed defects (2026-07-25 audit, 2 verifiers each) meant shadows could not render end-to-end:

1. **Spot shadows crashed the render loop** — units 16–19 don't exist in the `TextureUnit` enum, so `OpenGLDevice.ToGL` threw whenever a spot light cast shadows. GL 3.3 also only *guarantees* 16 fragment texture units, and material (0–4) + IBL (5–7) + four CSM cascades (8–11) already occupy twelve — the old layout could never fit. Spot/point shadow capacity drops from 4 to 2 each: point cubemaps on units 12–13, spot maps on 14–15, filling the guaranteed range exactly. The PBR shadow shader's samplers, uniform arrays, and index helpers shrink to match.
2. **Point shadow maps were never written** — the pass used the depth-only shader (writes `gl_FragDepth` into a discarded renderbuffer) while the PBR shader samples linear distance from the cubemap's **color** faces. The pass now uses a dedicated shader outputting normalized light distance as color, and clears each face to white (max distance = lit) before rendering. Two adjacent latent bugs fixed in the same path: point cubemaps were bound via the 2D `BindTexture` (wrong ID space *and* wrong GL target) — now `BindCubemapTexture` — and inactive point slots no longer get a 2D white texture bound onto a `samplerCube` unit (they stay unbound; the shader never samples slots ≥ `uPointShadowCount`).
3. **Undefined depth sampling** — depth textures set `COMPARE_REF_TO_TEXTURE` while every shader samples them via plain `sampler2D` with manual comparison, which the GL spec leaves undefined. The compare parameters are removed (hardware PCF would need `sampler2DShadow`; the shaders' manual 3×3 PCF is kept).

Known limitation noted for follow-up: cubemap faces are RGBA8, so point-shadow distance has 8-bit precision — functional, but a float format would reduce acne at long ranges.

## Test plan
- [x] 5 new tests in `ShadowPipelineTests` (headless mock-device harness): all shadow unit ranges within 0–15, ranges disjoint, depth textures free of compare-mode parameters, point pass clears color+depth on all 6 faces to white, and point pass parameterizes the distance shader (`uLightPos`/`uFarPlane`)
- [x] 4 of 5 fail on the unfixed code (verified by revert; the survivor is the range-disjointness test, which the old layout also satisfied)
- [x] Full suite: 14,843 passed / 0 failed / 60 skipped; zero warnings; format clean

## Related Issues
Fixes #1280

Capacity note: engines needing >2 shadowed spot/point lights simultaneously will need per-light shadow atlasing or texture arrays — intentionally out of scope; the previous capacity of 4 never worked.
