### PR TITLE
fix(platform,samples): Require the main thread for window creation on macOS

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -128,6 +128,7 @@
     <Project Path="tests/KeenEyes.Particles.Tests/KeenEyes.Particles.Tests.csproj" />
     <Project Path="tests/KeenEyes.Persistence.Tests/KeenEyes.Persistence.Tests.csproj" />
     <Project Path="tests/KeenEyes.Physics.Tests/KeenEyes.Physics.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj" />
     <Project Path="tests/KeenEyes.Replay.Tests/KeenEyes.Replay.Tests.csproj" />
     <Project Path="tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj" />
     <Project Path="tests/KeenEyes.Shaders.Compiler.Tests/KeenEyes.Shaders.Compiler.Tests.csproj" />

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -115,6 +115,12 @@ world.CreateRunner()
 - **Backend-agnostic**: Works with any `ILoopProvider` implementation
 - **Clean syntax**: No manual event wiring
 
+> **macOS: call `Run()` on the process main thread.** `Run()` creates the OS window, and AppKit
+> only permits that on the thread the process started on. An `await` before `Run()` moves the rest
+> of an async `Main` onto a thread-pool thread and the Mac build dies at startup, even though
+> Windows and Linux are happy. See
+> [Runtime: threading](runtime.md#threading-call-run-on-the-process-main-thread).
+
 ### Explicit Update Control
 
 For custom update logic, provide an `OnUpdate` callback:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -230,6 +230,30 @@ world.CreateRunner()
 Console.WriteLine("Application ended.");
 ```
 
+## Threading: call `Run()` on the process main thread
+
+`Run()` is what creates the OS window, and macOS only allows that on the process main thread —
+AppKit terminates the process with `NSWindow should only be instantiated on the main thread!`
+rather than raising a catchable error. The trap is an `await` anywhere before `Run()`: in an async
+`Main`, everything after the first `await` resumes on a thread-pool thread, so the window ends up
+being created there. Windows and Linux accept it, which is why this shows up only once someone
+runs your game on a Mac. Do startup work synchronously before `Run()` (block with
+`GetAwaiter().GetResult()` if it is async), or move it into `OnReady`/after `Run()` returns —
+awaiting is fine there, because the window already exists. The Silk loop provider checks the
+calling thread on macOS immediately before window creation and throws an `InvalidOperationException`
+naming this cause, so the failure is a managed exception instead of a process abort.
+
+```csharp
+// Wrong on macOS: the continuation - including Run() - resumes off the main thread.
+await bridgeServer.StartAsync();
+world.CreateRunner().Run();
+
+// Right: startup stays synchronous, so Run() still runs where the process started.
+bridgeServer.StartAsync().GetAwaiter().GetResult();
+world.CreateRunner().Run();
+await bridgeServer.StopAsync();   // after Run() returns, awaiting is safe
+```
+
 ## Error Handling
 
 If no `ILoopProvider` is registered, `CreateRunner()` throws:

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -220,6 +220,14 @@ Console.WriteLine("Starting...");
 // TestBridge: expose the live game world to external tools (the MCP server)
 // over a named pipe, following the editor's integration pattern. Windowed
 // mode only — headless CI runs stay free of IPC endpoints.
+//
+// The start is blocked on rather than awaited ON PURPOSE, and this is not a
+// tidy-up candidate: an 'await' here would resume the rest of this file - Run()
+// included - on a thread-pool thread, and Run() is what creates the OS window.
+// macOS/AppKit only permits that on the process main thread and aborts the
+// process outright otherwise (#1364). Everything up to Run() therefore stays
+// synchronous. Blocking (rather than fire-and-forget) also keeps a failed start
+// reportable: it surfaces here instead of in an unobserved task.
 var bridgePlugin = new TestBridgePlugin(new TestBridgeOptions { EnableIpc = true });
 var bridgeServer = default(IpcBridgeServer);
 try
@@ -228,7 +236,7 @@ try
     bridgeServer = new IpcBridgeServer(
         world.GetExtension<ITestBridge>(),
         new IpcOptions { PipeName = "KeenEyes.NovaFall.TestBridge" });
-    await bridgeServer.StartAsync();
+    bridgeServer.StartAsync().GetAwaiter().GetResult();
     Console.WriteLine("[TestBridge] IPC server started on pipe: KeenEyes.NovaFall.TestBridge");
 }
 catch (Exception ex)
@@ -295,7 +303,9 @@ catch (Exception ex)
 finally
 {
     // TestBridge teardown mirrors the editor's: stop the pipe server before the
-    // world (and the bridge plugin inside it) is disposed.
+    // world (and the bridge plugin inside it) is disposed. Awaiting is safe here
+    // and nowhere above: Run() has already returned, so the only work the
+    // continuation can land on a thread-pool thread is teardown.
     if (bridgeServer is not null)
     {
         await bridgeServer.StopAsync();

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -153,11 +153,13 @@ using var world = new World();
 // the gameplay/juice plugins that build on them).
 //
 // The window, graphics and input plugins are the hard requirements, and they are
-// the ones that touch the platform: SilkWindowPlugin.Install creates the window
-// (and therefore initializes GLFW) right here, so on a machine with no display
-// this is where startup fails - before the game loop is ever reached. Guarding
-// only the loop would let that surface as an unhandled crash, so the same
-// diagnostic covers the installation.
+// the ones that touch the platform. SilkWindowPlugin.Install initializes GLFW here
+// but only builds the managed window object - the OS window itself is created
+// later, by Run(). A machine with no display therefore fails at this install, so
+// guarding only the loop would let that surface as an unhandled crash and the same
+// diagnostic has to cover the installation too. (The two-stage split is not
+// cosmetic: it is why an await before Run() moves OS window creation onto a
+// thread-pool thread, which macOS rejects - see the ordering note below.)
 try
 {
     world.InstallPlugin(new SilkWindowPlugin(windowConfig));

--- a/src/KeenEyes.Platform.Silk/KeenEyes.Platform.Silk.csproj
+++ b/src/KeenEyes.Platform.Silk/KeenEyes.Platform.Silk.csproj
@@ -5,7 +5,13 @@
     <Description>Silk.NET window and platform plugin for KeenEyes ECS</Description>
     <PackageTags>ecs;silk.net;window;platform;opengl;vulkan</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Required by [LibraryImport]: the source-generated marshalling stub is unsafe code. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Platform.Silk.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />

--- a/src/KeenEyes.Platform.Silk/SilkLoopProvider.cs
+++ b/src/KeenEyes.Platform.Silk/SilkLoopProvider.cs
@@ -96,6 +96,12 @@ public sealed class SilkLoopProvider : ILoopProvider
     /// <inheritdoc />
     public void Run()
     {
+        // The OS window does not exist yet: SilkWindowProvider's constructor only built the
+        // managed IWindow. Initialize() below is what reaches glfwCreateWindow, so this is the
+        // last point at which a wrong-thread caller can still be told about it in managed code -
+        // on macOS the AppKit failure is an Objective-C exception that aborts the process.
+        WindowThreadGuard.EnsureWindowCreationThread();
+
         // Initialize the window first - this creates the GL context and fires Load events.
         // All subscribers to windowProvider.OnLoad (like SilkGraphicsContext) will run here.
         windowProvider.Window.Initialize();

--- a/src/KeenEyes.Platform.Silk/WindowThreadGuard.cs
+++ b/src/KeenEyes.Platform.Silk/WindowThreadGuard.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices;
+
+namespace KeenEyes.Platform.Silk;
+
+/// <summary>
+/// Verifies that the OS window is created on the process main thread, which macOS requires.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AppKit refuses to instantiate an <c>NSWindow</c> anywhere but the process main thread and
+/// raises an Objective-C exception that terminates the process rather than a catchable managed
+/// one. GLFW - and therefore Silk.NET - creates that <c>NSWindow</c> inside
+/// <c>IWindow.Initialize()</c>, so the check runs immediately before that call.
+/// </para>
+/// <para>
+/// Windows and Linux place no such restriction on window creation, so the guard is a no-op there.
+/// </para>
+/// </remarks>
+internal static partial class WindowThreadGuard
+{
+    /// <summary>
+    /// Throws if the current thread cannot legally create an OS window on this platform.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown on macOS when the calling thread is not the process main thread.
+    /// </exception>
+    internal static void EnsureWindowCreationThread()
+    {
+        // The P/Invoke below resolves a macOS-only library, so it must stay behind this check.
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        Validate(isMacOS: true, isProcessMainThread: PthreadMainNp() != 0);
+    }
+
+    /// <summary>
+    /// Applies the guard's decision to already-observed platform and thread facts.
+    /// </summary>
+    /// <param name="isMacOS">Whether the process is running on macOS.</param>
+    /// <param name="isProcessMainThread">Whether the calling thread is the process main thread.</param>
+    /// <remarks>
+    /// Split out from <see cref="EnsureWindowCreationThread"/> so the decision is testable on
+    /// platforms where neither input can be reproduced.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="isMacOS"/> is <see langword="true"/> and
+    /// <paramref name="isProcessMainThread"/> is <see langword="false"/>.
+    /// </exception>
+    internal static void Validate(bool isMacOS, bool isProcessMainThread)
+    {
+        if (!isMacOS || isProcessMainThread)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "macOS requires the OS window to be created on the process main thread, and this call "
+            + $"is running on managed thread {Environment.CurrentManagedThreadId}, which is not it. "
+            + "The most likely cause is an 'await' somewhere before Run(): an async Main resumes its "
+            + "continuation on a thread-pool thread, so Run() - and the window creation inside it - "
+            + "no longer runs where the process started. The remedy is to do that startup work "
+            + "synchronously before Run() (for example 'StartAsync().GetAwaiter().GetResult()'), or "
+            + "to move it after Run() returns. Windows and Linux accept window creation on any "
+            + "thread, so a program that works there can still fail here.");
+    }
+
+    /// <summary>
+    /// Returns non-zero when the calling thread is the process main thread.
+    /// </summary>
+    /// <remarks>
+    /// Declared by <c>&lt;pthread.h&gt;</c> and exported from libSystem on macOS. This is the
+    /// definitive answer AppKit itself relies on; managed thread identity cannot supply it.
+    /// </remarks>
+    [LibraryImport("libSystem.B.dylib", EntryPoint = "pthread_main_np")]
+    private static partial int PthreadMainNp();
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj
+++ b/tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk\KeenEyes.Platform.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk.Abstractions\KeenEyes.Platform.Silk.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Platform.Silk.Tests/Mocks/WindowlessSilkWindowProvider.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/Mocks/WindowlessSilkWindowProvider.cs
@@ -1,0 +1,51 @@
+using Silk.NET.Input;
+using Silk.NET.Windowing;
+
+namespace KeenEyes.Platform.Silk.Tests.Mocks;
+
+/// <summary>
+/// An <see cref="ISilkWindowProvider"/> that owns no OS window and reports a sentinel exception
+/// the moment anything reaches for one.
+/// </summary>
+/// <remarks>
+/// This makes "the caller got as far as touching the window" observable in a headless test: a
+/// <see cref="NotSupportedException"/> carrying <see cref="WindowAccessMessage"/> means execution
+/// passed every check that runs before window creation.
+/// </remarks>
+internal sealed class WindowlessSilkWindowProvider : ISilkWindowProvider
+{
+    /// <summary>
+    /// The message carried by the sentinel exception thrown from <see cref="Window"/>.
+    /// </summary>
+    internal const string WindowAccessMessage = "The test window provider owns no OS window.";
+
+    public IWindow Window => throw new NotSupportedException(WindowAccessMessage);
+
+    public IInputContext InputContext => throw new NotSupportedException(WindowAccessMessage);
+
+    public int Width => 0;
+
+    public int Height => 0;
+
+    public int FramebufferWidth => 0;
+
+    public int FramebufferHeight => 0;
+
+#pragma warning disable CS0067 // Events exist to satisfy the interface; this provider raises none.
+    public event Action? OnLoad;
+
+    public event Action<double>? OnUpdate;
+
+    public event Action<double>? OnRender;
+
+    public event Action<int, int>? OnResize;
+
+    public event Action<int, int>? OnFramebufferResize;
+
+    public event Action? OnClosing;
+#pragma warning restore CS0067
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/SilkLoopProviderTests.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/SilkLoopProviderTests.cs
@@ -1,0 +1,45 @@
+using KeenEyes.Platform.Silk.Tests.Mocks;
+
+namespace KeenEyes.Platform.Silk.Tests;
+
+/// <summary>
+/// Tests for <see cref="SilkLoopProvider"/>, focused on the thread check that runs immediately
+/// before the OS window is created (#1364).
+/// </summary>
+public class SilkLoopProviderTests
+{
+    #region Run
+
+    [Fact]
+    public void Run_OnNonMacOS_ReachesWindowCreation()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        using var windowProvider = new WindowlessSilkWindowProvider();
+        var loopProvider = new SilkLoopProvider(windowProvider);
+
+        // The sentinel proves Run() got all the way to the window, so nothing before it -
+        // including the thread check - short-circuited the call.
+        var exception = Assert.Throws<NotSupportedException>(loopProvider.Run);
+
+        Assert.Equal(WindowlessSilkWindowProvider.WindowAccessMessage, exception.Message);
+    }
+
+    [Fact]
+    public async Task Run_OnNonMacOSFromThreadPoolThread_ReachesWindowCreation()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        using var windowProvider = new WindowlessSilkWindowProvider();
+        var loopProvider = new SilkLoopProvider(windowProvider);
+
+        // Task.Run reproduces exactly what an 'await' before Run() does to the calling thread.
+        // Platforms other than macOS must be unaffected by the new check.
+        var exception = await Task.Run(() => Record.Exception(loopProvider.Run));
+
+        var notSupported = Assert.IsType<NotSupportedException>(exception);
+        Assert.Equal(WindowlessSilkWindowProvider.WindowAccessMessage, notSupported.Message);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/WindowThreadGuardTests.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/WindowThreadGuardTests.cs
@@ -1,0 +1,96 @@
+namespace KeenEyes.Platform.Silk.Tests;
+
+/// <summary>
+/// Tests for <see cref="WindowThreadGuard"/>, the macOS main-thread requirement for OS window
+/// creation (#1364).
+/// </summary>
+/// <remarks>
+/// The guard only fires on macOS, so its decision is exercised through
+/// <see cref="WindowThreadGuard.Validate(bool, bool)"/>, which takes the two platform facts as
+/// inputs and can therefore be tested from any operating system.
+/// </remarks>
+public class WindowThreadGuardTests
+{
+    #region Validate
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        // Distinguishing fragments only - the wording around them is free to change.
+        Assert.Contains("main thread", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("macOS", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_NamesTheLikelyCause()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        Assert.Contains("await", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("thread-pool thread", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_StatesTheRemedy()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        Assert.Contains("GetAwaiter().GetResult()", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("after Run() returns", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOnTheMainThread_DoesNotThrow()
+    {
+        var exception = Record.Exception(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: true));
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Validate_OffMacOS_DoesNotThrowRegardlessOfThread(bool isProcessMainThread)
+    {
+        var exception = Record.Exception(
+            () => WindowThreadGuard.Validate(isMacOS: false, isProcessMainThread));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+
+    #region EnsureWindowCreationThread
+
+    [Fact]
+    public void EnsureWindowCreationThread_OnNonMacOSPlatform_DoesNotThrow()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        var exception = Record.Exception(WindowThreadGuard.EnsureWindowCreationThread);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task EnsureWindowCreationThread_OnNonMacOSFromThreadPoolThread_DoesNotThrow()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        // Windows and Linux allow window creation from any thread; the guard must not have
+        // silently imposed the macOS restriction on them. The thread-pool thread here is exactly
+        // what an 'await' before Run() would resume on.
+        var exception = await Task.Run(
+            () => Record.Exception(WindowThreadGuard.EnsureWindowCreationThread));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/packages.lock.json
+++ b/tests/KeenEyes.Platform.Silk.Tests/packages.lock.json
@@ -1,0 +1,304 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
@@ -17,4 +17,13 @@
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- StartupOrderingTests inspects the entry point itself: the ordering of the
+         TestBridge start against Run() is a startup property no runtime test can
+         observe, because Run() needs a window (#1364). Embedding the file keeps the
+         test hermetic - it cannot drift onto a stale copy or a wrong path. -->
+    <EmbeddedResource Include="..\..\samples\KeenEyes.Sample.NovaFall\Program.cs"
+                      LogicalName="KeenEyes.Sample.NovaFall.Tests.Program.cs.txt" />
+  </ItemGroup>
+
 </Project>

--- a/tests/KeenEyes.Sample.NovaFall.Tests/StartupOrderingTests.cs
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/StartupOrderingTests.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+
+namespace KeenEyes.Sample.NovaFall.Tests;
+
+/// <summary>
+/// Pins down the startup ordering the windowed entry point depends on: nothing between process
+/// start and the game loop may be awaited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Regression coverage for #1364. An <c>await</c> in an async <c>Main</c> resumes the remainder of
+/// the method on a thread-pool thread, and the remainder here includes <c>Run()</c>, which creates
+/// the OS window. macOS/AppKit only permits window creation on the process main thread and
+/// terminates the process otherwise, so on a Mac the sample died right after starting the
+/// TestBridge.
+/// </para>
+/// <para>
+/// The property cannot be observed at runtime - reaching <c>Run()</c> requires a display - so it is
+/// asserted against the entry point's source, which the test project embeds. Comments are stripped
+/// first so that prose about <c>await</c> and <c>Run()</c> (including the comment that explains why
+/// this ordering matters) cannot decide the outcome.
+/// </para>
+/// </remarks>
+public class StartupOrderingTests
+{
+    [Fact]
+    public void WindowedStartup_DoesNotAwaitBeforeTheGameLoopStarts()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var runLine = IndexOfLineContaining(code, ".Run()");
+        Assert.True(runLine >= 0, "Expected the entry point to start the loop with '.Run()'.");
+
+        var awaitLine = IndexOfLineWithAwait(code);
+
+        Assert.True(
+            awaitLine < 0 || awaitLine > runLine,
+            $"An 'await' on source line {awaitLine + 1} precedes the '.Run()' call on line "
+            + $"{runLine + 1}. The continuation after that await resumes on a thread-pool thread, "
+            + "so the window would be created off the process main thread and macOS would abort "
+            + "the process. Block on the work instead (GetAwaiter().GetResult()), or move it after "
+            + "Run() returns.");
+    }
+
+    [Fact]
+    public void WindowedStartup_StillStartsTheTestBridgeBeforeTheGameLoop()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var startLine = IndexOfLineContaining(code, "StartAsync()");
+        var runLine = IndexOfLineContaining(code, ".Run()");
+
+        // The fix must not have been "delete the bridge": it still starts, just synchronously.
+        Assert.True(startLine >= 0, "Expected the entry point to start the TestBridge server.");
+        Assert.True(
+            startLine < runLine,
+            "Expected the TestBridge to start before the game loop, as it did before #1364.");
+    }
+
+    [Fact]
+    public void WindowedStartup_StopsTheTestBridgeAfterTheGameLoop()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var runLine = IndexOfLineContaining(code, ".Run()");
+        var stopLine = IndexOfLineContaining(code, "StopAsync()");
+
+        // Teardown may still be awaited: by then Run() has returned, so a thread-pool
+        // continuation can no longer reach window creation.
+        Assert.True(stopLine >= 0, "Expected the entry point to stop the TestBridge server.");
+        Assert.True(
+            stopLine > runLine,
+            "Expected the TestBridge to be stopped after the game loop returns.");
+    }
+
+    private static string[] ReadEntryPointSource()
+    {
+        const string ResourceName = "KeenEyes.Sample.NovaFall.Tests.Program.cs.txt";
+
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded entry-point source '{ResourceName}' is missing from the test assembly.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd().Split('\n');
+    }
+
+    /// <summary>
+    /// Blanks out line comments so prose cannot satisfy or break a code-ordering assertion.
+    /// </summary>
+    private static string[] StripComments(string[] lines)
+    {
+        var stripped = new string[lines.Length];
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var commentStart = lines[i].IndexOf("//", StringComparison.Ordinal);
+            stripped[i] = commentStart >= 0 ? lines[i][..commentStart] : lines[i];
+        }
+
+        return stripped;
+    }
+
+    private static int IndexOfLineContaining(string[] lines, string token)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains(token, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Finds the first line using <c>await</c> as a keyword rather than as part of an identifier.
+    /// </summary>
+    private static int IndexOfLineWithAwait(string[] lines)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            foreach (var word in lines[i].Split(
+                [' ', '\t', '(', ')', ';', '=', '{', '}', ','],
+                StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (string.Equals(word, "await", StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1364. NOVAFALL died on Apple Silicon with an AppKit process abort:

> `*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'NSWindow should only be instantiated on the main thread!'`

**Root cause is an ordering bug, and the two-stage window creation is what hides it:**

| Step | What happens |
|---|---|
| `SilkWindowPlugin.Install` | Initializes GLFW and builds the **managed** `IWindow` — no OS window yet |
| **`await bridgeServer.StartAsync()`** (line 231) | async `Main` resumes its continuation on a **thread-pool thread** |
| `.Run()` (line 284) | → `Window.Initialize()` → `glfwCreateWindow` → `NSWindow` **off the main thread** → AppKit aborts |

The stack confirms it: `glfwCreateWindow` sits above `KickOffThread_Worker / CPalThread::ThreadEntry / _pthread_start`. Windows and Linux accept window creation on any thread, which is why this survived every prior run. **NOVAFALL was the only entry point with an `await` before `Run()`** — all other samples and the editor were checked and are clean (`Sample.UI` uses fire-and-forget `_ = ipcServer.StartAsync()`).

## Two changes

**1. Sample:** no `await` precedes `Run()`. The bridge still starts, failure is still non-fatal with the same warning, and `StopAsync` stays an await in the `finally` because it runs after `Run()` returns. A comment explains *why* the ordering matters, since the natural instinct is to "tidy" it back into an await.

**2. Engine guard:** `WindowThreadGuard`, called as the first statement of `SilkLoopProvider.Run()` — the last managed instruction before `glfwCreateWindow`, covering every caller (`WorldRunnerBuilder.Run()` delegates here; `Initialize()` is a no-op). Gated on `OperatingSystem.IsMacOS()` so **nothing changes on Windows or Linux**. Thread identity comes from `pthread_main_np` via `[LibraryImport]` — definitive, not a managed-thread-ID heuristic.

The message it throws instead of an ObjC abort:

> macOS requires the OS window to be created on the process main thread, and this call is running on managed thread {N}, which is not it. The most likely cause is an 'await' somewhere before Run(): an async Main resumes its continuation on a thread-pool thread, so Run() — and the window creation inside it — no longer runs where the process started. The remedy is to do that startup work synchronously before Run() (for example 'StartAsync().GetAwaiter().GetResult()'), or to move it after Run() returns. Windows and Linux accept window creation on any thread, so a program that works there can still fail here.

**3. Also corrects a comment I wrote in #1259** claiming `Install` creates the OS window. Only the GLFW-init half was true, and that distinction is precisely what this bug turns on — leaving it would tell the next reader an await before `Run()` can't matter.

## Test plan
- [x] `tests/KeenEyes.Platform.Silk.Tests` (new, 10 tests). The decision logic is a pure `Validate(isMacOS, isProcessMainThread)`, so **macOS behaviour is asserted from Linux** — observation, likely-cause and remedy each checked by distinguishing substrings. Real guard verified to no-op on Linux including from `Task.Run`, and `SilkLoopProvider.Run()` still reaches window creation there (sentinel exception proves no short-circuit).
- [x] `StartupOrderingTests` (3) assert the ordering property against the entry point's source, embedded as a resource so it can't drift onto a stale path, with comments stripped so prose about `await`/`Run()` can't decide the outcome.
- [x] **Fail-on-old:** reverting the sample fails `WindowedStartup_DoesNotAwaitBeforeTheGameLoopStarts` with `An 'await' on source line 231 precedes the '.Run()' call on line 284` — the exact lines from the analysis, confirmed empirically rather than by reading.
- [x] Full suite **14,950, 0 failed**; build 0 warnings; format clean; `--simulate 600` double-run byte-identical.

## Honest limits
- **The ordering test is a source-order assertion, not a runtime one.** The property can't be observed at runtime because reaching `Run()` needs a display. Stated plainly rather than dressed up as behavioural coverage.
- **The engine guard has no behavioural fail-on-old on Linux** by design — the platform gate means reverting it changes nothing observable here. Its only "failure" on revert is a compile error, which isn't proof.
- **Needs a real Mac to confirm:** that `pthread_main_np` resolves as expected under CoreCLR; that the guard fires with a managed exception instead of an AppKit abort; and that NOVAFALL now reaches a window — i.e. that this was the *only* thread-affinity violation. Note `glfwInit` during `Install` is also main-thread-only on macOS; it happened to be on the main thread before and after this change, so this fix leaves it unchanged rather than proving it safe.
