### PR TITLE
fix(graphics,samples): Select system fonts by loadability so macOS collections are skipped

### DIFF
--- a/KeenEyes.slnx
+++ b/KeenEyes.slnx
@@ -128,6 +128,7 @@
     <Project Path="tests/KeenEyes.Particles.Tests/KeenEyes.Particles.Tests.csproj" />
     <Project Path="tests/KeenEyes.Persistence.Tests/KeenEyes.Persistence.Tests.csproj" />
     <Project Path="tests/KeenEyes.Physics.Tests/KeenEyes.Physics.Tests.csproj" />
+    <Project Path="tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj" />
     <Project Path="tests/KeenEyes.Replay.Tests/KeenEyes.Replay.Tests.csproj" />
     <Project Path="tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj" />
     <Project Path="tests/KeenEyes.Shaders.Compiler.Tests/KeenEyes.Shaders.Compiler.Tests.csproj" />

--- a/docs/graphics.md
+++ b/docs/graphics.md
@@ -115,6 +115,12 @@ world.CreateRunner()
 - **Backend-agnostic**: Works with any `ILoopProvider` implementation
 - **Clean syntax**: No manual event wiring
 
+> **macOS: call `Run()` on the process main thread.** `Run()` creates the OS window, and AppKit
+> only permits that on the thread the process started on. An `await` before `Run()` moves the rest
+> of an async `Main` onto a thread-pool thread and the Mac build dies at startup, even though
+> Windows and Linux are happy. See
+> [Runtime: threading](runtime.md#threading-call-run-on-the-process-main-thread).
+
 ### Explicit Update Control
 
 For custom update logic, provide an `OnUpdate` callback:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -230,6 +230,30 @@ world.CreateRunner()
 Console.WriteLine("Application ended.");
 ```
 
+## Threading: call `Run()` on the process main thread
+
+`Run()` is what creates the OS window, and macOS only allows that on the process main thread —
+AppKit terminates the process with `NSWindow should only be instantiated on the main thread!`
+rather than raising a catchable error. The trap is an `await` anywhere before `Run()`: in an async
+`Main`, everything after the first `await` resumes on a thread-pool thread, so the window ends up
+being created there. Windows and Linux accept it, which is why this shows up only once someone
+runs your game on a Mac. Do startup work synchronously before `Run()` (block with
+`GetAwaiter().GetResult()` if it is async), or move it into `OnReady`/after `Run()` returns —
+awaiting is fine there, because the window already exists. The Silk loop provider checks the
+calling thread on macOS immediately before window creation and throws an `InvalidOperationException`
+naming this cause, so the failure is a managed exception instead of a process abort.
+
+```csharp
+// Wrong on macOS: the continuation - including Run() - resumes off the main thread.
+await bridgeServer.StartAsync();
+world.CreateRunner().Run();
+
+// Right: startup stays synchronous, so Run() still runs where the process started.
+bridgeServer.StartAsync().GetAwaiter().GetResult();
+world.CreateRunner().Run();
+await bridgeServer.StopAsync();   // after Run() returns, awaiting is safe
+```
+
 ## Error Handling
 
 If no `ILoopProvider` is registered, `CreateRunner()` throws:

--- a/editor/KeenEyes.Editor/Application/EditorApplication.cs
+++ b/editor/KeenEyes.Editor/Application/EditorApplication.cs
@@ -462,10 +462,13 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
             return default;
         }
 
-        var fontPath = FindSystemFont();
+        // Selects by loadability, not existence: a candidate that exists but the
+        // rasterizer cannot open (macOS ships most system fonts as multi-face .ttc
+        // collections) is skipped rather than shadowing a working one.
+        var fontPath = SystemFonts.FindFirstUsable();
         if (fontPath is null)
         {
-            Console.WriteLine("Warning: No suitable system font found");
+            Console.WriteLine("Warning: No usable system font found");
             return default;
         }
 
@@ -1736,30 +1739,6 @@ public sealed class EditorApplication : IDisposable, IEditorShortcutActions
 
         var entity = sceneWorld!.Spawn("New Entity").Build();
         Console.WriteLine($"Created entity: {sceneWorld.GetName(entity)}");
-    }
-
-    private static string? FindSystemFont()
-    {
-        string[] candidates =
-        [
-            @"C:\Windows\Fonts\segoeui.ttf",
-            @"C:\Windows\Fonts\arial.ttf",
-            @"C:\Windows\Fonts\calibri.ttf",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-            "/usr/share/fonts/TTF/DejaVuSans.ttf",
-            "/System/Library/Fonts/Helvetica.ttc",
-            "/Library/Fonts/Arial.ttf"
-        ];
-
-        foreach (var path in candidates)
-        {
-            if (File.Exists(path))
-            {
-                return path;
-            }
-        }
-
-        return null;
     }
 
     #region IEditorShortcutActions Implementation

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -220,6 +220,14 @@ Console.WriteLine("Starting...");
 // TestBridge: expose the live game world to external tools (the MCP server)
 // over a named pipe, following the editor's integration pattern. Windowed
 // mode only — headless CI runs stay free of IPC endpoints.
+//
+// The start is blocked on rather than awaited ON PURPOSE, and this is not a
+// tidy-up candidate: an 'await' here would resume the rest of this file - Run()
+// included - on a thread-pool thread, and Run() is what creates the OS window.
+// macOS/AppKit only permits that on the process main thread and aborts the
+// process outright otherwise (#1364). Everything up to Run() therefore stays
+// synchronous. Blocking (rather than fire-and-forget) also keeps a failed start
+// reportable: it surfaces here instead of in an unobserved task.
 var bridgePlugin = new TestBridgePlugin(new TestBridgeOptions { EnableIpc = true });
 var bridgeServer = default(IpcBridgeServer);
 try
@@ -228,7 +236,7 @@ try
     bridgeServer = new IpcBridgeServer(
         world.GetExtension<ITestBridge>(),
         new IpcOptions { PipeName = "KeenEyes.NovaFall.TestBridge" });
-    await bridgeServer.StartAsync();
+    bridgeServer.StartAsync().GetAwaiter().GetResult();
     Console.WriteLine("[TestBridge] IPC server started on pipe: KeenEyes.NovaFall.TestBridge");
 }
 catch (Exception ex)
@@ -295,7 +303,9 @@ catch (Exception ex)
 finally
 {
     // TestBridge teardown mirrors the editor's: stop the pipe server before the
-    // world (and the bridge plugin inside it) is disposed.
+    // world (and the bridge plugin inside it) is disposed. Awaiting is safe here
+    // and nowhere above: Run() has already returned, so the only work the
+    // continuation can land on a thread-pool thread is teardown.
     if (bridgeServer is not null)
     {
         await bridgeServer.StopAsync();

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -153,11 +153,13 @@ using var world = new World();
 // the gameplay/juice plugins that build on them).
 //
 // The window, graphics and input plugins are the hard requirements, and they are
-// the ones that touch the platform: SilkWindowPlugin.Install creates the window
-// (and therefore initializes GLFW) right here, so on a machine with no display
-// this is where startup fails - before the game loop is ever reached. Guarding
-// only the loop would let that surface as an unhandled crash, so the same
-// diagnostic covers the installation.
+// the ones that touch the platform. SilkWindowPlugin.Install initializes GLFW here
+// but only builds the managed window object - the OS window itself is created
+// later, by Run(). A machine with no display therefore fails at this install, so
+// guarding only the loop would let that surface as an unhandled crash and the same
+// diagnostic has to cover the installation too. (The two-stage split is not
+// cosmetic: it is why an await before Run() moves OS window creation onto a
+// thread-pool thread, which macOS rejects - see the ordering note below.)
 try
 {
     world.InstallPlugin(new SilkWindowPlugin(windowConfig));

--- a/samples/KeenEyes.Sample.NovaFall/Program.cs
+++ b/samples/KeenEyes.Sample.NovaFall/Program.cs
@@ -66,6 +66,10 @@ using KeenEyes.TestBridge;
 using KeenEyes.TestBridge.Ipc;
 using KeenEyes.UI;
 
+// Aliased rather than imported wholesale: KeenEyes.Graphics.Abstractions also defines an
+// Environment type, which would collide with System.Environment used below.
+using SystemFonts = KeenEyes.Graphics.Abstractions.SystemFonts;
+
 // --- Parse arguments ---
 
 var pinnedSeed = default(ulong?);
@@ -118,10 +122,13 @@ Console.WriteLine("  J                             - Toggle juice on/off");
 Console.WriteLine("  Escape                        - Exit");
 Console.WriteLine();
 
-var fontPath = FindSystemFont();
+// Find a font the rasterizer can actually open. SystemFonts checks loadability rather
+// than existence, so a present-but-unsupported candidate (macOS ships most of its system
+// fonts as multi-face .ttc collections) is skipped instead of shadowing a working one.
+var fontPath = SystemFonts.FindFirstUsable();
 if (fontPath is null)
 {
-    Console.WriteLine("Warning: no system font found; the score will show in the window title.");
+    Console.WriteLine("Warning: no usable system font found; the score will show in the window title.");
 }
 
 var windowConfig = new WindowConfig
@@ -394,30 +401,4 @@ static void RunHeadlessSimulation(int frames, ulong seed, GameMode mode)
         CultureInfo.InvariantCulture,
         $"final: depth={scroll.Depth:F3}m speed={scroll.Speed:F3} floorsSpawned={scroll.NextFloorIndex} " +
         $"score={score.Score:F3} heat={heat.Heat:F3} tier={heat.Tier} phase={phase}"));
-}
-
-// Finds a usable system font for the HUD, or null if none exists.
-static string? FindSystemFont()
-{
-    string[] candidates =
-    [
-        @"C:\Windows\Fonts\segoeui.ttf",
-        @"C:\Windows\Fonts\arial.ttf",
-        @"C:\Windows\Fonts\calibri.ttf",
-        @"C:\Windows\Fonts\verdana.ttf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-        "/usr/share/fonts/TTF/DejaVuSans.ttf",
-        "/System/Library/Fonts/Helvetica.ttc",
-        "/Library/Fonts/Arial.ttf"
-    ];
-
-    foreach (var path in candidates)
-    {
-        if (File.Exists(path))
-        {
-            return path;
-        }
-    }
-
-    return null;
 }

--- a/samples/KeenEyes.Sample.Showcase/Program.cs
+++ b/samples/KeenEyes.Sample.Showcase/Program.cs
@@ -46,11 +46,13 @@ Console.WriteLine("  Left Click         - Capture mouse for look control");
 Console.WriteLine("  Escape             - Release mouse / Exit");
 Console.WriteLine();
 
-// Find a suitable font file
-var fontPath = FindSystemFont();
+// Find a font the rasterizer can actually open. SystemFonts checks loadability rather
+// than existence, so a present-but-unsupported candidate (macOS ships most of its system
+// fonts as multi-face .ttc collections) is skipped instead of shadowing a working one.
+var fontPath = SystemFonts.FindFirstUsable();
 if (fontPath is null)
 {
-    Console.WriteLine("Warning: No suitable system font found. Text will not be visible.");
+    Console.WriteLine("Warning: No usable system font found. Text will not be visible.");
 }
 else
 {
@@ -176,41 +178,20 @@ try
 }
 catch (Exception ex)
 {
-    // Top-level demo entry point: initializing the windowing/graphics stack can surface a
-    // wide range of platform exceptions (missing display, driver, or GL context errors).
+    // Top-level demo entry point: Run() covers window creation, graphics initialization,
+    // asset loading, and the frame loop, so a wide range of exceptions can surface here.
     // A demo recovers by reporting the failure and exiting rather than crashing, so a
-    // catch-all is appropriate here.
-    Console.WriteLine($"Error: {ex.Message}");
-    Console.WriteLine("This sample requires a display.");
+    // catch-all is appropriate - but it must report WHAT failed rather than assert a
+    // cause it never checked. A blanket "requires a display" is actively misleading on a
+    // machine that has one, and hides the real exception behind a wrong diagnosis.
+    Console.WriteLine($"Showcase stopped: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine("Run() covers startup and the frame loop, so this may be a fault from the "
+        + "first frames rather than from starting up.");
+    Console.WriteLine("Windowed mode needs a display, a GPU driver, OpenGL 3.3, and a loadable "
+        + "system font; the line above says which of those actually failed.");
 }
 
 Console.WriteLine("Sample complete!");
-
-// Find a suitable system font
-static string? FindSystemFont()
-{
-    string[] candidates =
-    [
-        @"C:\Windows\Fonts\segoeui.ttf",
-        @"C:\Windows\Fonts\arial.ttf",
-        @"C:\Windows\Fonts\calibri.ttf",
-        @"C:\Windows\Fonts\verdana.ttf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-        "/usr/share/fonts/TTF/DejaVuSans.ttf",
-        "/System/Library/Fonts/Helvetica.ttc",
-        "/Library/Fonts/Arial.ttf"
-    ];
-
-    foreach (var path in candidates)
-    {
-        if (File.Exists(path))
-        {
-            return path;
-        }
-    }
-
-    return null;
-}
 
 // Create the 3D scene
 static void CreateScene(World world, IGraphicsContext graphics, MeshHandle groundMesh, MeshHandle wallMesh)

--- a/samples/KeenEyes.Sample.UI/Program.cs
+++ b/samples/KeenEyes.Sample.UI/Program.cs
@@ -58,11 +58,13 @@ Console.WriteLine("  Mouse            - Click and interact");
 Console.WriteLine("  Escape           - Exit");
 Console.WriteLine();
 
-// Find a suitable font file
-var fontPath = FindSystemFont();
+// Find a font the rasterizer can actually open. SystemFonts checks loadability rather
+// than existence, so a present-but-unsupported candidate (macOS ships most of its system
+// fonts as multi-face .ttc collections) is skipped instead of shadowing a working one.
+var fontPath = SystemFonts.FindFirstUsable();
 if (fontPath is null)
 {
-    Console.WriteLine("Warning: No suitable system font found. Text will not be visible.");
+    Console.WriteLine("Warning: No usable system font found. Text will not be visible.");
 }
 else
 {
@@ -219,12 +221,17 @@ try
 }
 catch (Exception ex)
 {
-    // Top-level demo entry point: initializing the windowing/graphics stack can surface a
-    // wide range of platform exceptions (missing display, driver, or GL context errors).
+    // Top-level demo entry point: Run() covers window creation, graphics initialization,
+    // asset loading, and the frame loop, so a wide range of exceptions can surface here.
     // A demo recovers by reporting the failure and exiting rather than crashing, so a
-    // catch-all is appropriate here.
-    Console.WriteLine($"Error: {ex.Message}");
-    Console.WriteLine("This sample requires a display.");
+    // catch-all is appropriate - but it must report WHAT failed rather than assert a
+    // cause it never checked. A blanket "requires a display" is actively misleading on a
+    // machine that has one, and hides the real exception behind a wrong diagnosis.
+    Console.WriteLine($"UI gallery stopped: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine("Run() covers startup and the frame loop, so this may be a fault from the "
+        + "first frames rather than from starting up.");
+    Console.WriteLine("Windowed mode needs a display, a GPU driver, OpenGL 3.3, and a loadable "
+        + "system font; the line above says which of those actually failed.");
 }
 
 Console.WriteLine("Sample complete!");
@@ -1106,36 +1113,6 @@ static void SubscribeToUIEvents(World world)
         var name = world.GetName(e.Element) ?? e.Element.ToString();
         Console.WriteLine($"[Focus] {name}");
     });
-}
-
-// ============================================================================
-// Font Discovery
-// ============================================================================
-
-static string? FindSystemFont()
-{
-    string[] candidates =
-    [
-        @"C:\Windows\Fonts\segoeui.ttf",
-        @"C:\Windows\Fonts\arial.ttf",
-        @"C:\Windows\Fonts\calibri.ttf",
-        @"C:\Windows\Fonts\verdana.ttf",
-        @"C:\Windows\Fonts\tahoma.ttf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-        "/usr/share/fonts/TTF/DejaVuSans.ttf",
-        "/System/Library/Fonts/Helvetica.ttc",
-        "/Library/Fonts/Arial.ttf"
-    ];
-
-    foreach (var path in candidates)
-    {
-        if (File.Exists(path))
-        {
-            return path;
-        }
-    }
-
-    return null;
 }
 
 // ============================================================================

--- a/src/KeenEyes.Graphics.Abstractions/Text/IFontManager.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Text/IFontManager.cs
@@ -35,7 +35,13 @@ public interface IFontManager : IResourceManager<FontHandle>
     /// <param name="path">The path to the font file (TTF, OTF).</param>
     /// <param name="size">The font size in pixels.</param>
     /// <returns>The font handle.</returns>
+    /// <remarks>
+    /// Only single-face fonts are supported. TrueType Collections (<c>.ttc</c>) bundle
+    /// several faces in one file and are rejected; use <see cref="SystemFonts.FindFirstUsable()"/>
+    /// to pick a system font that loads.
+    /// </remarks>
     /// <exception cref="FileNotFoundException">Thrown when the font file is not found.</exception>
+    /// <exception cref="NotSupportedException">Thrown when the file is a TrueType Collection.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the font cannot be loaded.</exception>
     FontHandle LoadFont(string path, float size);
 
@@ -46,6 +52,7 @@ public interface IFontManager : IResourceManager<FontHandle>
     /// <param name="size">The font size in pixels.</param>
     /// <param name="name">A name for the font (for debugging).</param>
     /// <returns>The font handle.</returns>
+    /// <exception cref="NotSupportedException">Thrown when the data is a TrueType Collection.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the font data is invalid.</exception>
     FontHandle LoadFontFromMemory(ReadOnlySpan<byte> data, float size, string? name = null);
 

--- a/src/KeenEyes.Graphics.Abstractions/Text/SystemFonts.cs
+++ b/src/KeenEyes.Graphics.Abstractions/Text/SystemFonts.cs
@@ -1,0 +1,287 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+namespace KeenEyes.Graphics.Abstractions;
+
+/// <summary>
+/// Locates a usable system font file for applications that need a default UI font.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Selection is by <em>loadability</em>, not by mere existence. A candidate path that
+/// exists but cannot be handed to a rasterizer is skipped and the search continues with
+/// the next candidate. This matters on macOS, where most system fonts ship as TrueType
+/// Collections (<c>.ttc</c>) that single-face rasterizers reject: picking the first
+/// existing path would let an unusable file shadow every later candidate that works.
+/// </para>
+/// <para>
+/// The candidate lists are deliberately short and ordered — single-font files first —
+/// rather than an exhaustive survey of every font an operating system might ship. The
+/// usability check, not the list, is what keeps this correct when a platform relocates
+/// or reformats its fonts.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var fontPath = SystemFonts.FindFirstUsable();
+/// if (fontPath is null)
+/// {
+///     Console.WriteLine("No usable system font found; text will not be drawn.");
+/// }
+/// else
+/// {
+///     var font = fontManager.LoadFont(fontPath, 16f);
+/// }
+/// </code>
+/// </example>
+public static class SystemFonts
+{
+    /// <summary>
+    /// The <c>ttcf</c> tag, big-endian, that begins every TrueType Collection file.
+    /// </summary>
+    private const uint CollectionTag = 0x74746366;
+
+    /// <summary>
+    /// Leading 4-byte tags that identify a single-face font a rasterizer can open at
+    /// offset zero: <c>0x00010000</c> (TrueType outlines), <c>true</c> (legacy Macintosh
+    /// TrueType), <c>typ1</c> (PostScript Type 1 in an sfnt wrapper), and <c>OTTO</c>
+    /// (OpenType with CFF outlines).
+    /// </summary>
+    private static readonly uint[] singleFaceTags =
+    [
+        0x00010000,
+        0x74727565,
+        0x74797031,
+        0x4F54544F,
+    ];
+
+    /// <summary>
+    /// Candidate font paths for Windows, in preference order.
+    /// </summary>
+    private static readonly string[] windowsCandidates =
+    [
+        @"C:\Windows\Fonts\segoeui.ttf",
+        @"C:\Windows\Fonts\arial.ttf",
+        @"C:\Windows\Fonts\calibri.ttf",
+        @"C:\Windows\Fonts\verdana.ttf",
+        @"C:\Windows\Fonts\tahoma.ttf",
+    ];
+
+    /// <summary>
+    /// Candidate font paths for macOS, in preference order.
+    /// </summary>
+    /// <remarks>
+    /// Single-font <c>.ttf</c> files come first. Modern macOS keeps most system faces in
+    /// <c>/System/Library/Fonts</c> as TrueType Collections and puts the classic
+    /// single-font files under <c>/System/Library/Fonts/Supplemental</c>. The collections
+    /// are listed last so a rasterizer that gains collection support can still reach them,
+    /// while <see cref="IsUsable(string)"/> skips them until then.
+    /// </remarks>
+    private static readonly string[] macOSCandidates =
+    [
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/Supplemental/Verdana.ttf",
+        "/System/Library/Fonts/Supplemental/Tahoma.ttf",
+        "/Library/Fonts/Arial.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+    ];
+
+    /// <summary>
+    /// Candidate font paths for Linux and other Unix-like systems, in preference order.
+    /// </summary>
+    private static readonly string[] linuxCandidates =
+    [
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/TTF/DejaVuSans.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    ];
+
+    /// <summary>
+    /// Gets the candidate font paths for the operating system this process is running on,
+    /// in preference order.
+    /// </summary>
+    public static IReadOnlyList<string> Candidates => GetCandidates(CurrentPlatform());
+
+    /// <summary>
+    /// Gets the candidate font paths for a specific operating system, in preference order.
+    /// </summary>
+    /// <param name="platform">The operating system whose candidates to return.</param>
+    /// <returns>
+    /// The candidate paths, most preferred first. Platforms other than
+    /// <see cref="OSPlatform.Windows"/> and <see cref="OSPlatform.OSX"/> receive the
+    /// freedesktop-style list used on Linux.
+    /// </returns>
+    /// <remarks>
+    /// The paths are returned unfiltered: they are not checked for existence or
+    /// loadability. Use <see cref="FindFirstUsable()"/> to get a path that can actually
+    /// be loaded.
+    /// </remarks>
+    public static IReadOnlyList<string> GetCandidates(OSPlatform platform)
+    {
+        if (platform == OSPlatform.Windows)
+        {
+            return windowsCandidates;
+        }
+
+        if (platform == OSPlatform.OSX)
+        {
+            return macOSCandidates;
+        }
+
+        return linuxCandidates;
+    }
+
+    /// <summary>
+    /// Finds the first candidate font for the current operating system that can be loaded.
+    /// </summary>
+    /// <returns>The path of the first usable font, or <see langword="null"/> if none is usable.</returns>
+    public static string? FindFirstUsable() => FindFirstUsable(Candidates);
+
+    /// <summary>
+    /// Finds the first path in a caller-supplied list that can be loaded.
+    /// </summary>
+    /// <param name="candidates">The candidate paths to test, most preferred first.</param>
+    /// <returns>The path of the first usable font, or <see langword="null"/> if none is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="candidates"/> is null.</exception>
+    public static string? FindFirstUsable(IEnumerable<string> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        foreach (var path in candidates)
+        {
+            if (IsUsable(path))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether a font file exists, is readable, and holds a single face that a
+    /// rasterizer can open at offset zero.
+    /// </summary>
+    /// <param name="path">The font file path to test.</param>
+    /// <returns>
+    /// <see langword="true"/> when the file begins with a single-face sfnt tag;
+    /// <see langword="false"/> when it is missing, unreadable, too short to identify, a
+    /// TrueType Collection, or any other format the rasterizer cannot open directly.
+    /// </returns>
+    /// <remarks>
+    /// This inspects only the 4-byte tag at the start of the file, so it is cheap enough
+    /// to run over a whole candidate list. It rules out the formats that fail at load
+    /// time; it does not prove that the rest of the file is well-formed.
+    /// </remarks>
+    public static bool IsUsable(string path)
+    {
+        if (!TryReadTag(path, out var tag))
+        {
+            return false;
+        }
+
+        return Array.IndexOf(singleFaceTags, tag) >= 0;
+    }
+
+    /// <summary>
+    /// Determines whether a font file is a TrueType Collection.
+    /// </summary>
+    /// <param name="path">The font file path to test.</param>
+    /// <returns>
+    /// <see langword="true"/> when the file begins with the <c>ttcf</c> tag; otherwise
+    /// <see langword="false"/>, including when the file is missing or unreadable.
+    /// </returns>
+    public static bool IsFontCollection(string path)
+        => TryReadTag(path, out var tag) && tag == CollectionTag;
+
+    /// <summary>
+    /// Determines whether in-memory font data is a TrueType Collection.
+    /// </summary>
+    /// <param name="data">The font file bytes to test.</param>
+    /// <returns>
+    /// <see langword="true"/> when the data begins with the <c>ttcf</c> tag; otherwise
+    /// <see langword="false"/>, including when the data is shorter than four bytes.
+    /// </returns>
+    public static bool IsFontCollection(ReadOnlySpan<byte> data)
+        => data.Length >= 4 && BinaryPrimitives.ReadUInt32BigEndian(data) == CollectionTag;
+
+    /// <summary>
+    /// Builds the message used when a TrueType Collection is handed to a loader that only
+    /// supports single-face fonts.
+    /// </summary>
+    /// <param name="path">The font file path or name to name in the message.</param>
+    /// <returns>The diagnostic message.</returns>
+    /// <remarks>
+    /// The wording states the observation (the file's leading tag) and the remedy, and
+    /// stops short of guessing why the caller reached for a collection.
+    /// </remarks>
+    public static string DescribeUnsupportedCollection(string path)
+        => $"Font '{path}' is a TrueType Collection: its first four bytes are the 'ttcf' tag, "
+            + "so it holds several faces rather than one. Collections are not supported. "
+            + "Use a single-font .ttf or .otf file instead - on macOS the single-font files "
+            + "live in /System/Library/Fonts/Supplemental, and SystemFonts.FindFirstUsable() "
+            + "picks one automatically.";
+
+    /// <summary>
+    /// Reads the 4-byte tag at the start of a file.
+    /// </summary>
+    /// <param name="path">The file to read.</param>
+    /// <param name="tag">The tag, interpreted big-endian, when the read succeeds.</param>
+    /// <returns><see langword="true"/> when four bytes were read; otherwise <see langword="false"/>.</returns>
+    private static bool TryReadTag(string path, out uint tag)
+    {
+        tag = 0;
+
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            Span<byte> header = stackalloc byte[4];
+
+            if (stream.ReadAtLeast(header, 4, throwOnEndOfStream: false) < 4)
+            {
+                return false;
+            }
+
+            tag = BinaryPrimitives.ReadUInt32BigEndian(header);
+            return true;
+        }
+        catch (IOException)
+        {
+            // Missing, locked, or a directory: not a font we can use. Fall through so the
+            // caller tries the next candidate rather than failing the whole search.
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the operating system this process is running on, as an <see cref="OSPlatform"/>.
+    /// </summary>
+    /// <returns>
+    /// <see cref="OSPlatform.Windows"/>, <see cref="OSPlatform.OSX"/>, or
+    /// <see cref="OSPlatform.Linux"/> for everything else.
+    /// </returns>
+    private static OSPlatform CurrentPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return OSPlatform.Windows;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return OSPlatform.OSX;
+        }
+
+        return OSPlatform.Linux;
+    }
+}

--- a/src/KeenEyes.Graphics.Silk/Text/SilkFontManager.cs
+++ b/src/KeenEyes.Graphics.Silk/Text/SilkFontManager.cs
@@ -58,8 +58,9 @@ internal sealed class SilkFontManager : IFontManager
         // Get or create FontSystem for this file
         if (!fontSystems.TryGetValue(path, out var fontSystem))
         {
+            var data = File.ReadAllBytes(path);
             fontSystem = CreateFontSystem();
-            fontSystem.AddFont(File.ReadAllBytes(path));
+            AddFont(fontSystem, data, path);
             fontSystems[path] = fontSystem;
         }
 
@@ -74,7 +75,7 @@ internal sealed class SilkFontManager : IFontManager
         if (!fontSystems.TryGetValue(key, out var fontSystem))
         {
             fontSystem = CreateFontSystem();
-            fontSystem.AddFont(data.ToArray());
+            AddFont(fontSystem, data.ToArray(), key);
             fontSystems[key] = fontSystem;
         }
 
@@ -281,6 +282,43 @@ internal sealed class SilkFontManager : IFontManager
         };
 
         return new FontSystem(settings);
+    }
+
+    /// <summary>
+    /// Adds font data to a font system, translating the rasterizer's opaque failures into
+    /// messages that name the font and say what to do about it.
+    /// </summary>
+    /// <param name="fontSystem">The font system to add the face to.</param>
+    /// <param name="data">The font file bytes.</param>
+    /// <param name="source">The path or name identifying the font, for diagnostics.</param>
+    /// <exception cref="NotSupportedException">Thrown when the data is a TrueType Collection.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the rasterizer rejects the data.</exception>
+    private static void AddFont(FontSystem fontSystem, byte[] data, string source)
+    {
+        // Checked before AddFont because FontStashSharp reports a collection as a bare
+        // "stbtt_InitFont failed", which names neither the file nor the format.
+        if (SystemFonts.IsFontCollection(data))
+        {
+            fontSystem.Dispose();
+            throw new NotSupportedException(SystemFonts.DescribeUnsupportedCollection(source));
+        }
+
+        try
+        {
+            fontSystem.AddFont(data);
+        }
+        catch (Exception ex)
+        {
+            // Boundary wrap: FontStashSharp throws a bare System.Exception whose message
+            // carries no indication of which font failed. Report the observation - this
+            // font, this rasterizer message - without asserting a cause we did not check.
+            fontSystem.Dispose();
+            throw new InvalidOperationException(
+                $"Font '{source}' was rejected by the FontStashSharp rasterizer ({ex.Message}). "
+                + "Check that the file is an uncorrupted single-font .ttf or .otf; "
+                + "TrueType Collections (.ttc) and web formats (.woff, .woff2) are not supported.",
+                ex);
+        }
     }
 
     private FontHandle CreateFontHandle(FontSystem fontSystem, float size)

--- a/src/KeenEyes.Platform.Silk/KeenEyes.Platform.Silk.csproj
+++ b/src/KeenEyes.Platform.Silk/KeenEyes.Platform.Silk.csproj
@@ -5,7 +5,13 @@
     <Description>Silk.NET window and platform plugin for KeenEyes ECS</Description>
     <PackageTags>ecs;silk.net;window;platform;opengl;vulkan</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Required by [LibraryImport]: the source-generated marshalling stub is unsafe code. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="KeenEyes.Platform.Silk.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\KeenEyes.Abstractions\KeenEyes.Abstractions.csproj" />

--- a/src/KeenEyes.Platform.Silk/SilkLoopProvider.cs
+++ b/src/KeenEyes.Platform.Silk/SilkLoopProvider.cs
@@ -96,6 +96,12 @@ public sealed class SilkLoopProvider : ILoopProvider
     /// <inheritdoc />
     public void Run()
     {
+        // The OS window does not exist yet: SilkWindowProvider's constructor only built the
+        // managed IWindow. Initialize() below is what reaches glfwCreateWindow, so this is the
+        // last point at which a wrong-thread caller can still be told about it in managed code -
+        // on macOS the AppKit failure is an Objective-C exception that aborts the process.
+        WindowThreadGuard.EnsureWindowCreationThread();
+
         // Initialize the window first - this creates the GL context and fires Load events.
         // All subscribers to windowProvider.OnLoad (like SilkGraphicsContext) will run here.
         windowProvider.Window.Initialize();

--- a/src/KeenEyes.Platform.Silk/WindowThreadGuard.cs
+++ b/src/KeenEyes.Platform.Silk/WindowThreadGuard.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices;
+
+namespace KeenEyes.Platform.Silk;
+
+/// <summary>
+/// Verifies that the OS window is created on the process main thread, which macOS requires.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AppKit refuses to instantiate an <c>NSWindow</c> anywhere but the process main thread and
+/// raises an Objective-C exception that terminates the process rather than a catchable managed
+/// one. GLFW - and therefore Silk.NET - creates that <c>NSWindow</c> inside
+/// <c>IWindow.Initialize()</c>, so the check runs immediately before that call.
+/// </para>
+/// <para>
+/// Windows and Linux place no such restriction on window creation, so the guard is a no-op there.
+/// </para>
+/// </remarks>
+internal static partial class WindowThreadGuard
+{
+    /// <summary>
+    /// Throws if the current thread cannot legally create an OS window on this platform.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown on macOS when the calling thread is not the process main thread.
+    /// </exception>
+    internal static void EnsureWindowCreationThread()
+    {
+        // The P/Invoke below resolves a macOS-only library, so it must stay behind this check.
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        Validate(isMacOS: true, isProcessMainThread: PthreadMainNp() != 0);
+    }
+
+    /// <summary>
+    /// Applies the guard's decision to already-observed platform and thread facts.
+    /// </summary>
+    /// <param name="isMacOS">Whether the process is running on macOS.</param>
+    /// <param name="isProcessMainThread">Whether the calling thread is the process main thread.</param>
+    /// <remarks>
+    /// Split out from <see cref="EnsureWindowCreationThread"/> so the decision is testable on
+    /// platforms where neither input can be reproduced.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="isMacOS"/> is <see langword="true"/> and
+    /// <paramref name="isProcessMainThread"/> is <see langword="false"/>.
+    /// </exception>
+    internal static void Validate(bool isMacOS, bool isProcessMainThread)
+    {
+        if (!isMacOS || isProcessMainThread)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "macOS requires the OS window to be created on the process main thread, and this call "
+            + $"is running on managed thread {Environment.CurrentManagedThreadId}, which is not it. "
+            + "The most likely cause is an 'await' somewhere before Run(): an async Main resumes its "
+            + "continuation on a thread-pool thread, so Run() - and the window creation inside it - "
+            + "no longer runs where the process started. The remedy is to do that startup work "
+            + "synchronously before Run() (for example 'StartAsync().GetAwaiter().GetResult()'), or "
+            + "to move it after Run() returns. Windows and Linux accept window creation on any "
+            + "thread, so a program that works there can still fail here.");
+    }
+
+    /// <summary>
+    /// Returns non-zero when the calling thread is the process main thread.
+    /// </summary>
+    /// <remarks>
+    /// Declared by <c>&lt;pthread.h&gt;</c> and exported from libSystem on macOS. This is the
+    /// definitive answer AppKit itself relies on; managed thread identity cannot supply it.
+    /// </remarks>
+    [LibraryImport("libSystem.B.dylib", EntryPoint = "pthread_main_np")]
+    private static partial int PthreadMainNp();
+}

--- a/tests/KeenEyes.Graphics.Tests/FontDiscoveryCallSiteTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/FontDiscoveryCallSiteTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Pins the four font-discovery call sites to the shared <see cref="SystemFonts"/> locator.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Regression coverage for #1365. The same existence-only <c>FindSystemFont</c> helper was copied
+/// into four files - <c>Sample.UI</c>, <c>Sample.Showcase</c>, <c>Sample.NovaFall</c>, and
+/// <c>EditorApplication</c> - so the macOS bug had to be fixed four times or not at all. These
+/// tests fail if a copy comes back.
+/// </para>
+/// <para>
+/// The call sites live in projects this one cannot reference (two samples and the editor app), so
+/// their sources are embedded at build time. That keeps the tests hermetic - MSBuild fails if a
+/// path drifts, and the test cannot silently read a stale copy.
+/// </para>
+/// </remarks>
+public class FontDiscoveryCallSiteTests
+{
+    /// <summary>
+    /// The logical names of the embedded call-site sources, matching the test project's
+    /// <c>EmbeddedResource</c> items.
+    /// </summary>
+    public static TheoryData<string> CallSites =>
+    [
+        "KeenEyes.Graphics.Tests.CallSites.Sample.UI.Program.cs.txt",
+        "KeenEyes.Graphics.Tests.CallSites.Sample.Showcase.Program.cs.txt",
+        "KeenEyes.Graphics.Tests.CallSites.Sample.NovaFall.Program.cs.txt",
+        "KeenEyes.Graphics.Tests.CallSites.EditorApplication.cs.txt",
+    ];
+
+    [Theory]
+    [MemberData(nameof(CallSites))]
+    public void CallSite_ResolvesItsFontThroughTheSharedLocator(string resourceName)
+    {
+        var code = ReadEmbeddedSource(resourceName);
+
+        Assert.Contains("SystemFonts.FindFirstUsable()", code, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(CallSites))]
+    public void CallSite_NoLongerDeclaresItsOwnFontSearch(string resourceName)
+    {
+        var code = ReadEmbeddedSource(resourceName);
+
+        Assert.DoesNotContain(
+            "FindSystemFont",
+            code,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(CallSites))]
+    public void CallSite_NoLongerHardcodesTheMacOsFontCollection(string resourceName)
+    {
+        var code = ReadEmbeddedSource(resourceName);
+
+        // The exact path from the #1365 report. Any copy of it outside SystemFonts is a
+        // duplicated candidate list growing back.
+        Assert.DoesNotContain(
+            "/System/Library/Fonts/Helvetica.ttc",
+            code,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Proves the shared locator resolves on the machine running the suite, which is what all
+    /// four call sites now depend on.
+    /// </summary>
+    [Fact]
+    public void SharedLocator_ResolvesAFontOnAMachineWithSystemFontsInstalled()
+    {
+        var found = SystemFonts.FindFirstUsable();
+        Assert.SkipWhen(found is null, "No system font is installed on this machine.");
+
+        Assert.True(
+            SystemFonts.IsUsable(found!),
+            $"'{found}' was returned by the locator but does not pass its own usability check.");
+    }
+
+    private static string ReadEmbeddedSource(string resourceName)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded source '{resourceName}' was not found. Check the EmbeddedResource "
+                + "items in KeenEyes.Graphics.Tests.csproj.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/KeenEyes.Graphics.Tests.csproj
+++ b/tests/KeenEyes.Graphics.Tests/KeenEyes.Graphics.Tests.csproj
@@ -20,4 +20,20 @@
     <PackageReference Include="StbImageWriteSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- FontDiscoveryCallSiteTests asserts that the four font-discovery call sites all go
+         through the shared SystemFonts locator instead of re-growing the existence-only
+         copies that made every macOS sample fail (#1365). Two of them are samples and one
+         is the editor app, none of which this project can reference, so their sources are
+         embedded: MSBuild then fails if a path drifts, and the test cannot read a stale copy. -->
+    <EmbeddedResource Include="..\..\samples\KeenEyes.Sample.UI\Program.cs"
+                      LogicalName="KeenEyes.Graphics.Tests.CallSites.Sample.UI.Program.cs.txt" />
+    <EmbeddedResource Include="..\..\samples\KeenEyes.Sample.Showcase\Program.cs"
+                      LogicalName="KeenEyes.Graphics.Tests.CallSites.Sample.Showcase.Program.cs.txt" />
+    <EmbeddedResource Include="..\..\samples\KeenEyes.Sample.NovaFall\Program.cs"
+                      LogicalName="KeenEyes.Graphics.Tests.CallSites.Sample.NovaFall.Program.cs.txt" />
+    <EmbeddedResource Include="..\..\editor\KeenEyes.Editor\Application\EditorApplication.cs"
+                      LogicalName="KeenEyes.Graphics.Tests.CallSites.EditorApplication.cs.txt" />
+  </ItemGroup>
+
 </Project>

--- a/tests/KeenEyes.Graphics.Tests/SilkFontManagerCollectionTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/SilkFontManagerCollectionTests.cs
@@ -1,0 +1,107 @@
+using KeenEyes.Graphics.Silk.Text;
+using KeenEyes.Graphics.Tests.Mocks;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests the diagnostics <c>SilkFontManager</c> produces for fonts it cannot load.
+/// </summary>
+/// <remarks>
+/// Regression coverage for #1365. Handing a TrueType Collection to FontStashSharp surfaced a
+/// bare <c>Error: stbtt_InitFont failed</c> that named neither the file nor the format, which is
+/// what left the macOS report guessing. Per the #1274 diagnostics contract the message must state
+/// the observation and the remedy without asserting a cause that was never checked.
+/// </remarks>
+public sealed class SilkFontManagerCollectionTests : IDisposable
+{
+    /// <summary>
+    /// A minimal TrueType Collection header: the <c>ttcf</c> tag, version 1.0, one face.
+    /// </summary>
+    private static readonly byte[] collectionBytes =
+        [0x74, 0x74, 0x63, 0x66, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+
+    private readonly string tempDirectory;
+
+    /// <summary>
+    /// Creates a private scratch directory for the synthetic font files.
+    /// </summary>
+    public SilkFontManagerCollectionTests()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), $"keeneyes-fontmgr-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover scratch directory must never fail a test run.
+        }
+    }
+
+    [Fact]
+    public void LoadFont_WithTrueTypeCollection_ThrowsNamingTheFileAndTheFormat()
+    {
+        using var device = new MockGraphicsDevice();
+        using var manager = new SilkFontManager(device);
+
+        var path = Path.Combine(tempDirectory, "Helvetica.ttc");
+        File.WriteAllBytes(path, collectionBytes);
+
+        var ex = Assert.Throws<NotSupportedException>(() => manager.LoadFont(path, 14f));
+
+        Assert.Contains(path, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("collection", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFontFromMemory_WithTrueTypeCollection_ThrowsNamingTheFontAndTheFormat()
+    {
+        using var device = new MockGraphicsDevice();
+        using var manager = new SilkFontManager(device);
+
+        var ex = Assert.Throws<NotSupportedException>(
+            () => manager.LoadFontFromMemory(collectionBytes, 14f, "Helvetica"));
+
+        Assert.Contains("Helvetica", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("collection", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LoadFont_WithDataTheRasterizerRejects_ThrowsNamingTheFile()
+    {
+        using var device = new MockGraphicsDevice();
+        using var manager = new SilkFontManager(device);
+
+        // Not a collection, just not a font: the boundary wrap must still name the file rather
+        // than let FontStashSharp's anonymous message escape. An all-zero buffer is the safe
+        // shape of "invalid": stb reads a table count of zero and gives up immediately, where
+        // arbitrary bytes would send its table walk past the end of the buffer.
+        var path = Path.Combine(tempDirectory, "not-a-font.ttf");
+        File.WriteAllBytes(path, new byte[1024]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.LoadFont(path, 14f));
+
+        Assert.Contains(path, ex.Message, StringComparison.Ordinal);
+        Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public void LoadFont_WithMissingFile_ThrowsFileNotFoundException()
+    {
+        using var device = new MockGraphicsDevice();
+        using var manager = new SilkFontManager(device);
+
+        var path = Path.Combine(tempDirectory, "absent.ttf");
+
+        // A distinct condition gets a distinct exception: "the file is not there" must not be
+        // reported as "the format is unsupported".
+        Assert.Throws<FileNotFoundException>(() => manager.LoadFont(path, 14f));
+    }
+}

--- a/tests/KeenEyes.Graphics.Tests/SystemFontsTests.cs
+++ b/tests/KeenEyes.Graphics.Tests/SystemFontsTests.cs
@@ -1,0 +1,421 @@
+using System.Runtime.InteropServices;
+
+using KeenEyes.Graphics.Abstractions;
+
+namespace KeenEyes.Graphics.Tests;
+
+/// <summary>
+/// Tests for <see cref="SystemFonts"/>, the shared locator that picks a default UI font.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Regression coverage for #1365. Every windowed sample used to pick the first candidate path
+/// that <c>File.Exists</c> returned true for, and on macOS the first candidate was
+/// <c>/System/Library/Fonts/Helvetica.ttc</c> - a TrueType Collection, which the single-face
+/// rasterizer rejects with a bare <c>stbtt_InitFont failed</c>. Existence is not loadability, so
+/// an unusable file shadowed every later candidate that would have worked.
+/// </para>
+/// <para>
+/// The macOS paths do not exist on the Linux and Windows machines that run this suite, so the
+/// fall-through behaviour is proven against synthetic files rather than real system fonts, and
+/// the platform ordering is asserted as a pure list property.
+/// </para>
+/// </remarks>
+public sealed class SystemFontsTests : IDisposable
+{
+    /// <summary>
+    /// The first four bytes of every TrueType Collection.
+    /// </summary>
+    private static readonly byte[] collectionMagic = [0x74, 0x74, 0x63, 0x66];
+
+    private readonly string tempDirectory;
+
+    /// <summary>
+    /// Creates a private scratch directory for the synthetic font files.
+    /// </summary>
+    public SystemFontsTests()
+    {
+        tempDirectory = Path.Combine(Path.GetTempPath(), $"keeneyes-fonts-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover scratch directory must never fail a test run.
+        }
+    }
+
+    #region IsUsable Tests
+
+    [Fact]
+    public void IsUsable_WithTrueTypeCollection_ReturnsFalse()
+    {
+        var collection = WriteCollection("Helvetica.ttc");
+
+        Assert.False(SystemFonts.IsUsable(collection));
+    }
+
+    [Fact]
+    public void IsUsable_WithRealTrueTypeFont_ReturnsTrue()
+    {
+        var font = FindInstalledTrueTypeFont();
+        Assert.SkipWhen(font is null, "No installed .ttf font found on this machine.");
+
+        Assert.True(SystemFonts.IsUsable(font!));
+    }
+
+    [Fact]
+    public void IsUsable_WithNonexistentPath_ReturnsFalse()
+    {
+        Assert.False(SystemFonts.IsUsable(Path.Combine(tempDirectory, "no-such-font.ttf")));
+    }
+
+    [Fact]
+    public void IsUsable_WithEmptyPath_ReturnsFalse()
+    {
+        Assert.False(SystemFonts.IsUsable(string.Empty));
+    }
+
+    [Fact]
+    public void IsUsable_WithTruncatedFile_ReturnsFalse()
+    {
+        // Shorter than the 4-byte tag: unidentifiable, so it must be skipped rather than returned.
+        var truncated = Path.Combine(tempDirectory, "truncated.ttf");
+        File.WriteAllBytes(truncated, [0x00, 0x01]);
+
+        Assert.False(SystemFonts.IsUsable(truncated));
+    }
+
+    [Fact]
+    public void IsUsable_WithNonFontFile_ReturnsFalse()
+    {
+        // A .ttf extension over WOFF2 content: the extension lies, the leading tag does not.
+        var woff2 = Path.Combine(tempDirectory, "webfont.ttf");
+        File.WriteAllBytes(woff2, "wOF2placeholder"u8.ToArray());
+
+        Assert.False(SystemFonts.IsUsable(woff2));
+    }
+
+    [Fact]
+    public void IsUsable_WithDirectory_ReturnsFalse()
+    {
+        // Directories exist, which is exactly the trap the old File.Exists-free check would
+        // have fallen into if the candidate list ever named one.
+        Assert.False(SystemFonts.IsUsable(tempDirectory));
+    }
+
+    [Theory]
+    // The four leading tags a single-face rasterizer can open at offset zero.
+    [InlineData(new byte[] { 0x00, 0x01, 0x00, 0x00 })]  // TrueType outlines
+    [InlineData(new byte[] { 0x74, 0x72, 0x75, 0x65 })]  // "true" - legacy Macintosh TrueType
+    [InlineData(new byte[] { 0x74, 0x79, 0x70, 0x31 })]  // "typ1" - Type 1 in an sfnt wrapper
+    [InlineData(new byte[] { 0x4F, 0x54, 0x54, 0x4F })]  // "OTTO" - OpenType with CFF outlines
+    public void IsUsable_WithSingleFaceTag_ReturnsTrue(byte[] tag)
+    {
+        var path = Path.Combine(tempDirectory, $"face-{Convert.ToHexString(tag)}.ttf");
+        File.WriteAllBytes(path, [.. tag, 0x00, 0x00, 0x00, 0x00]);
+
+        Assert.True(SystemFonts.IsUsable(path));
+    }
+
+    #endregion
+
+    #region IsFontCollection Tests
+
+    [Fact]
+    public void IsFontCollection_WithCollectionFile_ReturnsTrue()
+    {
+        Assert.True(SystemFonts.IsFontCollection(WriteCollection("Collection.ttc")));
+    }
+
+    [Fact]
+    public void IsFontCollection_WithSingleFaceFile_ReturnsFalse()
+    {
+        var single = Path.Combine(tempDirectory, "single.ttf");
+        File.WriteAllBytes(single, [0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+
+        Assert.False(SystemFonts.IsFontCollection(single));
+    }
+
+    [Fact]
+    public void IsFontCollection_WithMissingFile_ReturnsFalse()
+    {
+        Assert.False(SystemFonts.IsFontCollection(Path.Combine(tempDirectory, "absent.ttc")));
+    }
+
+    [Fact]
+    public void IsFontCollection_WithCollectionData_ReturnsTrue()
+    {
+        Assert.True(SystemFonts.IsFontCollection(new byte[] { 0x74, 0x74, 0x63, 0x66, 0x00, 0x01 }));
+    }
+
+    [Fact]
+    public void IsFontCollection_WithDataShorterThanTheTag_ReturnsFalse()
+    {
+        Assert.False(SystemFonts.IsFontCollection(new byte[] { 0x74, 0x74, 0x63 }));
+    }
+
+    #endregion
+
+    #region FindFirstUsable Tests
+
+    /// <summary>
+    /// The behavioural heart of #1365: a candidate that exists but cannot be loaded must not
+    /// shadow a later candidate that can.
+    /// </summary>
+    /// <remarks>
+    /// This is the case that reproduces the macOS report. The old implementation returned the
+    /// first path <c>File.Exists</c> accepted, which here would be the collection.
+    /// </remarks>
+    [Fact]
+    public void FindFirstUsable_WithNonexistentThenCollectionThenValidFont_ReturnsTheValidFont()
+    {
+        var validFont = FindInstalledTrueTypeFont();
+        Assert.SkipWhen(validFont is null, "No installed .ttf font found on this machine.");
+
+        var missing = Path.Combine(tempDirectory, "missing.ttf");
+        var collection = WriteCollection("Helvetica.ttc");
+
+        var found = SystemFonts.FindFirstUsable([missing, collection, validFont!]);
+
+        Assert.Equal(validFont, found);
+    }
+
+    [Fact]
+    public void FindFirstUsable_WithNoLoadableCandidate_ReturnsNull()
+    {
+        var missing = Path.Combine(tempDirectory, "missing.ttf");
+        var collection = WriteCollection("OnlyCollection.ttc");
+
+        Assert.Null(SystemFonts.FindFirstUsable([missing, collection]));
+    }
+
+    [Fact]
+    public void FindFirstUsable_WithEmptyCandidateList_ReturnsNull()
+    {
+        Assert.Null(SystemFonts.FindFirstUsable([]));
+    }
+
+    [Fact]
+    public void FindFirstUsable_WithNullCandidates_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => SystemFonts.FindFirstUsable(null!));
+    }
+
+    [Fact]
+    public void FindFirstUsable_PrefersAnEarlierUsableCandidateOverALaterOne()
+    {
+        var first = Path.Combine(tempDirectory, "first.ttf");
+        var second = Path.Combine(tempDirectory, "second.ttf");
+        File.WriteAllBytes(first, [0x00, 0x01, 0x00, 0x00]);
+        File.WriteAllBytes(second, [0x00, 0x01, 0x00, 0x00]);
+
+        Assert.Equal(first, SystemFonts.FindFirstUsable([first, second]));
+    }
+
+    /// <summary>
+    /// Covers what the four call sites actually do: resolve a font on the machine running them.
+    /// </summary>
+    [Fact]
+    public void FindFirstUsable_OnThisMachine_ResolvesALoadableFontWhenOneIsInstalled()
+    {
+        Assert.SkipWhen(
+            FindInstalledTrueTypeFont() is null,
+            "No installed .ttf font found on this machine.");
+
+        var found = SystemFonts.FindFirstUsable();
+
+        Assert.NotNull(found);
+        Assert.True(SystemFonts.IsUsable(found));
+        Assert.False(SystemFonts.IsFontCollection(found));
+    }
+
+    #endregion
+
+    #region Candidate Ordering Tests
+
+    /// <summary>
+    /// The macOS ordering that unblocks the samples, asserted as a pure list property so it is
+    /// verifiable on any platform.
+    /// </summary>
+    [Fact]
+    public void GetCandidates_ForMacOS_ListsEverySingleFontFileBeforeAnyCollection()
+    {
+        var candidates = SystemFonts.GetCandidates(OSPlatform.OSX);
+
+        var firstCollection = IndexOfFirst(candidates, p => p.EndsWith(".ttc", StringComparison.Ordinal));
+        var lastSingleFont = IndexOfLast(candidates, p => !p.EndsWith(".ttc", StringComparison.Ordinal));
+
+        Assert.True(firstCollection >= 0, "Expected the macOS list to still mention a .ttc.");
+        Assert.True(lastSingleFont >= 0, "Expected the macOS list to offer single-font files.");
+        Assert.True(
+            lastSingleFont < firstCollection,
+            $"Single-font candidates must precede collections. '{candidates[firstCollection]}' at "
+            + $"index {firstCollection} comes before '{candidates[lastSingleFont]}' at index "
+            + $"{lastSingleFont}, which is the ordering that made every macOS sample fail (#1365).");
+    }
+
+    [Fact]
+    public void GetCandidates_ForMacOS_LeadsWithASupplementalSingleFontFile()
+    {
+        var candidates = SystemFonts.GetCandidates(OSPlatform.OSX);
+
+        // Apple moved the classic single-font TTFs into Supplemental; the collections that
+        // remain in /System/Library/Fonts are what the old list reached first.
+        Assert.StartsWith("/System/Library/Fonts/Supplemental/", candidates[0], StringComparison.Ordinal);
+        Assert.EndsWith(".ttf", candidates[0], StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\Fonts\segoeui.ttf")]
+    [InlineData(@"C:\Windows\Fonts\arial.ttf")]
+    [InlineData(@"C:\Windows\Fonts\calibri.ttf")]
+    [InlineData(@"C:\Windows\Fonts\verdana.ttf")]
+    [InlineData(@"C:\Windows\Fonts\tahoma.ttf")]
+    public void GetCandidates_ForWindows_KeepsTheExistingEntries(string expected)
+    {
+        Assert.Contains(expected, SystemFonts.GetCandidates(OSPlatform.Windows));
+    }
+
+    [Theory]
+    [InlineData("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")]
+    [InlineData("/usr/share/fonts/TTF/DejaVuSans.ttf")]
+    public void GetCandidates_ForLinux_KeepsTheExistingEntries(string expected)
+    {
+        Assert.Contains(expected, SystemFonts.GetCandidates(OSPlatform.Linux));
+    }
+
+    [Fact]
+    public void GetCandidates_ForWindows_LeadsWithSegoeUi()
+    {
+        Assert.Equal(@"C:\Windows\Fonts\segoeui.ttf", SystemFonts.GetCandidates(OSPlatform.Windows)[0]);
+    }
+
+    [Fact]
+    public void GetCandidates_ForLinux_LeadsWithDejaVuSans()
+    {
+        Assert.Equal(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            SystemFonts.GetCandidates(OSPlatform.Linux)[0]);
+    }
+
+    [Fact]
+    public void GetCandidates_ForAnUnrecognizedPlatform_FallsBackToTheLinuxList()
+    {
+        Assert.Equal(
+            SystemFonts.GetCandidates(OSPlatform.Linux),
+            SystemFonts.GetCandidates(OSPlatform.FreeBSD));
+    }
+
+    [Fact]
+    public void Candidates_MatchesTheListForTheRunningOperatingSystem()
+    {
+        var expected = OperatingSystem.IsWindows()
+            ? SystemFonts.GetCandidates(OSPlatform.Windows)
+            : OperatingSystem.IsMacOS()
+                ? SystemFonts.GetCandidates(OSPlatform.OSX)
+                : SystemFonts.GetCandidates(OSPlatform.Linux);
+
+        Assert.Equal(expected, SystemFonts.Candidates);
+    }
+
+    #endregion
+
+    #region Diagnostic Message Tests
+
+    [Fact]
+    public void DescribeUnsupportedCollection_NamesTheFileAndTheFormat()
+    {
+        var message = SystemFonts.DescribeUnsupportedCollection("/System/Library/Fonts/Helvetica.ttc");
+
+        Assert.Contains("/System/Library/Fonts/Helvetica.ttc", message, StringComparison.Ordinal);
+        Assert.Contains("collection", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ttcf", message, StringComparison.Ordinal);
+        Assert.Contains("not supported", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Writes a file whose header is the <c>ttcf</c> tag, as a real TrueType Collection's is.
+    /// </summary>
+    /// <param name="fileName">The file name to create inside the scratch directory.</param>
+    /// <returns>The full path of the created file.</returns>
+    private string WriteCollection(string fileName)
+    {
+        var path = Path.Combine(tempDirectory, fileName);
+
+        // ttcf, version 1.0, one face, offset 12 - enough structure to look like the real thing.
+        File.WriteAllBytes(path, [.. collectionMagic, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Finds a real single-face TrueType font installed on the machine running the tests.
+    /// </summary>
+    /// <returns>The font path, or <see langword="null"/> when the machine has none.</returns>
+    private static string? FindInstalledTrueTypeFont()
+    {
+        foreach (var candidate in SystemFonts.Candidates)
+        {
+            if (SystemFonts.IsUsable(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        // Fall back to a scan so a machine with fonts in a non-standard prefix still exercises
+        // the positive case instead of skipping it.
+        foreach (var root in (string[])["/usr/share/fonts", "/usr/local/share/fonts"])
+        {
+            if (!Directory.Exists(root))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(root, "*.ttf", SearchOption.AllDirectories))
+            {
+                if (SystemFonts.IsUsable(file))
+                {
+                    return file;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static int IndexOfFirst(IReadOnlyList<string> values, Func<string, bool> predicate)
+    {
+        for (int i = 0; i < values.Count; i++)
+        {
+            if (predicate(values[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int IndexOfLast(IReadOnlyList<string> values, Func<string, bool> predicate)
+    {
+        for (int i = values.Count - 1; i >= 0; i--)
+        {
+            if (predicate(values[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj
+++ b/tests/KeenEyes.Platform.Silk.Tests/KeenEyes.Platform.Silk.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk\KeenEyes.Platform.Silk.csproj" />
+    <ProjectReference Include="..\..\src\KeenEyes.Platform.Silk.Abstractions\KeenEyes.Platform.Silk.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/KeenEyes.Platform.Silk.Tests/Mocks/WindowlessSilkWindowProvider.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/Mocks/WindowlessSilkWindowProvider.cs
@@ -1,0 +1,51 @@
+using Silk.NET.Input;
+using Silk.NET.Windowing;
+
+namespace KeenEyes.Platform.Silk.Tests.Mocks;
+
+/// <summary>
+/// An <see cref="ISilkWindowProvider"/> that owns no OS window and reports a sentinel exception
+/// the moment anything reaches for one.
+/// </summary>
+/// <remarks>
+/// This makes "the caller got as far as touching the window" observable in a headless test: a
+/// <see cref="NotSupportedException"/> carrying <see cref="WindowAccessMessage"/> means execution
+/// passed every check that runs before window creation.
+/// </remarks>
+internal sealed class WindowlessSilkWindowProvider : ISilkWindowProvider
+{
+    /// <summary>
+    /// The message carried by the sentinel exception thrown from <see cref="Window"/>.
+    /// </summary>
+    internal const string WindowAccessMessage = "The test window provider owns no OS window.";
+
+    public IWindow Window => throw new NotSupportedException(WindowAccessMessage);
+
+    public IInputContext InputContext => throw new NotSupportedException(WindowAccessMessage);
+
+    public int Width => 0;
+
+    public int Height => 0;
+
+    public int FramebufferWidth => 0;
+
+    public int FramebufferHeight => 0;
+
+#pragma warning disable CS0067 // Events exist to satisfy the interface; this provider raises none.
+    public event Action? OnLoad;
+
+    public event Action<double>? OnUpdate;
+
+    public event Action<double>? OnRender;
+
+    public event Action<int, int>? OnResize;
+
+    public event Action<int, int>? OnFramebufferResize;
+
+    public event Action? OnClosing;
+#pragma warning restore CS0067
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/SilkLoopProviderTests.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/SilkLoopProviderTests.cs
@@ -1,0 +1,45 @@
+using KeenEyes.Platform.Silk.Tests.Mocks;
+
+namespace KeenEyes.Platform.Silk.Tests;
+
+/// <summary>
+/// Tests for <see cref="SilkLoopProvider"/>, focused on the thread check that runs immediately
+/// before the OS window is created (#1364).
+/// </summary>
+public class SilkLoopProviderTests
+{
+    #region Run
+
+    [Fact]
+    public void Run_OnNonMacOS_ReachesWindowCreation()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        using var windowProvider = new WindowlessSilkWindowProvider();
+        var loopProvider = new SilkLoopProvider(windowProvider);
+
+        // The sentinel proves Run() got all the way to the window, so nothing before it -
+        // including the thread check - short-circuited the call.
+        var exception = Assert.Throws<NotSupportedException>(loopProvider.Run);
+
+        Assert.Equal(WindowlessSilkWindowProvider.WindowAccessMessage, exception.Message);
+    }
+
+    [Fact]
+    public async Task Run_OnNonMacOSFromThreadPoolThread_ReachesWindowCreation()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        using var windowProvider = new WindowlessSilkWindowProvider();
+        var loopProvider = new SilkLoopProvider(windowProvider);
+
+        // Task.Run reproduces exactly what an 'await' before Run() does to the calling thread.
+        // Platforms other than macOS must be unaffected by the new check.
+        var exception = await Task.Run(() => Record.Exception(loopProvider.Run));
+
+        var notSupported = Assert.IsType<NotSupportedException>(exception);
+        Assert.Equal(WindowlessSilkWindowProvider.WindowAccessMessage, notSupported.Message);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/WindowThreadGuardTests.cs
+++ b/tests/KeenEyes.Platform.Silk.Tests/WindowThreadGuardTests.cs
@@ -1,0 +1,96 @@
+namespace KeenEyes.Platform.Silk.Tests;
+
+/// <summary>
+/// Tests for <see cref="WindowThreadGuard"/>, the macOS main-thread requirement for OS window
+/// creation (#1364).
+/// </summary>
+/// <remarks>
+/// The guard only fires on macOS, so its decision is exercised through
+/// <see cref="WindowThreadGuard.Validate(bool, bool)"/>, which takes the two platform facts as
+/// inputs and can therefore be tested from any operating system.
+/// </remarks>
+public class WindowThreadGuardTests
+{
+    #region Validate
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        // Distinguishing fragments only - the wording around them is free to change.
+        Assert.Contains("main thread", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("macOS", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_NamesTheLikelyCause()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        Assert.Contains("await", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("thread-pool thread", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOffTheMainThread_StatesTheRemedy()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: false));
+
+        Assert.Contains("GetAwaiter().GetResult()", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("after Run() returns", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_OnMacOSOnTheMainThread_DoesNotThrow()
+    {
+        var exception = Record.Exception(
+            () => WindowThreadGuard.Validate(isMacOS: true, isProcessMainThread: true));
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Validate_OffMacOS_DoesNotThrowRegardlessOfThread(bool isProcessMainThread)
+    {
+        var exception = Record.Exception(
+            () => WindowThreadGuard.Validate(isMacOS: false, isProcessMainThread));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+
+    #region EnsureWindowCreationThread
+
+    [Fact]
+    public void EnsureWindowCreationThread_OnNonMacOSPlatform_DoesNotThrow()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        var exception = Record.Exception(WindowThreadGuard.EnsureWindowCreationThread);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task EnsureWindowCreationThread_OnNonMacOSFromThreadPoolThread_DoesNotThrow()
+    {
+        Assert.SkipWhen(OperatingSystem.IsMacOS(), "The guard is expected to apply on macOS.");
+
+        // Windows and Linux allow window creation from any thread; the guard must not have
+        // silently imposed the macOS restriction on them. The thread-pool thread here is exactly
+        // what an 'await' before Run() would resume on.
+        var exception = await Task.Run(
+            () => Record.Exception(WindowThreadGuard.EnsureWindowCreationThread));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+}

--- a/tests/KeenEyes.Platform.Silk.Tests/packages.lock.json
+++ b/tests/KeenEyes.Platform.Silk.Tests/packages.lock.json
@@ -1,0 +1,304 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "GitHubActionsTestLogger": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "24fDBf5g5KuyeK9OIu4z0zIkOu6DE3JCmRP+NyNGL3PVmd2Yls8sR8dC1/j34t2tZQS/0arQs7GZTmwWYk4qbQ=="
+      },
+      "Microsoft.Testing.Extensions.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
+        "dependencies": {
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "JzCtiOAmIfkPP2PpAKZeiH1hVYIVC9jMhsPWrd6PnH/Wtuct1UMuxpKi2F1cmXgfokc/HOadC6HOO1qzI23tnA==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Direct",
+        "requested": "[2.3.2, )",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.0.2"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.2"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Silk.NET.Core": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "D7AT/nnwlB+4RZ84XY8QNGBZMJI5z9l4CSSETIJ1wCfRJzRt/341y3MRZ4HbnFz4r/IGaWOEZr86iE+0/65yyQ==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Microsoft.Extensions.DependencyModel": "9.0.9"
+        }
+      },
+      "Silk.NET.GLFW": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "UIs4sH57xlPUNHQ/1bt9rymPWlGy8IMDCNv86h0iM4TOA1CkIx0XM/n/tA4AReh1zQkNrvkxPEdZ3Blvy1dyXg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Ultz.Native.GLFW": "3.4.0"
+        }
+      },
+      "Silk.NET.Input.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "QbJVV7kFBHEByayXCYdJtXXI9Sp4a+QAf0IdGV6uCWkFYcEmqBYW3aaNGvFOdSwTBDbHL5T/OtOCrGh4qYhk7A==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "Silk.NET.Input.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "KGHYqsv/IQRJtD6dloYh2tN4CkaM40vxM2kj0cGKBoCQiBDYHHhJiyDTyMPx0W7Fz5IgnhnG42ELmIAa0DH69A==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Common": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "ThStSinmY9KQI8DGiF5XEhkLJVnBcgRTBTzL9ijg1wMZAYuckz7ykrNw04fjRm2Gryh6tCNGbvz2XaY0efeFzg==",
+        "dependencies": {
+          "Silk.NET.Core": "2.23.0",
+          "Silk.NET.Maths": "2.23.0"
+        }
+      },
+      "Silk.NET.Windowing.Glfw": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "aYBudKmENmvLRn9p15HbdvlQTnnXskcDfTfbYwSb/4fr263rGLwYuDw/txUEc2jihHJiWCp5+75Y7z5wTJWl7g==",
+        "dependencies": {
+          "Silk.NET.GLFW": "2.23.0",
+          "Silk.NET.Windowing.Common": "2.23.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Ultz.Native.GLFW": {
+        "type": "Transitive",
+        "resolved": "3.4.0",
+        "contentHash": "Iy22JopynbOJ32vA0lBhFEzGi65GQJBuJHYBYRBpydrDpNoTiHnjIXfA65Gu+8qsOr/ZEoIF8r9aHCgAXuO6DA=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "keeneyes.abstractions": {
+        "type": "Project"
+      },
+      "keeneyes.platform.silk": {
+        "type": "Project",
+        "dependencies": {
+          "KeenEyes.Abstractions": "[1.0.0, )",
+          "KeenEyes.Platform.Silk.Abstractions": "[1.0.0, )",
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "keeneyes.platform.silk.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Silk.NET.Input": "[2.23.0, )",
+          "Silk.NET.Windowing": "[2.23.0, )"
+        }
+      },
+      "Silk.NET.Input": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "Xzl+tVwAp2eEd8blmGQjmJrsZPnp3PWG0KJjiAQHaY2Zr/ELVWeAROKXmZdCAvexzmte2JVGEy/dxnMycbxlpg==",
+        "dependencies": {
+          "Silk.NET.Input.Common": "2.23.0",
+          "Silk.NET.Input.Glfw": "2.23.0"
+        }
+      },
+      "Silk.NET.Maths": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "r8PdIVzME8EH0qAgbmRPO87I4GfgR2j8TofT7EMuRJDf1QluoQwnVypDoFJjQ2ZBSRsGYk5unYxxogI05Ogsmw=="
+      },
+      "Silk.NET.Windowing": {
+        "type": "CentralTransitive",
+        "requested": "[2.23.0, )",
+        "resolved": "2.23.0",
+        "contentHash": "OPNPmt/lRyUKVYrFLQXVxyATqD3MKLc1iY1oKx1/2GppgmZxVZPwN12tekrQ4C7408kgB1L5JD1Wnirqqeb2kg==",
+        "dependencies": {
+          "Silk.NET.Windowing.Common": "2.23.0",
+          "Silk.NET.Windowing.Glfw": "2.23.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/KeenEyes.Sample.NovaFall.Tests.csproj
@@ -17,4 +17,13 @@
     <ProjectReference Include="..\..\src\KeenEyes.Testing\KeenEyes.Testing.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- StartupOrderingTests inspects the entry point itself: the ordering of the
+         TestBridge start against Run() is a startup property no runtime test can
+         observe, because Run() needs a window (#1364). Embedding the file keeps the
+         test hermetic - it cannot drift onto a stale copy or a wrong path. -->
+    <EmbeddedResource Include="..\..\samples\KeenEyes.Sample.NovaFall\Program.cs"
+                      LogicalName="KeenEyes.Sample.NovaFall.Tests.Program.cs.txt" />
+  </ItemGroup>
+
 </Project>

--- a/tests/KeenEyes.Sample.NovaFall.Tests/StartupOrderingTests.cs
+++ b/tests/KeenEyes.Sample.NovaFall.Tests/StartupOrderingTests.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+
+namespace KeenEyes.Sample.NovaFall.Tests;
+
+/// <summary>
+/// Pins down the startup ordering the windowed entry point depends on: nothing between process
+/// start and the game loop may be awaited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Regression coverage for #1364. An <c>await</c> in an async <c>Main</c> resumes the remainder of
+/// the method on a thread-pool thread, and the remainder here includes <c>Run()</c>, which creates
+/// the OS window. macOS/AppKit only permits window creation on the process main thread and
+/// terminates the process otherwise, so on a Mac the sample died right after starting the
+/// TestBridge.
+/// </para>
+/// <para>
+/// The property cannot be observed at runtime - reaching <c>Run()</c> requires a display - so it is
+/// asserted against the entry point's source, which the test project embeds. Comments are stripped
+/// first so that prose about <c>await</c> and <c>Run()</c> (including the comment that explains why
+/// this ordering matters) cannot decide the outcome.
+/// </para>
+/// </remarks>
+public class StartupOrderingTests
+{
+    [Fact]
+    public void WindowedStartup_DoesNotAwaitBeforeTheGameLoopStarts()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var runLine = IndexOfLineContaining(code, ".Run()");
+        Assert.True(runLine >= 0, "Expected the entry point to start the loop with '.Run()'.");
+
+        var awaitLine = IndexOfLineWithAwait(code);
+
+        Assert.True(
+            awaitLine < 0 || awaitLine > runLine,
+            $"An 'await' on source line {awaitLine + 1} precedes the '.Run()' call on line "
+            + $"{runLine + 1}. The continuation after that await resumes on a thread-pool thread, "
+            + "so the window would be created off the process main thread and macOS would abort "
+            + "the process. Block on the work instead (GetAwaiter().GetResult()), or move it after "
+            + "Run() returns.");
+    }
+
+    [Fact]
+    public void WindowedStartup_StillStartsTheTestBridgeBeforeTheGameLoop()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var startLine = IndexOfLineContaining(code, "StartAsync()");
+        var runLine = IndexOfLineContaining(code, ".Run()");
+
+        // The fix must not have been "delete the bridge": it still starts, just synchronously.
+        Assert.True(startLine >= 0, "Expected the entry point to start the TestBridge server.");
+        Assert.True(
+            startLine < runLine,
+            "Expected the TestBridge to start before the game loop, as it did before #1364.");
+    }
+
+    [Fact]
+    public void WindowedStartup_StopsTheTestBridgeAfterTheGameLoop()
+    {
+        var code = StripComments(ReadEntryPointSource());
+
+        var runLine = IndexOfLineContaining(code, ".Run()");
+        var stopLine = IndexOfLineContaining(code, "StopAsync()");
+
+        // Teardown may still be awaited: by then Run() has returned, so a thread-pool
+        // continuation can no longer reach window creation.
+        Assert.True(stopLine >= 0, "Expected the entry point to stop the TestBridge server.");
+        Assert.True(
+            stopLine > runLine,
+            "Expected the TestBridge to be stopped after the game loop returns.");
+    }
+
+    private static string[] ReadEntryPointSource()
+    {
+        const string ResourceName = "KeenEyes.Sample.NovaFall.Tests.Program.cs.txt";
+
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded entry-point source '{ResourceName}' is missing from the test assembly.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd().Split('\n');
+    }
+
+    /// <summary>
+    /// Blanks out line comments so prose cannot satisfy or break a code-ordering assertion.
+    /// </summary>
+    private static string[] StripComments(string[] lines)
+    {
+        var stripped = new string[lines.Length];
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var commentStart = lines[i].IndexOf("//", StringComparison.Ordinal);
+            stripped[i] = commentStart >= 0 ? lines[i][..commentStart] : lines[i];
+        }
+
+        return stripped;
+    }
+
+    private static int IndexOfLineContaining(string[] lines, string token)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].Contains(token, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Finds the first line using <c>await</c> as a keyword rather than as part of an identifier.
+    /// </summary>
+    private static int IndexOfLineWithAwait(string[] lines)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            foreach (var word in lines[i].Split(
+                [' ', '\t', '(', ')', ';', '=', '{', '}', ','],
+                StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (string.Equals(word, "await", StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1365.

> ⚠️ **Stacked on #1366** — branched from that PR's head because both edit `samples/KeenEyes.Sample.NovaFall/Program.cs`. Merge #1366 first.

Every windowed sample failed to load a font on macOS. `.ttc` is a TrueType **Collection** (multiple faces, `ttcf` magic), and `SilkFontManager` loads via `AddFont(bytes)` at offset 0, so stb rejects it. `/System/Library/Fonts/Helvetica.ttc` was the first macOS candidate in **all four** duplicated discovery lists, and `FindSystemFont` selected on `File.Exists` alone — **existence is not loadability**, so an unusable file shadowed every later candidate that would have worked.

## One locator, selecting on usability
`SystemFonts` in `Graphics.Abstractions` replaces four hand-maintained lists (which had already drifted — the editor's copy was missing an entry). `IsUsable` reads the leading 4-byte sfnt tag and accepts only the four a single-face rasterizer can open at offset zero (`0x00010000`, `true`, `typ1`, `OTTO`).

That's a **positive** list mirroring what stb accepts, not a `ttcf` special case — so it also rejects WOFF/WOFF2, truncated files, directories and unreadable paths. Which is the point: it stays correct regardless of what Apple relocates or reformats next, where adding `Supplemental/Arial.ttf` alone would just be a guess about one OS version.

macOS order is now Supplemental TTFs → `/Library/Fonts/Arial.ttf` → `Helvetica.ttc` **last**. The collection is kept rather than deleted so a future collection-capable rasterizer can reach it. Windows unchanged; Linux gained two fallbacks.

## Also
- **`LoadFont` on a collection** now throws `NotSupportedException` naming the file, the `ttcf` tag and the remedy, instead of FontStashSharp's bare `stbtt_InitFont failed`; other rasterizer failures wrap in `InvalidOperationException` naming the file with the inner exception preserved. Missing files still get a distinct `FileNotFoundException` — one condition, one message (#1274).
- **`Sample.UI` and `Sample.Showcase` catch-alls** stop claiming "This sample requires a display" on machines that had just logged `OpenGL 4.1 Metal … Apple M5 Max`. They now lead with the exception type and message. The other four samples don't load fonts, so they remain #1273's scope.
- **No `.ttc` support added** — deliberately deferred per the issue.

## A process-abort hazard found while testing
Worth flagging on its own: stb reads `numTables` at offset 4 and walks the table directory **without bounds-checking against the buffer**. A `.ttc` survives (its face count is small), but arbitrary non-font bytes make it read far past the end and **SIGABRT the test host** — hit during development, exit 134, non-deterministically. The test now uses an all-zero buffer (`numTables == 0`, stb gives up immediately), verified stable over five runs.

`IsUsable` keeps malformed files away from the rasterizer on the *discovery* path, but `LoadFont` called directly with a corrupt font can still take the process down. Filed separately — not fixed here.

## Test plan
- [x] 53 new tests. **Fail-on-old proven**: reverting `IsUsable` to `File.Exists` semantics makes the fall-through test return `Helvetica.ttc` instead of DejaVu (exit 2).
- [x] `SystemFontsTests` (36) — collection skip, real `.ttf` accept (skips gracefully if absent), fall-through, no-usable-candidate, all four single-face tags, truncated/WOFF2/directory rejects, macOS ordering as a pure list assertion, Windows/Linux preserved.
- [x] `SilkFontManagerCollectionTests` (4), `FontDiscoveryCallSiteTests` (13) — call-site sources embedded as resources so MSBuild fails on path drift.
- [x] Graphics 702, UI 2000, NovaFall 56, Editor 1302; full suite **15,003 total, 0 failed**; 0 warnings; format clean; `--simulate 600` byte-identical.

## Needs a real Mac
Whether `/System/Library/Fonts/Supplemental/Arial.ttf` exists on that macOS version — a wrong guess is non-fatal (it falls through to Verdana, Tahoma, `/Library/Fonts/Arial.ttf`), but *that some candidate resolves* is unproven here. Likewise that the chosen font rasterizes correctly on Apple's GL 4.1 Metal path: these tests prove selection and error reporting, never rasterization.
