### PR TITLE
docs(adr): Record macOS in ADR-016 as iOS build host and Metal beneficiary

### DIFF
--- a/docs/adr/016-mobile-platform-support.md
+++ b/docs/adr/016-mobile-platform-support.md
@@ -1,7 +1,7 @@
 # ADR-016: Mobile Platform Support (iOS & Android)
 
 **Status:** Proposed
-**Revision:** v1
+**Revision:** v2
 **Implementation:** Not started
 **First accepted:** — (proposed 2026-07-27)
 **Relates to:** [ADR-004](004-reflection-elimination.md) (AOT compatibility) · [ADR-005](005-graphics-input-abstraction-layers.md) (graphics/input abstraction layers) · [ADR-009](009-kesl-shader-language.md) (KESL) · [Mobile Platform Support research](../research/mobile-platform-support.md) · tracking [#1344](https://github.com/orion-ecs/keen-eye/issues/1344) [#1345](https://github.com/orion-ecs/keen-eye/issues/1345) [#1346](https://github.com/orion-ecs/keen-eye/issues/1346) [#1347](https://github.com/orion-ecs/keen-eye/issues/1347) [#1348](https://github.com/orion-ecs/keen-eye/issues/1348) [#1349](https://github.com/orion-ecs/keen-eye/issues/1349) [#1350](https://github.com/orion-ecs/keen-eye/issues/1350)
@@ -50,6 +50,29 @@ A new `KeenEyes.Audio.MiniAudio` backend wraps vanilla miniaudio via a small **e
 - **iOS:** `net10.0-ios` + `PublishAot=true`, statically linked natives (SDL3, ANGLE, miniaudio), standard Xcode signing.
 - **Android:** `net10.0-android` + MonoAOT now (store-ready; zero-reflection code runs identically on Mono), flipping to `PublishAot` on the same TFM when it exits experimental; `linux-bionic-arm64` + custom Gradle packaging is the escape hatch.
 
+### macOS: build host and beneficiary
+
+macOS appears in this plan in two distinct roles. Both are recorded here because neither is optional and neither was previously stated.
+
+**1. macOS is a hard prerequisite for the iOS phases.** `net10.0-ios` builds, `PublishAot` for iOS, and the simulator work in the ANGLE spike all require a Mac running Xcode — Apple's toolchain is not available on other hosts, and "standard Xcode signing" above presumes it. Concretely:
+
+- Phases 3 (iOS half) and 5 cannot be executed, and the #1346 go/no-go cannot be answered, without Mac hardware or a macOS CI runner.
+- The minimum macOS and Xcode versions are those the .NET 10 iOS workload requires; pin the exact pair in this ADR when the workload is first installed rather than guessing here.
+- CI has no macOS runner for iOS packaging today. The existing macOS jobs are the Native AOT publish in `aot-compatibility.yml` (`osx-arm64`) and the full test-suite run added by #1356 — neither installs the iOS workload. Phase 5 needs that gap closed or an explicit "local Mac only" decision.
+
+**2. macOS gains a Metal-backed renderer as a consequence of the iOS work.** Apple deprecated OpenGL; the desktop backend is GL 3.3 core, which macOS still honours only up to its 4.1 ceiling. `KeenEyes.Graphics.Gles` on ANGLE (phase 3) is Metal-backed, so it is also a macOS-viable renderer — the iOS investment hands desktop macOS a path off deprecated GL for free.
+
+*Open decision:* whether `Graphics.Gles` becomes the macOS **default** over GL 3.3, and when. The recommendation is to keep GL 3.3 as the macOS default until the GLES backend has shipped on mobile and reached visual parity, then re-evaluate — treating a macOS switch as its own migration with its own evidence, not as an implicit side effect of the iOS phases. This needs confirming before phase 3 concludes.
+
+**Distribution prerequisites (not required for local testing, blocking for shipping).** Signing a macOS build requires an Apple Developer account, and *notarization plus the hardened runtime are mandatory* for distribution — see [cross-platform deployment research](../research/cross-platform-deployment.md), which covers macOS RIDs (`osx-x64`, `osx-arm64`), per-platform Native AOT startup measurements, and the notarization requirement in detail. That report predates this ADR and remains the reference; it is not restated here.
+
+**Current macOS status (measured, 2026-07-28).** The desktop engine already substantially runs on Apple Silicon, which lowers the risk of both roles above:
+
+- 14,892 tests executed on `macos-latest`; 14,811 passed. All 21 failures shared one root cause — the Unix domain-socket path limit on pipe names (#1359).
+- macOS natives already ship in build output (`runtimes/osx-arm64`, `runtimes/osx-x64`: `libglfw.3.dylib`, `libopenal.dylib`).
+- The GL context request is already macOS-correct: `WindowOptions.Default` resolves to OpenGL / Core / ForwardCompatible / 3.3, which is what macOS requires above 2.1, and sits inside its 4.1 ceiling.
+- Two macOS-specific defects were found and fixed while establishing this: HiDPI viewport sizing (#1355) and the pipe path limit (#1359).
+
 ### Sequencing
 
 1. `KeenEyes.Platform.Sdl3` + loop inversion (desktop-testable).
@@ -68,6 +91,7 @@ A new `KeenEyes.Audio.MiniAudio` backend wraps vanilla miniaudio via a small **e
 - SDL3 alignment matches where the C# ecosystem converged (FNA, osu!framework, Silk.NET 3.0's own direction), so the backend stays forward-compatible with future stacks.
 - The GLES-first path defers the SPIR-V toolchain; shipping mobile does not block on new shader infrastructure.
 - Tick-based loop inversion also benefits the editor and headless/CI hosting (an externally driven frame step is broadly useful).
+- Desktop macOS gains a Metal-backed renderer for free via the iOS GLES/ANGLE work, giving the engine an exit from deprecated OpenGL on Apple hardware without a macOS-specific project.
 
 ### Negative
 
@@ -77,6 +101,7 @@ A new `KeenEyes.Audio.MiniAudio` backend wraps vanilla miniaudio via a small **e
 - Android runs MonoAOT interim — two runtime configurations to support until workload Native AOT stabilizes.
 - The engine owns gesture recognition and virtual-gamepad UI; SDL3 provides only raw fingers.
 - Betting against Silk.NET 3.0's windowing means a possible future migration if it ships and wins — mitigated by it also being SDL3-based.
+- The iOS phases are gated on Mac hardware or a macOS CI runner with the iOS workload, neither of which the project has today; that is a scheduling dependency, not just a tooling detail.
 
 ## Alternatives Considered
 
@@ -95,4 +120,5 @@ A new `KeenEyes.Audio.MiniAudio` backend wraps vanilla miniaudio via a small **e
 
 ## Changelog
 
+- **v2 — 2026-07-28 (#1354):** Added the macOS section covering both roles the plan depends on and neither of which was stated: macOS as the hard prerequisite for the iOS phases (Xcode requirement, version pinning deferred to workload install, no macOS CI runner for iOS packaging today), and macOS as beneficiary of the GLES/ANGLE work — recording as an open decision whether `Graphics.Gles` supersedes GL 3.3 as the macOS default, with a recommendation to defer until mobile parity is proven. Named notarization / hardened runtime / Apple Developer account as distribution prerequisites, referencing the existing cross-platform deployment research. Recorded measured macOS status (14,811 of 14,892 tests passing on Apple Silicon; natives and GL context request already correct; #1355 and #1359 fixed en route). Consequences updated for the free Metal path and the Mac-hardware scheduling dependency.
 - **v1 — 2026-07-27 (#1344–#1350):** Proposed — SDL3 platform container, GLES 3.0-first graphics (ANGLE-on-Metal on iOS) with SDL3 GPU as the strategic successor, miniaudio mobile audio, and `net10.0-ios PublishAot` / `net10.0-android` packaging, based on the July 2026 mobile platform research.


### PR DESCRIPTION
## Summary
Closes #1354. ADR-016 governs the mobile track but mentioned macOS only incidentally — "standard Xcode signing", an `ios-arm64` ANGLE RID, and GLFW's FAQ listing macOS as a desktop platform. Two roles the plan depends on went unstated.

### 1. macOS is a hard prerequisite for the iOS phases
`net10.0-ios`, iOS `PublishAot`, and the ANGLE simulator spike all require a Mac with Xcode — so **phases 3 (iOS half) and 5, and the #1346 go/no-go, are gated on hardware the project doesn't have**. CI has no macOS runner with the iOS workload; the two existing macOS jobs are the AOT publish in `aot-compatibility.yml` and the suite run from #1356.

Exact macOS/Xcode minimums are deliberately **left to be pinned when the workload is first installed** rather than invented here — a wrong version number in an ADR is worse than an explicit TODO.

### 2. macOS gains a Metal-backed renderer for free
Apple deprecated OpenGL and the desktop backend is GL 3.3 core. The Metal-backed `Graphics.Gles` work in phase 3 is therefore also a macOS-viable renderer.

Whether it becomes the macOS **default** is recorded as an **open decision**, not settled unilaterally. The recommendation is to defer until the GLES backend has shipped on mobile and reached visual parity — a macOS switch deserves its own migration and its own evidence rather than arriving as an implicit side effect of the iOS phases. Flagged as needing confirmation before phase 3 concludes.

### 3. Distribution prerequisites
Notarization, hardened runtime, and an Apple Developer account are named as shipping blockers (irrelevant for local testing), referencing the existing `cross-platform-deployment.md` research rather than restating it — that report already covers macOS RIDs, per-platform AOT startup numbers, and the notarization requirement.

### 4. Measured status, not speculation
The ADR now records what enabling macOS CI actually showed: **14,811 of 14,892 tests passing on Apple Silicon** (all 21 failures one root cause, fixed in #1359), natives already shipping, and a GL context request that was already macOS-correct (`OpenGL / Core / ForwardCompatible / 3.3`). Two macOS defects were found and fixed en route (#1355, #1359).

Consequences updated both ways: the free Metal path (positive) and the Mac-hardware scheduling dependency (negative).

## Notes
- **Revision v2; Status stays `Proposed`.** This refines a proposal rather than amending an accepted decision — matching ADR-011, which kept `Accepted` through its v2. `index.md` needs no change (Status and Implementation are both unchanged).
- **docfx build verified**: 0 errors, 32 warnings — all pre-existing out-of-tree links, **none from this file**. The new `../research/cross-platform-deployment.md` link resolves.
